### PR TITLE
fix(#1796): record IPv6 connection events via NDP neighbor (not lan_prefix_v6)

### DIFF
--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -21,11 +21,13 @@ config wifihaven 'wifihaven'
 	# LAN subnet prefix used to identify outbound (egress) flows
 	option lan_prefix '192.168.1.'
 
-	# Optional v6 LAN ULA prefix used to identify outbound v6 flows (#1688).
-	# Leave unset to filter all v6 flows out of connection_events (today's
-	# prod behaviour). Set to the router's LAN ULA prefix (e.g.
-	# 'fdaa:bbbb:cccc:') to let v6 traffic through the same is_wan_bound
-	# filter the v4 path uses.
+	# Optional v6 LAN prefix override (#1688/#1796). NOT required: as of #1796
+	# outbound v6 flows are identified by NDP-neighbor membership (the agent's
+	# existing ip->mac table), which covers GUA / ULA / privacy addresses and
+	# the ISP-dynamic GUA prefix automatically. Leave unset. Authoring a value
+	# here only ADDS an extra prefix-match accept path (union); it cannot fix v6
+	# on its own because devices source internet traffic from their GUA, not the
+	# ULA, and the GUA prefix is delegated/dynamic.
 	# option lan_prefix_v6 'fdaa:bbbb:cccc:'
 
 	# How many connection_attempt events to accumulate before flushing

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -966,19 +966,45 @@ end
 -- (#575)
 --
 -- Family is detected from src_ip — a colon means IPv6, otherwise v4 — so a
--- single helper handles both stacks (#1688). lan_prefix_v6 is the LAN v6 ULA
--- prefix (e.g. "fdaa:bbbb:cccc:"); when empty/nil v6 flows are rejected so a
--- prod router without an authored v6 LAN keeps today's behavior.
+-- single helper handles both stacks (#1688).
+--
+-- v4 LAN membership is a stable RFC1918 prefix match (`lan_prefix`).
+--
+-- v6 (#1796): a static `lan_prefix_v6` cannot identify LAN-sourced traffic in
+-- practice. Home IPv6 is not NATed, so devices source internet flows from their
+-- GUA — which is ISP-delegated and dynamic — not the ULA. Matching on the ULA
+-- (the only stable prefix) therefore records ZERO internet v6, which is why the
+-- option shipped commented-out and every unconfigured router silently dropped
+-- all v6 connection events. Instead, when the caller passes `lan_ip_set` (the
+-- NDP/ARP neighbor map { ip -> mac } the agent already builds for v6 MAC
+-- attribution), a v6 flow is LAN-bound iff `src` is a known LAN neighbor and
+-- `dst` is not — covering GUA, ULA, and privacy/temporary addresses with no
+-- prefix bookkeeping. `lan_prefix_v6`, if authored, is honored as an additional
+-- accept path (union). With neither a neighbor set nor a prefix, v6 is rejected
+-- (back-compat: the prior empty-prefix default).
 --
 -- lan_prefix    example: "192.168.1."
--- lan_prefix_v6 example: "fdaa:bbbb:cccc:"
+-- lan_prefix_v6 example: "fdaa:bbbb:cccc:"  (optional override; usually unset)
+-- lan_ip_set    example: { ["2601:280:4700:f32::42"] = "aa:bb:.." }  (parse_arp_table)
 -- ---------------------------------------------------------------------------
-function M.is_wan_bound(flow, lan_prefix, lan_prefix_v6)
+function M.is_wan_bound(flow, lan_prefix, lan_prefix_v6, lan_ip_set)
   local is_v6 = flow.src_ip:find(":", 1, true) ~= nil
-  local prefix = is_v6 and lan_prefix_v6 or lan_prefix
-  if not prefix or prefix == "" then return false end
-  return flow.src_ip:sub(1, #prefix) == prefix
-     and flow.dst_ip:sub(1, #prefix) ~= prefix
+  if not is_v6 then
+    if not lan_prefix or lan_prefix == "" then return false end
+    return flow.src_ip:sub(1, #lan_prefix) == lan_prefix
+       and flow.dst_ip:sub(1, #lan_prefix) ~= lan_prefix
+  end
+  -- v6: neighbor-membership (preferred) unioned with an optional authored prefix.
+  local src_lan, dst_lan = false, false
+  if lan_ip_set then
+    src_lan = lan_ip_set[flow.src_ip] ~= nil
+    dst_lan = lan_ip_set[flow.dst_ip] ~= nil
+  end
+  if lan_prefix_v6 and lan_prefix_v6 ~= "" then
+    src_lan = src_lan or flow.src_ip:sub(1, #lan_prefix_v6) == lan_prefix_v6
+    dst_lan = dst_lan or flow.dst_ip:sub(1, #lan_prefix_v6) == lan_prefix_v6
+  end
+  return src_lan and not dst_lan
 end
 
 -- is_outbound is kept as a backward-compatible alias so existing call sites
@@ -1098,13 +1124,30 @@ function M.watch(cfg)
   local pending_hostname_macs = {}
   local leases_path           = cfg.leases_path or "/tmp/dhcp.leases"
 
+  -- #1796: v6 LAN-source is decided by NDP-neighbor membership, so the neighbor
+  -- table must be available *before* the wan-bound check (v4 still uses the
+  -- prefix and needs no table). Cache it per wall-clock second so a burst of
+  -- conntrack NEW events can't shell out to `ip -6 neigh` once per line.
+  local arp_cache, arp_cache_sec = nil, nil
+  local function neighbor_table()
+    local now = os.time()
+    if arp_cache and arp_cache_sec == now then return arp_cache end
+    arp_cache, arp_cache_sec = M.parse_arp_table(), now
+    return arp_cache
+  end
+
   while true do
     local line = handle:read("*l")
     if not line then break end
 
     local flow = M.parse_conntrack_line(line)
-    if flow and M.is_wan_bound(flow, lan_prefix, lan_prefix_v6) then
-      local arp = M.parse_arp_table()
+    -- Only v6 needs the neighbor set for the LAN-source decision; v4 stays on
+    -- the prefix and pays no per-line table cost.
+    local lan_ip_set = (flow and flow.src_ip:find(":", 1, true)) and neighbor_table() or nil
+    if flow and M.is_wan_bound(flow, lan_prefix, lan_prefix_v6, lan_ip_set) then
+      -- v6 reuses the cached neighbor table (src is guaranteed present — it just
+      -- passed the membership check); v4 fetches a fresh ARP table as before.
+      local arp = lan_ip_set or M.parse_arp_table()
       local mac_candidate = M.arp_lookup_mac(flow.src_ip, arp)
       -- Parse the lease file when (a) MAC is new, or (b) MAC is pending a
       -- late hostname (#249 — re-emit dhcp_lease once dnsmasq writes it).

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -995,6 +995,11 @@ function M.is_wan_bound(flow, lan_prefix, lan_prefix_v6, lan_ip_set)
        and flow.dst_ip:sub(1, #lan_prefix) ~= lan_prefix
   end
   -- v6: neighbor-membership (preferred) unioned with an optional authored prefix.
+  -- lan_ip_set may include neighbors from all interfaces (parse_arp_table runs
+  -- `ip -6 neigh show` without a dev filter), but that's safe here: an internet
+  -- dst reached via the default route is never on-link, so it can't appear and
+  -- falsely mark a flow LAN-internal; and a WAN host's src is never a forwarded
+  -- LAN flow's src.
   local src_lan, dst_lan = false, false
   if lan_ip_set then
     src_lan = lan_ip_set[flow.src_ip] ~= nil

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -1924,6 +1924,47 @@ describe("is_wan_bound (#575)", function()
     assert.is_false(conntrack.is_wan_bound(
       { src_ip = "2001:db8::99", dst_ip = "2001:db8::10" }, LAN, LAN6))
   end)
+
+  -- #1796: a static lan_prefix_v6 cannot identify LAN-sourced v6 in practice —
+  -- devices source internet flows from their GUA (ISP-delegated, dynamic), not
+  -- the ULA, so the ULA prefix records ZERO internet v6 and ships off by
+  -- default. The durable fix passes the NDP neighbor set (ip -> mac, the table
+  -- the agent already builds for v6 MAC attribution) as a 4th arg: a v6 flow is
+  -- LAN-bound iff src is a known neighbor and dst is not. v4 stays prefix-based.
+  describe("v6 via NDP neighbor table (#1796)", function()
+    -- Real prod shape: device GUA -> Cloudflare (mathplayground). No ULA in sight.
+    local GUA   = "2601:280:4700:f32:cd10:109c:441c:49df"
+    local CFv6  = "2606:4700::6812:446"
+    local PEER6 = "2601:280:4700:f32:aef7:a1ee:2623:6f41"
+    local NEIGH = { [GUA] = "04:72:ef:d6:e4:5a", [PEER6] = "78:78:35:a2:03:3a" }
+
+    it("accepts a GUA-sourced v6 flow to a public dst even with NO v6 prefix", function()
+      assert.is_true(conntrack.is_wan_bound(
+        { src_ip = GUA, dst_ip = CFv6 }, LAN, "", NEIGH))
+    end)
+
+    it("rejects a v6 flow between two LAN neighbors (LAN-internal)", function()
+      assert.is_false(conntrack.is_wan_bound(
+        { src_ip = GUA, dst_ip = PEER6 }, LAN, "", NEIGH))
+    end)
+
+    it("rejects a v6 flow whose src is not a known neighbor", function()
+      assert.is_false(conntrack.is_wan_bound(
+        { src_ip = "2001:db8::99", dst_ip = CFv6 }, LAN, "", NEIGH))
+    end)
+
+    it("still accepts via the authored prefix when src matches it (union, back-compat)", function()
+      assert.is_true(conntrack.is_wan_bound(
+        { src_ip = "fdaa:bbbb:cccc::42", dst_ip = CFv6 }, LAN, "fdaa:bbbb:cccc:", NEIGH))
+    end)
+
+    it("does not affect v4 (still prefix-based even when a neighbor set is passed)", function()
+      assert.is_true(conntrack.is_wan_bound(
+        { src_ip = "192.168.1.42", dst_ip = "1.2.3.4" }, LAN, "", NEIGH))
+      assert.is_false(conntrack.is_wan_bound(
+        { src_ip = "10.0.0.5", dst_ip = "1.2.3.4" }, LAN, "", NEIGH))
+    end)
+  end)
 end)
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Outbound **IPv6 connection events** are silently dropped on every router that hasn't manually authored `lan_prefix_v6` — which ships **commented out by default** (`openwrt/files/etc/config/wifihaven`). `conntrack.lua is_wan_bound` decided LAN-source by matching `src_ip` against that prefix; empty ⇒ all v6 flows rejected.

Worse, the *only* stable prefix — the ULA — never matches real traffic. Home IPv6 isn't NATed, so devices source internet flows from their **GUA**, which is ISP-delegated and **dynamic**. Live prod proof (the mathplayground flow this all started from):

```
src=2601:280:4700:f32:cd10:109c:441c:49df   dst=2606:4700::6812:446   (Cloudflare / mathplayground)
```

So `lan_prefix_v6='fdcd:f224:23d6:'` (the ULA) would record **zero** internet v6. This is the **connection_events** half of #1796; the **usage/traffic** half is #1802 (and is prefix-independent, so it was a separate gap).

## Fix

`is_wan_bound` now takes an optional 4th arg — the **NDP/ARP neighbor map** `{ ip -> mac }` the agent *already builds* (`conntrack.parse_arp_table`, used for v6 MAC attribution). A v6 flow is LAN-bound iff **`src` is a known neighbor and `dst` is not** — robust across GUA, ULA, privacy/temporary addresses and dynamic prefix re-delegation, with no prefix bookkeeping.

- **v4 unchanged** — stable RFC1918 prefix match.
- **`lan_prefix_v6`** is kept as an optional *additional* accept path (union); no longer required. Config comment updated to say so.
- The watch loop fetches the neighbor table **only for v6 lines**, cached per wall-clock second to bound `ip -6 neigh` cost, and reuses it for MAC attribution (the src is guaranteed present — it just passed the membership check).

Confirmed live: 31 device GUAs/ULAs are present in `ip -6 neigh` on prod with `lladdr`, so the membership check resolves real flows.

## Tests (TDD, red→green)

`conntrack_spec.lua` → new `is_wan_bound v6 via NDP neighbor table (#1796)` block:
- GUA-sourced v6 to public dst accepted with **no** v6 prefix (the bug);
- v6 between two neighbors rejected (LAN-internal);
- unknown-src v6 rejected;
- authored prefix still works (union);
- v4 unaffected when a neighbor set is passed.

Full openwrt busted suite: **827 passing**. Existing 3-arg `is_wan_bound` callers/tests are unaffected (4th arg optional).

## Back-compat

Agent-only; `is_wan_bound` signature change is additive (optional 4th arg). No wire/API change. nft/UCI keys aren't the wire contract.

Part of #1796 (paired with #1802). Related: #1793 (v6 recorded as bare literal), #1688 (v6 attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)