### PR TITLE
fix(cd): live-staging e2e §5b — seed-from-templates instead of retired POST /api/apps

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -390,23 +390,42 @@ esac
 
 # ── 5b. #1105: time_limited app + exemptFromDaily carves around the MAC block ─
 #
-# Profile is currently blocked (reason=TimeLimit from §3's 90s usage). Create a
-# Khan-shaped app, assign it `mode=time_limited, exemptFromDaily=true` with
-# remaining per-host budget, and re-fetch the snapshot. The app's host MUST
-# appear in profile.rules.extraAllowed even though `blocked=true` is still
-# set — that's the contract the router (render.lua) relies on to carve the
-# host out of @blocked_macs. PolicySnapshotAppsSpec covers the same logic in
-# the unit tests; this step locks it in over the wire so a future refactor
-# can't drop the extraAllowed entry without tripping CI.
+# Profile is currently blocked (reason=TimeLimit from §3's 90s usage). Pick a
+# template-seeded app, assign it `mode=time_limited, exemptFromDaily=true`, and
+# re-fetch the snapshot. The app's host MUST appear in profile.rules.extraAllowed
+# even though `blocked=true` is still set — that's the contract the router
+# (render.lua) relies on to carve the host out of @blocked_macs.
+# PolicySnapshotAppsSpec covers the same logic in the unit tests; this step locks
+# it in over the wire so a future refactor can't drop the extraAllowed entry
+# without tripping CI.
+#
+# #1798 retired POST /api/apps (app *definitions* are now template-authored
+# only). So instead of minting a Khan-shaped app on the fly, seed the built-in
+# AppTemplates, then drive the assertion off whichever seeded app the API
+# returns (its real host-set) — the carve-out contract is host-agnostic.
 step "#1105: exempt time_limited app folds host into extraAllowed under MAC block"
-APP_BODY='{"name":"e2e-khan-'"$RUN_ID"'","hosts":["khan.example.com"]}'
-APP_JSON=$(curl -fsS -X POST "$BASE/api/apps" "${AUTH[@]}" \
-  -H 'content-type: application/json' -d "$APP_BODY")
-APP_ID=$(_py "import json; print(json.loads('''$APP_JSON''')['app']['id'])")
+# Idempotent on a persistent staging DB — re-seeding an already-seeded slug is a
+# no-op (preserved), so concurrent runs don't collide.
+curl -fsS -X POST "$BASE/api/apps/seed-from-templates" "${AUTH[@]}" >/dev/null
+# Pick the first seeded app that exposes at least one host; assert on that host.
+curl -fsS "${AUTH[@]}" "$BASE/api/apps" >"$TMP/apps.json"
+APP_SEL=$(_py "
+import json
+apps = json.load(open('$TMP/apps.json'))
+for a in apps:
+    hosts = a.get('hosts') or []
+    if hosts:
+        print(a['app']['id'], hosts[0]); break
+else:
+    raise SystemExit('no seeded app with a host found in GET /api/apps')
+") || fail "could not select a seeded app+host (see stderr)"
+APP_ID=${APP_SEL%% *}
+APP_HOST=${APP_SEL#* }
+[ -n "$APP_ID" ] && [ -n "$APP_HOST" ] || fail "empty app id/host from selection: '$APP_SEL'"
 curl -fsS -X PUT "$BASE/api/apps/$APP_ID/policy/$PID" "${AUTH[@]}" \
   -H 'content-type: application/json' \
   -d '{"mode":"time_limited","dailyMinutes":60,"exemptFromDaily":true}' >/dev/null
-pass "app $APP_ID created + assigned time_limited+exempt to profile $PID"
+pass "seeded app $APP_ID (host=$APP_HOST) assigned time_limited+exempt to profile $PID"
 
 # Snapshot's extraAllowed must now include the app host while the profile
 # remains blocked.
@@ -424,14 +443,14 @@ r = p['rules']
 ea = set(r.get('extraAllowed') or [])
 blocked = r.get('blocked')
 reason = r.get('blockReason')
-ok = ('khan.example.com' in ea) and bool(blocked) and reason == 'TimeLimit'
+ok = ('$APP_HOST' in ea) and bool(blocked) and reason == 'TimeLimit'
 print('ok' if ok else f'fail: blocked={blocked} reason={reason} ea={sorted(ea)}')
 ")
   [ "$EA_OK" = "ok" ] && break
   sleep 1
 done
-[ "$EA_OK" = "ok" ] || fail "expected blocked=True+reason=TimeLimit+ea contains 'khan.example.com', got: $EA_OK"
-pass "extraAllowed carves 'khan.example.com' under blocked=True/TimeLimit"
+[ "$EA_OK" = "ok" ] || fail "expected blocked=True+reason=TimeLimit+ea contains '$APP_HOST', got: $EA_OK"
+pass "extraAllowed carves '$APP_HOST' under blocked=True/TimeLimit"
 
 # ── 6. Paused profile reflected immediately in snapshot ───────────────────
 #

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -407,17 +407,26 @@ step "#1105: exempt time_limited app folds host into extraAllowed under MAC bloc
 # Idempotent on a persistent staging DB — re-seeding an already-seeded slug is a
 # no-op (preserved), so concurrent runs don't collide.
 curl -fsS -X POST "$BASE/api/apps/seed-from-templates" "${AUTH[@]}" >/dev/null
-# Pick the first seeded app that exposes at least one host; assert on that host.
 curl -fsS "${AUTH[@]}" "$BASE/api/apps" >"$TMP/apps.json"
+# Pick a seeded app+host whose host is NOT already in the profile's extraAllowed
+# *before* we assign anything. The global infra-allowlist (#1311) seeds some
+# hosts into every profile's extraAllowed, so picking a host that's already
+# allowed would let the post-assignment assertion pass even if the
+# time_limited+exempt → extraAllowed fold regressed. Selecting an as-yet-unallowed
+# host keeps the carve-out attributable solely to the assignment (the property
+# the synthetic-host version relied on pre-#1798).
+curl -fsS "${RAUTH[@]}" "$BASE/api/router/policy" >"$TMP/snap_pre.json"
 APP_SEL=$(_py "
 import json
+snap = json.load(open('$TMP/snap_pre.json'))
+p = snap['profiles'].get('$PID') or {}
+ea_before = set((p.get('rules') or {}).get('extraAllowed') or [])
 apps = json.load(open('$TMP/apps.json'))
 for a in apps:
-    hosts = a.get('hosts') or []
-    if hosts:
-        print(a['app']['id'], hosts[0]); break
-else:
-    raise SystemExit('no seeded app with a host found in GET /api/apps')
+    for h in (a.get('hosts') or []):
+        if h not in ea_before:
+            print(a['app']['id'], h); raise SystemExit(0)
+raise SystemExit('no seeded app host outside the pre-existing extraAllowed set')
 ") || fail "could not select a seeded app+host (see stderr)"
 APP_ID=${APP_SEL%% *}
 APP_HOST=${APP_SEL#* }


### PR DESCRIPTION
## What was red
**Master API/UI CD** on main. The "Live e2e against staging stack" job — which builds a fresh local compose stack from current main (`docker compose ... up --build`) and runs `scripts/e2e-router.sh` against `127.0.0.1:8080` — fails:

```
▶ #1105: exempt time_limited app folds host into extraAllowed under MAC block
curl: (22) The requested URL returned error: 404
```

Runs [#1798](https://github.com/wifihaven/wifihaven/actions/runs/27884251144) and [#1793](https://github.com/wifihaven/wifihaven/actions/runs/27884399894) fail identically here.

## Root cause
[#1798](https://github.com/wifihaven/wifihaven/issues/1798) (b99ed2b8) retired the operator-facing app-definition mutators including `POST /api/apps` (apps are now template-authored only). The SPA + Scala unit tests were updated, but `e2e-router.sh` §5b still minted a Khan-shaped app via `POST /api/apps`, which now 404s and aborts `curl -f`.

## Fix
Rewrite §5b to seed the built-in templates and drive the #1105 assertion off a seeded app's real host:
- `POST /api/apps/seed-from-templates` (idempotent; admin-gated — `AUTH` is admin)
- `GET /api/apps` → pick first seeded app with ≥1 host
- assert that host folds into `extraAllowed` under `blocked=True`/`TimeLimit`

The carve-out contract is host-agnostic, so this preserves the exact #1105 wire assertion. `PUT /api/apps/:id/policy/:profileId` (kept by #1798) is unchanged.

## Validation
- `bash -n` + `shellcheck -S warning` clean.
- `GET /api/apps` response shape (`app.id` + `hosts[]`) confirmed against live staging (32 seeded apps, all with hosts).
- Selection parse (skip no-host apps, pick first with host) simulated offline.
- Full local compose e2e **not** runnable on this host (Docker down) — relies on this PR's CI "Live e2e against staging stack" gate, which exercises the exact path.

## Out of scope (tracked)
Gate 3a router e2e (`scripts/e2e/lib/api_admin.py` `create_app` + `scripts/e2e/gate3/conftest.py`) hits the same retired route but needs specific VM-reachable block/allow hosts — a redesign tracked in #1810. Master Router CD is not currently red (latest completed run was `cancelled`, superseded), so it is deliberately left out of this conservative CD-restore fix.

Fixes #1809

🤖 Generated with [Claude Code](https://claude.com/claude-code)