### PR TITLE
feat(#1790): self-healing admin auth helper for staging smoke (handles 30-day DB reset)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ scripts/e2e/**/__pycache__/
 # from openwrt/files/ on every build; not source.
 openwrt/wifihaven_*.ipk
 openwrt/wifihaven_*.apk
+.venv-test/

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -59,6 +59,7 @@ export STAGING_ADMIN_USER="admin"
 export STAGING_ADMIN_PASSWORD="$ADMIN_PASS"
 ADMIN=$(admin_login_self_heal) || fail "admin login failed (see stderr)"
 [ -n "$ADMIN" ] || fail "admin_login_self_heal returned empty token"
+unset STAGING_API_URL STAGING_ADMIN_USER STAGING_ADMIN_PASSWORD
 pass "logged in"
 AUTH=(-H "authorization: Bearer $ADMIN")
 

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -48,13 +48,17 @@ _py() { python3 -c "$1"; }
 E2E_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/e2e/lib" && pwd)"
 
 # ── Admin login ────────────────────────────────────────────────────────────
+# #1790: shared self-healing helper. On a fresh staging DB reset, rotates
+# the seeded 'changeme' password back to $ADMIN_PASS before returning a JWT;
+# on the normal day this is a single-login pass-through.
 step "Admin login"
-LOGIN=$(curl -fsS -X POST "$BASE/api/auth/login" \
-  -H 'content-type: application/json' \
-  -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PASS\"}")
-ADMIN=$(_py "import sys,json; print(json.loads('$LOGIN'.replace(\"'\",\"'\"))['token'])" 2>/dev/null \
-  || echo "$LOGIN" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
-[ -n "$ADMIN" ] || fail "no token in login response: $LOGIN"
+# shellcheck source=scripts/e2e/lib/admin-auth.sh
+source "$E2E_LIB/admin-auth.sh"
+export STAGING_API_URL="$BASE"
+export STAGING_ADMIN_USER="admin"
+export STAGING_ADMIN_PASSWORD="$ADMIN_PASS"
+ADMIN=$(admin_login_self_heal) || fail "admin login failed (see stderr)"
+[ -n "$ADMIN" ] || fail "admin_login_self_heal returned empty token"
 pass "logged in"
 AUTH=(-H "authorization: Bearer $ADMIN")
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -52,6 +52,7 @@ export STAGING_ADMIN_USER="admin"
 export STAGING_ADMIN_PASSWORD="$ADMIN_PASS"
 TOKEN=$(admin_login_self_heal) || fail "admin login failed (see stderr)"
 [ -n "$TOKEN" ] || fail "admin_login_self_heal returned empty token"
+unset STAGING_API_URL STAGING_ADMIN_USER STAGING_ADMIN_PASSWORD
 pass "logged in"
 
 AUTH=(-H "authorization: Bearer $TOKEN")

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -42,12 +42,16 @@ for i in $(seq 1 60); do
 done
 
 step "Login as admin"
-LOGIN=$(curl -fsS -X POST "$BASE/api/auth/login" \
-  -H 'content-type: application/json' \
-  -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PASS\"}")
-TOKEN=$(echo "$LOGIN" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
-[ -n "$TOKEN" ] || fail "no token in login response: $LOGIN"
-echo "$LOGIN" | grep -q '"role":"admin"' || fail "admin role missing"
+# #1790: shared self-healing helper. On a fresh staging DB reset, rotates
+# the seeded 'changeme' password back to $ADMIN_PASS before returning a JWT;
+# on the normal day this is a single-login pass-through.
+# shellcheck source=scripts/e2e/lib/admin-auth.sh
+source "$(dirname "${BASH_SOURCE[0]}")/e2e/lib/admin-auth.sh"
+export STAGING_API_URL="$BASE"
+export STAGING_ADMIN_USER="admin"
+export STAGING_ADMIN_PASSWORD="$ADMIN_PASS"
+TOKEN=$(admin_login_self_heal) || fail "admin login failed (see stderr)"
+[ -n "$TOKEN" ] || fail "admin_login_self_heal returned empty token"
 pass "logged in"
 
 AUTH=(-H "authorization: Bearer $TOKEN")

--- a/scripts/e2e/lib/admin-auth.sh
+++ b/scripts/e2e/lib/admin-auth.sh
@@ -70,6 +70,11 @@ admin_login_self_heal() {
       : # got changeme working; continue to rotation
       ;;
     401)
+      # Concurrent-gate race: a sibling gate may have already rotated
+      # changeme back to the stored password between our first attempt and
+      # this one. Retry the stored password once before declaring hard fail.
+      _admin_auth_retry_stored_after_race "$base" "$user" "$stored" "$body_file" \
+        && return 0
       echo "admin-auth: neither stored password nor 'changeme' worked on $base — staging admin credentials need manual rotation" >&2
       return 1
       ;;
@@ -94,6 +99,12 @@ admin_login_self_heal() {
     -H "authorization: Bearer $bootstrap_token" \
     -d "$(_admin_auth_json_cp "$default_pw" "$stored")" || echo "000")
   if [ "$code" != "200" ]; then
+    # Same race as above — a sibling gate may have rotated between our
+    # changeme-login and our change-password call, so currentPassword is
+    # no longer 'changeme'. Retry login with the stored value before giving up.
+    if [ "$code" = "401" ] && _admin_auth_retry_stored_after_race "$base" "$user" "$stored" "$body_file"; then
+      return 0
+    fi
     _admin_auth_log "change-password failed: HTTP $code"
     cat "$cp_body" >&2 2>/dev/null || true
     return 1
@@ -137,6 +148,20 @@ _admin_auth_post_login() {
 
 _admin_auth_extract_token() {
   python3 -c 'import json,sys; b=json.load(open(sys.argv[1])); t=b.get("token") or ""; print(t); sys.exit(0 if t else 1)' "$1"
+}
+
+_admin_auth_retry_stored_after_race() {
+  # Sibling-gate race recovery: try the stored password once. On success
+  # echoes the JWT and returns 0; on any non-200 returns non-zero quietly so
+  # the caller can emit its own "neither worked" error.
+  local base="$1" user="$2" stored="$3" body_file="$4" code
+  _admin_auth_log "race-suspect: re-trying stored password (sibling gate may have rotated)"
+  code=$(_admin_auth_post_login "$base" "$user" "$stored" "$body_file")
+  if [ "$code" = "200" ]; then
+    _admin_auth_emit_token "$body_file"
+    return $?
+  fi
+  return 1
 }
 
 _admin_auth_emit_token() {

--- a/scripts/e2e/lib/admin-auth.sh
+++ b/scripts/e2e/lib/admin-auth.sh
@@ -1,0 +1,149 @@
+# Self-healing admin auth helper for staging smoke jobs. See #1790.
+#
+# Why this exists: staging's Postgres resets every 30 days (free-tier
+# behavior). On reset the seeded admin password reverts to 'changeme' with
+# the must-change flag set. CI's stored secret holds the operator-chosen
+# value — so without this helper, the next CD's auth step 401s and every
+# staging-gated job (Gate 1, Gate 3a, Gate 3b) cascade-fails until someone
+# rotates the secret by hand.
+#
+# This file is `source`d, not executed. Callers invoke `admin_login_self_heal`
+# and capture the JWT from stdout. Diagnostic output goes to stderr; the
+# token itself is never logged.
+#
+# Algorithm (the one source of truth — Python's AdminAPI.login mirrors it):
+#   1. POST /api/auth/login {STAGING_ADMIN_USER, STAGING_ADMIN_PASSWORD}
+#   2. If 200 → echo token, return 0.
+#   3. If 401 → POST /api/auth/login {admin, 'changeme'} (the post-reset
+#      bootstrap password).
+#      a. If 200 → POST /api/auth/change-password to rotate back to
+#         STAGING_ADMIN_PASSWORD, then re-login with that, then echo token.
+#         (Per #623 /api/auth/change-password returns JSON, not empty.)
+#      b. If 401 → hard fail with a clear message naming both arms.
+#   4. Any other HTTP status → propagate the error; do NOT swallow.
+#
+# Env required (callers set these):
+#   STAGING_API_URL          base URL (e.g. https://api-staging.wifihaven.net)
+#   STAGING_ADMIN_USER       admin username (defaults to 'admin')
+#   STAGING_ADMIN_PASSWORD   operator-chosen password (CI secret)
+
+_admin_auth_log() { echo "[admin-auth] $*" >&2; }
+
+# admin_login_self_heal — echoes a JWT on stdout, exits 0 on success.
+# On hard failure prints a clear stderr message and returns non-zero.
+admin_login_self_heal() {
+  local base="${STAGING_API_URL:?STAGING_API_URL not set}"
+  local user="${STAGING_ADMIN_USER:-admin}"
+  local stored="${STAGING_ADMIN_PASSWORD:?STAGING_ADMIN_PASSWORD not set}"
+  local default_pw="changeme"
+
+  base="${base%/}"
+  local tmp
+  tmp=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" RETURN
+
+  local body_file="$tmp/body.json"
+  local code
+
+  _admin_auth_log "attempting login with stored password"
+  code=$(_admin_auth_post_login "$base" "$user" "$stored" "$body_file")
+  case "$code" in
+    200)
+      _admin_auth_emit_token "$body_file" || return 1
+      return 0
+      ;;
+    401)
+      : # fall through to the self-heal path
+      ;;
+    *)
+      _admin_auth_log "unexpected HTTP $code from /api/auth/login (stored password)"
+      cat "$body_file" >&2 2>/dev/null || true
+      return 1
+      ;;
+  esac
+
+  _admin_auth_log "stored password rejected; trying post-reset bootstrap ('changeme')"
+  code=$(_admin_auth_post_login "$base" "$user" "$default_pw" "$body_file")
+  case "$code" in
+    200)
+      : # got changeme working; continue to rotation
+      ;;
+    401)
+      echo "admin-auth: neither stored password nor 'changeme' worked on $base — staging admin credentials need manual rotation" >&2
+      return 1
+      ;;
+    *)
+      _admin_auth_log "unexpected HTTP $code on changeme login"
+      cat "$body_file" >&2 2>/dev/null || true
+      return 1
+      ;;
+  esac
+
+  local bootstrap_token
+  bootstrap_token=$(_admin_auth_extract_token "$body_file") || {
+    _admin_auth_log "changeme login returned no token"
+    return 1
+  }
+
+  _admin_auth_log "rotating admin password back to stored value"
+  local cp_body="$tmp/cp.json"
+  code=$(curl -sS -o "$cp_body" -w '%{http_code}' \
+    -X POST "$base/api/auth/change-password" \
+    -H 'content-type: application/json' \
+    -H "authorization: Bearer $bootstrap_token" \
+    -d "$(_admin_auth_json_cp "$default_pw" "$stored")" || echo "000")
+  if [ "$code" != "200" ]; then
+    _admin_auth_log "change-password failed: HTTP $code"
+    cat "$cp_body" >&2 2>/dev/null || true
+    return 1
+  fi
+  # #623 — body is JSON {"mustChangePassword": false}. We don't strictly
+  # need to read it, but verify the response is parseable JSON so a future
+  # regression to empty body is caught loudly.
+  if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$cp_body" >/dev/null 2>&1; then
+    _admin_auth_log "change-password returned non-JSON body (regression of #623?)"
+    return 1
+  fi
+
+  _admin_auth_log "re-logging in with the now-restored stored password"
+  code=$(_admin_auth_post_login "$base" "$user" "$stored" "$body_file")
+  if [ "$code" != "200" ]; then
+    _admin_auth_log "post-rotation login failed: HTTP $code"
+    cat "$body_file" >&2 2>/dev/null || true
+    return 1
+  fi
+  _admin_auth_emit_token "$body_file" || return 1
+  return 0
+}
+
+# Internals. Underscored to discourage callers from depending on them.
+
+_admin_auth_json_login() {
+  python3 -c 'import json,sys; print(json.dumps({"username": sys.argv[1], "password": sys.argv[2]}))' "$1" "$2"
+}
+
+_admin_auth_json_cp() {
+  python3 -c 'import json,sys; print(json.dumps({"currentPassword": sys.argv[1], "newPassword": sys.argv[2]}))' "$1" "$2"
+}
+
+_admin_auth_post_login() {
+  local base="$1" user="$2" pw="$3" body_file="$4"
+  curl -sS -o "$body_file" -w '%{http_code}' \
+    -X POST "$base/api/auth/login" \
+    -H 'content-type: application/json' \
+    -d "$(_admin_auth_json_login "$user" "$pw")" || echo "000"
+}
+
+_admin_auth_extract_token() {
+  python3 -c 'import json,sys; b=json.load(open(sys.argv[1])); t=b.get("token") or ""; print(t); sys.exit(0 if t else 1)' "$1"
+}
+
+_admin_auth_emit_token() {
+  local body_file="$1" token
+  token=$(_admin_auth_extract_token "$body_file") || {
+    _admin_auth_log "login response missing token"
+    return 1
+  }
+  printf '%s\n' "$token"
+}

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -11,6 +11,10 @@ import urllib.request
 log = logging.getLogger(__name__)
 
 
+class _LoginUnauthorized(Exception):
+    """Internal — raised by _raw_login on a 401, caught by self-heal."""
+
+
 class AdminAPI:
     def __init__(self, base_url: str, *, username: str = "admin", password: str = "changeme"):
         self.base_url = base_url.rstrip("/")
@@ -20,17 +24,67 @@ class AdminAPI:
 
     # ── auth ──────────────────────────────────────────────────────────────
 
+    # #1790: staging's Postgres resets every 30 days; on reset the admin user
+    # reverts to 'changeme' with must_change_password set. CI's stored secret
+    # holds the operator-chosen value, so a normal login() 401s. Self-heal:
+    # try 'changeme', rotate the password back to self.password, re-login.
+    # Bash mirror lives at scripts/e2e/lib/admin-auth.sh — keep both in sync.
+    _DEFAULT_PASSWORD = "changeme"
+
     def login(self) -> str:
-        body = self._request(
-            "POST", "/api/auth/login",
-            body={"username": self.username, "password": self.password},
-            authed=False,
-        )
-        token = body.get("token")
-        if not token:
-            raise RuntimeError(f"login response missing token: {body!r}")
+        try:
+            token = self._raw_login(self.password)
+        except _LoginUnauthorized:
+            token = self._self_heal_after_reset()
         self._token = token
         return token
+
+    def _raw_login(self, password: str) -> str:
+        try:
+            body = self._request(
+                "POST", "/api/auth/login",
+                body={"username": self.username, "password": password},
+                authed=False,
+            )
+        except RuntimeError as e:
+            if "HTTP 401" in str(e):
+                raise _LoginUnauthorized() from e
+            raise
+        token = body.get("token") if isinstance(body, dict) else None
+        if not token:
+            raise RuntimeError(f"login response missing token: {body!r}")
+        return token
+
+    def _self_heal_after_reset(self) -> str:
+        log.info("admin login 401 — attempting post-reset bootstrap with 'changeme'")
+        try:
+            bootstrap_token = self._raw_login(self._DEFAULT_PASSWORD)
+        except _LoginUnauthorized as e:
+            raise RuntimeError(
+                "neither stored password nor 'changeme' worked on "
+                f"{self.base_url} — staging admin credentials need manual rotation",
+            ) from e
+        # Rotate back to the stored password BEFORE returning a token — that
+        # way every caller gets a token good for the post-rotation state, and
+        # the must_change_password guard can't bite the next admin call.
+        self._token = bootstrap_token
+        # #623: change-password returns JSON ({"mustChangePassword": false}).
+        # AdminAPI._request already json-decodes a JSON-content-type response;
+        # a regression to an empty body would surface as None here.
+        resp = self._request(
+            "POST", "/api/auth/change-password",
+            body={
+                "currentPassword": self._DEFAULT_PASSWORD,
+                "newPassword": self.password,
+            },
+        )
+        if not isinstance(resp, dict) or "mustChangePassword" not in resp:
+            raise RuntimeError(
+                f"change-password did not return the expected JSON body (#623 regression?): {resp!r}",
+            )
+        log.info("admin password rotated back to stored value; re-logging in")
+        self._token = None
+        return self._raw_login(self.password)
 
     @property
     def token(self) -> str:

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -60,10 +60,16 @@ class AdminAPI:
         try:
             bootstrap_token = self._raw_login(self._DEFAULT_PASSWORD)
         except _LoginUnauthorized as e:
-            raise RuntimeError(
-                "neither stored password nor 'changeme' worked on "
-                f"{self.base_url} — staging admin credentials need manual rotation",
-            ) from e
+            # Concurrent-gate race: a sibling gate may have rotated 'changeme'
+            # back to the stored password between our first stored-login and
+            # this one. Retry stored once before declaring hard fail.
+            try:
+                return self._raw_login(self.password)
+            except _LoginUnauthorized:
+                raise RuntimeError(
+                    "neither stored password nor 'changeme' worked on "
+                    f"{self.base_url} — staging admin credentials need manual rotation",
+                ) from e
         # Rotate back to the stored password BEFORE returning a token — that
         # way every caller gets a token good for the post-rotation state, and
         # the must_change_password guard can't bite the next admin call.
@@ -71,13 +77,22 @@ class AdminAPI:
         # #623: change-password returns JSON ({"mustChangePassword": false}).
         # AdminAPI._request already json-decodes a JSON-content-type response;
         # a regression to an empty body would surface as None here.
-        resp = self._request(
-            "POST", "/api/auth/change-password",
-            body={
-                "currentPassword": self._DEFAULT_PASSWORD,
-                "newPassword": self.password,
-            },
-        )
+        try:
+            resp = self._request(
+                "POST", "/api/auth/change-password",
+                body={
+                    "currentPassword": self._DEFAULT_PASSWORD,
+                    "newPassword": self.password,
+                },
+            )
+        except RuntimeError as e:
+            # Same race: a sibling rotated between our changeme-login and
+            # this change-password call, so currentPassword=changeme is no
+            # longer valid. Fall back to a stored-password login.
+            if "HTTP 401" in str(e):
+                self._token = None
+                return self._raw_login(self.password)
+            raise
         if not isinstance(resp, dict) or "mustChangePassword" not in resp:
             raise RuntimeError(
                 f"change-password did not return the expected JSON body (#623 regression?): {resp!r}",

--- a/scripts/e2e/lib/test_admin_auth.py
+++ b/scripts/e2e/lib/test_admin_auth.py
@@ -1,0 +1,198 @@
+"""Integration cover for the #1790 self-healing admin auth helper.
+
+Staging's Postgres resets every 30 days; on reset the admin user reverts to
+the seeded `changeme` password (with mustChangePassword=true). The CI secret
+holds the operator-chosen value, so every staging-gated job would 401 until
+the operator intervened.
+
+The helper (Python: `AdminAPI.login`; bash: `scripts/e2e/lib/admin-auth.sh`)
+self-heals: try the stored password; on 401 try `changeme`; on success
+immediately POST /api/auth/change-password back to the stored value and
+re-login. The two helpers share the same algorithm so every staging-gated
+job is covered by one logical handshake.
+
+Run standalone:
+
+    python3 -m pytest scripts/e2e/lib/test_admin_auth.py
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from api_admin import AdminAPI  # noqa: E402
+
+
+HERE = Path(__file__).parent
+BASH_HELPER = HERE / "admin-auth.sh"
+
+DEFAULT_PASSWORD = "changeme"
+STORED_PASSWORD = "operator-chosen-pw-do-not-share"
+
+
+class _FakeAuthAPI(http.server.BaseHTTPRequestHandler):
+    """Tiny mock of the WifiHaven auth surface.
+
+    Server-shared state lives on the HTTPServer instance:
+      server.current_password    — the password the admin login accepts
+      server.must_change         — whether logins return mustChangePassword=true
+      server.token               — the JWT we hand back
+      server.change_password_calls — for assertions
+    """
+
+    def log_message(self, fmt: str, *args) -> None:  # noqa: D401
+        return
+
+    def _read_json(self) -> dict:
+        n = int(self.headers.get("content-length", "0"))
+        return json.loads(self.rfile.read(n).decode("utf-8")) if n else {}
+
+    def _send(self, code: int, body: dict | None) -> None:
+        payload = b"" if body is None else json.dumps(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        srv = self.server
+        if self.path == "/api/auth/login":
+            body = self._read_json()
+            if body.get("password") == srv.current_password:
+                self._send(200, {
+                    "token": srv.token,
+                    "role": "admin",
+                    "username": body.get("username", "admin"),
+                    "mustChangePassword": srv.must_change,
+                })
+            else:
+                self._send(401, {"error": "Invalid credentials"})
+            return
+        if self.path == "/api/auth/change-password":
+            auth = self.headers.get("authorization", "")
+            if not auth.startswith("Bearer "):
+                self._send(401, {"error": "missing bearer"})
+                return
+            body = self._read_json()
+            srv.change_password_calls.append(body)
+            if body.get("currentPassword") != srv.current_password:
+                self._send(401, {"error": "Current password incorrect"})
+                return
+            srv.current_password = body["newPassword"]
+            srv.must_change = False
+            # #623: change-password returns JSON body, not empty.
+            self._send(200, {"mustChangePassword": False})
+            return
+        self._send(404, {"error": "not found"})
+
+
+@contextmanager
+def _fake_api(*, current_password: str, must_change: bool = False):
+    srv = http.server.HTTPServer(("127.0.0.1", 0), _FakeAuthAPI)
+    srv.current_password = current_password
+    srv.must_change = must_change
+    srv.token = "fake-jwt-token-xyz"
+    srv.change_password_calls = []
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        host, port = srv.server_address
+        yield f"http://{host}:{port}", srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        t.join(timeout=2)
+
+
+# ── Python helper ────────────────────────────────────────────────────────
+
+
+def test_python_normal_day_single_login():
+    """Stored password works → exactly one login call, no change-password."""
+    with _fake_api(current_password=STORED_PASSWORD) as (url, srv):
+        api = AdminAPI(url, username="admin", password=STORED_PASSWORD)
+        token = api.login()
+        assert token == srv.token
+        assert srv.change_password_calls == []
+        # Stored password unchanged.
+        assert srv.current_password == STORED_PASSWORD
+
+
+def test_python_post_reset_self_heals():
+    """After DB reset (admin=changeme, must_change=true) the helper rotates
+    the password back to the stored value and returns a JWT good for the
+    rotated state."""
+    with _fake_api(current_password=DEFAULT_PASSWORD, must_change=True) as (url, srv):
+        api = AdminAPI(url, username="admin", password=STORED_PASSWORD)
+        token = api.login()
+        assert token == srv.token
+        assert len(srv.change_password_calls) == 1
+        call = srv.change_password_calls[0]
+        assert call["currentPassword"] == DEFAULT_PASSWORD
+        assert call["newPassword"] == STORED_PASSWORD
+        # Server state is now back to the stored password.
+        assert srv.current_password == STORED_PASSWORD
+
+
+def test_python_hard_fail_when_neither_password_works():
+    """Stored AND changeme both 401 → clear runtime error, no silent retry."""
+    with _fake_api(current_password="some-other-pw") as (url, _srv):
+        api = AdminAPI(url, username="admin", password=STORED_PASSWORD)
+        with pytest.raises(RuntimeError) as ei:
+            api.login()
+        msg = str(ei.value)
+        assert "neither" in msg.lower() or "default" in msg.lower() or "changeme" in msg.lower(), msg
+
+
+# ── Bash helper ──────────────────────────────────────────────────────────
+
+
+def _run_bash(url: str, password: str) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "STAGING_API_URL": url,
+        "STAGING_ADMIN_USER": "admin",
+        "STAGING_ADMIN_PASSWORD": password,
+    }
+    return subprocess.run(
+        ["bash", "-c", f"source {BASH_HELPER} && admin_login_self_heal"],
+        env=env, capture_output=True, text=True, timeout=10,
+    )
+
+
+def test_bash_normal_day_single_login():
+    with _fake_api(current_password=STORED_PASSWORD) as (url, srv):
+        r = _run_bash(url, STORED_PASSWORD)
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == srv.token
+        assert srv.change_password_calls == []
+
+
+def test_bash_post_reset_self_heals():
+    with _fake_api(current_password=DEFAULT_PASSWORD, must_change=True) as (url, srv):
+        r = _run_bash(url, STORED_PASSWORD)
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == srv.token
+        assert len(srv.change_password_calls) == 1
+        assert srv.change_password_calls[0]["newPassword"] == STORED_PASSWORD
+        assert srv.current_password == STORED_PASSWORD
+
+
+def test_bash_hard_fail_when_neither_password_works():
+    with _fake_api(current_password="some-other-pw") as (url, _srv):
+        r = _run_bash(url, STORED_PASSWORD)
+        assert r.returncode != 0
+        assert "neither" in r.stderr.lower() or "changeme" in r.stderr.lower(), r.stderr

--- a/scripts/e2e/lib/test_admin_auth.py
+++ b/scripts/e2e/lib/test_admin_auth.py
@@ -23,8 +23,6 @@ import os
 import subprocess
 import sys
 import threading
-import urllib.error
-import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -196,3 +194,113 @@ def test_bash_hard_fail_when_neither_password_works():
         r = _run_bash(url, STORED_PASSWORD)
         assert r.returncode != 0
         assert "neither" in r.stderr.lower() or "changeme" in r.stderr.lower(), r.stderr
+
+
+# ── Concurrent-gate race recovery (sibling rotated between our calls) ────
+
+
+class _SiblingRaceHandler(_FakeAuthAPI):
+    """Mock variant simulating a sibling gate that rotated 'changeme' to the
+    stored password between our first changeme-call and our next call.
+
+    Server state is set to (current_password=STORED_PASSWORD, must_change=False)
+    BUT login returns 401 on the FIRST `changeme` attempt only (post-reset
+    state we sampled), then 200 on the stored password — modelling a sibling
+    that won the race after our initial stored-password login failed.
+
+    Practically: stored-password login → 200 (sibling already rotated).
+    changeme login → 401 (sibling already rotated).
+    change-password with currentPassword=changeme → 401 (same reason).
+    """
+
+
+def test_bash_race_recovery_on_changeme_401():
+    """Sibling rotated between our stored-login and our changeme-login.
+    The helper must retry the stored password before declaring hard-fail."""
+    # Start the server with the post-rotation state — stored works, changeme
+    # does not. The test simulates: we already saw a 401 on stored (the
+    # original reset state), then tried changeme and got 401 because a
+    # sibling rotated. The helper should retry stored and succeed.
+    # Force the first stored attempt to 401 by giving the mock a different
+    # password initially, then swap mid-flight — easier: subclass the mock
+    # to count requests and 401 the FIRST stored-password attempt only.
+    state = {"first_stored_seen": False}
+
+    class _Handler(_FakeAuthAPI):
+        def do_POST(self):
+            if self.path == "/api/auth/login":
+                body = self._read_json()
+                pw = body.get("password")
+                if pw == STORED_PASSWORD and not state["first_stored_seen"]:
+                    state["first_stored_seen"] = True
+                    self._send(401, {"error": "Invalid credentials"})
+                    return
+                if pw == STORED_PASSWORD:
+                    self._send(200, {
+                        "token": self.server.token, "role": "admin",
+                        "username": "admin", "mustChangePassword": False,
+                    })
+                    return
+                self._send(401, {"error": "Invalid credentials"})
+                return
+            self._send(404, {})
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    srv.current_password = STORED_PASSWORD
+    srv.must_change = False
+    srv.token = "race-recovered-jwt"
+    srv.change_password_calls = []
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        host, port = srv.server_address
+        url = f"http://{host}:{port}"
+        r = _run_bash(url, STORED_PASSWORD)
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == srv.token
+        # No change-password call: race-recovery skipped that step.
+        assert srv.change_password_calls == []
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        t.join(timeout=2)
+
+
+def test_python_race_recovery_on_changeme_401():
+    """Python helper mirrors the bash race recovery."""
+    state = {"first_stored_seen": False}
+
+    class _Handler(_FakeAuthAPI):
+        def do_POST(self):
+            if self.path == "/api/auth/login":
+                body = self._read_json()
+                pw = body.get("password")
+                if pw == STORED_PASSWORD and not state["first_stored_seen"]:
+                    state["first_stored_seen"] = True
+                    self._send(401, {"error": "Invalid credentials"})
+                    return
+                if pw == STORED_PASSWORD:
+                    self._send(200, {
+                        "token": self.server.token, "role": "admin",
+                        "username": "admin", "mustChangePassword": False,
+                    })
+                    return
+                self._send(401, {"error": "Invalid credentials"})
+                return
+            self._send(404, {})
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    srv.token = "race-recovered-jwt"
+    srv.change_password_calls = []
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        host, port = srv.server_address
+        api = AdminAPI(f"http://{host}:{port}", username="admin", password=STORED_PASSWORD)
+        token = api.login()
+        assert token == srv.token
+        assert srv.change_password_calls == []
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        t.join(timeout=2)


### PR DESCRIPTION
Closes #1790.

## Why

Staging's Postgres resets every 30 days (free-tier behaviour). On reset the admin user reverts to the seeded `changeme` password with the must-change flag set, so the CI secret's operator-chosen value 401s and every staging-gated job (Gate 1 / Gate 3a / Gate 3b) cascade-fails until someone rotates the secret by hand. #1789 was the inciting incident.

## Approach

One source-of-truth handshake, in two language flavours that share the same algorithm:

| Helper | Used by |
| --- | --- |
| `scripts/e2e/lib/admin-auth.sh` (sourced) | `scripts/e2e-tests.sh`, `scripts/e2e-router.sh` (Gate 1 admin + router smoke) |
| `AdminAPI.login` in `scripts/e2e/lib/api_admin.py` | `scripts/e2e/gate3/conftest.py` (Gate 3a + Gate 3b) |

Algorithm:

1. `POST /api/auth/login` with the stored password.
2. **200** → echo the JWT.
3. **401** → `POST /api/auth/login` with `changeme`.
   - **200** → `POST /api/auth/change-password` to rotate back to the stored value (parsing the JSON body per #623), then re-login with the stored value and echo the JWT.
   - **401** → hard-fail with a clear message naming both arms.
4. Any other status → propagate; do not swallow.

The bootstrap is idempotent across resets — every CD run either passes through (normal day, one login call) or self-heals (just after a reset).

## Test plan

- [x] Integration tests in `scripts/e2e/lib/test_admin_auth.py` cover both helpers against a mock of the WifiHaven auth surface — normal day, post-reset self-heal, and the hard-fail case. The mock also models the #623 JSON body for `/api/auth/change-password` so a regression to empty body trips the test.
- [ ] Operator can validate against the live staging reset on the next 30-day boundary: secret stays at the operator-chosen value, the CD run just after reset succeeds without intervention, and the admin password ends up rotated back.

Run the tests:

```sh
cd scripts/e2e/lib && python3 -m pytest test_admin_auth.py
```