### PR TITLE
fix(#1792): skip conf-file= for missing blocklist shards (Gate 3a)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -416,8 +416,8 @@ function M.render_shards(snapshot, fs, cache_dir, shard_dir, max_bytes, global_b
   for id, bl in pairs(bls) do
     local version    = bl.version
     local cache_path = cache_dir .. "/" .. id .. "-" .. tostring(version) .. ".txt"
-    local shard_tmp  = shard_dir .. "/wifihaven-blocklist-" .. id .. ".conf.tmp"
-    local shard_final = shard_dir .. "/wifihaven-blocklist-" .. id .. ".conf"
+    local shard_final = get_render().shard_path(id, shard_dir)
+    local shard_tmp  = shard_final .. ".tmp"
 
     -- Open the cache file for line-by-line reading.
     local rf = open_read_fn(cache_path)

--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -218,6 +218,16 @@ local function exec_ok(rc)
   return rc == 0 or rc == true
 end
 
+-- #1792: default shard-existence check for render.dnsmasq's bl_shard_exists
+-- hook. Module-level so the closure is allocated once, not per apply call.
+-- Reads render.SHARD_DIR at call time (not at module-load) so tests that
+-- mutate render.SHARD_DIR before driving policy.apply still see the override.
+local function default_bl_shard_exists(id)
+  local f = io.open(render.shard_path(id), "r")
+  if f then f:close(); return true end
+  return false
+end
+
 function M.apply(snapshot, write_fn, reload_fn, log, opts)
   log = log or default_log()
   opts = opts or {}
@@ -240,14 +250,18 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   -- whose cache file is missing (fetch not yet completed, transient HTTP
   -- error, cap_hit); a dangling conf-file= ref aborts dnsmasq startup with
   -- "cannot read ..." and :53 returns "connection refused" (Gate 3a regression
-  -- after #1788). Tests inject opts.bl_shard_exists; production uses io.open.
-  local bl_shard_exists = opts.bl_shard_exists or function(id)
-    local p = string.format("%s/wifihaven-blocklist-%s.conf", render.SHARD_DIR, id)
-    local f = io.open(p, "r")
-    if f then f:close(); return true end
-    return false
-  end
-  local dnsmasq_content = render.dnsmasq(snapshot, { bl_shard_exists = bl_shard_exists })
+  -- after #1788). Tests inject opts.bl_shard_exists; production uses the
+  -- module-level default_bl_shard_exists which stats the canonical shard path.
+  local bl_shard_exists = opts.bl_shard_exists or default_bl_shard_exists
+  local dnsmasq_content = render.dnsmasq(snapshot, {
+    bl_shard_exists = function(id)
+      local ok = bl_shard_exists(id)
+      if not ok then
+        log.debug("policy.apply: omitted conf-file= for id %s (shard missing)", tostring(id))
+      end
+      return ok
+    end,
+  })
   local nft_content     = render.nft(snapshot, opts)
 
   -- #414: dnsmasq only needs a full restart when its config-dir file

--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -235,7 +235,19 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
       pcall(on_apply, { result = result, dnsmasq_restarted = dnsmasq_restarted })
     end
   end
-  local dnsmasq_content = render.dnsmasq(snapshot)
+  -- #1792: gate per-blocklist conf-file= emission on whether the shard file
+  -- actually exists on disk. blocklists.render_shards silently skips an id
+  -- whose cache file is missing (fetch not yet completed, transient HTTP
+  -- error, cap_hit); a dangling conf-file= ref aborts dnsmasq startup with
+  -- "cannot read ..." and :53 returns "connection refused" (Gate 3a regression
+  -- after #1788). Tests inject opts.bl_shard_exists; production uses io.open.
+  local bl_shard_exists = opts.bl_shard_exists or function(id)
+    local p = string.format("%s/wifihaven-blocklist-%s.conf", render.SHARD_DIR, id)
+    local f = io.open(p, "r")
+    if f then f:close(); return true end
+    return false
+  end
+  local dnsmasq_content = render.dnsmasq(snapshot, { bl_shard_exists = bl_shard_exists })
   local nft_content     = render.nft(snapshot, opts)
 
   -- #414: dnsmasq only needs a full restart when its config-dir file

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -83,6 +83,17 @@ local M = {}
 -- wifihaven-agent).
 M.SHARD_DIR = "/tmp"
 
+-- Canonical path of a per-blocklist dnsmasq conf shard (#1792). Single source
+-- of truth — render.dnsmasq, policy.apply's shard-existence check, and
+-- blocklists.render_shards all call this so the prefix/extension can never
+-- drift between writer and reader. `dir` defaults to M.SHARD_DIR; pass an
+-- explicit dir for callers that already take shard_dir as a parameter
+-- (blocklists.render_shards / .gc_shards) so the test-injectable directory
+-- still flows through.
+function M.shard_path(id, dir)
+  return (dir or M.SHARD_DIR) .. "/wifihaven-blocklist-" .. id .. ".conf"
+end
+
 -- Replace dots and colons with underscores (nftables set/counter name-safe).
 local function sanitize(s)
   return (s:gsub("[%.%:]", "_"))
@@ -468,7 +479,7 @@ function M.dnsmasq(snapshot, opts)
     -- #1792: only reference shards that actually exist on disk; a dangling
     -- conf-file= ref aborts dnsmasq startup with "cannot read ...".
     for _, id in ipairs(bl_ids_with_shards) do
-      emit(string.format("conf-file=%s/wifihaven-blocklist-%s.conf", M.SHARD_DIR, id))
+      emit("conf-file=" .. M.shard_path(id))
     end
     emit("")
   end

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -366,7 +366,16 @@ end
 -- ---------------------------------------------------------------------------
 -- render.dnsmasq(snapshot) → string
 -- ---------------------------------------------------------------------------
-function M.dnsmasq(snapshot)
+function M.dnsmasq(snapshot, opts)
+  opts = opts or {}
+  -- #1792: blocklists.render_shards silently skips an id whose cache file is
+  -- missing (fetch never completed, transient HTTP error, cap_hit). Emitting
+  -- a conf-file= line for that id makes dnsmasq abort at startup with
+  -- "cannot read /tmp/wifihaven-blocklist-<id>.conf" and :53 returns
+  -- "connection refused". Callers that have observed which shards actually
+  -- landed on disk pass opts.bl_shard_exists(id) to gate the emission;
+  -- absent the option (e.g. legacy callers, tests) every id is referenced.
+  local bl_shard_exists = opts.bl_shard_exists or function() return true end
   local out = {}
   local function emit(s) out[#out + 1] = s end
 
@@ -447,10 +456,18 @@ function M.dnsmasq(snapshot)
   --   nftset=/<host>/4#inet#wifihaven#bl_<id>,6#inet#wifihaven#bl6_<id>
   -- Emit one conf-file= line per id in sorted order.
   local bl_ids = sorted_keys(snapshot.blocklists or {})
-  if #bl_ids > 0 then
+  local bl_ids_with_shards = {}
+  for _, id in ipairs(bl_ids) do
+    if bl_shard_exists(id) then
+      bl_ids_with_shards[#bl_ids_with_shards + 1] = id
+    end
+  end
+  if #bl_ids_with_shards > 0 then
     emit("# per-blocklist shard files written by blocklists.render_shards (#1782,#1783)")
     emit("# each shard contains nftset= directives for that list's member hosts")
-    for _, id in ipairs(bl_ids) do
+    -- #1792: only reference shards that actually exist on disk; a dangling
+    -- conf-file= ref aborts dnsmasq startup with "cannot read ...".
+    for _, id in ipairs(bl_ids_with_shards) do
       emit(string.format("conf-file=%s/wifihaven-blocklist-%s.conf", M.SHARD_DIR, id))
     end
     emit("")

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1161,6 +1161,30 @@ describe("render blocklist enforcement (#352)", function()
     assert.is_nil(conf:find("conf-file=/tmp/wifihaven-blocklist-", 1, true))
   end)
 
+  -- #1792: render_shards silently skips ids whose cache file is missing
+  -- (fetch never completed, transient HTTP error, cap_hit). If render.dnsmasq
+  -- still emits conf-file= for those ids, dnsmasq aborts at startup with
+  -- "cannot read /tmp/wifihaven-blocklist-<id>.conf" and :53 returns
+  -- "connection refused" — the Gate 3a regression after #1788. Skipping the
+  -- conf-file= line for an absent shard keeps dnsmasq alive; the bl_/bl6_
+  -- nft sets just stay empty until the next render_shards pass succeeds.
+  it("omits conf-file= for an id whose shard does not exist on disk (#1792)", function()
+    local s = snap_bl()
+    s.blocklists["test_social"] = { version = "v1", url = "http://api/api/blocklists/test_social" }
+    local conf = render.dnsmasq(s, {
+      bl_shard_exists = function(id) return id ~= "test_social" end,
+    })
+    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true),
+      "shard that exists must still be referenced")
+    assert.is_nil(conf:find("conf-file=/tmp/wifihaven-blocklist-test_social.conf", 1, true),
+      "shard that does not exist on disk must NOT be referenced (#1792)")
+  end)
+
+  it("emits all conf-file= lines when opts.bl_shard_exists is not provided (back-compat)", function()
+    local conf = render.dnsmasq(snap_bl())
+    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true))
+  end)
+
   it("still emits eb_ and ea_ nftset= directives in the merged per-host block (#1782)", function()
     -- Non-blocklist hosts (extraBlocked, extraAllowed) continue to have their
     -- nftset= directives in the main wifihaven.conf — only bl_ moves to shards.


### PR DESCRIPTION
Closes #1792.

## Root cause

`render.dnsmasq` emitted `conf-file=/tmp/wifihaven-blocklist-<id>.conf` for **every** id in `snapshot.blocklists` (`render.lua:449-457`), but `blocklists.render_shards` silently skips an id whose cache file is missing (`blocklists.lua:423-425`) — fetch never completed, transient HTTP error during VM boot, or cap_hit on an oversized list. The dangling `conf-file=` reference made dnsmasq abort at startup with `cannot read /tmp/wifihaven-blocklist-<id>.conf`, taking `:53` down. The Gate 3a smoke client then sees ``';; communications error to fdaa:bbbb:cccc::1#53: connection refused'`` for 60s and times out.

Gate 3a is the only arm that boots the freshly-built router image AND points at `api-staging.wifihaven.net`, so a transient blocklist-fetch latency during VM bring-up was enough to dangle a shard. Gate 3b uses the last-published image (pre-#1788) and isn't on this code path.

## Fix shape

Forward fix — one-line patch, no revert needed:

- `render.dnsmasq(snapshot, opts)` now accepts `opts.bl_shard_exists(id) → bool`. Ids that return false are omitted from the `conf-file=` block. When absent (legacy callers, tests) every id is referenced — back-compat for the existing #1782 tests.
- `policy.apply` wires a default that stats the shard path with `io.open()`. The bl_/bl6_ sets just stay empty for the missing id until the next `render_shards` pass succeeds; dnsmasq stays alive.

## Tests

- RED → GREEN via `test/render_spec.lua` — `omits conf-file= for an id whose shard does not exist on disk (#1792)` (commits in PR show red → green).
- Back-compat assertion: all existing `#1782` conf-file= tests still pass without supplying `bl_shard_exists`.
- Full openwrt busted suite: **774 successes / 0 failures** (one `nft` binary pending on macOS host; the 4 pre-existing `kmod-nf-log` build-script FAILs are unrelated).

## Post-merge

Next `master-router.yml` run validates Gate 3a + 3b green. Will confirm via `gh run list --workflow=master-router.yml --limit 1`.