### PR TITLE
feat(#1782,#1783): stream blocklist render to /tmp shards via dnsmasq conf-file

### DIFF
--- a/docs/process/router-agent-bounded-writes.md
+++ b/docs/process/router-agent-bounded-writes.md
@@ -39,3 +39,39 @@ introduces it.** Concretely:
 The same reasoning applies to anything else the agent persists under `/tmp`
 (JSON spools, NDJSON event journals, debug dumps). If it can grow, it gets a
 bound — in the same PR.
+
+## Per-blocklist dnsmasq conf shards (`/tmp/wifihaven-blocklist-<id>.conf`) {#blocklist-shards}
+
+Added in [#1782/#1783](https://github.com/wifihaven/wifihaven/issues/1782).
+One file per blocklist id in the current snapshot.
+
+**How they work.** `blocklists.render_shards` reads each list's on-disk cache
+file (`/etc/wifihaven/blocklists/<id>-<version>.txt`) line-by-line and writes
+one `nftset=/<host>/4#inet#wifihaven#bl_<id>,6#inet#wifihaven#bl6_<id>` line
+per host — never accumulating the full list in a Lua table. `render.dnsmasq`
+emits `conf-file=/tmp/wifihaven-blocklist-<id>.conf` for each id so dnsmasq
+picks up the host set at startup and on reload.
+
+**Atomic write.** Each shard is written to `<id>.conf.tmp`, then renamed onto
+`<id>.conf`. A partial shard is never visible to dnsmasq.
+
+**Sizing.** ~80 bytes per host × list member count. The two large StevenBlack
+lists are ~7 MB each; three curated lists total under 100 KB. A per-shard cap
+(default 10 MB, UCI `blocklist_max_list_bytes`) prevents a runaway list from
+filling `/tmp`.
+
+**Lifecycle (GC, NOT log rotation).** These are config files, not append-only
+logs — `copytruncate` is wrong here. The lifecycle is:
+
+- **On every render:** `blocklists.gc_shards` removes shards whose id is no
+  longer in the current snapshot (list unassigned or deleted). Stale
+  `.conf.tmp` files are also removed (crash-during-render defense).
+- **On agent startup:** `gc_shards` runs against the cached snapshot (or an
+  empty placeholder) before the first apply, so a crash-during-render from a
+  previous run can never leave a stale shard visible to the newly-started
+  dnsmasq.
+
+**NOT added to `wifihaven-rotate-dnsmasq-log`.** The rotate cron is for
+append-only logs. Shard lifecycle is precise removal of stale ids, not
+copytruncate — adding these to the cron would silently truncate a live shard
+mid-use.

--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -16,6 +16,18 @@ local M = {}
 
 local DEFAULT_CACHE_DIR = "/etc/wifihaven/blocklists"
 
+-- Lazy require render module — compatible with both the production on-device
+-- path (wifihaven.render) and the busted test path (render). Called at most
+-- once per process; result is cached in the upvalue.
+local _render_module
+local function get_render()
+  if not _render_module then
+    local ok, m = pcall(require, "wifihaven.render")
+    _render_module = ok and m or require("render")
+  end
+  return _render_module
+end
+
 -- classify_fetch_status(status) → bounded status enum (#1301).
 --
 -- The blocklist fetch surfaces as the `status` label of
@@ -361,12 +373,8 @@ function M.render_shards(snapshot, fs, cache_dir, shard_dir, max_bytes, global_b
   global_blocklist_ids = global_blocklist_ids or {}
 
   -- Require render.bl_sanitize for set-name normalization so there is
-  -- one source of truth.
-  -- In production (on-device) the module path is wifihaven.render; in the
-  -- busted test environment modules are loaded without the wifihaven. prefix.
-  local ok_render, render = pcall(require, "wifihaven.render")
-  if not ok_render then render = require("render") end
-  local bl_sanitize = render.bl_sanitize
+  -- one source of truth (see get_render() at the top of this module).
+  local bl_sanitize = get_render().bl_sanitize
 
   -- Resolve fs ops (injectable for tests, real I/O otherwise).
   local open_read_fn, open_write_fn, rename_fn, remove_fn, fsync_fn
@@ -547,10 +555,8 @@ function M.render_member_index(snapshot, fs, cache_dir, index_path)
   cache_dir  = cache_dir  or "/etc/wifihaven/blocklists"
   index_path = index_path or "/var/run/wifihaven/blocklist_members.tsv"
 
-  local ok_r2, render2 = pcall(require, "wifihaven.render")
-  if not ok_r2 then render2 = require("render") end
-  local bl_set_name  = render2.bl_set_name
-  local bl6_set_name = render2.bl6_set_name
+  local bl_set_name  = get_render().bl_set_name
+  local bl6_set_name = get_render().bl6_set_name
 
   local open_read_fn, open_write_fn, rename_fn
   if fs then

--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -323,6 +323,296 @@ function M.hosts_differ(a, b)
   return false
 end
 
+-- ---------------------------------------------------------------------------
+-- M.render_shards(snapshot, fs, cache_dir, shard_dir, max_bytes,
+--                 global_blocklist_ids)
+-- ---------------------------------------------------------------------------
+-- Streams per-blocklist shard files to <shard_dir>/wifihaven-blocklist-<id>.conf,
+-- one file per blocklist in snapshot.blocklists. Each line in the shard is:
+--
+--   nftset=/<host>/4#inet#wifihaven#bl_<sanid>,6#inet#wifihaven#bl6_<sanid>\n
+--
+-- When global_blocklist_ids[id] is truthy, each line also appends:
+--   ,4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6
+-- before the newline.
+--
+-- Reads from the on-disk cache file line-by-line (via fs.open_read) so the
+-- full host list is NEVER accumulated in a Lua table — the #1412 OOM source.
+-- Writes atomically: <id>.conf.tmp → <id>.conf.
+--
+-- Parameters:
+--   snapshot           — current policy snapshot (snapshot.blocklists used)
+--   fs                 — injectable filesystem ops (open_read, open_write,
+--                        rename, remove, fsync; defaults to real I/O)
+--   cache_dir          — directory holding <id>-<version>.txt cache files
+--                        (default /etc/wifihaven/blocklists)
+--   shard_dir          — directory to write shards into (default /tmp)
+--   max_bytes          — stop emitting once shard exceeds this many bytes;
+--                        nil = no cap (default 10 MB = 10485760 in agent)
+--   global_blocklist_ids — optional { [id] = true } set; ids in this set
+--                          have global_block/global_block6 appended to each
+--                          shard line
+--
+-- Returns:
+--   { rendered = { [id] = bytes }, skipped = { ids }, errors = { strings } }
+function M.render_shards(snapshot, fs, cache_dir, shard_dir, max_bytes, global_blocklist_ids)
+  cache_dir  = cache_dir  or "/etc/wifihaven/blocklists"
+  shard_dir  = shard_dir  or "/tmp"
+  global_blocklist_ids = global_blocklist_ids or {}
+
+  -- Require render.bl_sanitize for set-name normalization so there is
+  -- one source of truth.
+  -- In production (on-device) the module path is wifihaven.render; in the
+  -- busted test environment modules are loaded without the wifihaven. prefix.
+  local ok_render, render = pcall(require, "wifihaven.render")
+  if not ok_render then render = require("render") end
+  local bl_sanitize = render.bl_sanitize
+
+  -- Resolve fs ops (injectable for tests, real I/O otherwise).
+  local open_read_fn, open_write_fn, rename_fn, remove_fn, fsync_fn
+  if fs then
+    open_read_fn  = fs.open_read
+    open_write_fn = fs.open_write
+    rename_fn     = fs.rename
+    remove_fn     = fs.remove
+    fsync_fn      = fs.fsync
+  else
+    open_read_fn = function(path)
+      local f = io.open(path, "r")
+      return f  -- nil if missing; caller checks
+    end
+    open_write_fn = function(path)
+      local f, err = io.open(path, "w")
+      if not f then return nil, err end
+      return f
+    end
+    rename_fn = function(from, to)
+      local ok, err = os.rename(from, to)
+      if not ok then return nil, err end
+      return true, nil
+    end
+    remove_fn = function(path)
+      os.remove(path)
+      return true, nil
+    end
+    fsync_fn = function(path)
+      -- Best-effort: sync the parent directory so the rename is durable.
+      os.execute("sync " .. string.format("%q", path) .. " 2>/dev/null")
+      return true
+    end
+  end
+
+  local result = { rendered = {}, skipped = {}, errors = {} }
+  local bls    = snapshot and snapshot.blocklists or {}
+
+  for id, bl in pairs(bls) do
+    local version    = bl.version
+    local cache_path = cache_dir .. "/" .. id .. "-" .. tostring(version) .. ".txt"
+    local shard_tmp  = shard_dir .. "/wifihaven-blocklist-" .. id .. ".conf.tmp"
+    local shard_final = shard_dir .. "/wifihaven-blocklist-" .. id .. ".conf"
+
+    -- Open the cache file for line-by-line reading.
+    local rf = open_read_fn(cache_path)
+    if not rf then
+      result.skipped[#result.skipped + 1] = id
+    else
+      -- Build the per-host spec suffix for this id.
+      local san    = bl_sanitize(id)
+      local spec   = "4#inet#wifihaven#bl_" .. san .. ",6#inet#wifihaven#bl6_" .. san
+      if global_blocklist_ids[id] then
+        spec = spec .. ",4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6"
+      end
+
+      local wf, werr = open_write_fn(shard_tmp)
+      if not wf then
+        result.errors[#result.errors + 1] =
+          string.format("render_shards: open_write failed for %s: %s", shard_tmp, tostring(werr))
+        rf:close()
+      else
+        local bytes_written = 0
+        local cap_hit = false
+        -- Stream line-by-line — never accumulate.
+        while true do
+          local line = rf:read("*l")
+          if line == nil then break end
+          -- Trim whitespace; skip blank and comment lines.
+          line = line:match("^%s*(.-)%s*$")
+          if line ~= "" and line:sub(1, 1) ~= "#" then
+            local directive = "nftset=/" .. line .. "/" .. spec .. "\n"
+            -- Check byte cap BEFORE writing.
+            if max_bytes and (bytes_written + #directive) > max_bytes then
+              cap_hit = true
+              break
+            end
+            wf:write(directive)
+            bytes_written = bytes_written + #directive
+          end
+        end
+        rf:close()
+        wf:close()
+
+        if cap_hit then
+          -- Remove the truncated tmp file; record the id as skipped.
+          remove_fn(shard_tmp)
+          result.skipped[#result.skipped + 1] = id
+        else
+          -- fsync before rename for durability.
+          if fsync_fn then fsync_fn(shard_tmp) end
+          local rok, rerr = rename_fn(shard_tmp, shard_final)
+          if not rok then
+            result.errors[#result.errors + 1] =
+              string.format("render_shards: rename failed for %s → %s: %s",
+                shard_tmp, shard_final, tostring(rerr))
+            -- Best-effort cleanup of the tmp file.
+            remove_fn(shard_tmp)
+          else
+            result.rendered[id] = bytes_written
+          end
+        end
+      end
+    end
+  end
+
+  return result
+end
+
+-- ---------------------------------------------------------------------------
+-- M.gc_shards(snapshot, fs, shard_dir)
+-- ---------------------------------------------------------------------------
+-- Removes shard files in shard_dir whose blocklist id is no longer in
+-- snapshot.blocklists, and clears leftover .tmp files from a crash during
+-- render. Only touches files matching the pattern
+-- `wifihaven-blocklist-*.conf` or `wifihaven-blocklist-*.conf.tmp`.
+--
+-- Called at every render and at agent startup (defense against crash-
+-- during-render leaving stale shards visible to dnsmasq).
+function M.gc_shards(snapshot, fs, shard_dir)
+  shard_dir = shard_dir or "/tmp"
+
+  local list_fn, remove_fn
+  if fs then
+    list_fn   = fs.list
+    remove_fn = fs.remove
+  else
+    list_fn = function(dir)
+      local files = {}
+      local p = io.popen("ls -1 " .. dir .. " 2>/dev/null")
+      if p then
+        for line in p:lines() do files[#files + 1] = line end
+        p:close()
+      end
+      return files
+    end
+    remove_fn = function(path)
+      os.remove(path)
+      return true, nil
+    end
+  end
+
+  -- Build the set of ids present in the current snapshot.
+  local present = {}
+  local bls = snapshot and snapshot.blocklists or {}
+  for id, _ in pairs(bls) do present[id] = true end
+
+  local files = list_fn(shard_dir)
+  for _, fname in ipairs(files or {}) do
+    -- Match wifihaven-blocklist-<id>.conf or wifihaven-blocklist-<id>.conf.tmp
+    local id_from_conf     = fname:match("^wifihaven%-blocklist%-(.+)%.conf$")
+    local id_from_conf_tmp = fname:match("^wifihaven%-blocklist%-(.+)%.conf%.tmp$")
+
+    if id_from_conf_tmp then
+      -- Always remove .tmp files (leftover from crash-during-render).
+      remove_fn(shard_dir .. "/" .. fname)
+    elseif id_from_conf then
+      if not present[id_from_conf] then
+        remove_fn(shard_dir .. "/" .. fname)
+      end
+    end
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- M.render_member_index(snapshot, fs, cache_dir, index_path)
+-- ---------------------------------------------------------------------------
+-- Streams the blocklist member index (used by wifihaven-dns-tail for CNAME-
+-- aware bl_ set population) to index_path. Each line is:
+--   <host>\t<bl_set>\t<bl6_set>\n
+-- Reads from the on-disk cache files line-by-line so no large Lua table is
+-- built. Writes atomically: index_path.tmp → index_path.
+--
+-- This replaces render.blocklist_member_index for the on-disk output path
+-- while keeping render.blocklist_member_index available for the in-memory
+-- (tests / dns-tail in-process) path.
+function M.render_member_index(snapshot, fs, cache_dir, index_path)
+  cache_dir  = cache_dir  or "/etc/wifihaven/blocklists"
+  index_path = index_path or "/var/run/wifihaven/blocklist_members.tsv"
+
+  local ok_r2, render2 = pcall(require, "wifihaven.render")
+  if not ok_r2 then render2 = require("render") end
+  local bl_set_name  = render2.bl_set_name
+  local bl6_set_name = render2.bl6_set_name
+
+  local open_read_fn, open_write_fn, rename_fn
+  if fs then
+    open_read_fn  = fs.open_read
+    open_write_fn = fs.open_write
+    rename_fn     = fs.rename
+  else
+    open_read_fn = function(path)
+      return io.open(path, "r")
+    end
+    open_write_fn = function(path)
+      local f, err = io.open(path, "w")
+      if not f then return nil, err end
+      return f
+    end
+    rename_fn = function(from, to)
+      local ok, err = os.rename(from, to)
+      if not ok then return nil, err end
+      return true, nil
+    end
+  end
+
+  local tmp_path = index_path .. ".tmp"
+  local wf, werr = open_write_fn(tmp_path)
+  if not wf then
+    return { error = "render_member_index: open_write failed: " .. tostring(werr) }
+  end
+
+  local bls    = snapshot and snapshot.blocklists or {}
+  -- Sort ids for deterministic output (matches render.blocklist_member_index).
+  local ids = {}
+  for id, _ in pairs(bls) do ids[#ids + 1] = id end
+  table.sort(ids)
+
+  for _, id in ipairs(ids) do
+    local bl         = bls[id]
+    local cache_path = cache_dir .. "/" .. id .. "-" .. tostring(bl.version) .. ".txt"
+    local set4       = bl_set_name(id)
+    local set6       = bl6_set_name(id)
+
+    local rf = open_read_fn(cache_path)
+    if rf then
+      while true do
+        local line = rf:read("*l")
+        if line == nil then break end
+        line = line:match("^%s*(.-)%s*$")
+        if line ~= "" and line:sub(1, 1) ~= "#" then
+          wf:write(line .. "\t" .. set4 .. "\t" .. set6 .. "\n")
+        end
+      end
+      rf:close()
+    end
+  end
+  wf:close()
+
+  local rok, rerr = rename_fn(tmp_path, index_path)
+  if not rok then
+    return { error = "render_member_index: rename failed: " .. tostring(rerr) }
+  end
+  return {}
+end
+
 -- Remove cache files that are not referenced by the current snapshot.
 -- A file is kept only if its name matches "<id>-<version>.txt" where
 -- (id, version) is an entry in snapshot.blocklists.

--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -264,16 +264,16 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   end
 
   -- #1348: blocklist member → bl_ set index for the dns-tail bl_ populator.
-  -- Written in lockstep with the dnsmasq.conf above (whose nftset= directives
-  -- declare the same membership) so a directly-queried CNAME target landing on
-  -- a fresh CDN-anycast IP still populates the category drop-set. A write
-  -- failure here is non-fatal: it only loses the directly-queried-target
-  -- coverage until the next apply, not core enforcement, so we log and proceed.
-  local bl_index = render.blocklist_member_index(snapshot)
-  local okbl, errbl = write_fn(paths.bl_member_index, bl_index)
-  if not okbl then
-    log.warn("policy.apply: write bl member index failed: %s", tostring(errbl))
-  end
+  -- Post-#1782: this write is a no-op (the agent writes paths.bl_member_index
+  -- from blocklists.render_member_index, which streams from the cache files).
+  -- The old render.blocklist_member_index(snapshot) read from
+  -- snapshot._blocklist_hosts which is no longer populated; emitting it here
+  -- would overwrite the agent's populated index with an empty file on every
+  -- policy.apply call. The agent calls refresh_blocklists → render_member_index
+  -- → paths.bl_member_index BEFORE policy.apply so the index is ready when
+  -- dnsmasq restarts. (#1782 BLOCKER fix)
+  --
+  -- (The index is written by the agent's refresh_blocklists, not here.)
 
   if dnsmasq_changed then
     log.debug("policy.apply: wrote dnsmasq=%dB (changed) nft=%dB; restarting dnsmasq",

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -77,6 +77,12 @@
 
 local M = {}
 
+-- Directory where per-blocklist dnsmasq conf shards live (#1782). Default /tmp
+-- (= tmpfs on OpenWRT). Overridable for tests via M.SHARD_DIR assignment before
+-- calling M.dnsmasq(). Production: always /tmp (matches BLOCKLIST_SHARD_DIR in
+-- wifihaven-agent).
+M.SHARD_DIR = "/tmp"
+
 -- Replace dots and colons with underscores (nftables set/counter name-safe).
 local function sanitize(s)
   return (s:gsub("[%.%:]", "_"))
@@ -445,7 +451,7 @@ function M.dnsmasq(snapshot)
     emit("# per-blocklist shard files written by blocklists.render_shards (#1782,#1783)")
     emit("# each shard contains nftset= directives for that list's member hosts")
     for _, id in ipairs(bl_ids) do
-      emit(string.format("conf-file=/tmp/wifihaven-blocklist-%s.conf", id))
+      emit(string.format("conf-file=%s/wifihaven-blocklist-%s.conf", M.SHARD_DIR, id))
     end
     emit("")
   end
@@ -569,18 +575,21 @@ end
 -- ---------------------------------------------------------------------------
 -- A host → bl_ set mapping for the wifihaven-dns-tail bl_ populator.
 --
--- bl_<id>/bl6_<id> sets are populated at DNS resolve time by the dnsmasq
--- `nftset=/<member>/...#bl_<id>` directives emitted above, which only fire for
--- queries that suffix-match a member host. A device that re-queries a member's
--- CNAME target directly lands on a CDN-anycast IP dnsmasq never added, so the
--- category drop misses (silent filter bypass). dns-tail closes the gap the same
--- way it does for eb_ (#515): it resolves each answered name through the #1344
--- CNAME-alias map and, when the recovered brand is a blocklist member, adds the
--- IP to that member's bl_ set. dns-tail can see which bl_ sets EXIST but not
--- their MEMBERSHIP, so this exports it.
+-- bl_<id>/bl6_<id> sets are populated at DNS resolve time by dnsmasq nftset=
+-- callbacks. A device that re-queries a member's CNAME target directly lands on
+-- a CDN-anycast IP dnsmasq never added, so the category drop misses (silent
+-- filter bypass). dns-tail closes the gap the same way it does for eb_ (#515):
+-- it resolves each answered name through the #1344 CNAME-alias map and, when
+-- the recovered brand is a blocklist member, adds the IP to that member's bl_
+-- set. dns-tail can see which bl_ sets EXIST but not their MEMBERSHIP, so this
+-- exports it.
 --
--- Derived from the same `snapshot._blocklist_hosts` that drives the `nftset=`
--- directives, so the set names line up exactly with what render.nft declares.
+-- Post-#1782 (LEGACY / TEST PATH): the agent no longer calls this function to
+-- write paths.bl_member_index — it uses blocklists.render_member_index instead,
+-- which streams from the on-disk cache files without building a Lua table.
+-- This in-memory path is retained for unit tests (render_spec.lua) and any
+-- caller that already has _blocklist_hosts in memory. It reads from
+-- snapshot._blocklist_hosts; when that table is absent the output is empty.
 -- One row per (member host, blocklist id): "<host>\t<bl_set>\t<bl6_set>".
 function M.blocklist_member_index(snapshot)
   local bl_hosts = snapshot and snapshot._blocklist_hosts or {}

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -317,9 +317,18 @@ end
 M.global_allow_hosts = global_allow_hosts
 
 -- Sorted, de-duplicated list of hosts forming the @global_block set:
--- global.extraBlocked ∪ the member hosts of every id in global.blocklistIds
--- (expanded from snapshot._blocklist_hosts, the same source that drives the
--- per-category bl_ sets). Empty when there is nothing globally blocked by host.
+-- global.extraBlocked only.
+--
+-- Post-#1782: global.blocklistIds are no longer expanded here. When an id
+-- appears in global.blocklistIds, blocklists.render_shards appends
+-- `4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6` to each host
+-- line in that id's shard file, so dnsmasq populates @global_block at DNS
+-- resolve time via the shard's nftset= directives — exactly as the per-MAC
+-- bl_ ipsets are populated. The @global_block nft set declaration is still
+-- emitted by render.nft when global.blocklistIds is non-empty (has_global_block
+-- guards on both extraBlocked and blocklistIds), so the set exists for the
+-- shard's callbacks to land in.
+-- Empty when there is nothing globally blocked by host.
 local function global_block_hosts(snapshot)
   local g = global_rules(snapshot)
   if not g then return {} end
@@ -327,12 +336,10 @@ local function global_block_hosts(snapshot)
   if type(g.extraBlocked) == "table" then
     for _, h in ipairs(g.extraBlocked) do seen[h] = true end
   end
-  if type(g.blocklistIds) == "table" then
-    local bl = (snapshot and snapshot._blocklist_hosts) or {}
-    for _, id in ipairs(g.blocklistIds) do
-      for _, h in ipairs(bl[id] or {}) do seen[h] = true end
-    end
-  end
+  -- Note: g.blocklistIds expansion is intentionally omitted here (#1782).
+  -- The @global_block ipset for blocklist-id members is populated at DNS
+  -- resolve time via per-shard nftset= directives (see blocklists.render_shards
+  -- global_blocklist_ids parameter), not by expanding hosts in-memory.
   local hosts = {}
   for h in pairs(seen) do hosts[#hosts + 1] = h end
   table.sort(hosts)
@@ -427,8 +434,22 @@ function M.dnsmasq(snapshot)
   -- populator — the #1307 infra-allow copy lands the same host in every
   -- profile's extraAllowed, so one ea_ spec per device would pile onto a
   -- single line. We skip the redundant ones in the ea_ loop below.
-  local bl_hosts = snapshot._blocklist_hosts or {}
-  local bl_ids   = sorted_keys(snapshot.blocklists or {})
+  -- #1782: per-blocklist shard files are included via conf-file= directives so
+  -- dnsmasq loads the nftset= host entries from /tmp/wifihaven-blocklist-<id>.conf
+  -- without the agent ever holding the full host list in Lua memory. The shard
+  -- files are written by blocklists.render_shards; each line contains:
+  --   nftset=/<host>/4#inet#wifihaven#bl_<id>,6#inet#wifihaven#bl6_<id>
+  -- Emit one conf-file= line per id in sorted order.
+  local bl_ids = sorted_keys(snapshot.blocklists or {})
+  if #bl_ids > 0 then
+    emit("# per-blocklist shard files written by blocklists.render_shards (#1782,#1783)")
+    emit("# each shard contains nftset= directives for that list's member hosts")
+    for _, id in ipairs(bl_ids) do
+      emit(string.format("conf-file=/tmp/wifihaven-blocklist-%s.conf", id))
+    end
+    emit("")
+  end
+
   local ga_hosts = global_allow_hosts(snapshot)
   local gb_hosts = global_block_hosts(snapshot)
 
@@ -436,12 +457,17 @@ function M.dnsmasq(snapshot)
   -- host_specs accumulates the per-host spec list. Source order:
   --   1. ea_  (per-MAC, sorted by mac then host)
   --   2. eb_  (per-host, in effective_extra_blocked_hosts order)
-  --   3. bl_  (per-category, in bl_ids order; hosts in source order)
-  --   4. ga_  (global allow, sorted)
-  --   5. gb_  (global block, sorted)
+  --   3. ga_  (global allow, sorted)
+  --   4. gb_  (global block, sorted)
+  -- Note: bl_ specs are NO LONGER emitted here — they live in per-blocklist
+  -- shard files included via conf-file= above (#1782). A host that appears in
+  -- both a blocklist AND in ea_/eb_/global sets will have its bl_ spec in the
+  -- shard file and its other specs in this merged directive — dnsmasq applies
+  -- all matching nftset= directives across config files, so each set is
+  -- populated independently. See PR #1782 body for the rationale.
   -- Within each source the v4 spec precedes v6. add_spec de-duplicates
-  -- identical specs per host (e.g. the same host listed twice in one
-  -- blocklist) so the merged directive never carries a redundant comma entry.
+  -- identical specs per host (e.g. the same host listed twice) so the merged
+  -- directive never carries a redundant comma entry.
   local host_order, host_specs, host_seen = {}, {}, {}
   local function add_spec(host, spec)
     if not host_specs[host] then
@@ -481,14 +507,7 @@ function M.dnsmasq(snapshot)
     add_spec(host, "4#inet#wifihaven#" .. eb_set_name(host))
     add_spec(host, "6#inet#wifihaven#" .. eb6_set_name(host))
   end
-  for _, id in ipairs(bl_ids) do
-    local set4 = bl_set_name(id)
-    local set6 = bl6_set_name(id)
-    for _, host in ipairs(bl_hosts[id] or {}) do
-      add_spec(host, "4#inet#wifihaven#" .. set4)
-      add_spec(host, "6#inet#wifihaven#" .. set6)
-    end
-  end
+  -- bl_ specs removed from here (#1782): they now live in shard files.
   for _, host in ipairs(ga_hosts) do
     add_spec(host, "4#inet#wifihaven#" .. GLOBAL_ALLOW4)
     add_spec(host, "6#inet#wifihaven#" .. GLOBAL_ALLOW6)
@@ -672,7 +691,15 @@ function M.nft(snapshot, opts)
   local ga_hosts_list = global_allow_hosts(snapshot)
   local has_global_allow = #ga_hosts_list > 0
   local gb_hosts = global_block_hosts(snapshot)
-  local has_global_block = #gb_hosts > 0
+  -- #1782: has_global_block is true when global.extraBlocked is non-empty OR
+  -- global.blocklistIds is non-empty. In the latter case global_block_hosts()
+  -- returns {} (blocklist members are now populated via shard nftset= callbacks,
+  -- not by expanding in-memory), but the @global_block nft set still needs to
+  -- be declared so the shard's dnsmasq callbacks have a set to land in.
+  local g_for_block = global_rules(snapshot)
+  local has_global_block_from_ids = g_for_block and type(g_for_block.blocklistIds) == "table"
+    and #g_for_block.blocklistIds > 0
+  local has_global_block = #gb_hosts > 0 or (has_global_block_from_ids and true or false)
   local g_blocked = global_blocked(snapshot)
   local g_block_ip_only = global_block_ip_only(snapshot)
   local g_block_reason = (global_rules(snapshot) and global_rules(snapshot).blockReason)
@@ -1288,7 +1315,8 @@ end
 
 -- ---------------------------------------------------------------------------
 -- render.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
---                      eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+--                      eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac,
+--                      bl_member_iterator)
 -- ---------------------------------------------------------------------------
 -- Rebuilds blocked_macs / blocked_reason in place from each device's
 -- effective BlockRules. nft_sets is left intact — population is driven by
@@ -1309,8 +1337,22 @@ end
 --       blocklists contain the same host, the first by sorted id wins.
 -- All three tables are cleared and rebuilt on every call. Callers that do not
 -- need per-host block classification may omit them (pass nil).
+--
+-- bl_member_iterator (optional, #1782): a function `iterator(id)` that returns
+-- an iterable of hosts for blocklist `id` — typically by reading the cache file
+-- line-by-line, avoiding a full in-memory table. When nil, falls back to
+-- `snapshot._blocklist_hosts` (legacy / test path). Signature:
+--   iterator(id) → table-of-strings or iterator-function-returning-string
+-- The returned value must be iterable with `ipairs` OR be a 0-arg function
+-- returning successive host strings (then nil when done). For simplicity
+-- the agent passes a closure that returns a Lua table (streamed from disk).
+-- The residual memory cost is one flat list of hosts per subscribed blocklist id
+-- (no MAC multiplier), which is acceptable for update_shared's transient call
+-- scope — the steady-state OOM was the per-snapshot _blocklist_hosts table held
+-- across the agent's lifetime.
 function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
-                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac,
+                         bl_member_iterator)
   if blocked_macs then
     for k in pairs(blocked_macs) do blocked_macs[k] = nil end
   end
@@ -1328,7 +1370,23 @@ function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
   end
 
   -- Build a blocklist-id → [hosts] lookup so we can expand blocklistIds below.
-  local bl_hosts = (snapshot and snapshot._blocklist_hosts) or {}
+  -- #1782: when bl_member_iterator is provided (the agent streams from cache
+  -- files), use it instead of snapshot._blocklist_hosts. The iterator is called
+  -- once per unique id across all subscribed MACs; we cache the result per-id
+  -- so multiple MACs sharing the same blocklist id only trigger one read. The
+  -- in-memory cost is one flat host list per subscribed id — no MAC multiplier.
+  local bl_hosts_cache = {}
+  local function get_bl_hosts(id)
+    if bl_hosts_cache[id] ~= nil then return bl_hosts_cache[id] end
+    if bl_member_iterator then
+      local hosts = bl_member_iterator(id)
+      bl_hosts_cache[id] = hosts or {}
+    else
+      local legacy = (snapshot and snapshot._blocklist_hosts) or {}
+      bl_hosts_cache[id] = legacy[id] or {}
+    end
+    return bl_hosts_cache[id]
+  end
 
   for mac, dev in pairs(snapshot.devices or {}) do
     local r = effective_rules(dev, snapshot.profiles)
@@ -1361,7 +1419,7 @@ function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
         for _, id in ipairs(r.blocklistIds) do ids[#ids + 1] = id end
         table.sort(ids)
         for _, id in ipairs(ids) do
-          local hosts = bl_hosts[id]
+          local hosts = get_bl_hosts(id)
           if type(hosts) == "table" then
             for _, host in ipairs(hosts) do
               local eb_for_mac = eb_hosts_by_mac and eb_hosts_by_mac[mac]

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -78,7 +78,8 @@ local metrics_int   = tonumber(uci_get("metrics_report_interval", "60"))
 -- decoupled from the ~5 s policy poll. fetch_and_cache is a no-op read when the
 -- (id, version) file is already cached, so the cadence only does real work when
 -- a list's content version changed; the agent re-applies the ruleset only when
--- the loaded host set actually differs (blocklists.hosts_differ). Default 1 h.
+-- the snapshot's (id, version) pair set changes (post-#1782; pre-#1782 this used
+-- blocklists.hosts_differ on an in-memory host map). Default 1 h.
 local blocklist_int = tonumber(uci_get("blocklist_refresh_interval", "3600"))
 -- #1658: eb_/bl_ ipset re-resolve cadence (seconds). The per-host eb_<host>
 -- and per-blocklist bl_<id> sets are declared `flags dynamic,timeout 1h`,
@@ -494,14 +495,23 @@ local function refresh_blocklists(snap)
   blocklists.gc_shards(snap, nil, BLOCKLIST_SHARD_DIR)
 
   -- Step 4: write the member index for dns-tail's CNAME-aware bl_ population.
+  -- Written to paths.bl_member_index (= /tmp/wifihaven-bl-members.txt), the
+  -- path dns-tail reads (paths.lua:36). This replaces the
+  -- render.blocklist_member_index(snapshot) call in policy.apply (policy.lua:272)
+  -- which read from snapshot._blocklist_hosts — a table this PR no longer
+  -- attaches. policy.apply's write is skipped (see policy.lua) so the index
+  -- stays non-empty on every apply (#1782 BLOCKER fix).
   local idx_res = blocklists.render_member_index(
-    snap, nil, BLOCKLIST_CACHE_DIR, "/var/run/wifihaven/blocklist_members.tsv")
+    snap, nil, BLOCKLIST_CACHE_DIR, paths.bl_member_index)
   if idx_res and idx_res.error then
     log.warn("blocklist member index: %s", tostring(idx_res.error))
   end
 
-  -- Note: res.skipped is from load_cached (legacy path, now unused for render)
-  -- and is not surfaced separately since render_shards.skipped covers it.
+  -- Note: blocklists.refresh no longer receives max_bytes post-#1782, so
+  -- load_cached parses everything. The parsed res.hosts map is unused by the
+  -- agent's main path (update_shared uses bl_member_iterator to stream from
+  -- cache files). The map survives only for backward-compat callers and can be
+  -- removed in a follow-up once the fleet has rolled over fully.
 end
 
 -- make_bl_member_iterator(snap) → iterator(id) → {host,...}

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -92,15 +92,14 @@ local blocklist_int = tonumber(uci_get("blocklist_refresh_interval", "3600"))
 -- the 1h kernel timeout, ~2 refreshes per window, ≈one `dig` per host every
 -- 30 min (negligible router load even at ~50 distinct hosts).
 local eb_refresh_int = tonumber(uci_get("eb_refresh_interval", "1800"))
--- #1412 OOM guard: a single category list larger than this many BYTES is cached
--- but NOT parsed/rendered. The prod agent OOM-killed (~700 MB RSS / 1 GB router)
--- loading the StevenBlack "extended" lists (ads-extended ~1.6 MB / 83k hosts,
--- adult-extended ~1.3 MB / 76k hosts) into memory and rendering ~160k `nftset=`
--- directives — which killed ALL category enforcement, including the tiny curated
--- lists. 256 KiB (~12k hosts) keeps every curated list (ads/malware/adult/…) and
--- skips only the oversized aggregate lists, which are tracked for a real
--- large-list strategy in the design issue referenced from #1412.
-local blocklist_max_bytes = tonumber(uci_get("blocklist_max_list_bytes", "262144"))
+-- #1782: per-shard byte cap. With the streaming shard path each blocklist is
+-- rendered line-by-line from the on-disk cache file directly to a per-id conf
+-- shard, so the agent's Lua heap never holds the full member set. The cap
+-- here limits the size of each rendered shard file (not the parsed table) as
+-- defense-in-depth against runaway lists. Lifted from 256 KiB (#1434) to 10 MB
+-- — large enough for the extended StevenBlack lists (~7 MB each) while still
+-- bounding /tmp usage per shard (tmpfs = RAM on OpenWRT).
+local blocklist_max_bytes = tonumber(uci_get("blocklist_max_list_bytes", "10485760"))
 local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
@@ -443,36 +442,108 @@ local function rename_file(from, to)
   return true
 end
 
--- #1412: fetch + cache + load the category blocklists for `snap`, emit the
--- failure metric, log any errors, and return the loaded host map. Called from
--- BOTH the startup apply and the on_tick blocklist timer so the bl_ ipsets are
--- populated regardless of the 200/304 status of the policy poll. The prod no-op
--- was that this ran only in the policy-poll 200 branch and never at startup, so
--- a household with a stable snapshot left every bl_ set empty and category
--- enforcement silently did nothing. The returned map is attached to
--- snap._blocklist_hosts, which render reads to emit the nftset= populators.
--- Defined after http_get (its upvalue) so the closure captures it.
+-- #1782: fetch + cache + write per-blocklist shard files for `snap`, emit the
+-- failure metric, log any errors. Called from BOTH the startup apply and the
+-- on_tick blocklist timer so the bl_ ipsets are populated regardless of the
+-- 200/304 status of the policy poll.
+--
+-- Post-#1782: snap._blocklist_hosts is NO LONGER attached. The bl_ nftset=
+-- directives are not emitted inline by render.dnsmasq — instead dnsmasq reads
+-- per-blocklist shard files at /tmp/wifihaven-blocklist-<id>.conf (via
+-- conf-file= directives). This keeps the 80k+ host set out of the Lua heap.
+--
+-- Returns nothing (caller no longer attaches a host map to the snapshot).
+-- BLOCKLIST_CACHE_DIR: persistent on-flash cache of fetched list bodies;
+--   survives reboots; shards in BLOCKLIST_SHARD_DIR are rebuilt from it.
 local BLOCKLIST_CACHE_DIR = "/etc/wifihaven/blocklists"
+-- BLOCKLIST_SHARD_DIR: per-blocklist dnsmasq conf files (/tmp = tmpfs = RAM);
+--   written atomically (tmp→rename) and GC'd on each render + startup.
+local BLOCKLIST_SHARD_DIR = "/tmp"
 local function refresh_blocklists(snap)
+  -- Step 1: fetch new list versions + cache them to disk.
   local res = blocklists.refresh(
-    snap, http_get, nil, BLOCKLIST_CACHE_DIR, api_url, router_token, blocklist_max_bytes)
+    snap, http_get, nil, BLOCKLIST_CACHE_DIR, api_url, router_token)
   record_blocklist_failures(res)
   for _, e in ipairs(res.errors or {}) do
     log.warn("blocklist fetch: %s", tostring(e))
   end
-  -- #1412: surface lists skipped by the byte cap so an oversized list that is
-  -- silently not enforced is visible to an operator (the bl_ set stays empty
-  -- for these ids by design until the large-list strategy lands).
-  if res.skipped and #res.skipped > 0 then
-    log.warn("blocklist render cap: skipped %d oversized list(s) (>%d bytes): %s",
-             #res.skipped, blocklist_max_bytes, table.concat(res.skipped, ", "))
+
+  -- Step 2: stream cache files → per-shard dnsmasq conf files.
+  -- Determine which blocklist ids are referenced by global.blocklistIds so
+  -- render_shards appends the global_block nftset specs to those shard lines.
+  local global_bl_ids = {}
+  local snap_global = snap and snap.global
+  if type(snap_global) == "table" and type(snap_global.blocklistIds) == "table" then
+    for _, id in ipairs(snap_global.blocklistIds) do
+      global_bl_ids[id] = true
+    end
   end
-  return res.hosts
+
+  local shard_res = blocklists.render_shards(
+    snap, nil, BLOCKLIST_CACHE_DIR, BLOCKLIST_SHARD_DIR, blocklist_max_bytes, global_bl_ids)
+  for _, e in ipairs(shard_res.errors or {}) do
+    log.warn("blocklist shard render: %s", tostring(e))
+  end
+  if shard_res.skipped and #shard_res.skipped > 0 then
+    log.warn("blocklist shard cap: skipped %d oversized shard(s) (>%d bytes): %s",
+             #shard_res.skipped, blocklist_max_bytes,
+             table.concat(shard_res.skipped, ", "))
+  end
+
+  -- Step 3: GC stale shards for ids that are no longer in the snapshot.
+  blocklists.gc_shards(snap, nil, BLOCKLIST_SHARD_DIR)
+
+  -- Step 4: write the member index for dns-tail's CNAME-aware bl_ population.
+  local idx_res = blocklists.render_member_index(
+    snap, nil, BLOCKLIST_CACHE_DIR, "/var/run/wifihaven/blocklist_members.tsv")
+  if idx_res and idx_res.error then
+    log.warn("blocklist member index: %s", tostring(idx_res.error))
+  end
+
+  -- Note: res.skipped is from load_cached (legacy path, now unused for render)
+  -- and is not surfaced separately since render_shards.skipped covers it.
+end
+
+-- make_bl_member_iterator(snap) → iterator(id) → {host,...}
+-- #1782: factory for the bl_member_iterator argument to render.update_shared.
+-- Returns a closure that, when called with a blocklist id, reads the on-disk
+-- cache file line-by-line and returns a flat table of hosts for that id. This
+-- avoids holding the full member set in memory between calls — each invocation
+-- reads the file fresh, and the per-id result table is only alive during the
+-- update_shared call scope (no MAC multiplier at steady state).
+local function make_bl_member_iterator(snap)
+  return function(id)
+    local bl = (snap and snap.blocklists or {})[id]
+    if not bl then return {} end
+    local path = BLOCKLIST_CACHE_DIR .. "/" .. id .. "-" .. tostring(bl.version) .. ".txt"
+    local f = io.open(path, "r")
+    if not f then return {} end
+    local hosts = {}
+    for line in f:lines() do
+      line = line:match("^%s*(.-)%s*$")
+      if line ~= "" and line:sub(1, 1) ~= "#" then
+        hosts[#hosts + 1] = line
+      end
+    end
+    f:close()
+    return hosts
+  end
 end
 
 -- ── Ensure output directories exist ───────────────────────────────────────────
 
 os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven")
+
+-- GC stale shard files from a previous agent run / crash-during-render on
+-- startup. We do this before the first apply so dnsmasq never loads a shard
+-- for a list that is no longer in the current snapshot. An empty snapshot
+-- placeholder is used if no cached policy is available yet; gc_shards with
+-- an empty blocklists map removes all existing shards (safe: they'll be
+-- rewritten when refresh_blocklists runs after the first successful fetch).
+do
+  local startup_snap = policy.load_snapshot(read_file, log)
+  blocklists.gc_shards(startup_snap or { blocklists = {} }, nil, BLOCKLIST_SHARD_DIR)
+end
 
 -- ── Block-page runtime config ────────────────────────────────────────────────
 -- The block-page uhttpd handler (/www/wifihaven/handler.lua, served via
@@ -553,7 +624,7 @@ do
     metrics.observe(mreg, "policy_apply_duration_seconds", {},
                     clock.monotonic_seconds() - t0)
     if applied then
-      render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+      render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac, make_bl_member_iterator(cached))
       last_snapshot = cached
       log.info("startup: applied cached policy from /etc/wifihaven/policy.json")
     else
@@ -579,19 +650,19 @@ do
                   clock.monotonic_seconds() - pt0)
   if snap then
     record_poll("200")
-    -- #1412: fetch + cache the category blocklists and attach them BEFORE the
-    -- initial apply, so the boot ruleset already carries the bl_ nftset=
-    -- populators. Previously startup applied with no _blocklist_hosts, so a
-    -- freshly booted / re-enrolled router ran with empty bl_ sets until (and
-    -- unless) a later snapshot change happened to trigger a fetch.
-    snap._blocklist_hosts = refresh_blocklists(snap)
+    -- #1782: fetch + cache blocklists and write per-shard dnsmasq conf files
+    -- BEFORE the initial apply, so the boot ruleset's conf-file= directives
+    -- reference populated shards. Pre-#1782 this attached _blocklist_hosts to
+    -- the snapshot; now the shards carry the nftset= directives and the agent's
+    -- Lua heap never holds the full member set.
+    refresh_blocklists(snap)
     local at0 = clock.monotonic_seconds()
     local applied = policy.apply(snap, write_file, run_cmd, log,
                                  { on_apply = record_apply("boot") })
     metrics.observe(mreg, "policy_apply_duration_seconds", {},
                     clock.monotonic_seconds() - at0)
     if applied then
-      render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+      render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac, make_bl_member_iterator(snap))
       current_etag = etag
       last_snapshot = snap
       policy.mark_poll_success(os.time())
@@ -757,13 +828,11 @@ conntrack.watch({
       if snap then
         record_poll("200")
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.
-        -- #1360: the blocklist route is router-authenticated, so refresh_blocklists
-        -- passes the router token — without it the fetch 401s and category (bl_)
-        -- enforcement silently no-ops. #1412: the same refresh runs at startup
-        -- and on the periodic blocklist timer, so a stable (304-only) snapshot no
-        -- longer leaves the sets empty; emitting blocklist_fetch_failures_total
-        -- (#1301) is folded into refresh_blocklists.
-        snap._blocklist_hosts = refresh_blocklists(snap)
+        -- #1782: fetch + cache blocklists and write/GC shard files.
+        -- The router token is passed via http_get closure (router-authenticated
+        -- route). Shards are atomic-written to /tmp; dnsmasq picks them up via
+        -- conf-file= directives in the rendered wifihaven.conf.
+        refresh_blocklists(snap)
         last_blocklist_run = mono  -- this poll already refreshed; reset cadence
 
         -- Apply with no failover opts. If we were in failover, this
@@ -778,7 +847,7 @@ conntrack.watch({
         metrics.observe(mreg, "policy_apply_duration_seconds", {},
                         clock.monotonic_seconds() - at0)
         if applied then
-          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac, make_bl_member_iterator(snap))
           current_etag = etag
           last_snapshot = snap
           policy.mark_poll_success(wall)
@@ -859,12 +928,35 @@ conntrack.watch({
     -- file is already cached, so this only does real work when a list's content
     -- version changed; we re-apply (which reloads dnsmasq for the new nftset=
     -- directives) only when the loaded host set actually differs.
+    -- Blocklist refresh timer (#1782). Fetches new list versions, re-renders
+    -- shards, and re-applies if the snapshot's (id, version) set changed.
+    -- Pre-#1782 this used blocklists.hosts_differ on the in-memory _blocklist_hosts
+    -- map; post-#1782 we detect change via (id, version) pairs — a content change
+    -- always implies a new version, so a stable pair set ↔ stable host set.
+    -- Rendering shards is idempotent, so a no-op tick is cheap.
     if last_snapshot and not in_failover_render
        and (mono - last_blocklist_run) >= blocklist_int then
       last_blocklist_run = mono
-      local new_hosts = refresh_blocklists(last_snapshot)
-      if blocklists.hosts_differ(last_snapshot._blocklist_hosts, new_hosts) then
-        last_snapshot._blocklist_hosts = new_hosts
+      -- Capture (id, version) pairs before refresh to detect changes.
+      local bls_before = {}
+      for id, bl in pairs(last_snapshot.blocklists or {}) do
+        bls_before[id] = bl.version
+      end
+      refresh_blocklists(last_snapshot)
+      -- Re-apply only if the (id, version) set changed (new content version for
+      -- any list, or a list added/removed). Stable pairs → stable shard content;
+      -- no dnsmasq reload needed.
+      local changed = false
+      local bls_after = last_snapshot.blocklists or {}
+      for id, bl in pairs(bls_after) do
+        if bls_before[id] ~= bl.version then changed = true; break end
+      end
+      if not changed then
+        for id, _ in pairs(bls_before) do
+          if not bls_after[id] then changed = true; break end
+        end
+      end
+      if changed then
         fold_enforcement_drops()
         local bt0 = clock.monotonic_seconds()
         local applied = policy.apply(last_snapshot, write_file, run_cmd, log,
@@ -873,8 +965,9 @@ conntrack.watch({
                         clock.monotonic_seconds() - bt0)
         if applied then
           render.update_shared(last_snapshot, nft_sets, blocked_macs, blocked_reason,
-                               eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
-          log.info("blocklist timer: category lists changed, re-applied ruleset")
+                               eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac,
+                               make_bl_member_iterator(last_snapshot))
+          log.info("blocklist timer: list version(s) changed, re-applied ruleset")
         end
       end
     end

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -843,37 +843,69 @@ describe("blocklists.render_shards (#1782)", function()
   end)
 
   it("streams a large fixture without accumulating in Lua heap (#1412 OOM)", function()
-    -- Build a 50k-host cache file in memory (the fs stub holds it as a string,
-    -- which is fine — what we're testing is that render_shards itself does NOT
-    -- build an equivalent 50k-entry Lua table internally).
+    -- Build a 50k-host cache file. To isolate render_shards's internal heap use
+    -- from the test stub's storage of the *output* (~3.5 MB of nftset lines),
+    -- the fs here uses a DISCARDING write — writes are counted but not retained
+    -- in any Lua string. That way mem_after - mem_before reflects ONLY what
+    -- render_shards itself holds across the call. A 50k-string accumulator
+    -- inside render_shards would push heap past several MB; a streaming
+    -- implementation should stay near zero (single-line scratch only).
     local n       = 50000
     local lines   = {}
     for i = 1, n do lines[i] = string.format("host%d.example.com", i) end
     local body = table.concat(lines, "\n") .. "\n"
 
-    local fs        = make_shard_fs()
-    local cache_dir = "/etc/wifihaven/blocklists"
-    local shard_dir = "/tmp"
-    fs._files[cache_dir .. "/biglist-v1.txt"] = body
+    local renamed = {}
+    local fs = {
+      open_read = function(path)
+        if path ~= "/etc/wifihaven/blocklists/biglist-v1.txt" then return nil end
+        local pos = 1
+        return {
+          read = function(self, fmt)
+            if fmt == "*l" or fmt == "l" then
+              if pos > #body then return nil end
+              local nl = body:find("\n", pos, true)
+              if not nl then
+                local line = body:sub(pos); pos = #body + 1; return line
+              end
+              local line = body:sub(pos, nl - 1); pos = nl + 1; return line
+            end
+          end,
+          close = function() end,
+        }
+      end,
+      open_write = function(path)
+        return {
+          write = function(self, chunk) end,  -- discard, do NOT store
+          close = function() end,
+        }
+      end,
+      rename = function(from, to) renamed[to] = true; return true end,
+      remove = function() return true end,
+      list = function() return {} end,
+      mkdir = function() return true end,
+      fsync = function() return true end,
+      read = function() return nil end,
+      write = function() return true end,
+    }
 
     local s = snap({ biglist = { version = "v1", url = "/api/blocklists/biglist" } })
 
-    -- Measure heap before and after. collectgarbage("count") returns KB.
     collectgarbage("collect")
     local mem_before = collectgarbage("count")
-    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir)
+    local result = blocklists.render_shards(s, fs, "/etc/wifihaven/blocklists", "/tmp")
     collectgarbage("collect")
     local mem_after = collectgarbage("count")
 
-    -- The shard must have been written.
-    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-biglist.conf"]
-    assert.not_nil(shard, "shard must be written for 50k-host list")
+    assert.is_true(renamed["/tmp/wifihaven-blocklist-biglist.conf"] or false,
+      "shard must be renamed into place for 50k-host list")
 
-    -- Lua heap delta should be well under 5 MB (5000 KB). If render_shards
-    -- were building a 50k-entry table it would easily exceed this.
+    -- With output discarded, render_shards's own working set should be tiny.
+    -- 2 MB threshold absorbs interpreter noise without letting a hypothetical
+    -- 50k-string accumulator slip through (that would be ~6+ MB on its own).
     local heap_delta_kb = mem_after - mem_before
-    assert.is_true(heap_delta_kb < 5000,
-      string.format("render_shards heap delta %.1f KB exceeds 5 MB — likely accumulating in table", heap_delta_kb))
+    assert.is_true(heap_delta_kb < 2000,
+      string.format("render_shards heap delta %.1f KB exceeds 2 MB — likely accumulating in table", heap_delta_kb))
 
     assert.equal(0, #(result.errors or {}))
   end)

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -597,3 +597,481 @@ describe("blocklists size cap (#1412)", function()
   end)
 
 end)
+
+-- ── render_shards (#1782) ─────────────────────────────────────────────────────
+--
+-- Streams per-blocklist shard files containing `nftset=/<host>/...` directives
+-- to /tmp/wifihaven-blocklist-<id>.conf without accumulating the full host list
+-- in a Lua table (the #1412 OOM source). Each shard is written atomically
+-- (<id>.conf.tmp → <id>.conf). dnsmasq picks them up via `conf-file=`
+-- directives in the main wifihaven.conf (emitted by render.dnsmasq).
+
+describe("blocklists.render_shards (#1782)", function()
+
+  -- Helper: build a fake filesystem like make_fs() above, but also tracking
+  -- fsync calls and supporting forced rename failure injection.
+  local function make_shard_fs(opts)
+    opts = opts or {}
+    local files    = {}
+    local fsynced  = {}
+    local removed  = {}
+    return {
+      _files   = files,
+      _fsynced = fsynced,
+      _removed = removed,
+      write = function(path, content)
+        files[path] = content
+        return true, nil
+      end,
+      -- open_write: streaming write API used by render_shards.
+      -- Returns a handle with :write(chunk) and :close().
+      open_write = function(path)
+        files[path] = ""
+        return {
+          write = function(self, chunk)
+            files[path] = (files[path] or "") .. chunk
+          end,
+          close = function() end,
+        }
+      end,
+      open_read = function(path)
+        local content = files[path]
+        if not content then return nil end
+        local pos = 1
+        return {
+          read = function(self, fmt)
+            if fmt == "*l" or fmt == "l" then
+              local nl = content:find("\n", pos, true)
+              if not nl then
+                if pos > #content then return nil end
+                local line = content:sub(pos)
+                pos = #content + 1
+                return line
+              end
+              local line = content:sub(pos, nl - 1)
+              pos = nl + 1
+              return line
+            elseif fmt == "*a" or fmt == "a" then
+              local rest = content:sub(pos)
+              pos = #content + 1
+              return rest
+            end
+          end,
+          close = function() end,
+        }
+      end,
+      read = function(path) return files[path] end,
+      rename = function(from, to)
+        if opts.fail_rename then return nil, "injected rename failure" end
+        if files[from] then
+          files[to]   = files[from]
+          files[from] = nil
+          return true, nil
+        end
+        return nil, "no such file: " .. tostring(from)
+      end,
+      remove = function(path)
+        removed[#removed + 1] = path
+        files[path] = nil
+        return true, nil
+      end,
+      list = function(dir)
+        local result = {}
+        local prefix = dir:sub(-1) == "/" and dir or (dir .. "/")
+        for k, _ in pairs(files) do
+          if k:sub(1, #prefix) == prefix then
+            result[#result + 1] = k:sub(#prefix + 1)
+          end
+        end
+        return result
+      end,
+      fsync = function(path)
+        fsynced[path] = true
+        return true
+      end,
+    }
+  end
+
+  it("emits correct nftset= line shape for each host in the cache file", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "doubleclick.net\ngoogleadservices.com\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir)
+
+    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"]
+    assert.not_nil(shard, "shard file must exist after render_shards")
+    assert.truthy(shard:find(
+      "nftset=/doubleclick.net/4#inet#wifihaven#bl_ads,6#inet#wifihaven#bl6_ads\n",
+      1, true))
+    assert.truthy(shard:find(
+      "nftset=/googleadservices.com/4#inet#wifihaven#bl_ads,6#inet#wifihaven#bl6_ads\n",
+      1, true))
+    assert.equal(0, #(result.errors or {}))
+  end)
+
+  it("sanitizes id with dots, dashes, and colons in the set names", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/test.cat-1-v1.txt"] = "bad.host.com\n"
+
+    local s = snap({ ["test.cat-1"] = { version = "v1", url = "/api/blocklists/test.cat-1" } })
+    blocklists.render_shards(s, fs, cache_dir, shard_dir)
+
+    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-test.cat-1.conf"]
+    assert.not_nil(shard)
+    -- bl_sanitize: dots/dashes/colons → underscores
+    assert.truthy(shard:find("#bl_test_cat_1,", 1, true))
+    assert.truthy(shard:find("#bl6_test_cat_1", 1, true))
+  end)
+
+  it("skips blank lines and comment lines in the cache file", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "# header\n\ndoubleclick.net\n\n# comment\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    blocklists.render_shards(s, fs, cache_dir, shard_dir)
+
+    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"]
+    assert.not_nil(shard)
+    assert.is_nil(shard:find("# header", 1, true), "comment lines must be excluded")
+    assert.is_nil(shard:find("# comment", 1, true))
+    assert.truthy(shard:find("doubleclick.net", 1, true))
+    -- no blank nftset lines
+    assert.is_nil(shard:find("nftset=//", 1, true))
+  end)
+
+  it("writes atomically: tmp file is renamed, not left in place on success", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "doubleclick.net\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    blocklists.render_shards(s, fs, cache_dir, shard_dir)
+
+    -- Final shard must exist; tmp file must be gone.
+    assert.not_nil(fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"])
+    assert.is_nil(fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf.tmp"],
+      "tmp file must have been renamed away")
+  end)
+
+  it("does NOT create the canonical shard when rename fails (partial-state guard)", function()
+    local fs        = make_shard_fs({ fail_rename = true })
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "doubleclick.net\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir)
+
+    -- Canonical shard must NOT exist (would be a partial state visible to dnsmasq).
+    assert.is_nil(fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"],
+      "canonical shard must not exist when rename fails")
+    assert.truthy(#(result.errors or {}) > 0 or result.skipped,
+      "a rename failure must be recorded as an error or skip")
+  end)
+
+  it("skips an id whose cache file is absent and records it", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    -- NO cache file written for 'ads'.
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir)
+
+    assert.is_nil(fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"])
+    -- skipped list should contain "ads"
+    local sk = {}
+    for _, id in ipairs(result.skipped or {}) do sk[id] = true end
+    assert.truthy(sk["ads"], "absent cache file must be listed in result.skipped")
+  end)
+
+  it("stops emitting when the shard exceeds max_bytes and records the id in skipped", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    -- Build a body that exceeds a tiny cap.
+    local lines = {}
+    for i = 1, 200 do lines[#lines + 1] = "host" .. i .. ".example.com" end
+    fs._files[cache_dir .. "/ads-v1.txt"] = table.concat(lines, "\n") .. "\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local max_bytes = 200  -- well under the full content
+    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir, max_bytes)
+
+    local sk = {}
+    for _, id in ipairs(result.skipped or {}) do sk[id] = true end
+    assert.truthy(sk["ads"], "oversized shard must be reported in result.skipped")
+  end)
+
+  it("appends global_block + global_block6 specs when id is in global_blocklist_ids", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "doubleclick.net\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir, nil, { ads = true })
+
+    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"]
+    assert.not_nil(shard)
+    -- Must include bl_ specs AND global_block specs.
+    assert.truthy(shard:find("4#inet#wifihaven#bl_ads,6#inet#wifihaven#bl6_ads", 1, true))
+    assert.truthy(shard:find("4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6", 1, true))
+  end)
+
+  it("does NOT include global_block specs when id is not in global_blocklist_ids", function()
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "doubleclick.net\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    -- Pass global_blocklist_ids without "ads" in it.
+    blocklists.render_shards(s, fs, cache_dir, shard_dir, nil, { other_id = true })
+
+    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-ads.conf"]
+    assert.not_nil(shard)
+    assert.is_nil(shard:find("global_block", 1, true))
+  end)
+
+  it("streams a large fixture without accumulating in Lua heap (#1412 OOM)", function()
+    -- Build a 50k-host cache file in memory (the fs stub holds it as a string,
+    -- which is fine — what we're testing is that render_shards itself does NOT
+    -- build an equivalent 50k-entry Lua table internally).
+    local n       = 50000
+    local lines   = {}
+    for i = 1, n do lines[i] = string.format("host%d.example.com", i) end
+    local body = table.concat(lines, "\n") .. "\n"
+
+    local fs        = make_shard_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local shard_dir = "/tmp"
+    fs._files[cache_dir .. "/biglist-v1.txt"] = body
+
+    local s = snap({ biglist = { version = "v1", url = "/api/blocklists/biglist" } })
+
+    -- Measure heap before and after. collectgarbage("count") returns KB.
+    collectgarbage("collect")
+    local mem_before = collectgarbage("count")
+    local result = blocklists.render_shards(s, fs, cache_dir, shard_dir)
+    collectgarbage("collect")
+    local mem_after = collectgarbage("count")
+
+    -- The shard must have been written.
+    local shard = fs._files[shard_dir .. "/wifihaven-blocklist-biglist.conf"]
+    assert.not_nil(shard, "shard must be written for 50k-host list")
+
+    -- Lua heap delta should be well under 5 MB (5000 KB). If render_shards
+    -- were building a 50k-entry table it would easily exceed this.
+    local heap_delta_kb = mem_after - mem_before
+    assert.is_true(heap_delta_kb < 5000,
+      string.format("render_shards heap delta %.1f KB exceeds 5 MB — likely accumulating in table", heap_delta_kb))
+
+    assert.equal(0, #(result.errors or {}))
+  end)
+
+end)
+
+-- ── gc_shards (#1783) ─────────────────────────────────────────────────────────
+--
+-- Removes stale /tmp/wifihaven-blocklist-<id>.conf shards whose id is not
+-- in the current snapshot, and .tmp leftover files from crash-during-render.
+
+describe("blocklists.gc_shards (#1783)", function()
+
+  local function make_shard_fs_plain()
+    local files   = {}
+    local removed = {}
+    return {
+      _files   = files,
+      _removed = removed,
+      list = function(dir)
+        local result = {}
+        local prefix = dir:sub(-1) == "/" and dir or (dir .. "/")
+        for k, _ in pairs(files) do
+          if k:sub(1, #prefix) == prefix then
+            result[#result + 1] = k:sub(#prefix + 1)
+          end
+        end
+        return result
+      end,
+      remove = function(path)
+        removed[#removed + 1] = path
+        files[path] = nil
+        return true, nil
+      end,
+    }
+  end
+
+  it("removes shard for an id not in the current snapshot", function()
+    local fs = make_shard_fs_plain()
+    fs._files["/tmp/wifihaven-blocklist-old_ads.conf"] = "content"
+
+    local s = snap({})  -- no blocklists
+    blocklists.gc_shards(s, fs, "/tmp")
+
+    assert.is_nil(fs._files["/tmp/wifihaven-blocklist-old_ads.conf"],
+      "stale shard must be removed")
+    -- path must appear in removed list
+    local found = false
+    for _, p in ipairs(fs._removed) do
+      if p == "/tmp/wifihaven-blocklist-old_ads.conf" then found = true end
+    end
+    assert.is_true(found, "remove must have been called with the stale shard path")
+  end)
+
+  it("does NOT remove shards for ids present in the snapshot", function()
+    local fs = make_shard_fs_plain()
+    fs._files["/tmp/wifihaven-blocklist-ads.conf"] = "content"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    blocklists.gc_shards(s, fs, "/tmp")
+
+    assert.not_nil(fs._files["/tmp/wifihaven-blocklist-ads.conf"],
+      "current shard must NOT be removed")
+  end)
+
+  it("removes stale .tmp files left by a crash during render", function()
+    local fs = make_shard_fs_plain()
+    fs._files["/tmp/wifihaven-blocklist-ads.conf.tmp"] = "partial"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    blocklists.gc_shards(s, fs, "/tmp")
+
+    assert.is_nil(fs._files["/tmp/wifihaven-blocklist-ads.conf.tmp"],
+      "leftover .tmp file must be removed on gc")
+  end)
+
+  it("leaves non-wifihaven-blocklist files in the shard dir untouched", function()
+    local fs = make_shard_fs_plain()
+    fs._files["/tmp/dnsmasq.conf"] = "other content"
+    fs._files["/tmp/wifihaven.conf"] = "wifihaven content"
+
+    local s = snap({})
+    blocklists.gc_shards(s, fs, "/tmp")
+
+    assert.not_nil(fs._files["/tmp/dnsmasq.conf"])
+    assert.not_nil(fs._files["/tmp/wifihaven.conf"])
+  end)
+
+end)
+
+-- ── render_member_index (#1348, streaming rewrite) ───────────────────────────
+--
+-- Streams <host>\t<bl_set>\t<bl6_set>\n lines from cache files to an index
+-- file (atomic tmp→rename). Replaces the in-memory render.blocklist_member_index
+-- path for on-disk output used by wifihaven-dns-tail.
+
+describe("blocklists.render_member_index (#1782)", function()
+
+  local function make_index_fs()
+    local files = {}
+    return {
+      _files = files,
+      open_write = function(path)
+        files[path] = ""
+        return {
+          write = function(self, chunk)
+            files[path] = (files[path] or "") .. chunk
+          end,
+          close = function() end,
+        }
+      end,
+      open_read = function(path)
+        local content = files[path]
+        if not content then return nil end
+        local pos = 1
+        return {
+          read = function(self, fmt)
+            if fmt == "*l" or fmt == "l" then
+              local nl = content:find("\n", pos, true)
+              if not nl then
+                if pos > #content then return nil end
+                local line = content:sub(pos)
+                pos = #content + 1
+                return line
+              end
+              local line = content:sub(pos, nl - 1)
+              pos = nl + 1
+              return line
+            end
+          end,
+          close = function() end,
+        }
+      end,
+      rename = function(from, to)
+        if files[from] then
+          files[to]   = files[from]
+          files[from] = nil
+          return true, nil
+        end
+        return nil, "no such file: " .. tostring(from)
+      end,
+      remove = function(path)
+        files[path] = nil
+        return true, nil
+      end,
+    }
+  end
+
+  it("writes <host>\\t<bl_set>\\t<bl6_set> for each host in each blocklist cache file", function()
+    local fs        = make_index_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local index_path = "/var/run/wifihaven/blocklist_members.tsv"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "adserver.example.com\ndoubleclick.net\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local result = blocklists.render_member_index(s, fs, cache_dir, index_path)
+
+    local idx = fs._files[index_path]
+    assert.not_nil(idx, "index file must exist after render_member_index")
+    assert.truthy(idx:find("adserver.example.com\tbl_ads\tbl6_ads\n", 1, true))
+    assert.truthy(idx:find("doubleclick.net\tbl_ads\tbl6_ads\n", 1, true))
+    assert.is_nil(result and result.error, "render_member_index must not error")
+  end)
+
+  it("output matches render.blocklist_member_index shape for the same data", function()
+    -- Cross-check: the streaming output for a small fixture must be identical
+    -- to what render.blocklist_member_index (the in-memory path) would produce.
+    local render = require("render")
+    local fs        = make_index_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local index_path = "/var/run/wifihaven/blocklist_members.tsv"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "host1.example.com\nhost2.example.com\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    s._blocklist_hosts = { ads = { "host1.example.com", "host2.example.com" } }
+
+    blocklists.render_member_index(s, fs, cache_dir, index_path)
+    local streaming_out = fs._files[index_path]
+
+    local in_memory_out = render.blocklist_member_index(s)
+
+    -- Both must contain the same rows (order may differ if multiple lists, but
+    -- for a single list they must match exactly).
+    assert.equal(in_memory_out, streaming_out)
+  end)
+
+  it("writes atomically (tmp→rename, canonical path absent until rename succeeds)", function()
+    local fs        = make_index_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    local index_path = "/var/run/wifihaven/blocklist_members.tsv"
+    fs._files[cache_dir .. "/ads-v1.txt"] = "a.example.com\n"
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    blocklists.render_member_index(s, fs, cache_dir, index_path)
+
+    assert.not_nil(fs._files[index_path])
+    assert.is_nil(fs._files[index_path .. ".tmp"],
+      "tmp file must have been renamed away")
+  end)
+
+end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1125,42 +1125,51 @@ describe("render blocklist enforcement (#352)", function()
 
   -- ── dnsmasq nftset= directives (post-#394 nftset/ipset migration) ───────
 
-  it("emits combined v4+v6 nftset=/<host>/... for each host in _blocklist_hosts[id] (#392)", function()
+  -- Post-#1782: bl_ nftset= directives are NO LONGER emitted inline in
+  -- wifihaven.conf. Instead, render.dnsmasq emits `conf-file=` directives that
+  -- point dnsmasq to per-blocklist shard files written by blocklists.render_shards.
+  -- This keeps the 80k+ host nftset= directives out of the agent's Lua heap.
+
+  it("emits conf-file= directive for each id in snapshot.blocklists (#1782)", function()
     local conf = render.dnsmasq(snap_bl())
     assert.truthy(conf:find(
-      "nftset=/adserver.example.com/4#inet#wifihaven#bl_test_ads,6#inet#wifihaven#bl6_test_ads",
-      1, true))
-    assert.truthy(conf:find(
-      "nftset=/doubleclick.net/4#inet#wifihaven#bl_test_ads,6#inet#wifihaven#bl6_test_ads",
-      1, true))
+      "conf-file=/tmp/wifihaven-blocklist-test_ads.conf",
+      1, true), "dnsmasq conf must reference the per-blocklist shard via conf-file=")
   end)
 
-  it("merges both bl_ specs into ONE nftset= directive when the same host appears in two blocklists (#1460)", function()
-    -- Post-#1460 contract: every nft set targeting a given host lands in ONE
-    -- comma-joined `nftset=/<host>/...` directive. dnsmasq honours only the
-    -- first matching `nftset=/<host>/...` directive per domain and silently
-    -- drops the rest, which is the H3 enforcement-gap bug: an ea_ directive
-    -- emitted before a global_block directive for the same host leaves
-    -- @global_block empty. Two bl_ sets covering the same host are the
-    -- closest pre-existing analogue.
+  it("does NOT emit bl_/bl6_ specs inline in the merged nftset= directive (#1782)", function()
+    -- bl_ specs now live in shard files, not in the main wifihaven.conf.
+    local conf = render.dnsmasq(snap_bl())
+    -- No inline nftset= line should contain bl_test_ads or bl6_test_ads.
+    assert.is_nil(conf:find("#bl_test_ads", 1, true),
+      "bl_ specs must not appear inline in wifihaven.conf after #1782")
+    assert.is_nil(conf:find("#bl6_test_ads", 1, true))
+  end)
+
+  it("emits conf-file= for every id in snapshot.blocklists, sorted", function()
     local s = snap_bl()
     s.blocklists["test_social"] = { version = "v1", url = "http://api/api/blocklists/test_social" }
-    s._blocklist_hosts["test_social"] = { "doubleclick.net", "facebook.com" }
     local conf = render.dnsmasq(s)
-    local _, dir_count = conf:gsub("nftset=/doubleclick%.net/", "")
-    assert.equals(1, dir_count)
-    assert.truthy(conf:find(
-      "4#inet#wifihaven#bl_test_ads,6#inet#wifihaven#bl6_test_ads", 1, true))
-    assert.truthy(conf:find(
-      "4#inet#wifihaven#bl_test_social,6#inet#wifihaven#bl6_test_social", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_social.conf", 1, true))
   end)
 
-  it("emits no nftset= lines when _blocklist_hosts is absent or empty", function()
+  it("emits no conf-file= lines when snapshot.blocklists is empty (#1782)", function()
     local s = snap_bl()
-    s._blocklist_hosts = nil
+    s.blocklists = {}
     local conf = render.dnsmasq(s)
-    assert.is_nil(conf:find("bl_test_ads", 1, true))
-    assert.is_nil(conf:find("bl6_test_ads", 1, true))
+    assert.is_nil(conf:find("conf-file=/tmp/wifihaven-blocklist-", 1, true))
+  end)
+
+  it("still emits eb_ and ea_ nftset= directives in the merged per-host block (#1782)", function()
+    -- Non-blocklist hosts (extraBlocked, extraAllowed) continue to have their
+    -- nftset= directives in the main wifihaven.conf — only bl_ moves to shards.
+    local s = snap_bl()
+    -- Add an extraBlocked host that will produce an eb_ directive.
+    s.profiles["3"].rules.extraBlocked = { "evil.example" }
+    local conf = render.dnsmasq(s)
+    assert.truthy(conf:find("nftset=/evil.example/4#inet#wifihaven#eb_evil_example", 1, true),
+      "eb_ directives must still appear inline for extraBlocked hosts")
   end)
 
   -- ── nft drop rules ───────────────────────────────────────────────────────

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -2040,18 +2040,20 @@ describe("render.dnsmasq global section (#1319)", function()
       1, true))
   end)
 
-  it("expands global.blocklistIds members into @global_block at resolve time", function()
+  it("expands global.blocklistIds members into @global_block via shard conf-file= (#1782)", function()
+    -- Post-#1782: when global.blocklistIds = {"ads"} and "ads" is in
+    -- snapshot.blocklists, blocklists.render_shards appends global_block specs
+    -- to each host line in the shard file. render.dnsmasq emits a conf-file=
+    -- directive for the shard and does NOT emit inline nftset= for the members.
     local s = snap_global()
     s.global.blocklistIds = { "ads" }
     s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
     s._blocklist_hosts = { ads = { "ad.doubleclick.net" } }
     local conf = render.dnsmasq(s)
-    -- The member host gets the global_block specs (alongside any bl_ specs
-    -- if a profile/global also names the "ads" category — dnsmasq fires
-    -- every spec in the merged directive, see #1460).
-    assert.truthy(conf:find("nftset=/ad.doubleclick.net/", 1, true))
-    assert.truthy(conf:find(
-      "4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6", 1, true))
+    -- dnsmasq includes the shard file (which will carry the global_block spec).
+    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-ads.conf", 1, true))
+    -- The member is NOT inlined in the main conf (it's in the shard).
+    assert.is_nil(conf:find("nftset=/ad.doubleclick.net/", 1, true))
   end)
 
   it("emits no global nftset= lines when the global section is empty", function()
@@ -2217,10 +2219,13 @@ describe("render.dnsmasq global section (#1319)", function()
     assert.truthy(conf:find("dropped", 1, true))
   end)
 
-  -- Mixed case: a heavy host also carries a non-ea_ spec (e.g. it appears
-  -- in a blocklist). Capping drops the ea_ specs but keeps the bl_ spec, so
-  -- the surviving merged directive is still emitted and still under 1024.
-  it("preserves non-ea_ specs when capping an overflowing heavy host (#1489)", function()
+  -- Post-#1782: bl_ specs are in shard files, not the main conf. A host that
+  -- appears in both a blocklist AND a profile's extraAllowed no longer risks
+  -- overflowing the 1024-byte line limit from bl_ spec accumulation. The ea_
+  -- specs may still overflow if many MACs have the same extraAllowed host,
+  -- but when they do the capping only drops ea_ specs (never bl_, which are
+  -- now absent from the main conf). Verify all lines stay within 1024.
+  it("all nftset= lines stay within dnsmasq's 1024-byte line limit with 30 MACs sharing extraAllowed (#1489)", function()
     local s = snap_global()
     s.devices = {}
     s.profiles = {}
@@ -2243,10 +2248,10 @@ describe("render.dnsmasq global section (#1319)", function()
       assert.is_true(#line <= 1024, string.format(
         "nftset line exceeds 1024 bytes (%d): %s…", #line, line:sub(1, 72)))
     end
-    -- The bl_ad / bl6_ad specs survive — only the ea_ specs were dropped.
-    assert.truthy(conf:find(
-      "nftset=/shared.example/4#inet#wifihaven#bl_ads,6#inet#wifihaven#bl6_ads",
-      1, true))
+    -- conf-file= directive exists (bl_ specs are in the shard, not inline).
+    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-ads.conf", 1, true))
+    -- shared.example is NOT in the main conf as an nftset= host line (no bl_ inline).
+    assert.is_nil(conf:find("nftset=/shared.example/4#inet#wifihaven#bl_ads", 1, true))
   end)
 end)
 


### PR DESCRIPTION
## Summary

Streams blocklist host lists from the on-disk cache directly into `/tmp/wifihaven-blocklist-<id>.conf` shard files, included by dnsmasq via `conf-file=`. The agent no longer holds the full member set (~160k hosts) in a Lua table — fixes the #1412 OOM that motivated the byte cap in #1434. Lifts the cap to 10 MB per shard as defense-in-depth.

- Streaming render: `blocklists.render_shards` reads cache files line-by-line and writes `nftset=/<host>/4#inet#wifihaven#bl_<id>,6#inet#wifihaven#bl6_<id>` per host, never accumulating in Lua.
- Atomic write + lifecycle: `.tmp` → fsync → rename; stale shards GC'd at render + startup.
- `dnsmasq` emits `conf-file=/tmp/wifihaven-blocklist-<id>.conf` per blocklist; bl_ specs no longer appear in the per-host merged `nftset=` directives.
- `bl_member_iterator` closure passed to `update_shared` streams bl_hosts_by_mac from cache files at call time (no MAC multiplier at steady state).
- Version-pair change detection replaces `hosts_differ` on the blocklist timer.

## Design questions resolved in this implementation

**A. Merged-nftset-per-host (#1460):** Per the dnsmasq man page and the #1781 validation measurement (which loaded shards from `conf-dir`), dnsmasq applies all matching `nftset=` directives across config files. A host in both a blocklist shard AND in the main conf's merged `nftset=` directive will have both sets populated independently. The `only one wins` caveat from the #1460 comment applies within a _single directive's comma-separated spec list_ — multiple directives across files do fire. This makes the shard-per-blocklist approach safe without changes to the per-host merge logic (which now only carries ea_/eb_/global specs, not bl_).

**B. global.blocklistIds:** When an id appears in `global.blocklistIds`, `render_shards` appends `,4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6` to each shard line. The `@global_block` nft set is still declared by `render.nft` when `global.blocklistIds` is non-empty. `global_block_hosts()` now returns only `global.extraBlocked` (blocklist member expansion via `_blocklist_hosts` removed).

**C. update_shared bl_hosts_by_mac:** Accepts a new `bl_member_iterator(id)` parameter. The agent passes a closure that reads the cache file line-by-line and returns a flat table per-id call. One file read per subscribed id per `update_shared` call; result table is not retained across calls. Acceptable transient cost for `conntrack.lua` labeling.

## Architectural invariants preserved

- **DNS is not the enforcement plane.** Shards contain only `nftset=` directives; nftables still does the per-MAC drop.
- **Wire shape unchanged.** `Blocklist(version, url)` per-profile in the snapshot stays as-is. Agent-internal change only.
- **Per-MAC carve-outs intact.** `extraAllowed` still suppresses bl_ drops via the existing nft `ip daddr != @ea_<m>_<a>` clauses.
- **Bounded tmpfs** (AGENTS.md `#bounded-tmp-writes`): atomic write, precise lifecycle (GC not rotation), documented in `router-agent-bounded-writes.md`.

## Tests

TDD: red commit first, then green.

- `blocklists.render_shards`: line shape, sanitization, blank/comment skip, atomic rename, rename-failure guard, absent-cache skip, max_bytes cap, global_blocklist_ids append, 50k-host fixture with <5 MB heap delta guard
- `blocklists.gc_shards`: stale shard removal, current-id preservation, .tmp cleanup, non-wifihaven file safety
- `blocklists.render_member_index`: TSV format, matches in-memory path, atomic write
- `render.dnsmasq`: conf-file= emission, no inline bl_ specs, empty-blocklists skip, eb_ still inline

226/226 tests pass locally (1 pending = `nft -c` unavailable without CAP_NET_ADMIN on dev host).

## Validation gate (#1781)

#1781 is CLOSED with PASS: dnsmasq RSS +31 MB for 162k hosts on the 1 GB GL-MT6000, `MemAvailable` 71% (well above the 50% gate). Implementation built against those confirmed numbers.

Closes #1782
Closes #1783
Refs #1435 #1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>