### PR TITLE
feat(#1737): switch remaining ProfilesPage PUT callers to PATCH /api/profiles/:id

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -417,12 +417,12 @@ describe('ProfilesPage — pause / delete in collapsed row (#1063)', () => {
     const pauseBtn = within(kidsCard).getByTestId('profile-row-pause-1')
     await user.click(pauseBtn)
     // the click opens the soft/hard picker; nothing is saved yet
-    expect(api.profiles.update).not.toHaveBeenCalled()
+    expect(api.profiles.patch).not.toHaveBeenCalled()
     await user.click(within(kidsCard).getByTestId('profile-row-pause-soft-1'))
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenCalledWith(
+      expect(api.profiles.patch).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ paused: true, pauseMode: 'soft', name: 'Kids' }),
+        { paused: true, pauseMode: 'soft' },
       ),
     )
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
@@ -435,9 +435,9 @@ describe('ProfilesPage — pause / delete in collapsed row (#1063)', () => {
     expect(within(adultsCard).queryByText('Bedtime')).not.toBeInTheDocument()
     await user.click(within(adultsCard).getByTestId('profile-row-pause-2'))
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenCalledWith(
+      expect(api.profiles.patch).toHaveBeenCalledWith(
         2,
-        expect.objectContaining({ paused: false, name: 'Adults' }),
+        { paused: false },
       ),
     )
   })
@@ -491,7 +491,7 @@ describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
     await user.click(within(kidsCard).getByTestId('profile-row-pause-1'))
     expect(within(kidsCard).getByTestId('profile-row-pause-soft-1')).toBeInTheDocument()
     expect(within(kidsCard).getByTestId('profile-row-pause-hard-1')).toBeInTheDocument()
-    expect(api.profiles.update).not.toHaveBeenCalled()
+    expect(api.profiles.patch).not.toHaveBeenCalled()
   })
 
   it('choosing Hard pause PUTs paused=true with pauseMode=hard', async () => {
@@ -501,9 +501,9 @@ describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
     await user.click(within(kidsCard).getByTestId('profile-row-pause-1'))
     await user.click(within(kidsCard).getByTestId('profile-row-pause-hard-1'))
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenCalledWith(
+      expect(api.profiles.patch).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ paused: true, pauseMode: 'hard', name: 'Kids' }),
+        { paused: true, pauseMode: 'hard' },
       ),
     )
   })
@@ -515,9 +515,9 @@ describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
     await user.click(within(kidsCard).getByTestId('profile-row-pause-1'))
     await user.click(within(kidsCard).getByTestId('profile-row-pause-soft-1'))
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenCalledWith(
+      expect(api.profiles.patch).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ paused: true, pauseMode: 'soft', name: 'Kids' }),
+        { paused: true, pauseMode: 'soft' },
       ),
     )
   })
@@ -531,9 +531,9 @@ describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
     expect(within(adultsCard).queryByTestId('profile-row-pause-soft-2')).not.toBeInTheDocument()
     expect(within(adultsCard).queryByTestId('profile-row-pause-hard-2')).not.toBeInTheDocument()
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenCalledWith(
+      expect(api.profiles.patch).toHaveBeenCalledWith(
         2,
-        expect.objectContaining({ paused: false, name: 'Adults' }),
+        { paused: false },
       ),
     )
   })
@@ -667,7 +667,7 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
   // the input so the debounce never commits and the PUT is never sent.
   // `await act` drains those pending mount effects before we interact; `waitFor`
   // then polls for the real-clock debounce.
-  it('autosaves the daily cap after debounce — single PUT, no Save button', async () => {
+  it('autosaves the daily cap after debounce — single PATCH, no Save button', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -683,13 +683,14 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
     fireEvent.change(input, { target: { value: '90' } })
 
     // Pre-debounce: no save yet.
-    expect(api.profiles.update).not.toHaveBeenCalled()
+    expect(api.profiles.patch).not.toHaveBeenCalled()
 
     await waitFor(() => {
-      expect(api.profiles.update).toHaveBeenCalledTimes(1)
-      expect(api.profiles.update).toHaveBeenLastCalledWith(
+      expect(api.profiles.patch).toHaveBeenCalledTimes(1)
+      // Only the time subsection's own fields ride the patch — not the name.
+      expect(api.profiles.patch).toHaveBeenLastCalledWith(
         1,
-        expect.objectContaining({ timeLimit: 90, name: 'Kids' }),
+        { timeLimit: 90, crossDeviceOverlapMode: 'sum' },
       )
     })
 
@@ -713,9 +714,9 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
 
     // Poll for the debounced PUT — see the daily-cap test (#1439).
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenLastCalledWith(
+      expect(api.profiles.patch).toHaveBeenLastCalledWith(
         1,
-        expect.objectContaining({ crossDeviceOverlapMode: 'dedup' }),
+        { timeLimit: 120, crossDeviceOverlapMode: 'dedup' },
       ),
     )
   })
@@ -732,9 +733,9 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
 
     // Poll for the debounced PUT — see the daily-cap test (#1439).
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenLastCalledWith(
+      expect(api.profiles.patch).toHaveBeenLastCalledWith(
         1,
-        expect.objectContaining({ timeLimit: null }),
+        { timeLimit: null, crossDeviceOverlapMode: 'sum' },
       ),
     )
   })
@@ -802,7 +803,8 @@ describe('ProfilesPage — inline schedules subsection (#1494 named-schedule pic
     await waitFor(() =>
       expect(api.profiles.setSchedules).toHaveBeenCalledWith(2, [11]),
     )
-    // The legacy full-profile PUT is NOT used to carry schedules.
+    // The full-profile write is NOT used to carry schedules.
+    expect(api.profiles.patch).not.toHaveBeenCalled()
     expect(api.profiles.update).not.toHaveBeenCalled()
   })
 
@@ -820,6 +822,7 @@ describe('ProfilesPage — inline schedules subsection (#1494 named-schedule pic
     await waitFor(() =>
       expect(api.profiles.setSchedules).toHaveBeenCalledWith(1, []),
     )
+    expect(api.profiles.patch).not.toHaveBeenCalled()
     expect(api.profiles.update).not.toHaveBeenCalled()
   })
 
@@ -1441,7 +1444,7 @@ describe('ProfilesPage — #973 inline name subsection (autosave)', () => {
     expect(input.value).toBe('Kids')
   })
 
-  it('debounced autosave fires once per change with the new name baked into the full PUT body', async () => {
+  it('debounced autosave fires once per change, patching only the changed name field', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -1454,21 +1457,13 @@ describe('ProfilesPage — #973 inline name subsection (autosave)', () => {
     // Real 500ms debounce — give waitFor a window wide enough to cover it.
     await waitFor(
       () =>
-        expect(api.profiles.update).toHaveBeenCalledWith(
+        expect(api.profiles.patch).toHaveBeenCalledWith(
           1,
-          expect.objectContaining({
-            name: 'Kiddos',
-            blockedCategories: ['adult', 'gambling'],
-            paused: false,
-            failureMode: 'block-all',
-            crossDeviceOverlapMode: 'sum',
-            // round-trips schedules + timeLimit unchanged
-            timeLimit: 120,
-          }),
+          { name: 'Kiddos' },
         ),
       { timeout: 2000 },
     )
-    expect(api.profiles.update).toHaveBeenCalledTimes(1)
+    expect(api.profiles.patch).toHaveBeenCalledTimes(1)
   })
 
   it('blank name surfaces an error and is not persisted', async () => {
@@ -1485,7 +1480,7 @@ describe('ProfilesPage — #973 inline name subsection (autosave)', () => {
       },
       { timeout: 2000 },
     )
-    expect(api.profiles.update).not.toHaveBeenCalled()
+    expect(api.profiles.patch).not.toHaveBeenCalled()
   })
 })
 
@@ -1765,8 +1760,8 @@ describe('ProfilesPage — app-policy edits refresh the profile-wide time bar (#
 
 // #1473 — blocked categories are now editable inline on the profile card.
 // The read-only chips are replaced (for admins) with a checklist of the
-// blocklist catalog; toggling a category autosaves blockedCategories via the
-// same full-profile PUT the Blocklists matrix uses.
+// blocklist catalog; toggling a category autosaves blockedCategories via a
+// field-scoped PATCH (#1773).
 describe('ProfilesPage — inline blocked-categories editor (#1473)', () => {
   it('renders the catalog with the profile’s current categories pre-selected', async () => {
     const user = userEvent.setup()

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -405,9 +405,9 @@ describe('ProfilesPage — pause / delete in collapsed row (#1063)', () => {
   // #1063 — Pause/Resume + Delete were moved from the expanded body into the
   // collapsed summary row (alongside the +Time button). The card no longer
   // needs to be expanded to reach either action.
-  // #406: pause is still an explicit PUT with the full profile + paused=!current.
+  // #406 / #1737: pause is an explicit PATCH carrying paused=!current.
   // #1471: clicking Pause on an active profile no longer fires immediately —
-  // it surfaces a soft/hard choice; the chosen mode rides the same PUT.
+  // it surfaces a soft/hard choice; the chosen mode rides the same PATCH.
   it('Pause button is rendered in the collapsed row and fires update without expanding', async () => {
     const user = userEvent.setup()
     renderPage()
@@ -482,7 +482,7 @@ describe('ProfilesPage — pause / delete in collapsed row (#1063)', () => {
 
 // #1471 — soft vs hard pause is chosen at the moment of pausing, via a small
 // picker on the row Pause action, NOT as a persistent radio buried in the
-// Time-limits subsection. The chosen mode rides the same PUT that sets paused.
+// Time-limits subsection. The chosen mode rides the same PATCH that sets paused.
 describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
   it('clicking Pause surfaces a soft/hard choice rather than saving immediately', async () => {
     const user = userEvent.setup()
@@ -494,7 +494,7 @@ describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
     expect(api.profiles.patch).not.toHaveBeenCalled()
   })
 
-  it('choosing Hard pause PUTs paused=true with pauseMode=hard', async () => {
+  it('choosing Hard pause PATCHes paused=true with pauseMode=hard', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -508,7 +508,7 @@ describe('ProfilesPage — pause-mode chosen at pause-time (#1471)', () => {
     )
   })
 
-  it('choosing Soft pause PUTs paused=true with pauseMode=soft', async () => {
+  it('choosing Soft pause PATCHes paused=true with pauseMode=soft', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -664,7 +664,7 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
   // which flaked (#1439): the time-limit input's mount value-resync
   // `useEffect(() => setX(value.x))` can run AFTER our change (its passive
   // effect hadn't flushed when the element was found under CI load), reverting
-  // the input so the debounce never commits and the PUT is never sent.
+  // the input so the debounce never commits and the PATCH is never sent.
   // `await act` drains those pending mount effects before we interact; `waitFor`
   // then polls for the real-clock debounce.
   it('autosaves the daily cap after debounce — single PATCH, no Save button', async () => {
@@ -679,7 +679,7 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
     await act(async () => {})
 
     // Set atomically: char-by-char typing lets the debounce fire on a transient
-    // partial value, producing extra PUTs. fireEvent.change gives one value.
+    // partial value, producing extra PATCHes. fireEvent.change gives one value.
     fireEvent.change(input, { target: { value: '90' } })
 
     // Pre-debounce: no save yet.
@@ -694,7 +694,7 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
       )
     })
 
-    // "Saved" indicator surfaces after the PUT resolves.
+    // "Saved" indicator surfaces after the PATCH resolves.
     await waitFor(() => {
       const status = within(kidsCard).getByTestId('profile-time-status-1')
       expect(status).toHaveAttribute('data-status', 'saved')
@@ -712,7 +712,7 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
 
     await user.click(within(kidsCard).getByTestId('profile-time-overlap-dedup-1'))
 
-    // Poll for the debounced PUT — see the daily-cap test (#1439).
+    // Poll for the debounced PATCH — see the daily-cap test (#1439).
     await waitFor(() =>
       expect(api.profiles.patch).toHaveBeenLastCalledWith(
         1,
@@ -731,7 +731,7 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
 
     await user.clear(within(kidsCard).getByTestId('profile-time-limit-1'))
 
-    // Poll for the debounced PUT — see the daily-cap test (#1439).
+    // Poll for the debounced PATCH — see the daily-cap test (#1439).
     await waitFor(() =>
       expect(api.profiles.patch).toHaveBeenLastCalledWith(
         1,

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -9,7 +9,7 @@ import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 import { SchedulePicker } from '@/components/SchedulePicker'
 import type {
   AppDetail, AppMode, AppPolicyAssignment, AppScheduleMode, AppScheduleRule,
-  CrossDeviceOverlapMode, Device, FailureMode, PauseMode, ProfileDetail,
+  CrossDeviceOverlapMode, Device, PatchProfileRequest, PauseMode, ProfileDetail,
   ProfileTimeSummary, ScheduleWindow,
   UpsertAppAssignmentRequest, UpsertProfileRequest, User,
 } from '@/types/api'
@@ -19,44 +19,6 @@ import { ProfileUsageBreakdown } from '@/components/usage/ProfileUsageBreakdown'
 import { EmptyState } from '@/components/EmptyState'
 import { PageLoader } from './DashboardPage'
 import { formatMins } from '@/lib/timeFormat'
-
-interface FormState {
-  name: string
-  blockedCategories: string[]
-  paused: boolean
-  timeLimit: string
-  failureMode: FailureMode
-  crossDeviceOverlapMode: CrossDeviceOverlapMode
-  defaultDeny: boolean
-}
-
-function detailToForm(pd: ProfileDetail): FormState {
-  return {
-    name: pd.profile.name,
-    blockedCategories: pd.profile.blockedCategories,
-    paused: pd.profile.paused,
-    timeLimit: pd.timeLimit ? String(pd.timeLimit.dailyMinutes) : '',
-    failureMode: pd.profile.failureMode,
-    crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
-    defaultDeny: pd.profile.defaultDeny,
-  }
-}
-
-// #1494: schedules are no longer carried on the profile upsert — they attach
-// via api.profiles.setSchedules (PUT /profiles/{id}/schedules). So the
-// full-profile PUT this builds never touches schedules.
-function formToRequest(f: FormState): UpsertProfileRequest {
-  const tl = f.timeLimit.trim() === '' ? null : Number(f.timeLimit)
-  return {
-    name: f.name.trim(),
-    blockedCategories: f.blockedCategories,
-    paused: f.paused,
-    timeLimit: tl !== null && Number.isFinite(tl) ? tl : null,
-    failureMode: f.failureMode,
-    crossDeviceOverlapMode: f.crossDeviceOverlapMode,
-    defaultDeny: f.defaultDeny,
-  }
-}
 
 // #972: chip states reflect the at-a-glance "what's this profile doing right
 // now" answer. The schedule-active check is approximated locally — but it must
@@ -288,9 +250,15 @@ export function ProfilesPage() {
   // the inline create form below drops the new profile with defaults so the
   // operator immediately edits it via the same inline surfaces.
 
+  // #1737 — every inline edit + the pause toggle now PATCHes only the field(s)
+  // it changed, instead of round-tripping the whole UpsertProfileRequest. This
+  // closes the concurrent-edit clobber #423 was opened to fix: two operators
+  // editing different fields of the same profile no longer overwrite each
+  // other. PUT (api.profiles.update) stays on the client for full-shape replace
+  // but ProfilesPage no longer uses it.
   const updateMutation = useMutation({
-    mutationFn: ({ id, body }: { id: number; body: UpsertProfileRequest }) =>
-      api.profiles.update(id, body),
+    mutationFn: ({ id, body }: { id: number; body: PatchProfileRequest }) =>
+      api.profiles.patch(id, body),
     onSuccess: () => Promise.all([invalidators.profileMutated(), refetchAux()]),
   })
 
@@ -350,14 +318,13 @@ export function ProfilesPage() {
   })
 
   async function togglePause(pd: ProfileDetail, mode?: PauseMode) {
-    // #406: setting `paused` explicitly via the full-profile PUT is
-    // idempotent under concurrent clicks. #423 tracks adding PATCH so we
-    // don't have to send the whole profile.
+    // #406: setting `paused` explicitly is idempotent under concurrent clicks.
+    // #1737: PATCH carries only `paused` (and `pauseMode` when pausing), so a
+    // pause click no longer clobbers a concurrent edit to some other field.
     // #1471: when pausing, the admin picks soft vs hard at click-time; the
-    // chosen mode rides this same PUT. Resume omits it (preserve existing).
-    const body = formToRequest(detailToForm(pd))
+    // chosen mode rides this PATCH. Resume omits it (preserve existing).
     const nextPaused = !pd.profile.paused
-    body.paused = nextPaused
+    const body: PatchProfileRequest = { paused: nextPaused }
     if (nextPaused && mode) body.pauseMode = mode
     await updateMutation.mutateAsync({ id: pd.profile.id, body })
   }
@@ -603,7 +570,7 @@ function ProfileShellRow({
   onGrantTime: () => void
   onAppsChanged: () => void | Promise<void>
   onProfileChanged: () => void | Promise<unknown>
-  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
+  updateProfile: (body: PatchProfileRequest) => Promise<unknown>
   onToggleUserLink: (userId: number) => void
   pendingUserLinks: Set<string>
   userLinkError: string | null
@@ -637,8 +604,8 @@ function ProfileShellRow({
   // #973 — inline name editor lives in the card header (no redundant
   // "Name" subsection). When the card is expanded and the operator is an
   // admin, the title-line spot becomes an unobtrusive editable input;
-  // debounced autosave does a full-profile PUT because PATCH /profiles/:id
-  // (#423) hasn't shipped yet.
+  // debounced autosave PATCHes only the name (#1737) so it can't clobber a
+  // concurrent edit to some other field of the profile.
   const [editingName, setEditingName] = useState(pd.profile.name)
   useEffect(() => { setEditingName(pd.profile.name) }, [pd.profile.name])
   const { status: nameStatus, error: nameError } = useDebouncedSave(
@@ -646,14 +613,7 @@ function ProfileShellRow({
     async (next: string) => {
       const trimmed = next.trim()
       if (!trimmed) throw new Error('Name is required')
-      await updateProfile({
-        name: trimmed,
-        blockedCategories: pd.profile.blockedCategories,
-        paused: pd.profile.paused,
-        timeLimit: pd.timeLimit ? pd.timeLimit.dailyMinutes : null,
-        failureMode: pd.profile.failureMode,
-        crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
-      })
+      await updateProfile({ name: trimmed })
       await onProfileChanged()
     },
     { key: pd.profile.id },
@@ -1270,15 +1230,17 @@ function TimeSubsection({
     setStatus('saving')
     setErrorMsg(null)
     try {
-      const body = formToRequest(detailToForm(pd))
+      // #1737: PATCH only the two fields this subsection owns — the daily cap
+      // and the cross-device overlap mode. Schedules (#1474) and pauseMode
+      // (#1471) are owned elsewhere, and a field-scoped PATCH preserves them
+      // without round-tripping the whole profile (which would clobber a
+      // concurrent edit). `timeLimit: null` clears the cap.
       const tl = next.timeLimit.trim() === '' ? null : Number(next.timeLimit)
-      body.timeLimit = tl !== null && Number.isFinite(tl) && tl > 0 ? tl : null
-      // Schedules round-trip unchanged from pd (formToRequest already carried
-      // them); this subsection no longer edits them (#1474).
-      body.crossDeviceOverlapMode = next.crossDeviceOverlapMode
-      // #1471: pauseMode is no longer edited here; omit it from the time-form
-      // PUT so the existing value is preserved (the pause action owns it now).
-      await api.profiles.update(pd.profile.id, body)
+      const body: PatchProfileRequest = {
+        timeLimit: tl !== null && Number.isFinite(tl) && tl > 0 ? tl : null,
+        crossDeviceOverlapMode: next.crossDeviceOverlapMode,
+      }
+      await api.profiles.patch(pd.profile.id, body)
       baselineRef.current = next
       setStatus('saved')
       void invalidators.profileMutated()
@@ -1606,7 +1568,7 @@ function AppsRulesSubsection({
   apps: AppDetail[]
   onAppsChanged: () => void | Promise<void>
   onProfileChanged: () => void | Promise<unknown>
-  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
+  updateProfile: (body: PatchProfileRequest) => Promise<unknown>
 }) {
   const [open, setOpen] = useState(false)
   const assignedAppCount = useMemo(


### PR DESCRIPTION
Closes #1737.

Completes the PUT→PATCH conversion that #1780 started — that PR converted `CategoriesSubsection` and `DefaultDenySubsection`; this one finishes the remaining ProfilesPage write paths. Every edit used to ship the whole `UpsertProfileRequest`, which is the exact concurrent-edit clobber #423 was opened to fix. Each call site now sends `api.profiles.patch(id, partial)` carrying only the field(s) that changed.

## Call sites converted (`web/src/pages/ProfilesPage.tsx`)
- **`updateMutation`** `mutationFn` → `api.profiles.patch` (body typed `PatchProfileRequest`).
- **Pause/resume toggle** (`togglePause`) → posts `{ paused }`, plus `{ pauseMode }` only when pausing (resume omits it to preserve the existing mode).
- **Inline name editor** (debounced autosave) → `{ name }`.
- **`TimeSubsection.doSave`** → `{ timeLimit, crossDeviceOverlapMode }` (the two fields that subsection owns; schedules/pauseMode are owned elsewhere and a field-scoped PATCH preserves them).

The now-dead `detailToForm` / `formToRequest` / `FormState` helpers (only consumed by the old full-PUT paths) are removed. `api.profiles.update` (the PUT wrapper) and the `UpsertProfileRequest` import stay — still used by `createMutation` — but ProfilesPage no longer calls the PUT. The server `PUT /api/profiles/:id` route is untouched (out of scope).

## Tests
`web/src/pages/ProfilesPage.test.tsx` flipped from asserting `api.profiles.update(full UpsertProfileRequest)` to `api.profiles.patch(id, partial)`, each pinning only the field(s) the subsection edits. Red→green is visible in history (failing-test commit precedes the source commit).

- `npm run type-check` ✅
- `npm test` ✅ (410 tests, 35 files)