### PR TITLE
fix(#1794): auto-reconcile app templates on boot so duplicate apps self-heal (PR 1 of 2)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -130,8 +130,8 @@ object Main extends ZIOAppDefault {
             _ <- ZIO.logInfo("global profile sentinel ensured (is_global=TRUE)")
             // #768: seed the starter library of app templates. Idempotent —
             // operator host edits on previously-seeded apps are preserved.
-            seedSummary <- AppTemplates.seed(appRepoForSeed, templates)
-            _           <- ZIO.logInfo(
+            seedSummary      <- AppTemplates.seed(appRepoForSeed, templates)
+            _                <- ZIO.logInfo(
               s"app_templates seeded (${templates.size} templates): " +
                 s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
                 s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated
@@ -142,12 +142,35 @@ object Main extends ZIOAppDefault {
                   .mkString("[", ",", "]") + ", " +
                 s"preserved=${seedSummary.preserved.size}",
             )
+            // #1794: collapse any `<slug>-template` rows onto their canonical `<slug>`
+            // form right after seeding. The seeder's `findFreeSlug` falls back to the
+            // `-template` slug whenever an operator-added row already owns the canonical
+            // slug, leaving two rows for one logical app; that fallback can't self-heal
+            // because the `-template` row carries the `template_id` the seeder keys on,
+            // so it gets *preserved* forever (this is how prod accreted 8 dup pairs).
+            // Running the idempotent reconciler on boot makes the merge automatic — and
+            // safe to repeat, because `mergeAppInto` transfers `template_id` onto the
+            // canonical, so the next seed pass finds the canonical and never re-creates
+            // the `-template` fallback. Cheap (indexed `findBySlug`) and a no-op once
+            // clean — NOT a one-shot, so it stays (unlike #1608-class seeders).
+            reconcileSummary <- AppReconciler.reconcileTemplates(appRepoForSeed, templates)
+            _                <- ZIO.logInfo(
+              s"app_templates reconciled (#1794): " +
+                s"merged=${reconcileSummary.mergedSlugs.size} ${reconcileSummary.mergedSlugs
+                    .mkString("[", ",", "]")}, " +
+                s"renamed=${reconcileSummary.renamedSlugs.size} ${reconcileSummary.renamedSlugs
+                    .mkString("[", ",", "]")}, " +
+                s"hostsUnioned=${reconcileSummary.hostsUnioned.size}, " +
+                s"templateIdSet=${reconcileSummary.templateIdSet.size}, " +
+                s"created=${reconcileSummary.created.size}, " +
+                s"alreadyClean=${reconcileSummary.alreadyClean.size}",
+            )
             // #958: seed the bundled category blocklists. Inline lists pull hosts
             // straight from YAML; remote lists fetch from the declared upstream
             // URL (cached in-memory after first success — see BlocklistCache).
             // REPLACE semantics; remote-fetch failures leave existing rows alone.
-            _           <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
-            _           <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+            _ <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
+            _ <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
             // #1602: the boot-time ScheduleSeeder.seedAndMigrate call lived here. The
             // legacy → named_schedules migration is complete on every household, and
             // re-running it resurrected schedules the operator deleted from the SPA

--- a/api/test/src/feature/AppReconcilerSpec.scala
+++ b/api/test/src/feature/AppReconcilerSpec.scala
@@ -1,6 +1,6 @@
 package wifihaven.api.feature
 
-import wifihaven.api.{AppReconciler, AppTemplate}
+import wifihaven.api.{AppReconciler, AppTemplate, AppTemplates}
 import wifihaven.api.db.*
 import wifihaven.shared.*
 import wifihaven.shared.IconType
@@ -33,7 +33,70 @@ object AppReconcilerSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
     hosts = List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")),
   )
 
+  // #1794: the exact prod duplicate shape — operator-added canonical `1password` (template_id
+  // NULL, carrying assignments) co-existing with a seeded `1password-template` row. Pinned so the
+  // boot-time seed→reconcile pipeline that #1794 wires into `Main` provably collapses it.
+  private val onePasswordSlug     = AppTemplateId.unsafe("1password")
+  private val onePasswordTemplate = AppTemplate(
+    slug = onePasswordSlug,
+    name = "1Password",
+    icon = None,
+    iconType = IconType.Emoji,
+    hosts = List(Hostname.unsafe("1password.com"), Hostname.unsafe("1passwordusercontent.com")),
+  )
+
   def spec = suite("AppReconciler")(
+    test(
+      "#1794: seed-then-reconcile (the boot pipeline) collapses the prod operator+`-template` " +
+        "shape into one canonical row, preserving assignments",
+    ) {
+      for {
+        _        <- cleanDb
+        appRepo  <- ZIO.service[AppRepo]
+        profileR <- ZIO.service[ProfileRepo]
+        profiles <- profileR.listAll
+        kidsId   = profiles.find(_.name == "Kids").get.id
+        adultsId = profiles.find(_.name == "Adults").get.id
+        // Operator created `1password` BEFORE the template seeder ran (template_id NULL), and
+        // attached policy assignments to it — exactly prod app id17.
+        operatorId <- appRepo.create("1Password", "1password", None, Some("🔑"), IconType.Emoji)
+        _          <- appRepo.setHosts(operatorId, List(Hostname.unsafe("1password.com")))
+        _          <- appRepo.upsertAssignment(operatorId, kidsId, AppMode.Blocked, None, true)
+        _          <- appRepo.upsertAssignment(operatorId, adultsId, AppMode.Allowed, None, true)
+        // Boot step 1 — seed. `findByTemplateId(1password)` is None and the `1password` slug is
+        // taken, so `findFreeSlug` falls back to `1password-template`: this is how prod accreted
+        // the dup (the seeder can never un-create it because that row holds the template_id).
+        _          <- AppTemplates.seed(appRepo, List(onePasswordTemplate))
+        afterSeed  <- appRepo.listAll
+        // Boot step 2 — reconcile (what #1794 adds). Collapses the pair.
+        summary    <- AppReconciler.reconcileTemplates(appRepo, List(onePasswordTemplate))
+        afterRecon <- appRepo.listAll
+        canonical  <- appRepo.findBySlug("1password").someOrFailException
+        canonHosts <- appRepo.getHosts(canonical.id)
+        canonAsgn  <- appRepo.listAssignmentsForApp(canonical.id)
+        suffixGone <- appRepo.findBySlug("1password-template")
+        // Boot step 2 is idempotent on the next reboot.
+        second     <- AppReconciler.reconcileTemplates(appRepo, List(onePasswordTemplate))
+        afterAgain <- appRepo.listAll
+      } yield
+      // The seed reproduces the dup the operator saw: two rows for one logical app.
+      assertTrue(afterSeed.count(_.name == "1Password") == 2) &&
+        assertTrue(afterSeed.count(_.slug == "1password-template") == 1) &&
+        // Reconcile collapses to a single canonical row carrying the template_id…
+        assertTrue(afterRecon.count(_.name == "1Password") == 1) &&
+        assertTrue(canonical.id == operatorId) &&
+        assertTrue(canonical.templateId.contains(onePasswordSlug)) &&
+        assertTrue(suffixGone.isEmpty) &&
+        // …with the operator's assignments preserved on it…
+        assertTrue(canonAsgn.map(_.profileId).toSet == Set(kidsId, adultsId)) &&
+        // …and the template hosts unioned in.
+        assertTrue(canonHosts.toSet == onePasswordTemplate.hosts.toSet) &&
+        assertTrue(summary.mergedSlugs == List("1password")) &&
+        // The next reboot's reconcile is a clean no-op — no whack-a-mole.
+        assertTrue(second.mergedSlugs.isEmpty && second.renamedSlugs.isEmpty) &&
+        assertTrue(afterAgain.count(_.slug == "1password") == 1) &&
+        assertTrue(afterAgain.count(_.slug == "1password-template") == 0)
+    },
     test(
       "reconcileTemplates merges -template row INTO canonical, reattaches FK refs, unions hosts",
     ) {


### PR DESCRIPTION
## Problem

Operator still saw duplicate apps in prod after #1777's reconcile endpoint deployed (#1794).

**Root cause — confirmed against prod (read-only `GET /api/apps`, 2026-06-20):** `apps.slug` is already `UNIQUE` (V28), so no duplicate is a slug collision. Every dup is the **`<slug>` (operator/legacy, `template_id` NULL) + `<slug>-template` (seeded, `template_id` set)** shape — exactly what #1777's reconciler handles. 8 pairs on prod: `1password`, `eaglercraft`, `giphy`, `google-play`, `moc-pilot`, `plex`, `wifihaven`, `x`.

#1777 shipped the reconcile only as an **on-demand endpoint** (`POST /api/admin/apps/reconcile-templates`). It was **never invoked** against prod, so the pairs persisted. The seeder can't self-heal them: the `-template` row carries the `template_id` the seeder keys on (`findByTemplateId`), so it gets *preserved* every boot rather than merged.

## Fix (this PR — code)

Wire `AppReconciler.reconcileTemplates` into the boot sequence right after the template seed:
- **Idempotent + cheap** (indexed `findBySlug`); a no-op once clean.
- **Safe to repeat / no whack-a-mole:** `mergeAppInto` transfers `template_id` onto the canonical row, so the next seed pass finds the canonical and never re-creates the `-template` fallback. This stops the duplicate *source*.
- **Not a one-shot** (unlike #1608-class seeders) — it stays as a permanent self-heal, behaviorally consistent with the seed pass (which already re-unions template hosts every boot).

### Test
Regression test reproduces the **exact prod shape** through the real seed→reconcile boot pipeline: an operator `1password` row carrying assignments + a seeded `1password-template`. Asserts the seed first re-creates the dup (pinning the bug), reconcile collapses to one canonical row with assignments preserved and template hosts unioned, and the next reboot's reconcile is a clean no-op. Full `api.test` suite green.

## Not handled here (by design)
- **`tinker-cad` vs `tinkercad`** — a slug *variant* near-dup, not a `-template` suffix, so structurally out of the reconciler's reach. Code does **not** grow fuzzy hyphenation matching (risks merging genuinely-distinct apps). One-off operator cleanup (`DELETE /api/apps/21`, 0 assignments).
- **DB identity guard** — a partial unique index on `template_id` ships as a **separate schema-only PR** (PR 2 of 2) per the migration-isolation rule.

## Operator pre-flight
1. Merge + deploy **this PR** → next API boot auto-reconciles the 8 `-template` pairs (no manual curl).
2. Delete the orphan `tinker-cad` (app id 21) via the SPA / `DELETE /api/apps/21`.
3. Then merge the schema-only PR 2 (partial unique index on `template_id`).

Closes #1794 (together with the PR 2 schema guard).