### PR TITLE
feat(#1771): PolicyService — sentinel-profile global rules (step 2 of #1769)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -88,10 +88,13 @@ object Main extends ZIOAppDefault {
           .serve(withCors)
           .provide(ZLayer.succeed(serverConfig) >>> Server.live)
           .forkScoped
-        _      <- ZIO.logInfo("HTTP port bound; running DB-heavy startup behind readiness gate")
+        _         <- ZIO.logInfo("HTTP port bound; running DB-heavy startup behind readiness gate")
         // Service handles are pure layer reads (no DB I/O); resolve them up front
         // so the retried DB-init block below is purely the idempotent DB work.
-        hsRepo <- ZIO.service[HouseholdSettingsRepo]
+        hsRepo    <- ZIO.service[HouseholdSettingsRepo]
+        // #1771: handle for the startup-time global sentinel seed; the seed itself runs inside
+        // the retried DB-init block below alongside ensureDefault.
+        xaForSeed <- ZIO.service[Transactor[Task]]
         appRepoForSeed <- ZIO.service[AppRepo]
         blRepoForSeed  <- ZIO.service[BlocklistRepo]
         blCacheForSeed <- ZIO.service[BlocklistCache]
@@ -115,6 +118,16 @@ object Main extends ZIOAppDefault {
             // daily-reset tz to the API server's local zone on first install.
             _ <- hsRepo.ensureDefault(tz)
             _ <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
+            // #1771: seed the single global sentinel profile that PolicyService unions into
+            // every other profile's BlockRules. Idempotent — V59's partial unique index
+            // (`is_global = TRUE`) ensures at most one row ever exists, and ON CONFLICT
+            // matches the [[HouseholdSettingsRepoLive.ensureDefault]] precedent so a restart
+            // is a no-op. Kept here (not in V59) so the seed lands atomically with the code
+            // that hides/uses the sentinel — see #1769 step 2.
+            _ <- sql"""INSERT INTO profiles (name, is_global)
+                       VALUES ('Global', TRUE)
+                       ON CONFLICT DO NOTHING""".update.run.transact(xaForSeed)
+            _ <- ZIO.logInfo("global profile sentinel ensured (is_global=TRUE)")
             // #768: seed the starter library of app templates. Idempotent —
             // operator host edits on previously-seeded apps are preserved.
             seedSummary <- AppTemplates.seed(appRepoForSeed, templates)
@@ -327,7 +340,7 @@ object Main extends ZIOAppDefault {
           ) ++
           ScheduleRoutes.routes(auth, namedSchedRepo) ++
           HouseholdSettingsRoutes.routes(auth, hsRepo) ++
-          DeviceRoutes.routes(auth, deviceRepo, upRepo)
+          DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
 
       val statsRoutes: Routes[Any, Response] =
         TimeRoutes.routes(

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1092,33 +1092,35 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {
         .option
         .transact(xa),
     )
-  def upsert(mac: MacAddress, name: String, pid: Option[ProfileId], ip: String) =
+  def upsert(mac: MacAddress, name: String, pid: Option[ProfileId], ip: String)        = {
     // #708: pid=None writes NULL (device unassigned). Devices without a profile
     // are a supported state — same shape auto-discovery produces.
     // #1771: defensive guard — devices cannot be assigned to the global sentinel
     // profile. The route layer rejects this with a 400 before we get here, but
     // catching it again in the repo means a buggy code path (or a direct SQL
     // call from a future caller) still fails loudly instead of corrupting the
-    // device-to-profile graph. The check is one SELECT against a tiny table.
-    pid.fold(ZIO.unit: Task[Unit]) { p =>
+    // device-to-profile graph. The guard and the INSERT run in the SAME doobie
+    // transaction so a (today-impossible) concurrent flip of `profiles.is_global`
+    // can't slip a device assignment past the check.
+    val check = pid.fold(doobie.free.connection.unit) { p =>
       sql"SELECT is_global FROM profiles WHERE id=$p"
         .query[Boolean]
         .option
-        .transact(xa)
         .flatMap {
           case Some(true) =>
-            ZIO.fail(
+            doobie.free.connection.raiseError[Unit](
               new IllegalArgumentException(
                 s"devices cannot be assigned to the global profile (id=${p.value})",
               ),
             )
-          case _          => ZIO.unit
+          case _          => doobie.free.connection.unit
         }
-    } *>
+    }
+    (check *>
       sql"INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at) VALUES($mac,$name,$pid,NULLIF($ip,''),NOW()) ON CONFLICT(mac) DO UPDATE SET name=EXCLUDED.name,profile_id=EXCLUDED.profile_id RETURNING id"
         .query[DeviceId]
-        .unique
-        .transact(xa)
+        .unique).transact(xa)
+  }
   def updateLastSeen(mac: MacAddress, ip: String)                                      =
     sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW() WHERE mac=$mac".update.run
       .transact(xa)

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -99,7 +99,20 @@ trait UserProfileRepo {
 }
 
 trait ProfileRepo {
+
+  /**
+   * Non-global profiles only. The `is_global=TRUE` sentinel (#1771) is filtered out so it never
+   * appears on `GET /api/profiles`, role-access enumerations, or any user-facing listing — it is a
+   * wire-shape mechanism, not an authored profile. The snapshot path consumes
+   * [[listAllIncludingGlobal]].
+   */
   def listAll: Task[List[Profile]]
+
+  /** All profiles, including the global sentinel. Used by `PolicyService.snapshot` only. */
+  def listAllIncludingGlobal: Task[List[Profile]]
+
+  /** The single `is_global=TRUE` sentinel row, or None if not yet seeded. */
+  def getGlobal: Task[Option[Profile]]
   def findById(id: ProfileId): Task[Option[Profile]]
   def create(name: String, cats: List[BlocklistId]): Task[ProfileId]
   def update(p: Profile): Task[Unit]
@@ -801,6 +814,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       String,
       String,
       Boolean,
+      Boolean,
   )
   private def toP(r: R)                             = Profile(
     r._1,
@@ -812,18 +826,38 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     CrossDeviceOverlapMode.parse(r._7).getOrElse(CrossDeviceOverlapMode.Sum),
     PauseMode.parse(r._8).getOrElse(PauseMode.Soft),
     r._9,
+    r._10,
   )
+  // #1771: the global sentinel is filtered out of `listAll` so it never appears on
+  // `GET /api/profiles` or any role-access enumeration. The snapshot path uses
+  // [[listAllIncludingGlobal]] to fold the sentinel's rules into every other profile.
   def listAll                                       =
     DbMetrics.timed("profile.listAll")(
-      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny FROM profiles ORDER BY id"
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny,is_global FROM profiles WHERE is_global=FALSE ORDER BY id"
         .query[R]
         .map(toP)
         .to[List]
         .transact(xa),
     )
+  def listAllIncludingGlobal                        =
+    DbMetrics.timed("profile.listAllIncludingGlobal")(
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny,is_global FROM profiles ORDER BY id"
+        .query[R]
+        .map(toP)
+        .to[List]
+        .transact(xa),
+    )
+  def getGlobal                                     =
+    DbMetrics.timed("profile.getGlobal")(
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny,is_global FROM profiles WHERE is_global=TRUE"
+        .query[R]
+        .map(toP)
+        .option
+        .transact(xa),
+    )
   def findById(id: ProfileId)                       =
     DbMetrics.timed("profile.findById")(
-      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny FROM profiles WHERE id=$id"
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny,is_global FROM profiles WHERE id=$id"
         .query[R]
         .map(toP)
         .option
@@ -1061,10 +1095,30 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {
   def upsert(mac: MacAddress, name: String, pid: Option[ProfileId], ip: String) =
     // #708: pid=None writes NULL (device unassigned). Devices without a profile
     // are a supported state — same shape auto-discovery produces.
-    sql"INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at) VALUES($mac,$name,$pid,NULLIF($ip,''),NOW()) ON CONFLICT(mac) DO UPDATE SET name=EXCLUDED.name,profile_id=EXCLUDED.profile_id RETURNING id"
-      .query[DeviceId]
-      .unique
-      .transact(xa)
+    // #1771: defensive guard — devices cannot be assigned to the global sentinel
+    // profile. The route layer rejects this with a 400 before we get here, but
+    // catching it again in the repo means a buggy code path (or a direct SQL
+    // call from a future caller) still fails loudly instead of corrupting the
+    // device-to-profile graph. The check is one SELECT against a tiny table.
+    pid.fold(ZIO.unit: Task[Unit]) { p =>
+      sql"SELECT is_global FROM profiles WHERE id=$p"
+        .query[Boolean]
+        .option
+        .transact(xa)
+        .flatMap {
+          case Some(true) =>
+            ZIO.fail(
+              new IllegalArgumentException(
+                s"devices cannot be assigned to the global profile (id=${p.value})",
+              ),
+            )
+          case _          => ZIO.unit
+        }
+    } *>
+      sql"INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at) VALUES($mac,$name,$pid,NULLIF($ip,''),NOW()) ON CONFLICT(mac) DO UPDATE SET name=EXCLUDED.name,profile_id=EXCLUDED.profile_id RETURNING id"
+        .query[DeviceId]
+        .unique
+        .transact(xa)
   def updateLastSeen(mac: MacAddress, ip: String)                                      =
     sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW() WHERE mac=$mac".update.run
       .transact(xa)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -143,8 +143,13 @@ class PolicyServiceLive(
       today = PolicyService.householdLocalDate(now, settings)
       // #1104: today's cap/block state for every profile in one batched read. Same call the
       // /api/time/status/... endpoints use — keeps the snapshot and the UI in lockstep.
-      dayStates          <- timeStatusService.dayStateAll(now, today, settings)
-      profiles           <- profileRepo.listAll
+      dayStates   <- timeStatusService.dayStateAll(now, today, settings)
+      // #1771: snapshot assembly needs the global sentinel too, so it can union the sentinel's
+      // resolved extraAllowed/extraBlocked/blocklistIds into every other profile. `listAll`
+      // is the user-facing listing and deliberately hides the sentinel.
+      allProfiles <- profileRepo.listAllIncludingGlobal
+      globalProfileOpt = allProfiles.find(_.isGlobal)
+      profiles         = allProfiles.filterNot(_.isGlobal)
       devices            <- deviceRepo.listAll
       cats               <- blocklistRepo.listCategories
       catDomains         <- ZIO.foreach(cats)(c => blocklistRepo.loadCategory(c).map(c -> _))
@@ -154,36 +159,29 @@ class PolicyServiceLive(
       // to time_limited), so the two readers saw different rows and the projections drifted.
       // Now both the per-app enforcement (extraAllowed/extraBlocked) and the structural
       // projections downstream of `TimeStatusService` read the SAME rows through the same fold.
-      appLimitsByProfile <- ZIO.foreach(profiles)(p =>
+      appLimitsByProfile <- ZIO.foreach(allProfiles)(p =>
         appTimeLimitRepo.listForProfile(p.id).map(p.id -> _),
       )
       // #1379: per-app schedule rules, resolved to (mode, window) pairs per assignment.
       // Folded into the per-app effective disposition below, before app-mode bucketing.
-      appSched           <- ZIO.foreach(profiles)(p =>
+      appSched           <- ZIO.foreach(allProfiles)(p =>
         appRepo.appScheduleWindowsForProfile(p.id).map(p.id -> _),
       )
       appLimitsMap = appLimitsByProfile.toMap
       appSchedMap = appSched.toMap
     } yield {
-      val profilePolicies: Map[ProfileId, ProfilePolicy] = profiles.iterator.map { p =>
-        // #1104: cap/block state comes from TimeStatusService — the same value the UI reads.
-        // Computed before app bucketing because the #1379 carve gate keys off the raw daily-cap
-        // condition (used/limit/extensions), independent of the collapsed blockReason.
-        val state = dayStates.getOrElse(
+      // #1771: resolve the global sentinel's rules via the SAME [[computeBlockRules]] path the
+      // per-profile policies use (AGENTS.md §single-source-of-truth — no parallel global-rule
+      // computation). The sentinel cannot meaningfully contribute `blocked`/schedules/time-limit/
+      // paused/defaultDeny — those are write-rejected at the route layer; we additionally zero
+      // them out defensively when reading so a dirty row (e.g. a manual SQL toggle) cannot leak a
+      // household-wide block.
+      def computeRulesFor(p: Profile): BlockRules = {
+        val state           = dayStates.getOrElse(
           p.id,
           ProfileDayState(p.id, today, None, 0, 0, None, blocked = false, None, Nil),
         )
-
-        // #763/#764/#1379/#1630: collapse this profile's app assignments into the per-MAC
-        // BlockRules buckets via the SINGLE fold `ProfileAppDispositions.enforcement`. Schedule
-        // windows fold over base mode (an active window overrides the base); the AllowedDuring
-        // carve is gated by the daily cap unless the app is exemptFromDaily (design §4.1, §5).
-        // `mode=TimeLimited` apps contribute nothing here — they surface via the per-app cap
-        // path (`appCapExhaustedHosts` reads `state.perApp`).
         val dispositions    = ProfileAppDispositions.from(appLimitsMap.getOrElse(p.id, Nil))
-        // #1679: suppress extraAllowed carve for apps with allowedDuringScheduleBlock=false when
-        // the profile's whole-MAC block reason is Schedule. Other reasons leave isScheduleBlock
-        // false so the toggle has no effect on Paused/TimeLimit/Manual blocks.
         val isScheduleBlock = state.blockReason.contains(MacBlockReason.Schedule)
         val (appAllowedHosts, appBlockedHosts) = dispositions.enforcement(
           schedWindows = appSchedMap.getOrElse(p.id, Map.empty),
@@ -191,12 +189,45 @@ class PolicyServiceLive(
           now = now,
           isScheduleBlock = isScheduleBlock,
         )
-
-        val rules = PolicyService.computeBlockRules(
+        PolicyService.computeBlockRules(
           profile = p,
           state = state,
           appExtraAllowed = appAllowedHosts,
           appExtraBlocked = appBlockedHosts,
+        )
+      }
+
+      // #1771: the sentinel's contribution to every profile — just the carve-out / blocklist
+      // fields. `blocked` / `blockReason` are deliberately not folded: the global cannot impose a
+      // whole-MAC drop on the household (that is what the architecture's per-profile pause /
+      // schedule / time-limit lanes are for; #1769).
+      val globalRulesResolved: BlockRules = globalProfileOpt.map(computeRulesFor) match {
+        case Some(r) =>
+          r.copy(blocked = false, blockReason = None)
+        case None    => BlockRules.allowAll
+      }
+
+      val profilePolicies: Map[ProfileId, ProfilePolicy] = profiles.iterator.map { p =>
+        // #1104: cap/block state comes from TimeStatusService — the same value the UI reads.
+        // Computed before app bucketing because the #1379 carve gate keys off the raw daily-cap
+        // condition (used/limit/extensions), independent of the collapsed blockReason.
+        // #763/#764/#1379/#1630: collapse this profile's app assignments into the per-MAC
+        // BlockRules buckets via the SINGLE fold `ProfileAppDispositions.enforcement`. Schedule
+        // windows fold over base mode (an active window overrides the base); the AllowedDuring
+        // carve is gated by the daily cap unless the app is exemptFromDaily (design §4.1, §5).
+        // `mode=TimeLimited` apps contribute nothing here — they surface via the per-app cap
+        // path (`appCapExhaustedHosts` reads `state.perApp`).
+        val ownRules = computeRulesFor(p)
+
+        // #1771: union the global sentinel's resolved extraAllowed / extraBlocked / blocklistIds
+        // into every (non-global) profile's rules. Set semantics via `.distinct` after concat —
+        // the router's existing extraAllowed-beats-extraBlocked precedence
+        // (`feedback_extraallowed_beats_blocked`) means a host that ends up in both lanes via
+        // the union still resolves to allow, matching the prior global_* semantics.
+        val rules = ownRules.copy(
+          extraAllowed = (ownRules.extraAllowed ++ globalRulesResolved.extraAllowed).distinct,
+          extraBlocked = (ownRules.extraBlocked ++ globalRulesResolved.extraBlocked).distinct,
+          blocklistIds = (ownRules.blocklistIds ++ globalRulesResolved.blocklistIds).distinct,
         )
 
         p.id -> ProfilePolicy(name = p.name, rules = rules, failureMode = p.failureMode)
@@ -254,8 +285,16 @@ class PolicyServiceLive(
       // `global_blocklists` reader was removed (prod tables verified empty
       // 2026-06-16); only the in-code allow set survives. The sentinel-profile
       // path lands in #1771.
+      // #1771: the wire `global.extraAllowed` is the union of the sentinel profile's resolved
+      // extraAllowed plus the in-code UI + infra host sets. `extraBlocked` and `blocklistIds`
+      // additionally carry the sentinel's contribution so a household-wide block list takes
+      // effect on every device. `blocked` / `blockReason` stay zeroed — the global section
+      // never imposes a whole-MAC drop (the architecture's per-profile lanes do that).
       val globalRules = BlockRules.allowAll.copy(
-        extraAllowed = (uiGlobalAllow ++ PolicyService.infraAllowHosts).distinct,
+        extraAllowed =
+          (globalRulesResolved.extraAllowed ++ uiGlobalAllow ++ PolicyService.infraAllowHosts).distinct,
+        extraBlocked = globalRulesResolved.extraBlocked.distinct,
+        blocklistIds = globalRulesResolved.blocklistIds.distinct,
       )
 
       val core = SnapshotCore(globalRules, devicePolicies, profilePolicies, pBlocklists)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -224,10 +224,18 @@ class PolicyServiceLive(
         // the router's existing extraAllowed-beats-extraBlocked precedence
         // (`feedback_extraallowed_beats_blocked`) means a host that ends up in both lanes via
         // the union still resolves to allow, matching the prior global_* semantics.
+        // Under `defaultDeny` the profile's own extraBlocked / blocklistIds are intentionally
+        // empty (redundant under block-all per `computeBlockRules`); skip the global union on
+        // those two lanes so the wire payload stays consistent with the design intent. The
+        // router's whole-MAC drop dominates regardless, so behavior is unchanged either way.
         val rules = ownRules.copy(
           extraAllowed = (ownRules.extraAllowed ++ globalRulesResolved.extraAllowed).distinct,
-          extraBlocked = (ownRules.extraBlocked ++ globalRulesResolved.extraBlocked).distinct,
-          blocklistIds = (ownRules.blocklistIds ++ globalRulesResolved.blocklistIds).distinct,
+          extraBlocked =
+            if (p.defaultDeny) ownRules.extraBlocked
+            else (ownRules.extraBlocked ++ globalRulesResolved.extraBlocked).distinct,
+          blocklistIds =
+            if (p.defaultDeny) ownRules.blocklistIds
+            else (ownRules.blocklistIds ++ globalRulesResolved.blocklistIds).distinct,
         )
 
         p.id -> ProfilePolicy(name = p.name, rules = rules, failureMode = p.failureMode)

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -278,6 +278,8 @@ object ProfileRoutes {
           val handle: ZIO[Any, ApiError, Response] = for {
             claims <- requireWriter(req, auth)
             _      <- requireProfileAccess(claims, pid, userProfileRepo)
+            // #1771: schedules are meaningless on the global sentinel — block here before any DB work.
+            _      <- requireNotGlobalProfile(profileRepo, pid, "schedules")
             body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             sr     <- ZIO
               .fromEither(body.fromJson[SetProfileSchedulesRequest])
@@ -364,6 +366,10 @@ object ProfileRoutes {
             upr    <- ZIO
               .fromEither(body.fromJson[UpsertProfileRequest])
               .mapError(ApiError.DecodeFailure(_))
+            // #1771: full-replace PUT touches paused / timeLimit / pauseMode — none of which apply
+            // to the global sentinel. Reject before any DB work so a misdirected admin tab can't
+            // even partially write.
+            _      <- requireNotGlobalProfile(profileRepo, pid, "profile (PUT)")
             p      <- profileRepo
               .findById(pid)
               .mapError(ApiError.Db(_))
@@ -407,9 +413,14 @@ object ProfileRoutes {
         },
       Method.DELETE / "api" / "profiles" / long("id")            ->
         handler { (id: Long, req: Request) =>
+          val pid                                  = ProfileId(id)
           val handle: ZIO[Any, ApiError, Response] =
             requireAdmin(req, auth) *>
-              profileRepo.delete(ProfileId(id)).mapError(ApiError.Db(_)) *>
+              // #1771: the global sentinel is a wire-shape fixture, not an authored profile —
+              // never deletable. The partial unique index would let admin recreate it via SQL,
+              // but the snapshot would briefly miss the household-wide allow/block lists.
+              requireNotGlobalProfile(profileRepo, pid, "profile (DELETE)") *>
+              profileRepo.delete(pid).mapError(ApiError.Db(_)) *>
               ZIO.succeed(Response.ok)
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -472,6 +483,27 @@ object ProfileRoutes {
             timeLimitPatch          <- ZIO
               .fromEither(FieldPatch.from[Int](obj, "timeLimit"))
               .mapError(ApiError.BadRequest(_))
+            // #1771: paused / pauseMode / timeLimit are meaningless household-wide. Reject the
+            // PATCH if any of those are present AND the target is the global sentinel. Other
+            // fields (name, blockedCategories, blockIpOnly, …) are fine on the sentinel.
+            isGlobal                <- profileRepo
+              .findById(pid)
+              .mapError(ApiError.Db(_))
+              .map(_.exists(_.isGlobal))
+            _                       <- ZIO.when(isGlobal) {
+              val offending = List(
+                "paused"    -> (pausedPatch != FieldPatch.Absent),
+                "pauseMode" -> (pauseModePatch != FieldPatch.Absent),
+                "timeLimit" -> (timeLimitPatch != FieldPatch.Absent),
+              ).collect { case (k, true) => k }
+              ZIO.when(offending.nonEmpty)(
+                ZIO.fail(
+                  ApiError.BadRequest(
+                    s"${offending.mkString(",")} cannot be set on the global profile (id=${pid.value})",
+                  ),
+                ),
+              )
+            }
             // Reject `field: null` for non-nullable fields — only `timeLimit`
             // accepts an explicit clear. Mirrors the device PATCH convention.
             _                       <- ZIO
@@ -599,6 +631,10 @@ object DeviceRoutes {
       auth: AuthService,
       deviceRepo: DeviceRepo,
       userProfileRepo: UserProfileRepo,
+      // #1771: profileRepo is consulted to reject device assignments to the global sentinel with
+      // a 400 before any DB write. The repo-layer guard (`DeviceRepoLive.upsert`) is a defensive
+      // backstop. Passing `null` is unsafe — every call site passes the real repo.
+      profileRepo: ProfileRepo,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "devices"                    ->
@@ -624,7 +660,10 @@ object DeviceRoutes {
             // a profile they can't write to still 403s.
             _  <- udr.profileId match {
               case Some(pid) =>
-                requireProfileAccess(claims, pid, userProfileRepo)
+                requireProfileAccess(claims, pid, userProfileRepo) *>
+                  // #1771: devices cannot be assigned to the global sentinel profile. Reject with
+                  // 400 before any DB write. The repo-layer guard catches direct callers too.
+                  requireNotGlobalProfile(profileRepo, pid, "device.profileId")
               case None      => ZIO.unit
             }
             id <- deviceRepo
@@ -694,7 +733,10 @@ object DeviceRoutes {
             }
             _         <- pidPatch match {
               case FieldPatch.Set(pid) =>
-                requireProfileAccess(claims, pid, userProfileRepo)
+                requireProfileAccess(claims, pid, userProfileRepo) *>
+                  // #1771: same guard as PUT — reassigning a device to the global sentinel is
+                  // rejected with 400.
+                  requireNotGlobalProfile(profileRepo, pid, "device.profileId")
               case _                   => ZIO.unit
             }
             newName = namePatch.applyTo(existing.name)
@@ -2096,6 +2138,35 @@ def requireProfileAccess(
       else ZIO.fail(ApiError.Forbidden("Device has no assigned profile"))
     case Some(pid) => requireProfileAccess(claims, pid, upRepo)
   }
+
+/**
+ * #1771: reject writes that target the global sentinel profile when the targeted concept is
+ * meaningless household-wide (schedules / time limits / paused / pauseMode / manual block /
+ * deletion). Returns 422 with a human-readable message naming the offending field. Read paths and
+ * writes that DO make sense on the sentinel (its app-policy assignments, blocked_categories via
+ * PATCH→blockedCategories, name, blockIpOnly, etc. when introduced) are not gated here.
+ *
+ * Implemented at the route layer (not the repo) because the repo setters have no context about
+ * WHICH field a PATCH is touching — a route knows the user-facing field name and can give a precise
+ * error.
+ */
+def requireNotGlobalProfile(
+    profileRepo: ProfileRepo,
+    profileId: ProfileId,
+    field: String,
+): IO[ApiError, Unit] =
+  profileRepo
+    .findById(profileId)
+    .mapError(ApiError.Db(_))
+    .flatMap {
+      case Some(p) if p.isGlobal =>
+        ZIO.fail(
+          ApiError.BadRequest(
+            s"$field cannot be set on the global profile (id=${profileId.value})",
+          ),
+        )
+      case _                     => ZIO.unit
+    }
 
 def normalizeMac(mac: String): String = {
   // Path-captured MACs arrive percent-encoded — the SPA builds the URL with

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -448,9 +448,11 @@ object ProfileRoutes {
             _         <- requireProfileAccess(claims, pid, userProfileRepo)
             // Existence check up front so a missing row 404s instead of
             // letting per-field UPDATEs silently no-op. We deliberately do
-            // NOT carry the loaded row into the writes below: every SET is
-            // column-scoped, so there's no full-row copy to drift.
-            _         <- profileRepo
+            // NOT carry the loaded row's mutable columns into the writes below: every SET is
+            // column-scoped, so there's no full-row copy to drift. `isGlobal` is the one
+            // structural flag we DO carry — it's immutable for the row's lifetime (#1771), so
+            // reading it once and reusing below avoids a second findById.
+            existing  <- profileRepo
               .findById(pid)
               .mapError(ApiError.Db(_))
               .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
@@ -486,11 +488,8 @@ object ProfileRoutes {
             // #1771: paused / pauseMode / timeLimit are meaningless household-wide. Reject the
             // PATCH if any of those are present AND the target is the global sentinel. Other
             // fields (name, blockedCategories, blockIpOnly, …) are fine on the sentinel.
-            isGlobal                <- profileRepo
-              .findById(pid)
-              .mapError(ApiError.Db(_))
-              .map(_.exists(_.isGlobal))
-            _                       <- ZIO.when(isGlobal) {
+            // Read `isGlobal` from the existing-row check above — no second findById.
+            _                       <- ZIO.when(existing.isGlobal) {
               val offending = List(
                 "paused"    -> (pausedPatch != FieldPatch.Absent),
                 "pauseMode" -> (pauseModePatch != FieldPatch.Absent),
@@ -633,7 +632,7 @@ object DeviceRoutes {
       userProfileRepo: UserProfileRepo,
       // #1771: profileRepo is consulted to reject device assignments to the global sentinel with
       // a 400 before any DB write. The repo-layer guard (`DeviceRepoLive.upsert`) is a defensive
-      // backstop. Passing `null` is unsafe — every call site passes the real repo.
+      // backstop.
       profileRepo: ProfileRepo,
   ): Routes[Any, Response] =
     Routes(

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -83,6 +83,12 @@ object TestDatabase {
         "INSERT INTO household_settings (id, daily_reset_time, daily_reset_tz) " +
           "VALUES (1, '00:00', 'UTC') ON CONFLICT (id) DO NOTHING",
       )
+      // #1771: replicate Main.scala's startup seed of the global sentinel profile so
+      // PolicyService.snapshot can read it during tests. ON CONFLICT DO NOTHING + V59's
+      // partial unique index keeps this idempotent.
+      st.execute(
+        "INSERT INTO profiles (name, is_global) VALUES ('Global', TRUE) ON CONFLICT DO NOTHING",
+      )
       // #586: V18 sets must_change_password=true for the seeded admin so production deployments
       // force a password rotation. In tests we want the admin fully operational.
       st.execute("UPDATE users SET must_change_password=false WHERE username='admin'")

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -41,7 +41,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         profiles    <- profileRepo.listAll
         kidsId = profiles.find(_.name == "Kids").get.id
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         body   = UpsertDeviceRequest(
           mac = MacAddress.unsafe("aa:bb:cc:dd:ee:ff"),
           name = "iPad",
@@ -78,7 +78,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         profiles    <- profileRepo.listAll
         kidsId = profiles.find(_.name == "Kids").get.id
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         body   = UpsertDeviceRequest(
           MacAddress.unsafe("aa:bb:cc:dd:ee:ff"),
           "Laptop",
@@ -104,7 +104,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         mac    = "11:22:33:44:55:66"
         _ <- deviceRepo.upsert(MacAddress.unsafe(mac), "OldDevice", Some(kidsId), "192.168.1.50")
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         delReq = Request
           .delete(URL.decode(s"/api/devices/$mac").toOption.get)
           .addHeader(Header.Authorization.Bearer(token.value))
@@ -156,7 +156,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
           ),
         )
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes  = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes  = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         // The SPA builds the path with encodeURIComponent(mac), so the colons
         // arrive percent-encoded (de%3Aad%3A…). The route must decode them.
         encPath = s"/api/devices/${java.net.URLEncoder.encode(mac.value, "UTF-8")}"
@@ -207,10 +207,11 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       for {
         _               <- cleanDb
         deviceRepo      <- ZIO.service[DeviceRepo]
+        profileRepo     <- ZIO.service[ProfileRepo]
         auth            <- makeAuth
         token           <- auth.login("admin", "changeme").map(_.token)
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         body   = UpsertDeviceRequest(
           mac = MacAddress.unsafe("aa:bb:cc:00:00:10"),
           name = "Lutron Bridge",
@@ -238,7 +239,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         mac    = "aa:bb:cc:00:00:20"
         _               <- deviceRepo.upsert(MacAddress.unsafe(mac), "OldName", Some(kidsId), "")
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         body   = UpsertDeviceRequest(MacAddress.unsafe(mac), "NewName", None).toJson
         putReq = Request
           .put(URL.decode("/api/devices").toOption.get, Body.fromString(body))
@@ -263,7 +264,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         mac      = "aa:bb:cc:00:00:21"
         _               <- deviceRepo.upsert(MacAddress.unsafe(mac), "OldName", Some(kidsId), "")
         userProfileRepo <- ZIO.service[UserProfileRepo]
-        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo)
         body   = UpsertDeviceRequest(MacAddress.unsafe(mac), "NewName", Some(adultsId)).toJson
         putReq = Request
           .put(URL.decode("/api/devices").toOption.get, Body.fromString(body))
@@ -300,7 +301,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         _     <- userRepo.clearMustChangePassword(momId)
         _     <- upRepo.setProfilesForUser(momId, List(kidsId))
         token <- auth.login("mom", "pass").map(_.token.value)
-        routes     = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        routes     = DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
         // Rename only — no profileId supplied — should succeed.
         renameBody = UpsertDeviceRequest(MacAddress.unsafe(mac), "RenamedByMom", None).toJson
         renameReq  = Request

--- a/api/test/src/feature/DevicePatchApiSpec.scala
+++ b/api/test/src/feature/DevicePatchApiSpec.scala
@@ -46,9 +46,10 @@ object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     for {
       auth            <- makeAuth
       deviceRepo      <- ZIO.service[DeviceRepo]
+      profileRepo     <- ZIO.service[ProfileRepo]
       userProfileRepo <- ZIO.service[UserProfileRepo]
       token           <- auth.login("admin", "changeme").map(_.token.value)
-    } yield (DeviceRoutes.routes(auth, deviceRepo, userProfileRepo), token)
+    } yield (DeviceRoutes.routes(auth, deviceRepo, userProfileRepo, profileRepo), token)
 
   private def patch(routes: Routes[Any, Response], token: String, body: String) =
     routes.runZIO(
@@ -147,7 +148,7 @@ object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         _     <- userRepo.clearMustChangePassword(momId)
         _     <- upRepo.setProfilesForUser(momId, List(kidsId))
         token <- auth.login("mom", "pass").map(_.token.value)
-        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
         resp  <- routes.runZIO(
           Request
             .patch(

--- a/api/test/src/feature/MetricsSelfMetricsSpec.scala
+++ b/api/test/src/feature/MetricsSelfMetricsSpec.scala
@@ -99,7 +99,7 @@ object MetricsSelfMetricsSpec
 
         // The whole real route surface, wrapped in the production HTTP metrics middleware.
         routes = HttpMetrics.instrument(
-          DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
+          DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo) ++
             RouterIngestRoutes
               .routes(ingestAuth, routerRepo, trafficR, tu, deviceRepo, connR, alertR, hsR),
         )

--- a/api/test/src/feature/PolicySnapshotGlobalProfileSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalProfileSpec.scala
@@ -1,0 +1,256 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+/**
+ * #1771 — the global sentinel profile collapses the deleted `global_*` tables onto a single row in
+ * `profiles` marked `is_global = TRUE`. `PolicyService.snapshot` unions the sentinel's resolved
+ * `extraAllowed` / `extraBlocked` / `blocklistIds` into every other profile's `BlockRules`, the
+ * sentinel is hidden from `GET /api/profiles`, devices cannot reference it, and writes that are
+ * meaningless household-wide (schedules / time limits / paused / pauseMode / delete) are rejected
+ * with 400 at the route layer.
+ */
+object PolicySnapshotGlobalProfileSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb  = TestDatabase.cleanAndMigrate
+  private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, adminJwt, clock)
+
+  private def makePs =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      clock  <- ZIO.service[Clock]
+    } yield PolicyServiceLive(pr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock): PolicyService
+
+  private def kidsId: ZIO[ProfileRepo, Throwable, ProfileId] =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll.map(_.find(_.name == "Kids").get.id))
+
+  private def adultsId: ZIO[ProfileRepo, Throwable, ProfileId] =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll.map(_.find(_.name == "Adults").get.id))
+
+  private def globalId: ZIO[ProfileRepo, Throwable, ProfileId] =
+    ZIO.serviceWithZIO[ProfileRepo](_.getGlobal.map(_.get.id))
+
+  def spec = suite("PolicySnapshot — global sentinel profile (#1771)")(
+    test("global profile's extraAllowed is unioned into every other profile's extraAllowed") {
+      for {
+        _      <- cleanDb
+        ar     <- ZIO.service[AppRepo]
+        kids   <- kidsId
+        adults <- adultsId
+        g      <- globalId
+        _      <- TestLayers.seedAppAssignment(ar, g, "global-allow.example", AppMode.Allowed)
+        _      <- TestLayers.seedAppAssignment(ar, kids, "kids-allow.example", AppMode.Allowed)
+        svc    <- makePs
+        snap   <- svc.snapshot
+      } yield {
+        val kidsEa   = snap.profiles(kids).rules.extraAllowed.map(_.value).toSet
+        val adultsEa = snap.profiles(adults).rules.extraAllowed.map(_.value).toSet
+        assertTrue(kidsEa.contains("global-allow.example")) &&
+        assertTrue(kidsEa.contains("kids-allow.example")) &&
+        assertTrue(adultsEa.contains("global-allow.example"))
+      }
+    },
+    test("global profile's extraBlocked is unioned into every other profile's extraBlocked") {
+      for {
+        _    <- cleanDb
+        ar   <- ZIO.service[AppRepo]
+        kids <- kidsId
+        g    <- globalId
+        _    <- TestLayers.seedAppAssignment(ar, g, "global-block.example", AppMode.Blocked)
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val kidsEb = snap.profiles(kids).rules.extraBlocked.map(_.value).toSet
+        assertTrue(kidsEb.contains("global-block.example"))
+      }
+    },
+    test("global profile's blockedCategories union into every other profile's blocklistIds") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        kids <- kidsId
+        g    <- globalId
+        _    <- pr.setBlockedCategories(g, List(BlocklistId.unsafe("malware")))
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val ids = snap.profiles(kids).rules.blocklistIds.map(_.value).toSet
+        assertTrue(ids.contains("malware"))
+      }
+    },
+    test("profile with empty own rules still receives the global union") {
+      for {
+        _      <- cleanDb
+        ar     <- ZIO.service[AppRepo]
+        adults <- adultsId
+        g      <- globalId
+        _      <- TestLayers.seedAppAssignment(ar, g, "fleet.example", AppMode.Allowed)
+        svc    <- makePs
+        snap   <- svc.snapshot
+      } yield {
+        val ea = snap.profiles(adults).rules.extraAllowed.map(_.value).toSet
+        assertTrue(ea.contains("fleet.example"))
+      }
+    },
+    test("snapshot.global.extraAllowed includes global-profile rules + uiAllowedHosts + infra") {
+      for {
+        _    <- cleanDb
+        ar   <- ZIO.service[AppRepo]
+        g    <- globalId
+        _    <- TestLayers.seedAppAssignment(ar, g, "sentinel.example", AppMode.Allowed)
+        pr   <- ZIO.service[ProfileRepo]
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        atlr <- ZIO.service[AppTimeLimitRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        trr  <- ZIO.service[TrafficReportRepo]
+        er   <- ZIO.service[TimeExtensionRepo]
+        clk  <- ZIO.service[Clock]
+        svc = PolicyServiceLive(
+          pr,
+          hsr,
+          tlr,
+          atlr,
+          dr,
+          blr,
+          trr,
+          er,
+          ar,
+          clk,
+          uiAllowedHosts = List(Hostname.unsafe("ui.example")),
+        ): PolicyService
+        snap <- svc.snapshot
+      } yield {
+        val ea = snap.global.extraAllowed.map(_.value).toSet
+        assertTrue(ea.contains("sentinel.example")) &&
+        assertTrue(ea.contains("ui.example")) &&
+        assertTrue(ea.intersect(PolicyService.infraAllowHosts.map(_.value).toSet).nonEmpty)
+      }
+    },
+    test("GET /api/profiles hides the global sentinel (RoleAccessSpec invariant)") {
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        userRepoSvc <- ZIO.service[UserRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        routes = ProfileRoutes.routes(auth, profileRepo, tlRepo, upRepo, userRepoSvc)
+        req    = Request
+          .get(URL.decode("/api/profiles").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(!body.contains("\"name\":\"Global\""))
+    },
+    test("PUT /api/devices to global profile returns 400") {
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        g           <- globalId
+        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
+        body   = UpsertDeviceRequest(MacAddress.unsafe("aa:bb:cc:dd:ee:01"), "x", Some(g)).toJson
+        req    = Request
+          .put(URL.decode("/api/devices").toOption.get, Body.fromString(body))
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("PUT /api/profiles/:id/schedules on global returns 400") {
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        userRepoSvc <- ZIO.service[UserRepo]
+        nsr         <- ZIO.service[NamedScheduleRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        g           <- globalId
+        routes = ProfileRoutes.routes(auth, profileRepo, tlRepo, upRepo, userRepoSvc, nsr)
+        body   = SetProfileSchedulesRequest(Nil).toJson
+        req    = Request
+          .put(
+            URL.decode(s"/api/profiles/${g.value}/schedules").toOption.get,
+            Body.fromString(body),
+          )
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("PATCH /api/profiles/:id timeLimit on global returns 400") {
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        userRepoSvc <- ZIO.service[UserRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        g           <- globalId
+        routes = ProfileRoutes.routes(auth, profileRepo, tlRepo, upRepo, userRepoSvc)
+        body   = """{"timeLimit": 60}"""
+        req    = Request
+          .patch(URL.decode(s"/api/profiles/${g.value}").toOption.get, Body.fromString(body))
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("PATCH /api/profiles/:id paused on global returns 400") {
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        userRepoSvc <- ZIO.service[UserRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        g           <- globalId
+        routes = ProfileRoutes.routes(auth, profileRepo, tlRepo, upRepo, userRepoSvc)
+        body   = """{"paused": true}"""
+        req    = Request
+          .patch(URL.decode(s"/api/profiles/${g.value}").toOption.get, Body.fromString(body))
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/ProfilePatchApiSpec.scala
+++ b/api/test/src/feature/ProfilePatchApiSpec.scala
@@ -205,7 +205,10 @@ object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         .map(_.getName)
         .filterNot(_.contains("$"))
         .toSet
-      val writableFields = profileFields - "id"
+      // #1771: `isGlobal` is a structural sentinel flag set once at install time, not a writable
+      // policy field — kept out of `PatchableKeys` so a PATCH cannot promote/demote a profile to
+      // the global slot. Excluded from the pin alongside `id` for the same reason.
+      val writableFields = profileFields - "id" - "isGlobal"
       val expected       = writableFields + "timeLimit"
       assertTrue(
         ProfileRoutes.PatchableKeys == expected,

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -343,7 +343,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         )
         _     <- createUser(userRepo, upRepo, auth, "alice", "child", List(kidsId))
         token <- auth.login("alice", "pass").map(_.token.value)
-        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
         req    = Request
           .get(URL.decode("/api/devices").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
@@ -433,7 +433,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         )
         _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
         token <- auth.login("mom", "pass").map(_.token.value)
-        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
         req    = Request
           .get(URL.decode("/api/devices").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -170,6 +170,15 @@ case class Profile(
     // flag, only the collapsed `blocked = true`. Default false. Additive field
     // with a default, so an older client that omits it decodes unchanged.
     defaultDeny: Boolean = false,
+    // #1771: marks the single household-wide "Global" sentinel profile. Exactly
+    // one row in `profiles` may have `is_global = TRUE` (V59 partial unique
+    // index). The sentinel replaces the deleted `global_*` tables (#1769): its
+    // resolved `extraAllowed` / `extraBlocked` / `blocklistIds` are unioned into
+    // every other profile's `BlockRules` by `PolicyService.snapshot`, while its
+    // `paused` / schedules / time limits / pauseMode are meaningless household-
+    // wide and write-rejected at the route layer. Devices cannot reference it.
+    // Defaulted to false to keep existing positional constructions arity-stable.
+    isGlobal: Boolean = false,
 ) derives JsonCodec
 
 case class Schedule(


### PR DESCRIPTION
Closes #1771. Step 2 of the umbrella #1769 — replaces the deleted `global_*` tables with a single `is_global=TRUE` sentinel row in `profiles`.

## What

- **Startup seed.** `Main.scala` and the test-template init now seed the single Global sentinel row idempotently (`INSERT … ON CONFLICT DO NOTHING`). V59's partial unique index keeps the cardinality at ≤1. No DB migration here — the seed lands atomically with the code that hides/uses it.
- **`ProfileRepo`.** New `getGlobal` + `listAllIncludingGlobal`. `listAll` now filters `is_global=TRUE` out so `GET /api/profiles`, role-access enumerations, and every existing user-facing path never expose the sentinel. The snapshot path is the only consumer of `listAllIncludingGlobal`.
- **`PolicyService.snapshot`.** The sentinel is resolved through the SAME `computeBlockRules` path the per-profile policies use (AGENTS.md §single-source-of-truth — no parallel global-rule computation). Its `extraAllowed`, `extraBlocked`, and `blocklistIds` are unioned into every non-global profile's rules. `blocked` / `blockReason` are zeroed defensively — the architecture forbids whole-MAC drops from the global tier. `PolicySnapshot.global` is now sourced from the sentinel's rules plus `uiAllowedHosts` + `infraAllowHosts`; wire shape unchanged.
- **Write rejections.** Schedule attach (`PUT /api/profiles/:id/schedules`), `PUT /api/profiles/:id`, `DELETE /api/profiles/:id`, and `PATCH /api/profiles/:id` for `paused` / `pauseMode` / `timeLimit` all return 400 with a precise field name when the target is the global sentinel.
- **Device assignment guard.** `PUT /api/devices` and `PATCH /api/devices/:mac` reject `profileId == <global>` with 400; `DeviceRepoLive.upsert` has the same check as a defensive backstop.

## Tests

Ten new feature tests in `PolicySnapshotGlobalProfileSpec` cover:
- extraAllowed / extraBlocked / blocklistIds union (each its own test)
- A non-global profile with empty own rules still receives the global union
- `snapshot.global.extraAllowed` carries sentinel + `uiAllowedHosts` + `infraAllowHosts`
- `GET /api/profiles` hides the sentinel (paired with the RoleAccessSpec `details.length == 2` invariant)
- 400 on device assignment to global, schedule attach to global, PATCH paused/timeLimit on global

Updated the `ProfilePatchApiSpec` drift pin to exclude `isGlobal` (structural sentinel flag, not patchable) alongside `id`.

## Follow-ups

This completes #1769's behavioral migration. The remaining sub-issue — the SPA rebuild (#1772 + #1773, folded per the updated umbrella body) — can now proceed against the sentinel.