### PR TITLE
fix(#1801): stabilize TrafficUsagePage fetch-count tests against retention-gate auto-promote

### DIFF
--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -107,7 +107,16 @@ async function navigateToMonth(targetYear: number, targetMonth0: number) {
 }
 
 describe('TrafficUsagePage', () => {
+  // #1801: pin the wall clock. Several tests seed `until` / pick a calendar
+  // day around 2026-05-21, and `bucketAvailability` (#814) gates `raw` off once
+  // the anchor is older than the 30-day raw-retention horizon — measured
+  // against `new Date()`. With the real clock, those seeds aged past 30 days
+  // and the auto-promote effect fired an extra fetch, breaking the call-count
+  // assertions. Fake only `Date` (leave timers real so `waitFor`/userEvent
+  // behave normally) and freeze "now" near the seeds so the gate is stable.
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-05-22T12:00:00Z'))
     vi.clearAllMocks()
     ;(api.devices.list as ReturnType<typeof vi.fn>).mockResolvedValue([])
     ;(api.profiles.list as ReturnType<typeof vi.fn>).mockResolvedValue([])
@@ -116,6 +125,10 @@ describe('TrafficUsagePage', () => {
     ;(api.apps.list as ReturnType<typeof vi.fn>).mockResolvedValue([
       { app: { id: 1, name: 'YouTube', slug: 'youtube' } },
     ])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('loads raw view by default and renders rows', async () => {


### PR DESCRIPTION
Closes #1801.

## Diagnosis: real (time-relative) component behavior, NOT a test-isolation leak

`web/src/pages/TrafficUsagePage.test.tsx` fails the same way **in isolation** (`npx vitest run src/pages/TrafficUsagePage.test.tsx` → 2 failed / 9 passed), so the cross-file `useAuth must be used within AuthProvider` stderr from other files is unrelated noise, not the cause.

The two failing assertions had a **wall-clock dependency**:

- `:316` seeds `?until=2026-05-21T14:00:00.000Z`; `:294` picks calendar day `2026-05-21 14:00`.
- `bucketAvailability` (retention gating, #814) computes `daysAgo = (now − until) / DAY_MS` against the **real** `new Date()`, and gates the `raw` bucket off once `daysAgo > rawDays` (30).
- Today is 2026-06-20 — just past 30 days after 2026-05-21 — so `raw` gated **off**, the auto-promote effect (`TrafficUsagePage.tsx:118-125`) fired `setBucket(finest)`, `filterKey` changed, and the page issued **one extra fetch**. Hence `1→2` (`:316`) and `2→3` (`:294`).

When the tests were authored (~May 2026) the seeds were within 30 days, `raw` stayed enabled, no promotion. They aged out as real time crossed the horizon. The component is working as designed.

## Fix

Pin the system clock in this test file so the gate is deterministic and no longer depends on the calendar date the suite runs on:

- `beforeEach`: `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime('2026-05-22T12:00:00Z')` — fake **only** `Date`, leaving real timers so `waitFor`/`userEvent` behave normally; freeze "now" ~1 day after the seeds so `raw` stays enabled.
- `afterEach`: `vi.useRealTimers()`.

No assertion is weakened — the fetch-count pins still hold; only the wall-clock dependency is removed.

## Verification (local, node 22)

Mirrors the `Frontend Build & Lint` CI job:
- `npm run type-check` ✓
- `npm run lint` ✓
- `npm test` → 35 files / **410 passed** ✓
- `npm run build` ✓

Frontend-only diff; touches one test file.