### PR TITLE
fix(cd): blocklist shards must live inside dnsmasq confdir (procd jail) — restore Master Router CD (Gate 2 + Gate 3a DNS)

### DIFF
--- a/docs/process/router-agent-bounded-writes.md
+++ b/docs/process/router-agent-bounded-writes.md
@@ -40,7 +40,7 @@ The same reasoning applies to anything else the agent persists under `/tmp`
 (JSON spools, NDJSON event journals, debug dumps). If it can grow, it gets a
 bound — in the same PR.
 
-## Per-blocklist dnsmasq conf shards (`/tmp/wifihaven-blocklist-<id>.conf`) {#blocklist-shards}
+## Per-blocklist dnsmasq conf shards (`/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-<id>.conf`) {#blocklist-shards}
 
 Added in [#1782/#1783](https://github.com/wifihaven/wifihaven/issues/1782).
 One file per blocklist id in the current snapshot.
@@ -49,8 +49,22 @@ One file per blocklist id in the current snapshot.
 file (`/etc/wifihaven/blocklists/<id>-<version>.txt`) line-by-line and writes
 one `nftset=/<host>/4#inet#wifihaven#bl_<id>,6#inet#wifihaven#bl6_<id>` line
 per host — never accumulating the full list in a Lua table. `render.dnsmasq`
-emits `conf-file=/tmp/wifihaven-blocklist-<id>.conf` for each id so dnsmasq
-picks up the host set at startup and on reload.
+emits `conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-<id>.conf` for
+each id so dnsmasq picks up the host set at startup and on reload.
+
+**Shards MUST live inside the dnsmasq confdir** (`/tmp/dnsmasq.d`), not bare
+`/tmp` — [#1812](https://github.com/wifihaven/wifihaven/issues/1812). OpenWRT
+runs dnsmasq in a procd ujail (`/etc/init.d/dnsmasq`'s
+`procd_add_jail_mount $dnsmasqconfdir …`) that bind-mounts ONLY the confdir and
+a few known files. A `conf-file=` directive pointing at a shard outside the
+confdir is unreadable inside the jail: dnsmasq aborts with `cannot read …`,
+procd crash-loops it and gives up, and `:53` goes dark (connection refused, no
+DHCP leases). `dnsmasq --test` passes only because it runs unjailed. The shard
+dir is a *subdir* of the confdir (`…/blocklists/`) so dnsmasq's
+non-recursive `conf-dir=/tmp/dnsmasq.d` does not auto-load the shards — they
+load only via the explicit, shard-existence-gated `conf-file=` directives.
+`render.SHARD_DIR` is the single source of truth (the agent's
+`BLOCKLIST_SHARD_DIR` derives from it).
 
 **Atomic write.** Each shard is written to `<id>.conf.tmp`, then renamed onto
 `<id>.conf`. A partial shard is never visible to dnsmasq.

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -77,11 +77,21 @@
 
 local M = {}
 
--- Directory where per-blocklist dnsmasq conf shards live (#1782). Default /tmp
--- (= tmpfs on OpenWRT). Overridable for tests via M.SHARD_DIR assignment before
--- calling M.dnsmasq(). Production: always /tmp (matches BLOCKLIST_SHARD_DIR in
--- wifihaven-agent).
-M.SHARD_DIR = "/tmp"
+-- Directory where per-blocklist dnsmasq conf shards live (#1782). A SUBDIR of
+-- the dnsmasq confdir (/tmp/dnsmasq.d, itself tmpfs = RAM on OpenWRT), NOT bare
+-- /tmp — #1812. OpenWRT runs dnsmasq inside a procd ujail that bind-mounts ONLY
+-- the confdir (and a handful of known files): see /etc/init.d/dnsmasq's
+-- `procd_add_jail_mount $dnsmasqconfdir …`. A `conf-file=` directive in
+-- wifihaven.conf that points at a shard OUTSIDE the confdir is unreadable inside
+-- the jail — dnsmasq aborts with "cannot read …", procd crash-loops it and
+-- gives up, and :53 goes dark (connection refused, no DHCP leases). Keeping the
+-- shards under the confdir puts them inside the jail mount. A SUBDIR (not the
+-- confdir root) so dnsmasq's `conf-dir=/tmp/dnsmasq.d` does NOT auto-load them
+-- (it is non-recursive) — they load only via the explicit, shard-existence-gated
+-- conf-file= directives. Overridable for tests via M.SHARD_DIR assignment before
+-- calling M.dnsmasq(). Production: always this dir (matches BLOCKLIST_SHARD_DIR
+-- in wifihaven-agent, which derives from render.SHARD_DIR).
+M.SHARD_DIR = "/tmp/dnsmasq.d/blocklists"
 
 -- Canonical path of a per-blocklist dnsmasq conf shard (#1792). Single source
 -- of truth — render.dnsmasq, policy.apply's shard-existence check, and

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -458,9 +458,13 @@ end
 -- BLOCKLIST_CACHE_DIR: persistent on-flash cache of fetched list bodies;
 --   survives reboots; shards in BLOCKLIST_SHARD_DIR are rebuilt from it.
 local BLOCKLIST_CACHE_DIR = "/etc/wifihaven/blocklists"
--- BLOCKLIST_SHARD_DIR: per-blocklist dnsmasq conf files (/tmp = tmpfs = RAM);
---   written atomically (tmp→rename) and GC'd on each render + startup.
-local BLOCKLIST_SHARD_DIR = "/tmp"
+-- BLOCKLIST_SHARD_DIR: per-blocklist dnsmasq conf files (tmpfs = RAM); written
+--   atomically (tmp→rename) and GC'd on each render + startup. A SUBDIR of the
+--   dnsmasq confdir (#1812) — NOT bare /tmp — so OpenWRT's procd ujail (which
+--   bind-mounts only the confdir) can read the shards the conf-file= directives
+--   reference; a bare-/tmp shard is unreadable inside the jail and crash-loops
+--   dnsmasq. Derived from render.SHARD_DIR so writer and reader never drift.
+local BLOCKLIST_SHARD_DIR = render.SHARD_DIR
 local function refresh_blocklists(snap)
   -- Step 1: fetch new list versions + cache them to disk.
   local res = blocklists.refresh(
@@ -543,7 +547,11 @@ end
 
 -- ── Ensure output directories exist ───────────────────────────────────────────
 
-os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven")
+-- BLOCKLIST_SHARD_DIR is a subdir of the dnsmasq confdir (#1812); create it so
+-- blocklists.render_shards' atomic open_write of <id>.conf.tmp doesn't fail on a
+-- missing directory.
+os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven " ..
+           string.format("%q", BLOCKLIST_SHARD_DIR))
 
 -- GC stale shard files from a previous agent run / crash-during-render on
 -- startup. We do this before the first apply so dnsmasq never loads a shard

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -549,9 +549,17 @@ end
 
 -- BLOCKLIST_SHARD_DIR is a subdir of the dnsmasq confdir (#1812); create it so
 -- blocklists.render_shards' atomic open_write of <id>.conf.tmp doesn't fail on a
--- missing directory.
+-- missing directory. BLOCKLIST_SHARD_DIR is a trusted module constant (no shell
+-- metacharacters), so a bare append is safe here.
 os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven " ..
-           string.format("%q", BLOCKLIST_SHARD_DIR))
+           BLOCKLIST_SHARD_DIR)
+
+-- #1812: reclaim legacy bare-/tmp shards written by a pre-#1812 agent. They are
+-- no longer referenced by any conf-file= (the dir moved under the confdir), but
+-- on a package upgrade the agent restarts WITHOUT a reboot, so without this they
+-- linger in tmpfs (up to ~15 MB on a 512 MB router) until the next reboot. The
+-- glob is non-recursive, so it never touches the new BLOCKLIST_SHARD_DIR shards.
+os.execute("rm -f /tmp/wifihaven-blocklist-*.conf /tmp/wifihaven-blocklist-*.conf.tmp 2>/dev/null")
 
 -- GC stale shard files from a previous agent run / crash-during-render on
 -- startup. We do this before the first apply so dnsmasq never loads a shard

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1178,7 +1178,7 @@ describe("render blocklist enforcement (#352)", function()
   it("emits conf-file= directive for each id in snapshot.blocklists (#1782)", function()
     local conf = render.dnsmasq(snap_bl())
     assert.truthy(conf:find(
-      "conf-file=/tmp/wifihaven-blocklist-test_ads.conf",
+      "conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-test_ads.conf",
       1, true), "dnsmasq conf must reference the per-blocklist shard via conf-file=")
   end)
 
@@ -1195,15 +1195,15 @@ describe("render blocklist enforcement (#352)", function()
     local s = snap_bl()
     s.blocklists["test_social"] = { version = "v1", url = "http://api/api/blocklists/test_social" }
     local conf = render.dnsmasq(s)
-    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true))
-    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_social.conf", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-test_ads.conf", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-test_social.conf", 1, true))
   end)
 
   it("emits no conf-file= lines when snapshot.blocklists is empty (#1782)", function()
     local s = snap_bl()
     s.blocklists = {}
     local conf = render.dnsmasq(s)
-    assert.is_nil(conf:find("conf-file=/tmp/wifihaven-blocklist-", 1, true))
+    assert.is_nil(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-", 1, true))
   end)
 
   -- #1792: render_shards silently skips ids whose cache file is missing
@@ -1219,15 +1219,15 @@ describe("render blocklist enforcement (#352)", function()
     local conf = render.dnsmasq(s, {
       bl_shard_exists = function(id) return id ~= "test_social" end,
     })
-    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true),
+    assert.truthy(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-test_ads.conf", 1, true),
       "shard that exists must still be referenced")
-    assert.is_nil(conf:find("conf-file=/tmp/wifihaven-blocklist-test_social.conf", 1, true),
+    assert.is_nil(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-test_social.conf", 1, true),
       "shard that does not exist on disk must NOT be referenced (#1792)")
   end)
 
   it("emits all conf-file= lines when opts.bl_shard_exists is not provided (back-compat)", function()
     local conf = render.dnsmasq(snap_bl())
-    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-test_ads.conf", 1, true))
   end)
 
   -- #1812: OpenWRT runs dnsmasq inside a procd ujail that bind-mounts ONLY the
@@ -2146,7 +2146,7 @@ describe("render.dnsmasq global section (#1319)", function()
     s._blocklist_hosts = { ads = { "ad.doubleclick.net" } }
     local conf = render.dnsmasq(s)
     -- dnsmasq includes the shard file (which will carry the global_block spec).
-    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-ads.conf", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-ads.conf", 1, true))
     -- The member is NOT inlined in the main conf (it's in the shard).
     assert.is_nil(conf:find("nftset=/ad.doubleclick.net/", 1, true))
   end)
@@ -2344,7 +2344,7 @@ describe("render.dnsmasq global section (#1319)", function()
         "nftset line exceeds 1024 bytes (%d): %s…", #line, line:sub(1, 72)))
     end
     -- conf-file= directive exists (bl_ specs are in the shard, not inline).
-    assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-ads.conf", 1, true))
+    assert.truthy(conf:find("conf-file=/tmp/dnsmasq.d/blocklists/wifihaven-blocklist-ads.conf", 1, true))
     -- shared.example is NOT in the main conf as an nftset= host line (no bl_ inline).
     assert.is_nil(conf:find("nftset=/shared.example/4#inet#wifihaven#bl_ads", 1, true))
   end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1230,6 +1230,32 @@ describe("render blocklist enforcement (#352)", function()
     assert.truthy(conf:find("conf-file=/tmp/wifihaven-blocklist-test_ads.conf", 1, true))
   end)
 
+  -- #1812: OpenWRT runs dnsmasq inside a procd ujail that bind-mounts ONLY the
+  -- confdir (/tmp/dnsmasq.d) plus a handful of known files — see
+  -- /etc/init.d/dnsmasq's `procd_add_jail_mount $dnsmasqconfdir …`. A conf-file=
+  -- directive that points at a shard OUTSIDE the confdir (the pre-#1812 bare
+  -- /tmp location) is unreadable inside the jail: dnsmasq aborts with "cannot
+  -- read /tmp/wifihaven-blocklist-<id>.conf: No such file or directory", procd
+  -- crash-loops it 6× and gives up, and :53 goes dark — connection refused, no
+  -- DHCP leases (the Gate 3a regression: client DNS to fdaa:bbbb:cccc::1#53 is
+  -- refused). dnsmasq --test passes because it runs UNJAILED. Gate 2 never
+  -- tripped this because its blocklists 404, so no shard exists and no conf-file=
+  -- is emitted. So every shard MUST live under the confdir.
+  it("render.SHARD_DIR is a subdirectory of the dnsmasq confdir (#1812)", function()
+    assert.truthy(render.SHARD_DIR:match("^/tmp/dnsmasq%.d/.+"),
+      "shard dir must be a subdir of the jail-mounted confdir /tmp/dnsmasq.d/ " ..
+      "(a subdir so conf-dir does not auto-load the shards); got " ..
+      tostring(render.SHARD_DIR))
+  end)
+
+  it("render.dnsmasq emits conf-file= paths under the dnsmasq confdir (#1812)", function()
+    local conf = render.dnsmasq(snap_bl())
+    local p = conf:match("\nconf%-file=(%S+)")
+    assert.truthy(p, "expected a conf-file= directive")
+    assert.truthy(p:sub(1, #"/tmp/dnsmasq.d/") == "/tmp/dnsmasq.d/",
+      "conf-file= must point inside the confdir so the procd jail can read it; got " .. p)
+  end)
+
   it("still emits eb_ and ea_ nftset= directives in the merged per-host block (#1782)", function()
     -- Non-blocklist hosts (extraBlocked, extraAllowed) continue to have their
     -- nftset= directives in the main wifihaven.conf — only bl_ moves to shards.


### PR DESCRIPTION
## Summary

Master Router CD has been RED on `main` since #1734 (2026-06-15). **Root cause: the per-blocklist dnsmasq shard files (#1782) live in bare `/tmp`, outside OpenWRT's dnsmasq procd ujail, so the jailed dnsmasq cannot read the `conf-file=` shards it's told to load — it crash-loops, procd gives up, and `:53` goes dark.** Fix: move the shards into a subdir of the dnsmasq confdir (`/tmp/dnsmasq.d/blocklists/`), inside the jail's confdir bind-mount.

Fixes #1812.

## Confirmed root cause (refuting the issue's leading hypothesis)

The watchdog hypothesis was "dnsmasq config render regression / dangling conf-file". I **refuted** that with direct evidence and found the real cause:

- The real staging snapshot's full config — all 165k `nftset=` directives across 9 real blocklists (~15 MB of shards) — **passes `dnsmasq --test` cleanly in 0.22s** and dnsmasq uses **< 8 MB RSS**. So it's not a syntax, size, or OOM problem.
- The catch: `dnsmasq --test` runs **unjailed**. OpenWRT starts the real dnsmasq inside a **procd ujail** that bind-mounts **only the confdir** (`/tmp/dnsmasq.d`) plus a handful of known files — see `/etc/init.d/dnsmasq`'s `procd_add_jail_mount $dnsmasqconfdir …`. The #1782 shards sit in bare `/tmp`, **outside** the jail. So when `render.dnsmasq` emits `conf-file=/tmp/wifihaven-blocklist-<id>.conf` and the shard actually exists, the **jailed** dnsmasq cannot read it:
  ```
  daemon.crit dnsmasq[1]: cannot read /tmp/wifihaven-blocklist-ads.conf: No such file or directory
  daemon.crit dnsmasq[1]: FAILED to start up
  daemon.info procd: Instance dnsmasq is in a crash loop 6 crashes … 
  ```
  procd crash-loops it 6× and **gives up**, so `:53` stays permanently down → **Gate 3a**: client DNS to `fdaa:bbbb:cccc::1#53` is refused, and the client never gets a DHCP lease (`udhcpc: no lease`).

### Why Gate 2 stayed green but Gate 3a went red
Gate 2 (fake API) serves blocklists that **404**, so no shard is ever written and **no `conf-file=` is emitted** — the jail path is never exercised, dnsmasq stays up. Gate 3a points at **staging**, whose blocklists resolve to **real, populated shards**, so `conf-file=` references real out-of-jail files and dnsmasq dies. Same image, opposite outcome — which is exactly why this looked like a staging-only mystery.

### Why #1795 didn't fix it
#1795's `bl_shard_exists` gate (omit `conf-file=` for a *missing* shard) is correct and stays in place as defense-in-depth — but it addressed the *dangling-reference* case. The jail makes even a **present** shard unreadable, which the gate can't help with.

## Fix

`render.SHARD_DIR` moves from `/tmp` → `/tmp/dnsmasq.d/blocklists/` (single source of truth; the agent's `BLOCKLIST_SHARD_DIR` derives from it, and startup `mkdir -p` creates it). A **subdir** of the confdir — not the confdir root — so dnsmasq's non-recursive `conf-dir=/tmp/dnsmasq.d` does **not** auto-load the shards; they load only via the explicit, existence-gated `conf-file=` directives. Still tmpfs, still per-shard capped + GC'd (bounded-`/tmp` invariant preserved).

## Validation (on the self-hosted KVM host, `plex`)

Reproduced and fixed on the real OpenWRT 25.12 KVM VM — no macOS limitation:

1. **Reproduced** the exact Gate 3a failure (fresh boot, staging snapshot, real blocklists): `conf-file=/tmp/wifihaven-blocklist-ads.conf` referenced a real shard → jailed dnsmasq `cannot read` → crash-loop → `:53` refused, no lease. (`dnsmasq --test` passed throughout — the tell.)
2. **Fix verified end-to-end** on a freshly **rebuilt image** with the change, booted against the staging snapshot with real blocklists:
   - 9 shards under `/tmp/dnsmasq.d/blocklists/`, `conf-file=` paths inside the confdir;
   - dnsmasq **alive**, listening on `fdaa:bbbb:cccc::1:53` (the exact v6 ULA Gate 3a queries) and `192.168.100.1:53`;
   - **no crash loop**; a client **resolved `example.com` through the router**.
3. **Unit tests** (`busted`, 302 pass): a failing test committed first (red → green) asserting shards live under the confdir; existing #1782/#1792 conf-file path assertions updated.

CI's self-hosted Gate 2 + Gate 3a will run on this PR as the final gate.

## Note on #1810
This fix makes Gate 3a get past DNS setup, so the run now reaches the **separate** latent #1810 (Gate 3a's `test_smoke` still POSTs to the retired `/api/apps`). That is out of scope here and left to its own fix; it does not affect this PR's root cause or validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
