### PR TITLE
fix(#1796): account IPv6 traffic in per-device usage (was IPv4-only)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -807,15 +807,40 @@ function M.nft(snapshot, opts)
   ind("}")
   emit("")
 
+  -- #1796: IPv6 byte-accounting. The v4 sets above only match `ip daddr`, so
+  -- every IPv6 destination flow went uncounted and was invisible in
+  -- per-device traffic / recent-apexes (a v6-preferring client browsing a
+  -- dual-stack host showed nothing). These mirror the v4 sets with an
+  -- ipv6_addr shape; usage.lua reads both families through the same parsers
+  -- and `nft -j` emits compressed v6 that matches the dns-cache key, so
+  -- host attribution works without extra canonicalization.
+  ind("set mac_ip6_tracking {")
+  ind2("type ether_addr . ipv6_addr")
+  ind2("flags dynamic,timeout")
+  ind2("timeout 6h")
+  ind2("counter")
+  ind("}")
+  emit("")
+
+  ind("set ip_pair6_tracking_rx {")
+  ind2("type ipv6_addr . ipv6_addr")
+  ind2("flags dynamic,timeout")
+  ind2("timeout 6h")
+  ind2("counter")
+  ind("}")
+  emit("")
+
   ind("chain wifihaven_account_tx {")
   ind2("type filter hook forward priority 1; policy accept;")
   ind2("iifname \"br-lan\" update @mac_ip_tracking { ether saddr . ip daddr } counter")
+  ind2("iifname \"br-lan\" update @mac_ip6_tracking { ether saddr . ip6 daddr } counter")
   ind("}")
   emit("")
 
   ind("chain wifihaven_account_rx {")
   ind2("type filter hook forward priority 1; policy accept;")
   ind2("oifname \"br-lan\" update @ip_pair_tracking_rx { ip daddr . ip saddr } counter")
+  ind2("oifname \"br-lan\" update @ip_pair6_tracking_rx { ip6 daddr . ip6 saddr } counter")
   ind("}")
   emit("")
 

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -751,7 +751,11 @@ end
 -- lease table; v6 (#1796) comes from the NDP neighbor cache via
 -- conntrack.parse_arp_table (which reads /proc/net/arp + `ip -6 neigh`), since
 -- DHCP leases don't cover SLAAC/v6 device addresses. Leases win for any v4 IP
--- already mapped; the neighbor table only fills gaps (notably all v6 keys).
+-- already mapped; the neighbor table only fills gaps — all v6 keys, and (by
+-- design) any static-IP v4 LAN device with no DHCP lease, which previously had
+-- its rx download bytes dropped (#879). The rx set's lan_ip is always a real
+-- LAN device address (`oifname br-lan` ⇒ ip[6] daddr), so WAN-side entries in
+-- the ARP/NDP dump can't mis-resolve a flow.
 -- Cheap (a handful of lines on tmpfs / one netlink dump) so it runs every scrape.
 local function load_ip_to_mac()
   local leases = conntrack.parse_dhcp_leases()

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -713,30 +713,54 @@ local function read_set_json(name)
   return json_str
 end
 
+-- #1796: read v4 (mac_ip_tracking) AND v6 (mac_ip6_tracking) tracking sets and
+-- merge their parsed records. The parser is family-agnostic — concat[2] is the
+-- remote IP in whatever family the set holds — so the same parse path handles
+-- both. A missing set is treated as the empty side (transient render swap).
 local function read_tx_set()
-  local json_str = read_set_json("mac_ip_tracking")
-  if not json_str then return nil end
-  local ok, counters = pcall(usage.parse_nft_counters, json_str)
-  if not ok then return nil end
-  return counters
+  local out = {}
+  for _, name in ipairs({ "mac_ip_tracking", "mac_ip6_tracking" }) do
+    local json_str = read_set_json(name)
+    if json_str then
+      local ok, counters = pcall(usage.parse_nft_counters, json_str)
+      if ok and counters then
+        for _, c in ipairs(counters) do out[#out + 1] = c end
+      end
+    end
+  end
+  if #out == 0 then return nil end
+  return out
 end
 
 local function read_rx_set()
-  local json_str = read_set_json("ip_pair_tracking_rx")
-  if not json_str then return nil end
-  local ok, counters = pcall(usage.parse_nft_rx_counters, json_str)
-  if not ok then return nil end
-  return counters
+  local out = {}
+  for _, name in ipairs({ "ip_pair_tracking_rx", "ip_pair6_tracking_rx" }) do
+    local json_str = read_set_json(name)
+    if json_str then
+      local ok, counters = pcall(usage.parse_nft_rx_counters, json_str)
+      if ok and counters then
+        for _, c in ipairs(counters) do out[#out + 1] = c end
+      end
+    end
+  end
+  if #out == 0 then return nil end
+  return out
 end
 
--- Build { ip -> mac } from /tmp/dhcp.leases for rx-side resolution (#879).
--- Cheap (a handful of lines on tmpfs); read every counter scrape so freshly
--- DHCP'd clients are attributed without waiting for a re-read.
+-- Build { ip -> mac } for rx-side resolution (#879). v4 comes from the dnsmasq
+-- lease table; v6 (#1796) comes from the NDP neighbor cache via
+-- conntrack.parse_arp_table (which reads /proc/net/arp + `ip -6 neigh`), since
+-- DHCP leases don't cover SLAAC/v6 device addresses. Leases win for any v4 IP
+-- already mapped; the neighbor table only fills gaps (notably all v6 keys).
+-- Cheap (a handful of lines on tmpfs / one netlink dump) so it runs every scrape.
 local function load_ip_to_mac()
   local leases = conntrack.parse_dhcp_leases()
   local m = {}
   for mac, lease in pairs(leases) do
     if lease.ip then m[lease.ip] = mac end
+  end
+  for ip, mac in pairs(conntrack.parse_arp_table()) do
+    if m[ip] == nil then m[ip] = mac end
   end
   return m
 end
@@ -1105,6 +1129,10 @@ conntrack.watch({
         -- nft counters intact would double-count on the next bucket.
         os.execute("nft reset set inet wifihaven mac_ip_tracking >/dev/null 2>&1")
         os.execute("nft reset set inet wifihaven ip_pair_tracking_rx >/dev/null 2>&1")
+        -- #1796: reset the v6 accounting sets too, else v6 counters carry over
+        -- and double-count on the next bucket.
+        os.execute("nft reset set inet wifihaven mac_ip6_tracking >/dev/null 2>&1")
+        os.execute("nft reset set inet wifihaven ip_pair6_tracking_rx >/dev/null 2>&1")
         usage.tracker_reset(activity_tracker)
         if not posted then
           log.warn("usage timer: queued for retry (queue depth=%d)",

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -215,11 +215,20 @@ describe("render.nft", function()
   -- the remote-host axis (#897). The set now records (lan_device_ip,
   -- remote_ip) pairs and the agent resolves the lan_ip back to a MAC via
   -- the dnsmasq lease table.
+  -- Slice helper: body of a `set <name> { ... }` block (up to the first `}`),
+  -- so adjacent set declarations (e.g. the #1796 v6 sets) can't bleed into a
+  -- fixed-width window and break sibling assertions.
+  local function set_body(nft, name)
+    local start = nft:find("set " .. name .. " {", 1, true)
+    if not start then return nil end
+    local close = nft:find("}", start, true)
+    return nft:sub(start, close)
+  end
+
   it("declares the ip_pair_tracking_rx set keyed on (ipv4_addr . ipv4_addr) (#897)", function()
     local nft = render.nft(snap_one())
-    local pos = nft:find("set ip_pair_tracking_rx", 1, true)
-    assert.truthy(pos)
-    local block = nft:sub(pos, pos + 200)
+    local block = set_body(nft, "ip_pair_tracking_rx")
+    assert.truthy(block)
     assert.truthy(block:find("type ipv4_addr %. ipv4_addr"))
     -- Guards against regressing to ether_addr keying (#879) or single-key
     -- ipv4_addr keying (#897).
@@ -278,6 +287,42 @@ describe("render.nft", function()
     -- from the new `_tx`/`_rx` suffixes) must be gone.
     assert.is_nil(nft:find("chain wifihaven_account ", 1, true))
     assert.is_nil(nft:find("chain wifihaven_account\n", 1, true))
+  end)
+
+  -- #1796: the usage byte-accounting plane was IPv4-only — the tracking sets
+  -- were typed ipv4_addr and the update rules matched `ip daddr`/`ip saddr`, so
+  -- every IPv6 destination flow was never counted and never appeared in
+  -- per-device traffic / recent-apexes. (The enforcement plane was already
+  -- dual-stack via ip6 daddr + eb6_/bl6_/ea6_ sets; only accounting lagged.)
+  -- These mirror the v4 sets/chains with an ipv6_addr + ip6 daddr shape.
+  it("declares the mac_ip6_tracking set keyed on (ether_addr . ipv6_addr) (#1796)", function()
+    local nft = render.nft(snap_one())
+    local block = set_body(nft, "mac_ip6_tracking")
+    assert.truthy(block)
+    assert.truthy(block:find("type ether_addr %. ipv6_addr"))
+    assert.is_nil(block:find("ipv4_addr"))
+  end)
+
+  it("declares the ip_pair6_tracking_rx set keyed on (ipv6_addr . ipv6_addr) (#1796)", function()
+    local nft = render.nft(snap_one())
+    local block = set_body(nft, "ip_pair6_tracking_rx")
+    assert.truthy(block)
+    assert.truthy(block:find("type ipv6_addr %. ipv6_addr"))
+    assert.is_nil(block:find("ether_addr"))
+  end)
+
+  it("updates @mac_ip6_tracking from the tx chain via ip6 daddr (#1796)", function()
+    local nft  = render.nft(snap_one())
+    local body = chain_body(nft, "wifihaven_account_tx")
+    assert.truthy(body)
+    assert.truthy(body:find("update @mac_ip6_tracking%s+{%s*ether saddr %. ip6 daddr%s*}%s+counter"))
+  end)
+
+  it("updates @ip_pair6_tracking_rx from the rx chain via ip6 daddr/ip6 saddr (#1796)", function()
+    local nft  = render.nft(snap_one())
+    local body = chain_body(nft, "wifihaven_account_rx")
+    assert.truthy(body)
+    assert.truthy(body:find("update @ip_pair6_tracking_rx%s+{%s*ip6 daddr %. ip6 saddr%s*}%s+counter"))
   end)
 
   -- #354: blocked_macs is derived per-device from effective BlockRules.blocked.

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -164,6 +164,21 @@ describe("usage.merge_counters", function()
     assert.equal(0,         merged[1].bytes)
   end)
 
+  -- #1796: rx download bytes over IPv6. The agent's ip_to_mac now also carries
+  -- v6 device addresses (from the NDP neighbor cache), so a v6 lan_ip resolves
+  -- to its MAC and the v6 remote_ip is attributed the same as v4.
+  it("resolves an IPv6 rx record by v6 lan_ip→mac and attributes to (mac, v6 remote_ip) (#1796)", function()
+    local LAN_V6    = "2601:280:4700:f32:cd10:109c:441c:49df"
+    local REMOTE_V6 = "2606:4700::6812:446"
+    local ip2m_v6   = { [LAN_V6] = MAC }
+    local rx = { { lan_ip = LAN_V6, remote_ip = REMOTE_V6, bytes = 2282889, packets = 1907 } }
+    local merged = usage.merge_counters({}, rx, ip2m_v6)
+    assert.equal(1, #merged)
+    assert.equal(MAC,       merged[1].mac)
+    assert.equal(REMOTE_V6, merged[1].dst_ip)
+    assert.equal(2282889,   merged[1].bytes_out)
+  end)
+
   it("drops rx records whose lan_ip is not in the lease table (#879)", function()
     -- An unknown LAN IP (lease aged out, stale set element) must not produce
     -- a record. Otherwise bytesOut would land on a fake device row.
@@ -354,6 +369,28 @@ describe("usage.build_report", function()
                                  nil, lookup, full_tracker(counters), SAMPLE_S, BUCKET_S)
     assert.equal("fqdn",          r.records[1].host.type)
     assert.equal("api.github.com", r.records[1].host.value)
+  end)
+
+  -- #1796: an IPv6 destination flow (now counted via the mac_ip6_tracking set)
+  -- must attribute to its FQDN through the same dns-cache path. `nft -j` emits
+  -- compressed RFC 5952 v6 and dnsmasq's cache key is compressed too, so the
+  -- raw lookup hits with no extra canonicalization — this pins that contract.
+  it("attributes an IPv6 dst_ip to its FQDN via the dns-cache (#1796)", function()
+    local V6 = "2606:4700::6812:446"  -- compressed, as nft -j and the cache emit
+    local counters = {
+      { mac = "ca:ef:a1:72:6a:a3", dst_ip = V6,
+        bytes = 0, packets = 0, bytes_out = 2282889, packets_out = 1907 },
+    }
+    local lookup = function(ip)
+      if ip == V6 then return "www.mathplayground.com" end
+      return nil
+    end
+    local r = usage.build_report(counters, {}, P_START, P_END, ROUTER,
+                                 nil, lookup, full_tracker(counters), SAMPLE_S, BUCKET_S)
+    assert.equal(1, #r.records)
+    assert.equal("fqdn",                  r.records[1].host.type)
+    assert.equal("www.mathplayground.com", r.records[1].host.value)
+    assert.equal(2282889,                  r.records[1].bytesIn)
   end)
 
   it("prefers lookup_hostname over nft_sets when both have an entry", function()


### PR DESCRIPTION
## Problem

mathplayground.com (and any host) was invisible in prod per-device traffic for a device that reached it over **IPv6**, while the same host showed up for a device that used IPv4. Root-caused live on the prod router in #1796.

The **enforcement** plane is fully dual-stack (`ip6 daddr` + `ea6_/eb6_/bl6_/global_allow6/resolved6_`), but the **usage byte-accounting** plane was never extended to IPv6:

```
set mac_ip_tracking      { type ether_addr . ipv4_addr ... }
set ip_pair_tracking_rx  { type ipv4_addr . ipv4_addr  ... }
rule: iifname "br-lan" update @mac_ip_tracking     { ether saddr . ip daddr }   # ip daddr = IPv4 only
rule: oifname "br-lan" update @ip_pair_tracking_rx { ip daddr . ip saddr }
```

So every IPv6 destination flow was never counted → never reached `host_for_ip` → never appeared in `/api/usage/traffic`, `recent-apexes`, or `/api/dashboard/now`. Live proof on the prod router: a 2.2 MB `ESTABLISHED` flow to `2606:4700::...:6812:0446` (mathplayground v6) being accounted nowhere.

This is distinct from #1793 (the **connection_events** path records a bare v6 literal instead of the FQDN). This PR is the **usage/traffic** path, which dropped v6 entirely.

## Fix

- **`render.lua`**: declare `mac_ip6_tracking` (`ether_addr . ipv6_addr`) and `ip_pair6_tracking_rx` (`ipv6_addr . ipv6_addr`), and add `ip6 daddr`/`ip6 saddr` update rules to the existing tx/rx accounting chains — mirroring the v4 sets.
- **`wifihaven-agent`**: read both families' tx + rx sets through the existing family-agnostic parsers; resolve v6 rx `lan_ip→mac` via the NDP neighbor cache (`conntrack.parse_arp_table` reads `/proc/net/arp` + `ip -6 neigh`) since DHCP leases don't cover SLAAC/v6 addresses; reset the v6 sets at flush so they don't double-count.
- **No canonicalization needed**: `nft -j` emits compressed RFC 5952 v6 that already matches dnsmasq's compressed dns-cache key, so `host_for_ip`'s lookup hits as-is.
- **No wire/API change**: the usage report already carries `ipv6` HostId values (the contract spec passes unchanged).

## Tests (TDD, red→green in history)

- `render_spec`: assert the v6 tracking sets + `ip6 daddr` update rules are emitted; tightened the existing `ip_pair_tracking_rx` assertion to scope to its own `{...}` block (adjacent v6 sets broke the old fixed-width window).
- `usage_spec`: pin the v6 attribution round-trip (compressed v6 dst-ip → FQDN via the dns-cache) and the v6 rx `lan_ip→mac` resolution.
- Full openwrt busted suite: **828 passing**. New nftables constructs syntax-checked against a real `nft -c` on the test router.

## Back-compat

Agent-side only, additive wire (v6 usage records the API already accepts). Wire contract unchanged.

Fixes #1796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)