### PR TITLE
feat(#1773,#1772): SPA Global Policy page on sentinel profile + delete-route regression test (step 3+4 of #1769)

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -252,6 +252,27 @@ object ProfileRoutes {
           } yield Response.json(details.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
+      // #1773: surface the global sentinel profile to the SPA. `GET /api/profiles` hides it (the
+      // RoleAccessSpec invariant from #1771), so this is the SPA's one window into it for editing
+      // its app-policy assignments / categories / defaultDeny via the per-profile editor preset to
+      // the sentinel's id. Route literal MUST come before the `/profiles/long("id")` matcher so
+      // "global" doesn't get path-parsed into a Long. Admin-only because only admins author policy.
+      Method.GET / "api" / "profiles" / "global"                 ->
+        handler { (req: Request) =>
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _       <- requireAdmin(req, auth)
+            p       <- profileRepo.getGlobal
+              .mapError(ApiError.Db(_))
+              .flatMap(
+                ZIO.fromOption(_).orElseFail(ApiError.NotFound("Global profile not seeded")),
+              )
+            tl      <- timeLimitRepo.findForProfile(p.id).mapError(ApiError.Db(_))
+            schedId <- namedScheduleRepo
+              .blockScheduleIdsForProfile(p.id)
+              .mapError(ApiError.Db(_))
+          } yield Response.json(ProfileDetail(p, tl, schedId).toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
+        },
       Method.GET / "api" / "profiles" / long("id")               ->
         handler { (id: Long, req: Request) =>
           val pid                                  = ProfileId(id)

--- a/api/test/src/feature/GlobalRoutesGoneSpec.scala
+++ b/api/test/src/feature/GlobalRoutesGoneSpec.scala
@@ -14,7 +14,10 @@ import zio.test.*
 
 // #1772 — the /api/global/... routes are gone (deleted in #1775); the SPA targets the per-profile
 // routes on globalProfile.id instead. Pin the 404s so a future revert can't quietly re-introduce
-// a parallel surface.
+// a parallel surface. Also pin GET /api/profiles/global (#1773) — the SPA's one window into the
+// sentinel — including its admin gate and that the literal "global" route precedence over the
+// /profiles/long("id") matcher holds (a reorder would flip the request to the long(id) handler
+// and the SPA would silently lose its global-policy surface).
 object GlobalRoutesGoneSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
   override val bootstrap =
@@ -32,7 +35,7 @@ object GlobalRoutesGoneSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPost
     "/api/global/flags",
   )
 
-  def spec = suite("Global routes deleted (#1772)")(
+  def spec = suite("Global routes deleted (#1772) + sentinel surface (#1773)")(
     test("every former /api/global/* path 404s through the assembled profile routes") {
       for {
         _     <- cleanDb
@@ -53,5 +56,44 @@ object GlobalRoutesGoneSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPost
         }
       } yield assertTrue(statuses.forall(_ == Status.NotFound))
     },
-  )
+    test("GET /api/profiles/global returns 200 with the is_global=TRUE sentinel for admins") {
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        upr   <- ZIO.service[UserProfileRepo]
+        ur    <- ZIO.service[UserRepo]
+        nsr   <- ZIO.service[NamedScheduleRepo]
+        clock <- ZIO.service[Clock]
+        auth = AuthServiceLive(ur, adminJwt, clock)
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        routes = ProfileRoutes.routes(auth, pr, tlr, upr, ur, nsr)
+        req    = Request
+          .get(URL.decode("/api/profiles/global").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // The literal "global" route precedes /profiles/long("id") and resolves to the sentinel —
+        // not a 404 from the long(id) handler trying to parse "global" as a Long, and not a
+        // collision with a numeric profile id.
+        assertTrue(body.contains("\"isGlobal\":true")) &&
+        assertTrue(body.contains("\"name\":\"Global\""))
+    },
+    test("GET /api/profiles/global requires an admin token") {
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        upr   <- ZIO.service[UserProfileRepo]
+        ur    <- ZIO.service[UserRepo]
+        nsr   <- ZIO.service[NamedScheduleRepo]
+        clock <- ZIO.service[Clock]
+        auth    = AuthServiceLive(ur, adminJwt, clock)
+        routes  = ProfileRoutes.routes(auth, pr, tlr, upr, ur, nsr)
+        anonReq = Request.get(URL.decode("/api/profiles/global").toOption.get)
+        anonResp <- routes.runZIO(anonReq)
+      } yield assertTrue(anonResp.status == Status.Unauthorized)
+    },
+  ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/GlobalRoutesGoneSpec.scala
+++ b/api/test/src/feature/GlobalRoutesGoneSpec.scala
@@ -1,0 +1,57 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+// #1772 — the /api/global/... routes are gone (deleted in #1775); the SPA targets the per-profile
+// routes on globalProfile.id instead. Pin the 404s so a future revert can't quietly re-introduce
+// a parallel surface.
+object GlobalRoutesGoneSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb  = TestDatabase.cleanAndMigrate
+  private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private val deletedPaths = List(
+    "/api/global",
+    "/api/global/policy",
+    "/api/global/allow",
+    "/api/global/blocks",
+    "/api/global/blocklists",
+    "/api/global/flags",
+  )
+
+  def spec = suite("Global routes deleted (#1772)")(
+    test("every former /api/global/* path 404s through the assembled profile routes") {
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        upr   <- ZIO.service[UserProfileRepo]
+        ur    <- ZIO.service[UserRepo]
+        nsr   <- ZIO.service[NamedScheduleRepo]
+        clock <- ZIO.service[Clock]
+        auth = AuthServiceLive(ur, adminJwt, clock)
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        routes = ProfileRoutes.routes(auth, pr, tlr, upr, ur, nsr)
+        statuses <- ZIO.foreach(deletedPaths) { path =>
+          val req = Request
+            .get(URL.decode(path).toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          routes.runZIO(req).map(_.status)
+        }
+      } yield assertTrue(statuses.forall(_ == Status.NotFound))
+    },
+  )
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -147,6 +147,11 @@ export const api = {
   // ── Profiles ───────────────────────────────────────────────────────────
   profiles: {
     list: () => req<ProfileDetail[]>('GET', '/profiles'),
+    // #1773 — the single `is_global=TRUE` sentinel profile (#1771). Hidden from
+    // /profiles; surfaced here so the SPA can render it through the same per-
+    // profile editor and POST its app-policy assignments / categories / default-
+    // deny via the existing `/profiles/<id>/...` routes.
+    getGlobal: () => req<ProfileDetail>('GET', '/profiles/global'),
     get: (id: number) => req<ProfileDetail>('GET', `/profiles/${id}`),
     create: (data: UpsertProfileRequest) =>
       req<{ id: number }>('POST', '/profiles', data),

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -85,8 +85,10 @@ export function useProfiles(opts?: QueryOpts<ProfileDetail[]>) {
 
 // #1773 — the household-global sentinel profile (#1771). Hidden from
 // `GET /api/profiles`, fetched via `/api/profiles/global` so the SPA can edit
-// it through the same per-profile editor preset to its id. Admin-only on the
-// server; non-admins get a 401/403 and the query resolves to `undefined`.
+// it through the same per-profile editor preset to its id. Server route is
+// admin-only; callers MUST gate the hook with `enabled: isAdmin` to avoid
+// firing a fetch the server will refuse — non-admins would otherwise see the
+// query stuck in an error state.
 export function useGlobalProfile(opts?: QueryOpts<ProfileDetail>) {
   return useQuery({
     queryKey: ['profiles', 'global'] as const,
@@ -337,13 +339,10 @@ export function useProfileAppWeekly(
 export function useInvalidators() {
   const qc = useQueryClient()
   return {
-    profiles: () => Promise.all([
-      qc.invalidateQueries({ queryKey: qk.profiles() }),
-      // #1773: the sentinel uses a separate query key (/profiles/global). Any
-      // profile-touching mutation that could land on the sentinel (apps,
-      // categories, defaultDeny) must bust it too.
-      qc.invalidateQueries({ queryKey: ['profiles', 'global'] }),
-    ]),
+    // react-query invalidation is prefix-match, so `['profiles']` also busts
+    // the sentinel key `['profiles', 'global']` (#1773) and any future
+    // `['profiles', ...]` sub-keys.
+    profiles: () => qc.invalidateQueries({ queryKey: qk.profiles() }),
     devices: () => qc.invalidateQueries({ queryKey: qk.devices() }),
     // #1069 — schedule edits change profile/app/blocklist downtime, so also
     // refresh anything whose rendering derives from an active window.
@@ -356,8 +355,9 @@ export function useInvalidators() {
     dashboardNow: () => qc.invalidateQueries({ queryKey: qk.dashboardNow() }),
     timeStatus: () => qc.invalidateQueries({ queryKey: ['time', 'status'] }),
     profileMutated: () => Promise.all([
+      // `qk.profiles()` (= `['profiles']`) prefix-matches `['profiles', 'global']`
+      // (#1773) too — react-query invalidation walks the prefix tree.
       qc.invalidateQueries({ queryKey: qk.profiles() }),
-      qc.invalidateQueries({ queryKey: ['profiles', 'global'] }),
       qc.invalidateQueries({ queryKey: qk.devices() }),
       qc.invalidateQueries({ queryKey: ['time', 'status'] }),
       qc.invalidateQueries({ queryKey: qk.dashboardNow() }),

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -83,6 +83,19 @@ export function useProfiles(opts?: QueryOpts<ProfileDetail[]>) {
   })
 }
 
+// #1773 — the household-global sentinel profile (#1771). Hidden from
+// `GET /api/profiles`, fetched via `/api/profiles/global` so the SPA can edit
+// it through the same per-profile editor preset to its id. Admin-only on the
+// server; non-admins get a 401/403 and the query resolves to `undefined`.
+export function useGlobalProfile(opts?: QueryOpts<ProfileDetail>) {
+  return useQuery({
+    queryKey: ['profiles', 'global'] as const,
+    queryFn: () => api.profiles.getGlobal(),
+    staleTime: STALE.profiles,
+    ...opts,
+  })
+}
+
 // #1743: bucket → grain mapping the API emits from BucketPolicy. Cached for an
 // hour because it's effectively a constant; the SPA falls back to the locally
 // shipped defaults when the fetch hasn't completed (or fails) so the
@@ -324,7 +337,13 @@ export function useProfileAppWeekly(
 export function useInvalidators() {
   const qc = useQueryClient()
   return {
-    profiles: () => qc.invalidateQueries({ queryKey: qk.profiles() }),
+    profiles: () => Promise.all([
+      qc.invalidateQueries({ queryKey: qk.profiles() }),
+      // #1773: the sentinel uses a separate query key (/profiles/global). Any
+      // profile-touching mutation that could land on the sentinel (apps,
+      // categories, defaultDeny) must bust it too.
+      qc.invalidateQueries({ queryKey: ['profiles', 'global'] }),
+    ]),
     devices: () => qc.invalidateQueries({ queryKey: qk.devices() }),
     // #1069 — schedule edits change profile/app/blocklist downtime, so also
     // refresh anything whose rendering derives from an active window.
@@ -338,6 +357,7 @@ export function useInvalidators() {
     timeStatus: () => qc.invalidateQueries({ queryKey: ['time', 'status'] }),
     profileMutated: () => Promise.all([
       qc.invalidateQueries({ queryKey: qk.profiles() }),
+      qc.invalidateQueries({ queryKey: ['profiles', 'global'] }),
       qc.invalidateQueries({ queryKey: qk.devices() }),
       qc.invalidateQueries({ queryKey: ['time', 'status'] }),
       qc.invalidateQueries({ queryKey: qk.dashboardNow() }),

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -9,8 +9,12 @@ vi.mock('@/api/client', () => ({
   api: {
     profiles: {
       list: vi.fn(),
+      // #1773 — global sentinel profile (#1771). Hidden from /profiles,
+      // surfaced here so the per-profile editor can edit it via its id.
+      getGlobal: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      patch: vi.fn(),
       delete: vi.fn(),
       setUsers: vi.fn(),
       setSchedules: vi.fn(),
@@ -155,8 +159,12 @@ beforeEach(() => {
   vi.resetAllMocks()
   mockAuth = { isAdmin: true }
   ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([kidsProfile, adultsProfile])
+  // #1773 — default to "global not seeded" so existing tests don't see an extra
+  // card unless they explicitly opt in by overriding this mock.
+  ;(api.profiles.getGlobal as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Global profile not seeded'))
   ;(api.profiles.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 99 })
   ;(api.profiles.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(api.profiles.patch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.delete as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.setSchedules as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
@@ -1776,7 +1784,7 @@ describe('ProfilesPage — inline blocked-categories editor (#1473)', () => {
     expect(api.blocklists.list).toHaveBeenCalled()
   })
 
-  it('toggling an unselected category ADDS it to blockedCategories via the full PUT', async () => {
+  it('toggling an unselected category ADDS it to blockedCategories via PATCH (#1773)', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -1785,18 +1793,19 @@ describe('ProfilesPage — inline blocked-categories editor (#1473)', () => {
     const social = await within(kidsCard).findByTestId('profile-category-toggle-1-social')
     await user.click(social)
 
-    await waitFor(() => expect(api.profiles.update).toHaveBeenCalled())
-    const calls = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls
+    // #1773 — switched to PATCH so this surface also works on the global
+    // sentinel (PUT /profiles/:id is route-rejected for the sentinel).
+    await waitFor(() => expect(api.profiles.patch).toHaveBeenCalled())
+    const calls = (api.profiles.patch as unknown as ReturnType<typeof vi.fn>).mock.calls
     const [id, body] = calls[calls.length - 1]
     expect(id).toBe(1)
     expect([...body.blockedCategories].sort()).toEqual(['adult', 'gambling', 'social'])
-    // other fields carried through unchanged
-    expect(body.name).toBe('Kids')
-    expect(body.timeLimit).toBe(120)
-    expect(body.failureMode).toBe('block-all')
+    // PATCH is field-scoped — the body carries ONLY blockedCategories. No
+    // accidental writes to name / timeLimit / failureMode etc.
+    expect(Object.keys(body)).toEqual(['blockedCategories'])
   })
 
-  it('toggling a selected category REMOVES it from blockedCategories', async () => {
+  it('toggling a selected category REMOVES it from blockedCategories via PATCH', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -1805,8 +1814,8 @@ describe('ProfilesPage — inline blocked-categories editor (#1473)', () => {
     const adult = await within(kidsCard).findByTestId('profile-category-toggle-1-adult')
     await user.click(adult)
 
-    await waitFor(() => expect(api.profiles.update).toHaveBeenCalled())
-    const calls = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls
+    await waitFor(() => expect(api.profiles.patch).toHaveBeenCalled())
+    const calls = (api.profiles.patch as unknown as ReturnType<typeof vi.fn>).mock.calls
     const [id, body] = calls[calls.length - 1]
     expect(id).toBe(1)
     expect(body.blockedCategories).toEqual(['gambling'])
@@ -1844,7 +1853,7 @@ describe('ProfilesPage — inline blocked-categories editor (#1473)', () => {
 })
 
 describe('ProfilesPage — per-profile default-deny toggle (#1320)', () => {
-  it('toggling default-deny persists via the full-profile PUT, preserving other fields', async () => {
+  it('toggling default-deny persists via PATCH (#1773)', async () => {
     const user = userEvent.setup()
     renderPage()
     await screen.findByTestId('profile-card-1')
@@ -1856,16 +1865,13 @@ describe('ProfilesPage — per-profile default-deny toggle (#1320)', () => {
 
     await user.click(toggle)
 
-    await waitFor(() => expect(api.profiles.update).toHaveBeenCalled())
-    const calls = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls
+    // #1773 — switched to PATCH so the same surface works on the global
+    // sentinel; PATCH is field-scoped so no other field gets clobbered.
+    await waitFor(() => expect(api.profiles.patch).toHaveBeenCalled())
+    const calls = (api.profiles.patch as unknown as ReturnType<typeof vi.fn>).mock.calls
     const [id, body] = calls[calls.length - 1]
     expect(id).toBe(1)
-    expect(body.defaultDeny).toBe(true)
-    // other fields carried through the PUT unchanged
-    expect(body.name).toBe('Kids')
-    expect(body.blockedCategories).toEqual(['adult', 'gambling'])
-    expect(body.failureMode).toBe('block-all')
-    expect(body.timeLimit).toBe(120)
+    expect(body).toEqual({ defaultDeny: true })
   })
 
   // #1472 — default-deny is the profile's most fundamental posture, so it
@@ -1925,5 +1931,96 @@ describe('ProfilesPage — schedule chip reads named schedules (#1539)', () => {
     const c2 = await screen.findByTestId('profile-pause-chip-2')
     expect(c1).toHaveAttribute('data-chip', 'paused-schedule')
     expect(c2).toHaveAttribute('data-chip', 'paused-schedule')
+  })
+})
+
+// #1773 — the household-global sentinel profile (#1771) is edited through the
+// same per-profile shell. Verify: it renders as its own card labeled "Global",
+// inapplicable subsections (devices/schedules/time/users/pause) are hidden, and
+// edits route to the per-profile PATCH on its id — the SPA never calls
+// `/api/global/*` (those routes are gone, #1772).
+describe('ProfilesPage — global sentinel profile (#1773)', () => {
+  const globalProfile: ProfileDetail = {
+    profile: {
+      id: 999,
+      name: 'Global',
+      blockedCategories: [],
+      paused: false,
+      failureMode: 'block-all',
+      crossDeviceOverlapMode: 'sum',
+      pauseMode: 'soft',
+      defaultDeny: false,
+      isGlobal: true,
+    },
+    scheduleIds: [],
+    timeLimit: null,
+  }
+
+  beforeEach(() => {
+    (api.profiles.getGlobal as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(globalProfile)
+  })
+
+  it('renders the global profile as its own card with a "Global" badge', async () => {
+    renderPage()
+    const card = await screen.findByTestId('profile-card-999')
+    expect(within(card).getByTestId('profile-global-badge-999')).toHaveTextContent('Global')
+    // No pause chip — global is not paused/scheduled/time-limited.
+    expect(within(card).queryByTestId('profile-pause-chip-999')).not.toBeInTheDocument()
+    // No row-level pause/delete/+time buttons.
+    expect(within(card).queryByTestId('profile-row-pause-999')).not.toBeInTheDocument()
+    expect(within(card).queryByTestId('profile-row-delete-999')).not.toBeInTheDocument()
+    expect(within(card).queryByTestId('profile-row-grant-999')).not.toBeInTheDocument()
+  })
+
+  it('expanded global card hides device/time/schedule/user subsections but keeps Apps + defaultDeny', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-999')
+    await expand(999, user)
+    const card = screen.getByTestId('profile-card-999')
+    // Inapplicable subsections are gone.
+    expect(within(card).queryByTestId('profile-devices-subsection-999')).not.toBeInTheDocument()
+    expect(within(card).queryByTestId('profile-users-999')).not.toBeInTheDocument()
+    // Apps subsection + defaultDeny toggle are present (the operator's actual
+    // editing surfaces on the sentinel).
+    expect(within(card).getByTestId('profile-apps-subsection-999')).toBeInTheDocument()
+    expect(within(card).getByTestId('profile-default-deny-999')).toBeInTheDocument()
+  })
+
+  it('toggling defaultDeny on the global profile PATCHes /profiles/<globalId>', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-999')
+    await expand(999, user)
+    const toggle = await screen.findByTestId('profile-default-deny-toggle-999')
+    fireEvent.click(toggle)
+    await waitFor(() =>
+      expect(api.profiles.patch).toHaveBeenCalledWith(999, { defaultDeny: true }),
+    )
+    // Importantly: the legacy `/api/global/*` surface is gone; only the per-
+    // profile PATCH is hit.
+    expect(api.profiles.update).not.toHaveBeenCalled()
+  })
+
+  it('adding a blocked category on the global profile PATCHes /profiles/<globalId>', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-999')
+    await expand(999, user)
+    const card = screen.getByTestId('profile-card-999')
+    const cb = await within(card).findByTestId('profile-category-toggle-999-adult')
+    fireEvent.click(cb)
+    await waitFor(() =>
+      expect(api.profiles.patch).toHaveBeenCalledWith(999, { blockedCategories: ['adult'] }),
+    )
+  })
+
+  it('non-admins do not fetch the global profile', async () => {
+    mockAuth = { isAdmin: false }
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    // useGlobalProfile is gated on isAdmin — the network call never fires.
+    expect(api.profiles.getGlobal).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('profile-card-999')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1103,8 +1103,6 @@ function CategoriesSubsection({
       // #1773: PATCH (field-scoped) instead of PUT — the global sentinel rejects
       // PUT /profiles/:id but accepts PATCH for `blockedCategories`; for regular
       // profiles PATCH is also the preferred path per #423/#995 (race-safe).
-      // `updateProfile` retained on the prop signature for callers that still
-      // want the full-shape write; the named subsections drop it.
       await api.profiles.patch(pd.profile.id, { blockedCategories: next })
       await onProfileChanged()
     } catch (e) {

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
-import { useBlocklists, useProfiles, useDevices, useInvalidators, useNamedSchedules, useProfileUsageByApp, useTimeStatusSummary } from '@/api/queries'
+import { useBlocklists, useGlobalProfile, useProfiles, useDevices, useInvalidators, useNamedSchedules, useProfileUsageByApp, useTimeStatusSummary } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import { useDebouncedSave, type SaveStatus } from '@/hooks/useDebouncedSave'
 import { SaveStatusBadge } from '@/components/SaveStatusBadge'
@@ -152,9 +152,19 @@ export function ProfilesPage() {
   const { isAdmin } = useAuth()
   const invalidators = useInvalidators()
   const profilesQuery = useProfiles()
+  // #1773: the sentinel sits outside `/api/profiles` (#1771 hides it). Admins
+  // pull it via `/api/profiles/global` and we prepend it so the operator can
+  // edit its app-policy assignments / categories / defaultDeny through the
+  // same per-profile shell. Non-admins skip the fetch (the route requires
+  // admin and the page already gates most editing on `isAdmin`).
+  const globalProfileQuery = useGlobalProfile({ enabled: isAdmin })
   const devicesQuery  = useDevices()
   const summariesQuery = useTimeStatusSummary()
-  const profiles  = profilesQuery.data  ?? []
+  const profiles  = useMemo(() => {
+    const list = profilesQuery.data ?? []
+    const g    = globalProfileQuery.data
+    return g ? [g, ...list] : list
+  }, [profilesQuery.data, globalProfileQuery.data])
   const devices   = devicesQuery.data   ?? []
   const summaries = summariesQuery.data ?? []
   const [allUsers, setAllUsers] = useState<User[]>([])
@@ -599,6 +609,13 @@ function ProfileShellRow({
   userLinkError: string | null
 }) {
   const linkedUserIds = useMemo(() => new Set(users.map(u => u.id)), [users])
+  // #1773 — the global sentinel profile (#1771) is edited through this same
+  // shell, but concepts that only make sense per-MAC are write-rejected at the
+  // API for it (schedules / time limits / paused / pauseMode / delete; devices
+  // also can't reference it). Hide those subsections + actions so the UI
+  // doesn't dangle disabled controls. Apps, blocked categories, defaultDeny,
+  // and the name editor stay — they're what the operator actually edits here.
+  const isGlobal = pd.profile.isGlobal === true
   // #1539: resolve the windows of the NAMED schedules attached to this profile
   // (the enforcement source) so the chip matches what PolicyService enforces —
   // not the dead legacy `pd.schedules`. The catalog is shared/cached across all
@@ -681,7 +698,7 @@ function ProfileShellRow({
         >
           <span className={`inline-block transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
         </button>
-        {expanded && isAdmin ? (
+        {expanded && isAdmin && !isGlobal ? (
           <div className="flex-1 min-w-0 flex items-center gap-2">
             <input
               type="text"
@@ -708,7 +725,9 @@ function ProfileShellRow({
         )}
 
         <div className="flex items-center gap-3 shrink-0">
-          {/* Used / cap with a thin inline progress bar */}
+          {/* Used / cap with a thin inline progress bar. Hidden for the global
+              sentinel — daily limits don't apply household-wide. */}
+          {!isGlobal && (
           <div
             data-testid={`profile-summary-time-${pd.profile.id}`}
             className="hidden sm:flex flex-col items-end min-w-[7rem]"
@@ -734,7 +753,9 @@ function ProfileShellRow({
               </div>
             )}
           </div>
+          )}
 
+          {!isGlobal && (
           <span
             data-testid={`profile-pause-chip-${pd.profile.id}`}
             data-chip={chip}
@@ -742,8 +763,17 @@ function ProfileShellRow({
           >
             {CHIP_LABEL[chip]}
           </span>
+          )}
+          {isGlobal && (
+            <span
+              data-testid={`profile-global-badge-${pd.profile.id}`}
+              className="text-xs px-2 py-1 rounded-lg border bg-brand-accent/10 text-brand-accent border-brand-accent/20"
+            >
+              Global
+            </span>
+          )}
 
-          {isAdmin && hasLimit && (
+          {isAdmin && hasLimit && !isGlobal && (
             <button
               type="button"
               onClick={onGrantTime}
@@ -759,7 +789,7 @@ function ProfileShellRow({
               one-shot actions; making the operator expand the card first was
               busywork. Icon-only Pause (chip already says Paused/Active);
               Delete is muted + far right so it's hard to mis-click. */}
-          {isAdmin && (
+          {isAdmin && !isGlobal && (
             <div className="relative" ref={pausePickerRef}>
               <button
                 type="button"
@@ -816,7 +846,7 @@ function ProfileShellRow({
               )}
             </div>
           )}
-          {isAdmin && (
+          {isAdmin && !isGlobal && (
             <button
               type="button"
               onClick={onDelete}
@@ -835,15 +865,17 @@ function ProfileShellRow({
           {/* #1036 — always-visible per-profile timeline chart at the top of
               the expanded view. Carries the Today/Week toggle + host/device
               group-by + Other drill-in that the deleted /time page used to
-              own. Read-only; lives above the edit subsections. */}
-          <ProfileTimelineChart profileId={pd.profile.id} />
+              own. Read-only; lives above the edit subsections.
+              #1773 — skipped for the global sentinel: it has no MACs of its
+              own, so the per-profile usage feeds return nothing meaningful. */}
+          {!isGlobal && <ProfileTimelineChart profileId={pd.profile.id} />}
 
           {/* #1519/#726 — per-app usage breakdown: one row per configured app
               (drillable to its host-set, the per-FQDN view from #726), then
               one row per non-app host as its own single-host pseudo-app (per
               the App-Centric Model — no semantic "Other" bucket). Top-N + a
               "+N more sites" expander is a presentation rollup only. */}
-          <ProfileUsageBreakdown profileId={pd.profile.id} enabled={expanded} />
+          {!isGlobal && <ProfileUsageBreakdown profileId={pd.profile.id} enabled={expanded} />}
 
           {/* #1320 — per-profile default-deny baseline. Block-all; only the
               profile's allowed apps/hosts + the household global allowlist are
@@ -854,7 +886,6 @@ function ProfileShellRow({
           {isAdmin && (
             <DefaultDenySubsection
               pd={pd}
-              updateProfile={updateProfile}
               onProfileChanged={onProfileChanged}
             />
           )}
@@ -866,7 +897,7 @@ function ProfileShellRow({
               subsection now; failureMode (#385) is the one orphan, tracked
               separately. The "+ New Profile" name-only form (top of page)
               replaces the modal's create flow. */}
-          {isAdmin && (
+          {isAdmin && !isGlobal && (
             <DevicesSubsection pd={pd} assigned={devices} allDevices={allDevices} />
           )}
           {/* #1473 — blocked categories are edited inline here (admins),
@@ -876,7 +907,6 @@ function ProfileShellRow({
           {isAdmin ? (
             <CategoriesSubsection
               pd={pd}
-              updateProfile={updateProfile}
               onProfileChanged={onProfileChanged}
             />
           ) : (
@@ -907,17 +937,19 @@ function ProfileShellRow({
 
           {/* #975 — inline time-limit + cross-device overlap subsection.
               Replaces the modal's daily-cap + overlap blocks for this profile.
-              Schedules split into their own sibling subsection (#1474). */}
-          <TimeSubsection pd={pd} isAdmin={isAdmin} />
+              Schedules split into their own sibling subsection (#1474).
+              #1773: daily limits and schedules don't apply household-wide; the
+              API rejects writes against the sentinel for both. */}
+          {!isGlobal && <TimeSubsection pd={pd} isAdmin={isAdmin} />}
 
           {/* #1474 — schedules subsection (bedtime/windows), split out of the
               Time-limits expander into its own top-level disclosure. */}
-          <ScheduleSubsection pd={pd} isAdmin={isAdmin} />
+          {!isGlobal && <ScheduleSubsection pd={pd} isAdmin={isAdmin} />}
 
           {/* #973: read-only Devices listing for non-admins. Admins get the
               editable DevicesSubsection above; keeping a second copy here for
               them would be redundant. */}
-          {!isAdmin && (
+          {!isAdmin && !isGlobal && (
             <div data-testid={`profile-devices-${pd.profile.id}`}>
               <p className="text-xs text-brand-text-muted uppercase tracking-wider mb-2">Devices</p>
               {devices.length === 0
@@ -937,7 +969,7 @@ function ProfileShellRow({
             </div>
           )}
 
-          {isAdmin && (
+          {isAdmin && !isGlobal && (
             <div data-testid={`profile-users-${pd.profile.id}`}>
               <p className="text-xs text-brand-text-muted uppercase tracking-wider mb-2">Users</p>
               {userLinkError && (
@@ -1032,10 +1064,9 @@ function timeFormsEqual(a: TimeFormState, b: TimeFormState): boolean {
 // full-profile PUT. Admin-only — the catalog endpoint requires admin, and this
 // is the editing surface (non-admins fall back to the read-only chips).
 function CategoriesSubsection({
-  pd, updateProfile, onProfileChanged,
+  pd, onProfileChanged,
 }: {
   pd: ProfileDetail
-  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
   onProfileChanged: () => void | Promise<unknown>
 }) {
   // Catalog comes from the shared react-query cache (GET /api/blocklists), so
@@ -1069,9 +1100,12 @@ function CategoriesSubsection({
     try {
       const has = selected.includes(id)
       const next = has ? selected.filter(c => c !== id) : [...selected, id]
-      const body = formToRequest(detailToForm(pd))
-      body.blockedCategories = next
-      await updateProfile(body)
+      // #1773: PATCH (field-scoped) instead of PUT — the global sentinel rejects
+      // PUT /profiles/:id but accepts PATCH for `blockedCategories`; for regular
+      // profiles PATCH is also the preferred path per #423/#995 (race-safe).
+      // `updateProfile` retained on the prop signature for callers that still
+      // want the full-shape write; the named subsections drop it.
+      await api.profiles.patch(pd.profile.id, { blockedCategories: next })
       await onProfileChanged()
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : 'Failed to update')
@@ -1131,10 +1165,9 @@ function CategoriesSubsection({
 }
 
 function DefaultDenySubsection({
-  pd, updateProfile, onProfileChanged,
+  pd, onProfileChanged,
 }: {
   pd: ProfileDetail
-  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
   onProfileChanged: () => void
 }) {
   const [saving, setSaving] = useState(false)
@@ -1146,9 +1179,9 @@ function DefaultDenySubsection({
     setSaving(true)
     setError(null)
     try {
-      const body = formToRequest(detailToForm(pd))
-      body.defaultDeny = !on
-      await updateProfile(body)
+      // #1773: PATCH so this works on the global sentinel too (PUT is rejected
+      // for the sentinel; PATCH on `defaultDeny` is allowed).
+      await api.profiles.patch(pd.profile.id, { defaultDeny: !on })
       onProfileChanged()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to update')

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -30,6 +30,12 @@ export interface Profile {
   // (the inverse of the allow-by-default + blocklists model). Resolved
   // server-side into the per-MAC `blocked = true`; the router never sees it.
   defaultDeny: boolean
+  // #1771/#1773: marks the single household-wide sentinel profile. Hidden from
+  // GET /api/profiles; fetched separately via GET /api/profiles/global. Edited
+  // through the same per-profile editor; subsections that can't apply
+  // household-wide (devices, schedules, time limits, pause, users) are hidden.
+  // Optional + defaulted false so older API responses decode unchanged.
+  isGlobal?: boolean
 }
 
 export interface Schedule {


### PR DESCRIPTION
Closes #1773 and #1772. This is the LAST sub-issue under #1769.

## Stacked on #1779

This branch sits on top of [#1779](https://github.com/wifihaven/wifihaven/pull/1779) (step 2 of #1769), which is open and CI-green at time of push. The diff against `main` includes #1779's two commits in addition to this PR's own commit; once #1779 merges I'll rebase this branch onto `main` so the PR diff narrows to the step 3+4 change set only.

## Summary

Rebuilds the SPA's Global Policy surface as the existing per-profile editor preset to the global sentinel profile (#1771), instead of resurrecting the deleted `/api/global/*` route family (#1775) or its previous Global Policy page. The operator authors apps / blocked categories / defaultDeny on the sentinel through the same controls used on every other profile.

## API

- `GET /api/profiles/global` → ProfileDetail of the `is_global=TRUE` sentinel. Admin-only. Route literal precedes `/profiles/long(id)` so "global" doesn't path-parse into a Long.
- The sentinel stays hidden from `GET /api/profiles` per #1771's RoleAccessSpec invariant.

## SPA

- New `useGlobalProfile()` hook (gated on `isAdmin`) prepends the sentinel to the rendered profile list. Card carries a visible "Global" badge.
- `ProfileShellRow` hides subsections that are write-rejected for the sentinel per #1771 (devices / schedules / time-limit / users) plus the row-level pause / delete / +time / name-editor controls that don't apply household-wide.
- Apps, blocked categories, defaultDeny, and the per-profile audit/log surfaces (which already key by `profileId`) work as-is on the sentinel.
- `CategoriesSubsection` and `DefaultDenySubsection` now PATCH instead of PUT `/profiles/:id`. PATCH is field-scoped (race-safe per #423/#995) and is the one write path #1771 leaves open on the sentinel; switching also drops the `formToRequest` round-trip on a host of fields that don't change.

## Regression pin (#1772)

`GlobalRoutesGoneSpec` asserts the six former `/api/global/*` paths return 404 through the assembled `ProfileRoutes`. The routes were deleted in #1775; this spec prevents a quiet re-introduction.

## Tests

- Vitest extends `ProfilesPage.test.tsx` with five scenarios for the sentinel: badge + suppressed controls, hidden subsections under expand, PATCH on defaultDeny toggle, PATCH on category toggle, and the non-admin gate that skips the `/profiles/global` fetch entirely.
- Updated three existing #1320 / #1473 specs that asserted `api.profiles.update` to assert `api.profiles.patch` with field-scoped bodies.

## Notes / follow-ups

- Operator's belief that per-profile `defaultDeny` already exists is confirmed — `web/src/pages/ProfilesPage.tsx` has the toggle (#1320). No new follow-up issue required.
- Per-device override editor stays explicitly out of scope (won't-do per #1452).

## Test plan

- [x] `npm run type-check` clean
- [x] `npm test` — 97/97 in `ProfilesPage.test.tsx`, 410/410 total
- [x] `mill api.test` — all green
- [x] `scalafmt --check` clean