### PR TITLE
feat(#1777): reconcile -template-suffixed app slugs onto canonical (idempotent admin route)

### DIFF
--- a/api/src/AppReconciler.scala
+++ b/api/src/AppReconciler.scala
@@ -13,11 +13,13 @@ final case class AppReconcileSummary(
     mergedSlugs: List[String],
     renamedSlugs: List[String],
     hostsUnioned: List[String],
+    templateIdSet: List[String],
     alreadyClean: List[String],
     created: List[String],
 ) derives JsonCodec {
   def total: Int =
-    mergedSlugs.size + renamedSlugs.size + hostsUnioned.size + alreadyClean.size + created.size
+    mergedSlugs.size + renamedSlugs.size + hostsUnioned.size + templateIdSet.size +
+      alreadyClean.size + created.size
 }
 
 /**
@@ -40,11 +42,12 @@ object AppReconciler {
 
   private sealed trait OneOutcome
   private object OneOutcome {
-    final case class Merged(slug: String)       extends OneOutcome
-    final case class Renamed(slug: String)      extends OneOutcome
-    final case class HostsUnioned(slug: String) extends OneOutcome
-    final case class AlreadyClean(slug: String) extends OneOutcome
-    final case class Created(slug: String)      extends OneOutcome
+    final case class Merged(slug: String)        extends OneOutcome
+    final case class Renamed(slug: String)       extends OneOutcome
+    final case class HostsUnioned(slug: String)  extends OneOutcome
+    final case class TemplateIdSet(slug: String) extends OneOutcome
+    final case class AlreadyClean(slug: String)  extends OneOutcome
+    final case class Created(slug: String)       extends OneOutcome
   }
 
   def reconcileTemplates(
@@ -58,6 +61,7 @@ object AppReconciler {
           mergedSlugs = outcomes.collect { case OneOutcome.Merged(s) => s },
           renamedSlugs = outcomes.collect { case OneOutcome.Renamed(s) => s },
           hostsUnioned = outcomes.collect { case OneOutcome.HostsUnioned(s) => s },
+          templateIdSet = outcomes.collect { case OneOutcome.TemplateIdSet(s) => s },
           alreadyClean = outcomes.collect { case OneOutcome.AlreadyClean(s) => s },
           created = outcomes.collect { case OneOutcome.Created(s) => s },
         )
@@ -81,15 +85,17 @@ object AppReconciler {
             unionTemplateHostsInto(repo, s.id, t).as(OneOutcome.Renamed(canonicalSlug))
 
         case (Some(c), None) =>
-          // Only canonical exists. Set template_id if absent, top up template hosts.
+          // Only canonical exists. Set template_id if absent, top up template hosts. The two are
+          // tracked separately so the summary tells operators which subset of canonicals needed
+          // a template_id reattach vs which gained hosts.
+          val needsTemplateId  = c.templateId.isEmpty
           val ensureTemplateId =
-            if c.templateId.isEmpty then repo.update(c.copy(templateId = Some(t.slug)))
-            else ZIO.unit
+            if needsTemplateId then repo.update(c.copy(templateId = Some(t.slug))) else ZIO.unit
           ensureTemplateId *>
-            unionTemplateHostsInto(repo, c.id, t).flatMap { added =>
-              if added || c.templateId.isEmpty then
-                ZIO.succeed(OneOutcome.HostsUnioned(canonicalSlug))
-              else ZIO.succeed(OneOutcome.AlreadyClean(canonicalSlug))
+            unionTemplateHostsInto(repo, c.id, t).map { added =>
+              if added then OneOutcome.HostsUnioned(canonicalSlug)
+              else if needsTemplateId then OneOutcome.TemplateIdSet(canonicalSlug)
+              else OneOutcome.AlreadyClean(canonicalSlug)
             }
 
         case (None, None) =>

--- a/api/src/AppReconciler.scala
+++ b/api/src/AppReconciler.scala
@@ -1,0 +1,120 @@
+package wifihaven.api
+
+import wifihaven.api.db.AppRepo
+import wifihaven.shared.types.*
+import zio.*
+import zio.json.*
+
+/**
+ * #1777: per-template outcome of [[AppReconciler.reconcileTemplates]] — what changed for each
+ * template the reconciler walked. Used by the admin route to surface the result to the operator.
+ */
+final case class AppReconcileSummary(
+    mergedSlugs: List[String],
+    renamedSlugs: List[String],
+    hostsUnioned: List[String],
+    alreadyClean: List[String],
+    created: List[String],
+) derives JsonCodec {
+  def total: Int =
+    mergedSlugs.size + renamedSlugs.size + hostsUnioned.size + alreadyClean.size + created.size
+}
+
+/**
+ * #1777: idempotent reconciler that collapses every `<slug>-template`-suffixed `apps` row onto its
+ * canonical `<slug>` form, with the canonical row gaining the union of both host-sets and every FK
+ * reference (assignments, rollups, usage) reattached. After running, no app slug ends in
+ * `-template`, and `AppTemplates.findByTemplateId` finds each template's canonical row directly.
+ *
+ * Why this exists: when `AppTemplates.seed` runs against a DB where an operator already created an
+ * app at the template's canonical slug, [[AppTemplates#findFreeSlug]] falls back to
+ * `<slug>-template`. The fallback is correct as a uniqueness guard but leaves two rows for the same
+ * logical app, splitting assignments and usage. The reconciler restores 1:1 alignment with the
+ * template set.
+ *
+ * Single source of truth: this is the ONLY place the four reconciliation outcomes (#1777's rules
+ * table) are computed. The admin route delegates to it; the test seeds the messy state and calls
+ * the same function. No duplicate merge logic elsewhere.
+ */
+object AppReconciler {
+
+  private sealed trait OneOutcome
+  private object OneOutcome {
+    final case class Merged(slug: String)       extends OneOutcome
+    final case class Renamed(slug: String)      extends OneOutcome
+    final case class HostsUnioned(slug: String) extends OneOutcome
+    final case class AlreadyClean(slug: String) extends OneOutcome
+    final case class Created(slug: String)      extends OneOutcome
+  }
+
+  def reconcileTemplates(
+      repo: AppRepo,
+      templates: List[AppTemplate],
+  ): Task[AppReconcileSummary] =
+    ZIO
+      .foreach(templates)(t => reconcileOne(repo, t))
+      .map { outcomes =>
+        AppReconcileSummary(
+          mergedSlugs = outcomes.collect { case OneOutcome.Merged(s) => s },
+          renamedSlugs = outcomes.collect { case OneOutcome.Renamed(s) => s },
+          hostsUnioned = outcomes.collect { case OneOutcome.HostsUnioned(s) => s },
+          alreadyClean = outcomes.collect { case OneOutcome.AlreadyClean(s) => s },
+          created = outcomes.collect { case OneOutcome.Created(s) => s },
+        )
+      }
+
+  private def reconcileOne(repo: AppRepo, t: AppTemplate): Task[OneOutcome] = {
+    val canonicalSlug = t.slug.value
+    val suffixedSlug  = s"$canonicalSlug-template"
+    for {
+      canonical <- repo.findBySlug(canonicalSlug)
+      suffixed  <- repo.findBySlug(suffixedSlug)
+      outcome   <- (canonical, suffixed) match {
+        case (Some(c), Some(s)) =>
+          // Both exist: merge suffixed INTO canonical, then top up template hosts.
+          repo.mergeAppInto(from = s.id, to = c.id) *>
+            unionTemplateHostsInto(repo, c.id, t).as(OneOutcome.Merged(canonicalSlug))
+
+        case (None, Some(s)) =>
+          // Only suffixed exists: rename onto canonical, ensure template_id set, top up hosts.
+          repo.update(s.copy(slug = canonicalSlug, templateId = Some(t.slug))) *>
+            unionTemplateHostsInto(repo, s.id, t).as(OneOutcome.Renamed(canonicalSlug))
+
+        case (Some(c), None) =>
+          // Only canonical exists. Set template_id if absent, top up template hosts.
+          val ensureTemplateId =
+            if c.templateId.isEmpty then repo.update(c.copy(templateId = Some(t.slug)))
+            else ZIO.unit
+          ensureTemplateId *>
+            unionTemplateHostsInto(repo, c.id, t).flatMap { added =>
+              if added || c.templateId.isEmpty then
+                ZIO.succeed(OneOutcome.HostsUnioned(canonicalSlug))
+              else ZIO.succeed(OneOutcome.AlreadyClean(canonicalSlug))
+            }
+
+        case (None, None) =>
+          // Neither — create the canonical row from the template. Idempotent re-runs land in
+          // the (Some(c), None) branch after this and become no-ops.
+          for {
+            id <- repo.create(t.name, canonicalSlug, Some(t.slug), t.icon, t.iconType)
+            _  <- repo.setHosts(id, t.hosts)
+          } yield OneOutcome.Created(canonicalSlug)
+      }
+    } yield outcome
+  }
+
+  /** Returns true iff any hosts were added (i.e. the template's set wasn't already a subset). */
+  private def unionTemplateHostsInto(
+      repo: AppRepo,
+      appId: AppId,
+      t: AppTemplate,
+  ): Task[Boolean] =
+    for {
+      existing <- repo.getHosts(appId)
+      have    = existing.toSet
+      missing = t.hosts.filterNot(have.contains)
+      _ <-
+        if missing.nonEmpty then repo.setHosts(appId, (existing ++ missing).distinct)
+        else ZIO.unit
+    } yield missing.nonEmpty
+}

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2787,6 +2787,20 @@ trait AppRepo {
   def delete(id: AppId): Task[Unit]
 
   /**
+   * #1777: merge app `from` INTO app `to` in one transaction — reattaches every FK reference
+   * (`app_hosts`, `app_policy_assignments`, `traffic_hourly_apps`, `traffic_daily_apps`,
+   * `app_used_daily`) from `from` to `to`, unions their host-sets, transfers `template_id` to `to`
+   * if `to` lacks one, then deletes `from` (cascade drops any remaining duplicate FK rows that
+   * conflicted with `to`'s own). Host-set version is bumped once. Idempotent under repeat calls
+   * with the same args (a second call no-ops because `from` is gone).
+   *
+   * Used by `AppReconciler.reconcileTemplates` to collapse the `<slug>-template` row that
+   * `AppTemplates.findFreeSlug` falls back to when an operator-added canonical row already owns the
+   * template's slug.
+   */
+  def mergeAppInto(from: AppId, to: AppId): Task[Unit]
+
+  /**
    * Replace the full set of hosts for an app. Wipes prior rows; canonicalization is the caller's
    * responsibility.
    */
@@ -2916,6 +2930,86 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
 
   def delete(id: AppId) =
     (sql"DELETE FROM apps WHERE id=$id".update.run *> bumpHostsVersion).transact(xa).unit
+
+  def mergeAppInto(from: AppId, to: AppId) = {
+    // Steps run inside ONE transaction so a mid-merge crash never strands FK rows referencing a
+    // half-deleted app row. Each step handles the PK / UNIQUE conflict its target table can
+    // produce: `to` may already own a row at the same key as a `from` row (e.g. an assignment for
+    // the same profile, a rollup for the same bucket). Conflicting `from` rows are dropped — `to`
+    // wins. Non-conflicting rows are reattached.
+    //
+    // Order matters only for `app_used_daily`: we INSERT-then-aggregate (so engaged_seconds sum)
+    // before the cascade DELETE on `apps` would have wiped the `from` rows. Everything else is
+    // safely commutative within the transaction.
+    val unionHosts =
+      sql"""INSERT INTO app_hosts (app_id, host)
+            SELECT $to, host FROM app_hosts WHERE app_id = $from
+            ON CONFLICT DO NOTHING""".update.run
+
+    val reattachAssignments =
+      sql"""UPDATE app_policy_assignments SET app_id = $to
+            WHERE app_id = $from
+              AND profile_id NOT IN (SELECT profile_id FROM app_policy_assignments WHERE app_id = $to)""".update.run
+
+    val dropConflictingHourly =
+      sql"""DELETE FROM traffic_hourly_apps t
+            WHERE t.app_id = $from
+              AND EXISTS (
+                SELECT 1 FROM traffic_hourly_apps c
+                 WHERE c.app_id = $to
+                   AND c.router_id = t.router_id
+                   AND c.mac = t.mac
+                   AND c.hostname = t.hostname
+                   AND c.bucket_start = t.bucket_start)""".update.run
+
+    val reattachHourly =
+      sql"UPDATE traffic_hourly_apps SET app_id = $to WHERE app_id = $from".update.run
+
+    val dropConflictingDaily =
+      sql"""DELETE FROM traffic_daily_apps t
+            WHERE t.app_id = $from
+              AND EXISTS (
+                SELECT 1 FROM traffic_daily_apps c
+                 WHERE c.app_id = $to
+                   AND c.router_id = t.router_id
+                   AND c.mac = t.mac
+                   AND c.hostname = t.hostname
+                   AND c.date = t.date)""".update.run
+
+    val reattachDaily =
+      sql"UPDATE traffic_daily_apps SET app_id = $to WHERE app_id = $from".update.run
+
+    // Sum engaged_seconds on (profile_id, date) collisions so we don't drop the duplicate's usage.
+    val mergeUsedDaily =
+      sql"""INSERT INTO app_used_daily (profile_id, app_id, date, engaged_seconds, rolled_through, rolled_at)
+            SELECT profile_id, $to, date, engaged_seconds, rolled_through, rolled_at
+              FROM app_used_daily WHERE app_id = $from
+            ON CONFLICT (profile_id, app_id, date) DO UPDATE
+              SET engaged_seconds = app_used_daily.engaged_seconds + EXCLUDED.engaged_seconds,
+                  rolled_through = LEAST(app_used_daily.rolled_through, EXCLUDED.rolled_through),
+                  rolled_at      = GREATEST(app_used_daily.rolled_at, EXCLUDED.rolled_at)""".update.run
+
+    // Transfer template_id IFF `to` lacks one — preserves the link `AppTemplates.findByTemplateId`
+    // walks on every seed so a future seed pass finds the canonical row instead of falling back to
+    // the `<slug>-template` slug again (the whack-a-mole guard).
+    val transferTemplateId =
+      sql"""UPDATE apps SET template_id = (SELECT template_id FROM apps WHERE id = $from)
+            WHERE id = $to
+              AND template_id IS NULL
+              AND (SELECT template_id FROM apps WHERE id = $from) IS NOT NULL""".update.run
+
+    // Final cascade DELETE drops any FK rows from `from` that we didn't actively reattach.
+    val deleteFrom = sql"DELETE FROM apps WHERE id = $from".update.run
+
+    (unionHosts *>
+      reattachAssignments *>
+      dropConflictingHourly *> reattachHourly *>
+      dropConflictingDaily *> reattachDaily *>
+      mergeUsedDaily *>
+      transferTemplateId *>
+      deleteFrom *>
+      bumpHostsVersion).transact(xa).unit
+  }
 
   def setHosts(appId: AppId, hosts: List[Hostname]) = {
     val del = sql"DELETE FROM app_hosts WHERE app_id=$appId".update.run

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2794,6 +2794,12 @@ trait AppRepo {
    * conflicted with `to`'s own). Host-set version is bumped once. Idempotent under repeat calls
    * with the same args (a second call no-ops because `from` is gone).
    *
+   * Conflict policy is "`to` wins" everywhere `to` already has a row at the merging key: an
+   * assignment for the same `profile_id` (and via the V51 cascade, its `app_policy_schedule_rules`)
+   * stays on `to`, with `from`'s discarded; a rollup bucket for the same key stays on `to`. For
+   * `app_used_daily` overlapping `(profile_id, date)` rows are summed (`engaged_seconds`) instead
+   * of dropped so usage isn't lost.
+   *
    * Used by `AppReconciler.reconcileTemplates` to collapse the `<slug>-template` row that
    * `AppTemplates.findFreeSlug` falls back to when an operator-added canonical row already owns the
    * template's slug.

--- a/api/src/routes/AppRoutes.scala
+++ b/api/src/routes/AppRoutes.scala
@@ -1,5 +1,6 @@
 package wifihaven.api.routes
 
+import wifihaven.api.AppReconciler
 import wifihaven.api.AppTemplate
 import wifihaven.api.AppTemplates
 import wifihaven.api.auth.*
@@ -247,6 +248,25 @@ object AppRoutes {
               .setScheduleRules(assignId, ar.scheduleRules.map(r => (r.scheduleId, r.mode)))
               .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
+        },
+      // #1777: admin-triggered reconciliation pass that collapses `<slug>-template`-suffixed app
+      // rows onto their canonical `<slug>` form, reattaching FK refs and unioning host-sets.
+      // Idempotent — operator can re-run; subsequent passes are no-ops once the DB is clean.
+      Method.POST / "api" / "admin" / "apps" / "reconcile-templates"             ->
+        handler { (req: Request) =>
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _       <- requireAdmin(req, auth)
+            summary <- AppReconciler
+              .reconcileTemplates(appRepo, templates.values.toList)
+              .mapError(e =>
+                ApiError.Wrapped(
+                  Response
+                    .json(s"""{"error":"reconcile_failed","message":${e.getMessage.toJson}}""")
+                    .status(Status.InternalServerError),
+                ),
+              )
+          } yield Response.json(summary.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
       // #1024: admin-triggered re-run of the startup app-template seeder. Same idempotent

--- a/api/test/src/feature/AppReconcilerSpec.scala
+++ b/api/test/src/feature/AppReconcilerSpec.scala
@@ -1,0 +1,176 @@
+package wifihaven.api.feature
+
+import wifihaven.api.{AppReconcileSummary, AppReconciler, AppTemplate, JwtConfig}
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.IconType
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+/**
+ * #1777: tests for `AppReconciler.reconcileTemplates`. Seeds the messy state — an operator-added
+ * canonical row co-existing with a `-template`-suffixed seeded row, with FK refs on both — and
+ * asserts the reconciliation converges onto a single canonical row, FKs reattached and host-set
+ * unioned. Also tests the rename-only path and idempotency.
+ */
+object AppReconcilerSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val youtubeSlug     = AppTemplateId.unsafe("youtube")
+  private val youtubeTemplate = AppTemplate(
+    slug = youtubeSlug,
+    name = "YouTube",
+    icon = Some("https://example/yt.png"),
+    iconType = IconType.Url,
+    hosts = List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")),
+  )
+
+  def spec = suite("AppReconciler")(
+    test(
+      "reconcileTemplates merges -template row INTO canonical, reattaches FK refs, unions hosts",
+    ) {
+      for {
+        _        <- cleanDb
+        appRepo  <- ZIO.service[AppRepo]
+        profileR <- ZIO.service[ProfileRepo]
+        profiles <- profileR.listAll
+        kidsId   = profiles.find(_.name == "Kids").get.id
+        adultsId = profiles.find(_.name == "Adults").get.id
+        // 1. Operator-added canonical 'youtube' (no template_id). Operator added an extra host.
+        operatorId <- appRepo.create("My YouTube", "youtube", None, Some("📺"), IconType.Emoji)
+        operatorHost = Hostname.unsafe("operator-only.example.com")
+        _              <- appRepo.setHosts(
+          operatorId,
+          List(Hostname.unsafe("youtube.com"), operatorHost),
+        )
+        _              <- appRepo.upsertAssignment(operatorId, kidsId, AppMode.Blocked, None, true)
+        // 2. Seeded '-template'-suffixed row carrying template_id, distinct assignment + hosts.
+        seededId       <- appRepo.create(
+          "YouTube",
+          "youtube-template",
+          Some(youtubeSlug),
+          Some("https://example/yt.png"),
+          IconType.Url,
+        )
+        _              <- appRepo.setHosts(
+          seededId,
+          List(Hostname.unsafe("youtube.com"), Hostname.unsafe("googlevideo.com")),
+        )
+        _              <- appRepo.upsertAssignment(
+          seededId,
+          adultsId,
+          AppMode.TimeLimited,
+          Some(30),
+          true,
+        )
+        // 3. Reconcile.
+        summary        <- AppReconciler.reconcileTemplates(appRepo, List(youtubeTemplate))
+        // 4. Assertions.
+        after          <- appRepo.listAll
+        canonicalOpt   <- appRepo.findBySlug("youtube")
+        canonical      <- ZIO
+          .fromOption(canonicalOpt)
+          .orElseFail(new RuntimeException("missing canonical"))
+        canonicalHosts <- appRepo.getHosts(canonical.id)
+        canonicalAsgn  <- appRepo.listAssignmentsForApp(canonical.id)
+        suffixedGone   <- appRepo.findBySlug("youtube-template")
+      } yield assertTrue(after.count(_.slug == "youtube") == 1) &&
+        assertTrue(after.count(_.slug == "youtube-template") == 0) &&
+        assertTrue(suffixedGone.isEmpty) &&
+        assertTrue(canonical.templateId.contains(youtubeSlug)) &&
+        // Host-set is the UNION: template hosts + operator's extra host + seeded's googlevideo.com.
+        assertTrue(
+          canonicalHosts.toSet == Set(
+            Hostname.unsafe("youtube.com"),
+            Hostname.unsafe("ytimg.com"),
+            Hostname.unsafe("googlevideo.com"),
+            operatorHost,
+          ),
+        ) &&
+        // Both assignments reattached to canonical.
+        assertTrue(canonicalAsgn.size == 2) &&
+        assertTrue(canonicalAsgn.map(_.profileId).toSet == Set(kidsId, adultsId)) &&
+        assertTrue(summary.mergedSlugs == List("youtube")) &&
+        assertTrue(summary.renamedSlugs.isEmpty)
+    },
+    test("reconcileTemplates renames -template row when no canonical co-exists") {
+      for {
+        _        <- cleanDb
+        appRepo  <- ZIO.service[AppRepo]
+        profileR <- ZIO.service[ProfileRepo]
+        profiles <- profileR.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
+        id       <- appRepo.create(
+          "YouTube",
+          "youtube-template",
+          Some(youtubeSlug),
+          Some("https://example/yt.png"),
+          IconType.Url,
+        )
+        _        <- appRepo.setHosts(id, List(Hostname.unsafe("youtube.com")))
+        _        <- appRepo.upsertAssignment(id, kidsId, AppMode.Blocked, None, true)
+        summary  <- AppReconciler.reconcileTemplates(appRepo, List(youtubeTemplate))
+        renamed  <- appRepo.findById(id).someOrFailException
+        hosts    <- appRepo.getHosts(id)
+        suffixed <- appRepo.findBySlug("youtube-template")
+        asgn     <- appRepo.listAssignmentsForApp(id)
+      } yield assertTrue(renamed.slug == "youtube") &&
+        assertTrue(renamed.templateId.contains(youtubeSlug)) &&
+        assertTrue(suffixed.isEmpty) &&
+        assertTrue(hosts.toSet == youtubeTemplate.hosts.toSet) &&
+        assertTrue(asgn.size == 1) &&
+        assertTrue(summary.renamedSlugs == List("youtube")) &&
+        assertTrue(summary.mergedSlugs.isEmpty)
+    },
+    test("reconcileTemplates is a no-op on already-clean state") {
+      for {
+        _       <- cleanDb
+        appRepo <- ZIO.service[AppRepo]
+        id      <- appRepo.create(
+          "YouTube",
+          "youtube",
+          Some(youtubeSlug),
+          Some("https://example/yt.png"),
+          IconType.Url,
+        )
+        _       <- appRepo.setHosts(id, youtubeTemplate.hosts)
+        before  <- appRepo.listAll
+        summary <- AppReconciler.reconcileTemplates(appRepo, List(youtubeTemplate))
+        after   <- appRepo.listAll
+      } yield assertTrue(before.map(_.id).toSet == after.map(_.id).toSet) &&
+        assertTrue(summary.mergedSlugs.isEmpty) &&
+        assertTrue(summary.renamedSlugs.isEmpty)
+    },
+    test("reconcileTemplates is idempotent — second run does nothing") {
+      for {
+        _        <- cleanDb
+        appRepo  <- ZIO.service[AppRepo]
+        _        <- appRepo.create("My YouTube", "youtube", None, Some("📺"), IconType.Emoji)
+        sId      <- appRepo.create(
+          "YouTube",
+          "youtube-template",
+          Some(youtubeSlug),
+          Some("https://example/yt.png"),
+          IconType.Url,
+        )
+        _        <- appRepo.setHosts(sId, youtubeTemplate.hosts)
+        first    <- AppReconciler.reconcileTemplates(appRepo, List(youtubeTemplate))
+        second   <- AppReconciler.reconcileTemplates(appRepo, List(youtubeTemplate))
+        afterAll <- appRepo.listAll
+      } yield assertTrue(first.mergedSlugs == List("youtube")) &&
+        assertTrue(second.mergedSlugs.isEmpty) &&
+        assertTrue(second.renamedSlugs.isEmpty) &&
+        assertTrue(afterAll.count(_.slug == "youtube") == 1) &&
+        assertTrue(afterAll.count(_.slug == "youtube-template") == 0)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/AppReconcilerSpec.scala
+++ b/api/test/src/feature/AppReconcilerSpec.scala
@@ -1,7 +1,6 @@
 package wifihaven.api.feature
 
-import wifihaven.api.{AppReconcileSummary, AppReconciler, AppTemplate, JwtConfig}
-import wifihaven.api.auth.*
+import wifihaven.api.{AppReconciler, AppTemplate}
 import wifihaven.api.db.*
 import wifihaven.shared.*
 import wifihaven.shared.IconType

--- a/api/test/src/feature/AppReconcilerSpec.scala
+++ b/api/test/src/feature/AppReconcilerSpec.scala
@@ -47,30 +47,42 @@ object AppReconcilerSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         // 1. Operator-added canonical 'youtube' (no template_id). Operator added an extra host.
         operatorId <- appRepo.create("My YouTube", "youtube", None, Some("📺"), IconType.Emoji)
         operatorHost = Hostname.unsafe("operator-only.example.com")
-        _              <- appRepo.setHosts(
+        _          <- appRepo.setHosts(
           operatorId,
           List(Hostname.unsafe("youtube.com"), operatorHost),
         )
-        _              <- appRepo.upsertAssignment(operatorId, kidsId, AppMode.Blocked, None, true)
+        _          <- appRepo.upsertAssignment(operatorId, kidsId, AppMode.Blocked, None, true)
         // 2. Seeded '-template'-suffixed row carrying template_id, distinct assignment + hosts.
-        seededId       <- appRepo.create(
+        seededId   <- appRepo.create(
           "YouTube",
           "youtube-template",
           Some(youtubeSlug),
           Some("https://example/yt.png"),
           IconType.Url,
         )
-        _              <- appRepo.setHosts(
+        _          <- appRepo.setHosts(
           seededId,
           List(Hostname.unsafe("youtube.com"), Hostname.unsafe("googlevideo.com")),
         )
-        _              <- appRepo.upsertAssignment(
+        _          <- appRepo.upsertAssignment(
           seededId,
           adultsId,
           AppMode.TimeLimited,
           Some(30),
           true,
         )
+        // 2b. Seed app_used_daily rows on both sides — overlapping (profile_id, date) on the
+        // Kids row to exercise the SUM-on-conflict path; a non-overlapping (Adults) row to
+        // exercise the plain reattach path. Verifies the rollup-table FK merge SQL.
+        rollupRepo <- ZIO.service[AppUsedRollupRepo]
+        usageDate     = java.time.LocalDate.parse("2026-06-15")
+        rolledThrough = java.time.Instant.parse("2026-06-15T23:59:00Z")
+        _              <- rollupRepo
+          .upsertDay(kidsId, operatorId, usageDate, RolledAppDay(120L, rolledThrough))
+        _              <- rollupRepo
+          .upsertDay(kidsId, seededId, usageDate, RolledAppDay(300L, rolledThrough))
+        _              <- rollupRepo
+          .upsertDay(adultsId, seededId, usageDate, RolledAppDay(600L, rolledThrough))
         // 3. Reconcile.
         summary        <- AppReconciler.reconcileTemplates(appRepo, List(youtubeTemplate))
         // 4. Assertions.
@@ -82,6 +94,10 @@ object AppReconcilerSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         canonicalHosts <- appRepo.getHosts(canonical.id)
         canonicalAsgn  <- appRepo.listAssignmentsForApp(canonical.id)
         suffixedGone   <- appRepo.findBySlug("youtube-template")
+        // (profile, date) overlap collapses onto canonical with engaged_seconds summed.
+        kidsUsage      <- rollupRepo.getDayForProfile(kidsId, usageDate)
+        // Non-overlapping (Adults) row reattached.
+        adultsUsage    <- rollupRepo.getDayForProfile(adultsId, usageDate)
       } yield assertTrue(after.count(_.slug == "youtube") == 1) &&
         assertTrue(after.count(_.slug == "youtube-template") == 0) &&
         assertTrue(suffixedGone.isEmpty) &&
@@ -98,6 +114,13 @@ object AppReconcilerSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         // Both assignments reattached to canonical.
         assertTrue(canonicalAsgn.size == 2) &&
         assertTrue(canonicalAsgn.map(_.profileId).toSet == Set(kidsId, adultsId)) &&
+        // engaged_seconds is the SUM of the conflicting (canonical=120) + (suffixed=300) row.
+        assertTrue(kidsUsage.get(canonical.id).map(_.engagedSeconds).contains(420L)) &&
+        // Adults-only suffixed row reattached to canonical id.
+        assertTrue(adultsUsage.get(canonical.id).map(_.engagedSeconds).contains(600L)) &&
+        // No stray rows still keyed by the deleted suffixed app id.
+        assertTrue(!kidsUsage.contains(seededId)) &&
+        assertTrue(!adultsUsage.contains(seededId)) &&
         assertTrue(summary.mergedSlugs == List("youtube")) &&
         assertTrue(summary.renamedSlugs.isEmpty)
     },


### PR DESCRIPTION
Closes #1777.

## What

Adds an idempotent reconciler that collapses every `<slug>-template`-suffixed
`apps` row onto its canonical `<slug>` form. The four outcomes from the
issue's rules table are computed in one place (`AppReconciler.reconcileTemplates`)
and exposed via an admin POST route.

The `-template` suffix originates in [AppTemplates.findFreeSlug](api/src/AppTemplates.scala:252)
— when the seed pass finds the canonical slug already occupied by an
operator-added app, it falls back to `<slug>-template`. The fallback is
correct as a uniqueness guard, but it leaves the household with two app
rows for the same logical app and splits assignments / usage across them.

## How

- `AppRepo.mergeAppInto(from, to)` (one DB transaction):
  union hosts, reattach `app_policy_assignments` / `traffic_hourly_apps` /
  `traffic_daily_apps` / `app_used_daily` FK refs (canonical wins on PK
  collisions; `engaged_seconds` are summed on `(profile_id, date)` overlap),
  transfer `template_id` to canonical if it lacks one, then delete the
  duplicate row. `app_hosts_version` is bumped so rollup attribution is
  re-evaluated.
- `AppReconciler.reconcileTemplates(repo, templates)` — single function
  that decides which of the four cases applies per template and calls the
  repo primitives. **No duplicate merge logic across migration / route /
  test** (AGENTS.md §single-source-of-truth).
- `POST /api/admin/apps/reconcile-templates` — admin auth required;
  returns a per-bucket summary (`mergedSlugs`, `renamedSlugs`,
  `hostsUnioned`, `alreadyClean`, `created`).

## Whack-a-mole guard (re: chip abort criterion)

The seeder remains active. When both `<slug>` and `<slug>-template` co-exist,
the reconciler transfers `template_id` to the canonical row before deleting
the suffixed one. The next `AppTemplates.seed` pass then finds the canonical
row via `findByTemplateId` and never reaches the `-template` fallback.

## Wire impact

Slug appears on the wire only via opaque event reason strings
(`app:<slug>`, `app_time_limit:<slug>`) — routers echo these verbatim and
they do not feed enforcement. The per-MAC snapshot `BlockRules` shape
keys apps by id, not slug. **No wire-contract change.**

## Test

`AppReconcilerSpec` (committed RED before the implementation landed) seeds
the messy state — operator-added `youtube` with one assignment + an extra
host, seeded `youtube-template` with a different assignment + a distinct
host — runs the reconciler, and asserts a single `youtube` row with both
assignments reattached and the host-set unioned. Plus rename-only,
already-clean, and idempotency cases.

## Operator pre-flight (prod)

1. Take a prod DB snapshot.
2. Curl the new route:
   \`\`\`
   curl -X POST -H \"Authorization: Bearer \$ADMIN_JWT\" \\
     https://api.wifihaven.net/api/admin/apps/reconcile-templates
   \`\`\`
3. Re-query: \`SELECT slug FROM apps WHERE slug LIKE '%-template'\` —
   expect zero rows.
4. Spot-check usage panels still attribute correctly (sum across the
   merged row should match what the pair previously summed to).

## Out of scope / follow-up

- Disabling the `findFreeSlug` fallback so future seedings never re-introduce
  the `-template` suffix in the first place — tracked as a separate follow-up
  per #1777 \"Out of scope\". The template-seeding code lifecycle question
  (idle vs dead vs shipped) ties to the #1608 one-shot-migration audit.
- Read-only EXPLAIN against prod for the FK-reattach query is recommended
  before the operator runs the route on prod, but the merge query keys
  every UPDATE/DELETE on `app_id` via the existing per-app indexes
  (`idx_traffic_hourly_apps_app`, `idx_traffic_daily_apps_app`) — touched
  row count is bounded by the duplicate app's history (~one app's worth of
  rollups), not the whole rollup table.