### PR TITLE
fix(cd): gate3 e2e seeds apps from templates instead of retired POST /api/apps — restore Master API/UI CD (Gate 3b)

### DIFF
--- a/scripts/e2e/gate3/conftest.py
+++ b/scripts/e2e/gate3/conftest.py
@@ -20,6 +20,7 @@ import os
 import pytest
 
 from lib.api_admin import AdminAPI
+from lib.app_seed import pick_block_allow_apps
 from lib.enrollment import exchange_enrollment_token, provision_router_uci
 from lib.vm import Client, client_down, client_up, router_down, router_up
 from lib.wait import wait_for_client_dns, wait_for_etag_change, wait_for_router_active
@@ -136,34 +137,50 @@ def client_vm() -> Client:
 
 @pytest.fixture()
 def scratch_profile_and_device(admin, enrolled_router, client_vm):
-    """Create a namespaced profile + device + blocked/allowed apps; yield
-    the relevant ids; delete on teardown.
+    """Create a namespaced profile + device, assign one seeded app `blocked`
+    and another `allowed` to it, and yield the relevant ids + hosts; clean
+    up on teardown.
 
     Post-#764, extraBlocked / extraAllowed are no longer profile fields —
-    they come from app_policy_assignments. The Apps API is:
-      POST   /api/apps {name, slug, hosts}                   → create
-      PUT    /api/apps/{aid}/policy/{pid} {mode: "blocked"}  → assign
-      DELETE /api/apps/{aid}                                 → cascades the
-                                                              assignment
+    they come from app_policy_assignments. Post-#1798, app *definitions* are
+    template-authored ONLY — the arbitrary-host `POST /api/apps` create was
+    retired, so this can no longer mint `example.com` / `example.org` apps.
+    Instead it seeds the shipped templates (idempotent, admin-gated) and
+    drives its two-leg block/allow assertion off two distinct *seeded* apps'
+    real hosts. The block/allow contract is host-agnostic (block = HTTP/80
+    DNAT to the block page on the resolved IPs; allow = carve-out / no
+    over-block), so the assertion is unchanged — only the host source moves
+    from a hand-minted app to the template catalog. Like example.com/.org,
+    the chosen template apexes resolve + are reachable through qemu SLIRP v4
+    NAT (see lib/app_seed.BLOCK_PREF / ALLOW_PREF).
+
+    Apps surface used — all kept by #1798:
+      POST   /api/apps/seed-from-templates          → seed catalog (idempotent)
+      GET    /api/apps                               → read seeded apps + hosts
+      PUT    /api/apps/{aid}/policy/{pid} {mode}     → assign block/allow
+      DELETE /api/apps/{aid}/policy/{pid}            → detach (teardown)
+    The shared seeded apps are NEVER deleted on teardown — only this run's
+    namespaced profile/device + its policy assignments.
     """
     suffix = _suffix()
-    blocked_host = "example.com"
-    allowed_host = "example.org"
+
+    # Seed (idempotent) then pick two distinct seeded apps for the two legs.
+    admin.seed_apps_from_templates()
+    blocked_app, allowed_app = pick_block_allow_apps(admin.list_apps())
+    blocked_app_id = blocked_app["app"]["id"]
+    allowed_app_id = allowed_app["app"]["id"]
+    blocked_host = blocked_app["hosts"][0]
+    allowed_host = allowed_app["hosts"][0]
+    log.info(
+        "gate3: block leg app=%s host=%s; allow leg app=%s host=%s",
+        blocked_app["app"].get("slug"), blocked_host,
+        allowed_app["app"].get("slug"), allowed_host,
+    )
 
     pname = f"gate3-{suffix}"
     p = admin.create_profile(name=pname)
     pid = (p.get("profile") or p)["id"]
 
-    blocked_app = admin.create_app(
-        name=f"gate3-blk-{suffix}", slug=f"gate3-blk-{suffix}",
-        hosts=[blocked_host],
-    )
-    allowed_app = admin.create_app(
-        name=f"gate3-alw-{suffix}", slug=f"gate3-alw-{suffix}",
-        hosts=[allowed_host],
-    )
-    blocked_app_id = blocked_app["app"]["id"]
-    allowed_app_id = allowed_app["app"]["id"]
     admin.assign_app_policy(app_id=blocked_app_id, profile_id=pid, mode="blocked")
     admin.assign_app_policy(app_id=allowed_app_id, profile_id=pid, mode="allowed")
 
@@ -190,17 +207,18 @@ def scratch_profile_and_device(admin, enrolled_router, client_vm):
         "allowed_app_id": allowed_app_id,
     }
 
-    # Teardown — DELETE app cascades its assignment, so order is:
-    # device → apps (cascades assignments) → profile.
+    # Teardown — detach this profile's policy assignments (the seeded apps
+    # are shared and must survive), then delete the namespaced device +
+    # profile. Order: device → assignments → profile.
     try:
         admin.delete_device(mac)
     except Exception as e:  # noqa: BLE001
         log.warning("delete_device(%s) failed: %s", mac, e)
     for aid in (blocked_app_id, allowed_app_id):
         try:
-            admin.delete_app(aid)
+            admin.delete_app_policy(app_id=aid, profile_id=pid)
         except Exception as e:  # noqa: BLE001
-            log.warning("delete_app(%s) failed: %s", aid, e)
+            log.warning("delete_app_policy(app=%s, profile=%s) failed: %s", aid, pid, e)
     try:
         admin.delete_profile(pid)
     except Exception as e:  # noqa: BLE001

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -255,33 +255,29 @@ class AdminAPI:
     def delete_device(self, mac: str) -> None:
         self._request("DELETE", f"/api/devices/{mac}")
 
-    # ── apps (#761/#764) ──────────────────────────────────────────────────
+    # ── apps (#761/#764/#1798) ────────────────────────────────────────────
     # Post-#764, extraAllowed/extraBlocked are sourced exclusively from
     # app_policy_assignments — the legacy `extraBlocked`/`extraAllowed`
-    # fields on profile POST/PUT are silently dropped. To exercise the
-    # block/allow planes against a real API, callers must use the Apps
-    # surface: create an app with hosts, then assign it to a profile with
-    # a mode.
+    # fields on profile POST/PUT are silently dropped.
+    #
+    # Post-#1798, app *definitions* are template-authored ONLY — the
+    # arbitrary-host `POST /api/apps` create (and the update / replace-hosts
+    # / PATCH mutators) were retired. To exercise the block/allow planes
+    # against a real API, callers seed the shipped templates
+    # (`seed_apps_from_templates`), read them back (`list_apps`), and assign
+    # a seeded app to a profile with a mode (`assign_app_policy`). See
+    # lib/app_seed.pick_block_allow_apps for the gate3 selection (#1810).
 
-    def create_app(self, *, name: str, slug: str | None = None,
-                   hosts: list[str] | None = None,
-                   template_id: str | None = None,
-                   icon: str | None = None,
-                   icon_type: str | None = None) -> dict[str, Any]:
-        """POST /api/apps. Returns the app-detail body
-        ({app: {id, name, ...}, hosts: [...], assignments: [...]})."""
-        body: dict[str, Any] = {"name": name}
-        if slug is not None:
-            body["slug"] = slug
-        if hosts is not None:
-            body["hosts"] = hosts
-        if template_id is not None:
-            body["templateId"] = template_id
-        if icon is not None:
-            body["icon"] = icon
-        if icon_type is not None:
-            body["iconType"] = icon_type
-        return self._request("POST", "/api/apps", body=body)
+    def seed_apps_from_templates(self) -> dict[str, Any]:
+        """POST /api/apps/seed-from-templates (admin, idempotent). Find-or-
+        creates one `apps` row per built-in template; returns the seed
+        summary ({created, repopulated, preserved, augmented})."""
+        return self._request("POST", "/api/apps/seed-from-templates")
+
+    def list_apps(self) -> list[dict[str, Any]]:
+        """GET /api/apps. Returns a list of app-detail bodies
+        ({app: {id, slug, templateId, ...}, hosts: [...], assignments: [...]})."""
+        return self._request("GET", "/api/apps")
 
     def assign_app_policy(self, *, app_id: int, profile_id: int, mode: str,
                           daily_minutes: int | None = None,
@@ -296,8 +292,17 @@ class AdminAPI:
             body["exemptFromDaily"] = exempt_from_daily
         self._request("PUT", f"/api/apps/{app_id}/policy/{profile_id}", body=body)
 
+    def delete_app_policy(self, *, app_id: int, profile_id: int) -> None:
+        """DELETE /api/apps/{app_id}/policy/{profile_id}. Detaches this
+        profile's assignment WITHOUT touching the shared app definition —
+        the teardown path for seeded (template-authored) apps, which must
+        survive for other gates / the live catalog."""
+        self._request("DELETE", f"/api/apps/{app_id}/policy/{profile_id}")
+
     def delete_app(self, app_id: int) -> None:
-        """DELETE /api/apps/{id}. Cascades app_policy_assignments."""
+        """DELETE /api/apps/{id} (admin, #1798 stray-row cleanup). Cascades
+        app_policy_assignments. NOT used to tear down seeded apps — detach
+        the assignment with `delete_app_policy` instead."""
         self._request("DELETE", f"/api/apps/{app_id}")
 
     # ── logs / sessions / stats ───────────────────────────────────────────

--- a/scripts/e2e/lib/app_seed.py
+++ b/scripts/e2e/lib/app_seed.py
@@ -1,0 +1,65 @@
+"""Gate 3 app selection over the template-authored Apps surface (#1810).
+
+Post-#1798 the operator-facing app-definition mutators were retired — there
+is no `POST /api/apps`, so gate3 can no longer mint ad-hoc `example.com` /
+`example.org` apps with arbitrary hosts (apps are authored only via the
+built-in `AppTemplates`). Instead the gate3 fixture seeds the shipped
+templates (`POST /api/apps/seed-from-templates`, idempotent + admin-gated)
+and drives its host-agnostic two-leg block/allow assertion off two distinct
+*seeded* apps' real hosts.
+
+This module holds the pure selection — pick a block-leg app and an
+allow-leg app from `GET /api/apps` output — so it is unit-testable without a
+staging API or a KVM VM (see `test_app_seed.py`).
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+# Ordered preference of seeded template ids (== `app.templateId`) whose apex
+# resolves and is reachable over plain HTTP/80 through qemu SLIRP v4 NAT —
+# the same property `example.com` / `example.org` had, which is why those
+# were the original probe hosts. The block leg only needs the host to
+# RESOLVE (dnsmasq populates the per-host nft set from the upstream answer,
+# then the HTTP/80 DNAT to the block page is host-agnostic); the allow leg
+# needs a clean 2xx/3xx with no block-page markers. Distinct lists so the
+# two legs probe different hosts. Falls back to any hosted app (below) so a
+# template-catalog change never breaks the gate.
+BLOCK_PREF: tuple[str, ...] = ("youtube", "netflix", "roblox", "tiktok", "discord")
+ALLOW_PREF: tuple[str, ...] = ("duolingo", "khan-academy", "wifihaven", "brave", "1password")
+
+
+def _hosted(apps: Sequence[dict]) -> list[dict]:
+    """AppDetail dicts that have at least one host and a real app id."""
+    out = []
+    for a in apps:
+        app = a.get("app") or {}
+        if (a.get("hosts") or []) and app.get("id") is not None:
+            out.append(a)
+    return out
+
+
+def _find_by_template(hosted: Sequence[dict], template_id: str) -> dict | None:
+    return next(
+        (a for a in hosted if (a.get("app") or {}).get("templateId") == template_id),
+        None,
+    )
+
+
+def pick_block_allow_apps(
+    apps: Sequence[dict],
+    *,
+    block_pref: Sequence[str] = BLOCK_PREF,
+    allow_pref: Sequence[str] = ALLOW_PREF,
+) -> tuple[dict, dict]:
+    """Choose two DISTINCT seeded apps (each with >=1 host) for the gate3
+    block / allow legs from `GET /api/apps` output (a list of AppDetail
+    dicts: ``{"app": {id, slug, templateId, ...}, "hosts": [...], ...}``).
+
+    Returns ``(blocked_app, allowed_app)``. Prefers the stable
+    `templateId`-keyed picks above; falls back to the first / next hosted
+    app so the gate survives a catalog change. Raises if fewer than two
+    hosted apps exist (a broken/empty seed — surface it loudly rather than
+    silently degrade).
+    """
+    raise NotImplementedError  # implemented in the follow-up (green) commit

--- a/scripts/e2e/lib/app_seed.py
+++ b/scripts/e2e/lib/app_seed.py
@@ -62,4 +62,30 @@ def pick_block_allow_apps(
     hosted apps exist (a broken/empty seed — surface it loudly rather than
     silently degrade).
     """
-    raise NotImplementedError  # implemented in the follow-up (green) commit
+    hosted = _hosted(apps)
+    if len(hosted) < 2:
+        raise RuntimeError(
+            f"gate3 needs >=2 seeded apps with hosts; saw {len(hosted)} "
+            "(is the template catalog seeded?)",
+        )
+
+    blocked = next(
+        (a for a in (_find_by_template(hosted, s) for s in block_pref) if a is not None),
+        hosted[0],
+    )
+    block_id = blocked["app"]["id"]
+
+    allowed = next(
+        (
+            a
+            for a in (_find_by_template(hosted, s) for s in allow_pref)
+            if a is not None and a["app"]["id"] != block_id
+        ),
+        None,
+    )
+    if allowed is None:
+        # No distinct preferred allow pick — take any other hosted app.
+        allowed = next((a for a in hosted if a["app"]["id"] != block_id), None)
+    if allowed is None:
+        raise RuntimeError("gate3 could not pick two distinct hosted apps")
+    return blocked, allowed

--- a/scripts/e2e/lib/test_app_seed.py
+++ b/scripts/e2e/lib/test_app_seed.py
@@ -1,0 +1,90 @@
+"""Unit cover for the gate3 template-app selection (#1810).
+
+Pure — no staging API, no KVM VM. Run standalone:
+
+    python3 -m pytest scripts/e2e/lib/test_app_seed.py
+
+Pins the contract the gate3 `scratch_profile_and_device` fixture relies on
+post-#1798: seed the shipped templates, then pick two distinct *seeded* apps
+(one for the block leg, one for the allow leg) off `GET /api/apps` output —
+since `POST /api/apps` (arbitrary-host create) is gone.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app_seed import ALLOW_PREF, BLOCK_PREF, pick_block_allow_apps
+
+
+def _app(app_id: int, template_id: str | None, hosts: list[str]) -> dict:
+    """An AppDetail-shaped dict as `GET /api/apps` returns it."""
+    return {
+        "app": {"id": app_id, "slug": template_id or f"app-{app_id}", "templateId": template_id},
+        "hosts": hosts,
+        "assignments": [],
+    }
+
+
+def _catalog() -> list[dict]:
+    # A representative seeded catalog: preferred block/allow picks present,
+    # plus an unhosted app (must be skipped) and a CDN-ish extra.
+    return [
+        _app(1, "youtube", ["youtube.com", "youtu.be"]),
+        _app(2, "duolingo", ["duolingo.com"]),
+        _app(3, "khan-academy", ["khanacademy.org"]),
+        _app(4, "empty-app", []),  # no hosts → never selected
+        _app(5, "1password", ["1password.com"]),
+    ]
+
+
+def test_prefers_template_ids_for_both_legs():
+    blocked, allowed = pick_block_allow_apps(_catalog())
+    assert blocked["app"]["templateId"] == "youtube"      # first BLOCK_PREF present
+    assert allowed["app"]["templateId"] == "duolingo"     # first ALLOW_PREF present
+    assert blocked["hosts"][0] == "youtube.com"
+    assert allowed["hosts"][0] == "duolingo.com"
+
+
+def test_block_and_allow_are_always_distinct():
+    blocked, allowed = pick_block_allow_apps(_catalog())
+    assert blocked["app"]["id"] != allowed["app"]["id"]
+
+
+def test_skips_apps_with_no_hosts():
+    blocked, allowed = pick_block_allow_apps(_catalog())
+    for picked in (blocked, allowed):
+        assert picked["app"]["templateId"] != "empty-app"
+        assert picked["hosts"], "selected app must carry at least one host"
+
+
+def test_falls_back_to_any_hosted_app_when_prefs_absent():
+    # A catalog of two arbitrary hosted apps, none in the preference lists.
+    catalog = [
+        _app(10, "obscure-a", ["a.example"]),
+        _app(11, "obscure-b", ["b.example"]),
+    ]
+    blocked, allowed = pick_block_allow_apps(catalog)
+    assert {blocked["app"]["id"], allowed["app"]["id"]} == {10, 11}
+
+
+def test_allow_falls_back_when_only_pref_collides_with_block():
+    # Only one preferred app exists and it's a block pick; the allow leg must
+    # fall back to a different hosted app rather than reuse it.
+    catalog = [
+        _app(20, "youtube", ["youtube.com"]),   # block pick
+        _app(21, "obscure", ["obscure.example"]),
+    ]
+    blocked, allowed = pick_block_allow_apps(catalog)
+    assert blocked["app"]["templateId"] == "youtube"
+    assert allowed["app"]["id"] == 21
+
+
+def test_raises_when_fewer_than_two_hosted_apps():
+    with pytest.raises(RuntimeError):
+        pick_block_allow_apps([_app(1, "youtube", ["youtube.com"]), _app(2, "x", [])])
+
+
+def test_preference_lists_are_disjoint():
+    # Guards against a future edit that puts the same slug in both legs,
+    # which would make the distinct-picks guarantee rely purely on fallback.
+    assert not (set(BLOCK_PREF) & set(ALLOW_PREF))


### PR DESCRIPTION
## What was red
**Master API/UI CD** at **Gate 3b — last-published router + staging API** (run [27912992678](https://github.com/wifihaven/wifihaven/actions/runs/27912992678)). The job gets *past* the live-staging e2e (fixed by [#1811](https://github.com/wifihaven/wifihaven/pull/1811)) and then fails in the gate3 fixture:

```
gate3/conftest.py  scratch_profile_and_device → admin.create_app(...)
lib/api_admin.py   create_app → _request("POST", "/api/apps", ...)
RuntimeError: POST https://api-staging.wifihaven.net/api/apps → HTTP 404
```

## Root cause
[#1798](https://github.com/wifihaven/wifihaven/issues/1798) (b99ed2b8) retired the operator-facing app-definition mutators — including the arbitrary-host `POST /api/apps` create — because apps are **template-authored only** now. The gate3 fixture still minted a *blocked* app (`example.com`) and an *allowed* app (`example.org`) via `AdminAPI.create_app`, which now 404s. Gate 3b reaches this because it runs the **last-published router** (working DNS) against the **freshly-deployed staging API**. Same root cause as #1809/#1811; this is the analogous fix for the Python gate3 suite.

## Why this needed a redesign (and not the #1811 one-liner)
The shell e2e only needed *any* app+host. Gate 3 needs **two specific, VM-reachable hosts** — one to assert the nftables forward-DROP (block leg) and one to assert the `extraAllowed` carve-out / no-over-block (allow leg) at the connection layer.

I weighed the two options from #1810 and chose **Option 2 (drive off existing seeded templates)**, rejecting **Option 1 (add gate3-only `example.com`/`example.org` templates)**:

- **Gate 3b runs the freshly-deployed staging *binary*, which only knows the default template manifest.** To make `seed-from-templates` mint `example.com`/`example.org` apps, those test templates would have to ship in the production manifest — polluting **every household's** app catalog with test apps. That directly contradicts #1798, which *removed* app-editing precisely to clean up the catalog (#1777/#1794 churn). There is no per-environment manifest switch and no arbitrary-host create path, so Option 1 cannot be made prod-safe for gate3b.
- **Option 2 adds zero product surface** and uses only routes **kept** by #1798.

## The fix
`scratch_profile_and_device` now:
1. seeds the shipped templates — `POST /api/apps/seed-from-templates` (idempotent, admin-gated — the same route #1811 used),
2. reads them back — `GET /api/apps`, and
3. picks **two distinct seeded apps** via the new pure helper `lib/app_seed.pick_block_allow_apps`, assigning one `blocked` and one `allowed` to the namespaced profile (`PUT /api/apps/:id/policy/:profileId`, kept by #1798).

The block/allow contract is **host-agnostic** (block = HTTP/80 DNAT to the block page on the resolved IPs; allow = carve-out / no over-block), so the **two-leg connection-layer assertion in `test_smoke.py` is preserved exactly** — only the *source* of the hosts moves from a hand-minted app to the template catalog. The picker prefers stable apexes (`BLOCK_PREF`/`ALLOW_PREF`) that resolve and are reachable through qemu SLIRP v4 NAT — the property `example.com`/`example.org` were chosen for — and falls back to any hosted app so a catalog change never breaks the gate.

`lib/api_admin`: drop the dead `create_app` (route gone); add `seed_apps_from_templates`, `list_apps`, and `delete_app_policy`. **Teardown now detaches this profile's *assignment* — the shared seeded apps are never deleted** (other gates and the live catalog depend on them); only the namespaced profile/device + its assignments are cleaned up.

## TDD
- `test(#1810)` commit (red): `lib/test_app_seed.py` pins the selection contract against a stubbed `NotImplementedError` picker.
- `fix(cd)` commit (green): implements the picker + rewires the fixture/client. `python3 -m pytest scripts/e2e/lib/test_app_seed.py` → **7 passed**.

## Validation — real Gate 3b run on the KVM host (plex.lan / 192.168.10.43)
Ran the **exact Gate 3b invocation** against **live staging** with the **last-published** ipk router image (downloaded + sha256-verified from the `openwrt-latest` release, faithful to `e2e-vm-gate3b.yml`):

```
WH_API_URL=https://api-staging.wifihaven.net WH_GATE3_SIDE=3b PKG_FORMAT=ipk \
  scripts/e2e-vm.sh --mode=gate3
...
gate3: block leg app=youtube host=googlevideo.com; allow leg app=duolingo host=duolingo.com
gate3: block page hit for googlevideo.com (993 bytes)
gate3: upstream OK for duolingo.com (code=302, 138 bytes)
gate3: 17 /api/logs rows attributed to 02:e2:e3:13:da:72
gate3: time_status summary present for 02:e2:e3:...
1 passed in 72.07s
```

Both legs asserted at the connection layer end-to-end (block-page DNAT + upstream carve-out), usage round-tripped, `/api/time/status` surfaced the device. VMs/worktree torn down afterward; host left clean (no leaked qemu, bridges down, no secret in logs).

> Scope: this is the Python gate3 suite + `api_admin` only. The separate Gate **3a** DNS regression is fixed in #1812's parallel session (dnsmasq `render.lua`) — out of scope here by design, no file overlap.

Fixes #1810

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
