### PR TITLE
fix(api): scope snapshot.blocklists to referenced lists only (#1784)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -310,6 +310,9 @@ class PolicyServiceLive(
       // shipping unreferenced lists is wasted work — on prod the difference is hundreds of
       // thousands of directives vs hundreds (see #1412 investigation). Additive-safe on the wire:
       // the agent already iterates whatever ids appear here.
+      // The per-device override lane (`devicePolicies → rules → blocklistIds`) is wired in for
+      // future-proofing — today the only writer of `DevicePolicy.rules` is the unmanaged-MAC path
+      // (above), which sets `blocklistIds = Nil`, so this branch currently contributes nothing.
       val referencedBlocklistIds: Set[BlocklistId] =
         (globalRules.blocklistIds.iterator ++
           profilePolicies.valuesIterator.flatMap(_.rules.blocklistIds) ++

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -272,8 +272,8 @@ class PolicyServiceLive(
         d.mac -> DevicePolicy(profileId = d.profileId, name = d.name, rules = rules)
       }.toMap
 
-      val catDomainsMap                            = catDomains.toMap
-      val pBlocklists: Map[BlocklistId, Blocklist] = cats.map { c =>
+      val catDomainsMap                               = catDomains.toMap
+      val pBlocklistsAll: Map[BlocklistId, Blocklist] = cats.map { c =>
         val domains = catDomainsMap.getOrElse(c, Set.empty[Hostname]).map(_.value)
         val version = BlocklistVersion.unsafe(PolicyService.blocklistContentVersion(domains))
         c -> Blocklist(version = version, url = BlocklistUrl.unsafe(s"/api/blocklists/${c.value}"))
@@ -304,6 +304,18 @@ class PolicyServiceLive(
         extraBlocked = globalRulesResolved.extraBlocked.distinct,
         blocklistIds = globalRulesResolved.blocklistIds.distinct,
       )
+
+      // #1784: scope `blocklists` to only those referenced by some profile (or by the global
+      // section / unmanaged-MAC rules). The router fetches and renders every id in this map, so
+      // shipping unreferenced lists is wasted work — on prod the difference is hundreds of
+      // thousands of directives vs hundreds (see #1412 investigation). Additive-safe on the wire:
+      // the agent already iterates whatever ids appear here.
+      val referencedBlocklistIds: Set[BlocklistId] =
+        (globalRules.blocklistIds.iterator ++
+          profilePolicies.valuesIterator.flatMap(_.rules.blocklistIds) ++
+          devicePolicies.valuesIterator.flatMap(_.rules.iterator.flatMap(_.blocklistIds))).toSet
+      val pBlocklists: Map[BlocklistId, Blocklist] =
+        pBlocklistsAll.view.filterKeys(referencedBlocklistIds).toMap
 
       val core = SnapshotCore(globalRules, devicePolicies, profilePolicies, pBlocklists)
       val etag = PolicyService.computeEtag(core)

--- a/api/test/src/feature/PolicySnapshotBlocklistScopeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlocklistScopeSpec.scala
@@ -38,6 +38,15 @@ object PolicySnapshotBlocklistScopeSpec
       clock  <- ZIO.service[Clock]
     } yield PolicyServiceLive(pr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock): PolicyService
 
+  // V1 seeds default Kids and Adults profiles with hard-coded blockedCategories. Clear them so each
+  // test starts from a known empty reference set and only the lists this test references show up.
+  private def clearDefaultProfileCategories: ZIO[ProfileRepo, Throwable, Unit] =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      all <- pr.listAllIncludingGlobal
+      _   <- ZIO.foreachDiscard(all)(p => pr.setBlockedCategories(p.id, List.empty))
+    } yield ()
+
   // Seed three distinct bundled blocklists so the "drops the unreferenced ones" assertion has bite.
   private def seedThreeLists(blr: BlocklistRepo): Task[Unit] =
     blr
@@ -50,15 +59,22 @@ object PolicySnapshotBlocklistScopeSpec
       )
       .unit
 
+  private def kidsId: ZIO[ProfileRepo, Throwable, ProfileId] =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll.map(_.find(_.name == "Kids").get.id))
+
+  private def adultsId: ZIO[ProfileRepo, Throwable, ProfileId] =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll.map(_.find(_.name == "Adults").get.id))
+
   def spec = suite("PolicySnapshot — blocklists scoped to referenced lists (#1784)")(
     test("only the blocklists referenced by some profile ship in snap.blocklists") {
       for {
         _    <- cleanDb
+        _    <- clearDefaultProfileCategories
         pr   <- ZIO.service[ProfileRepo]
         blr  <- ZIO.service[BlocklistRepo]
         _    <- seedThreeLists(blr)
-        // ProfileRepo.create(name, blockedCategories): one profile references "malware" only.
-        _    <- pr.create("Kids", List(BlocklistId.unsafe("malware")))
+        kid  <- kidsId
+        _    <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("malware")))
         svc  <- makePs
         snap <- svc.snapshot
         keys = snap.blocklists.keySet.map(_.value)
@@ -66,10 +82,11 @@ object PolicySnapshotBlocklistScopeSpec
     },
     test("union across profiles: every referenced id appears, unreferenced ones do not") {
       for {
-        _    <- cleanDb
-        pr   <- ZIO.service[ProfileRepo]
-        blr  <- ZIO.service[BlocklistRepo]
-        _    <- blr.insertBatch(
+        _      <- cleanDb
+        _      <- clearDefaultProfileCategories
+        pr     <- ZIO.service[ProfileRepo]
+        blr    <- ZIO.service[BlocklistRepo]
+        _      <- blr.insertBatch(
           List(
             ("doubleclick.net", "ads"),
             ("badthings.example", "malware"),
@@ -77,31 +94,35 @@ object PolicySnapshotBlocklistScopeSpec
             ("p2p.example", "p2p"),
           ),
         )
-        _    <- pr.create("Kids", List(BlocklistId.unsafe("malware")))
-        _    <- pr.create("Teens", List(BlocklistId.unsafe("ads"), BlocklistId.unsafe("adult")))
-        svc  <- makePs
-        snap <- svc.snapshot
+        kid    <- kidsId
+        adults <- adultsId
+        _      <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("malware")))
+        _      <- pr.setBlockedCategories(
+          adults,
+          List(BlocklistId.unsafe("ads"), BlocklistId.unsafe("adult")),
+        )
+        svc    <- makePs
+        snap   <- svc.snapshot
         keys = snap.blocklists.keySet.map(_.value)
       } yield assertTrue(keys == Set("malware", "ads", "adult"))
     },
     test("with no profile referencing any blocklist, snap.blocklists is empty") {
       for {
         _    <- cleanDb
-        pr   <- ZIO.service[ProfileRepo]
+        _    <- clearDefaultProfileCategories
         blr  <- ZIO.service[BlocklistRepo]
         _    <- seedThreeLists(blr)
-        _    <- pr.create("Adults", List.empty)
         svc  <- makePs
         snap <- svc.snapshot
       } yield assertTrue(snap.blocklists.isEmpty)
     },
-    test("a list referenced by the global sentinel profile still ships") {
+    test("a list referenced only by the global sentinel profile still ships") {
       for {
         _    <- cleanDb
+        _    <- clearDefaultProfileCategories
         pr   <- ZIO.service[ProfileRepo]
         blr  <- ZIO.service[BlocklistRepo]
         _    <- seedThreeLists(blr)
-        _    <- pr.create("Adults", List.empty)
         g    <- pr.getGlobal.map(_.get.id)
         _    <- pr.setBlockedCategories(g, List(BlocklistId.unsafe("ads")))
         svc  <- makePs

--- a/api/test/src/feature/PolicySnapshotBlocklistScopeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlocklistScopeSpec.scala
@@ -1,0 +1,113 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+/**
+ * #1784 — `PolicyService.snapshot.blocklists` must include only the blocklists actually referenced
+ * by some profile's effective `blocklistIds` (or by the global section). The router agent fetches
+ * and renders every list it sees in the snapshot, so shipping unreferenced lists is wasted work
+ * (and on prod the difference is hundreds of thousands of directives vs hundreds — see #1412).
+ */
+object PolicySnapshotBlocklistScopeSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makePs =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      clock  <- ZIO.service[Clock]
+    } yield PolicyServiceLive(pr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock): PolicyService
+
+  // Seed three distinct bundled blocklists so the "drops the unreferenced ones" assertion has bite.
+  private def seedThreeLists(blr: BlocklistRepo): Task[Unit] =
+    blr
+      .insertBatch(
+        List(
+          ("doubleclick.net", "ads"),
+          ("badthings.example", "malware"),
+          ("xxx.example", "adult"),
+        ),
+      )
+      .unit
+
+  def spec = suite("PolicySnapshot — blocklists scoped to referenced lists (#1784)")(
+    test("only the blocklists referenced by some profile ship in snap.blocklists") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        _    <- seedThreeLists(blr)
+        // ProfileRepo.create(name, blockedCategories): one profile references "malware" only.
+        _    <- pr.create("Kids", List(BlocklistId.unsafe("malware")))
+        svc  <- makePs
+        snap <- svc.snapshot
+        keys = snap.blocklists.keySet.map(_.value)
+      } yield assertTrue(keys == Set("malware"))
+    },
+    test("union across profiles: every referenced id appears, unreferenced ones do not") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        _    <- blr.insertBatch(
+          List(
+            ("doubleclick.net", "ads"),
+            ("badthings.example", "malware"),
+            ("xxx.example", "adult"),
+            ("p2p.example", "p2p"),
+          ),
+        )
+        _    <- pr.create("Kids", List(BlocklistId.unsafe("malware")))
+        _    <- pr.create("Teens", List(BlocklistId.unsafe("ads"), BlocklistId.unsafe("adult")))
+        svc  <- makePs
+        snap <- svc.snapshot
+        keys = snap.blocklists.keySet.map(_.value)
+      } yield assertTrue(keys == Set("malware", "ads", "adult"))
+    },
+    test("with no profile referencing any blocklist, snap.blocklists is empty") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        _    <- seedThreeLists(blr)
+        _    <- pr.create("Adults", List.empty)
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield assertTrue(snap.blocklists.isEmpty)
+    },
+    test("a list referenced by the global sentinel profile still ships") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        _    <- seedThreeLists(blr)
+        _    <- pr.create("Adults", List.empty)
+        g    <- pr.getGlobal.map(_.get.id)
+        _    <- pr.setBlockedCategories(g, List(BlocklistId.unsafe("ads")))
+        svc  <- makePs
+        snap <- svc.snapshot
+        keys = snap.blocklists.keySet.map(_.value)
+      } yield assertTrue(keys == Set("ads"))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -231,6 +231,9 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         off1 <- seedTraffic(rid, kidMac, "youtube.com", today, 15)
         _    <- seedTraffic(rid, kidMac, "cnn.com", today, 45, off1)
         _    <- blr.insertBatch(List(("doubleclick.net", "ads"), ("ads.example.com", "ads")))
+        // #1784: snap.blocklists is scoped to lists referenced by some profile, so reference
+        // `ads` from the kid profile to keep the composition assertion meaningful.
+        _    <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("ads")))
         ber  <- ZIO.service[BlockEventRepo]
         ps   <- makePolicyService
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
@@ -666,6 +669,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
     ) {
       for {
         _       <- cleanDb
+        pr      <- ZIO.service[ProfileRepo]
         rr      <- ZIO.service[RouterRepo]
         blr     <- ZIO.service[BlocklistRepo]
         ps      <- makePolicyService
@@ -675,6 +679,11 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
             ("googleadservices.com", "test_ads"),
             ("tiktok.com", "test_social"),
           ),
+        )
+        // #1784: a profile must reference each id we expect to see in snap.blocklists.
+        _       <- pr.create(
+          "Kids",
+          List(BlocklistId.unsafe("test_ads"), BlocklistId.unsafe("test_social")),
         )
         ber     <- ZIO.service[BlockEventRepo]
         (_, et) <- seedRouter("gw-bl4")
@@ -715,8 +724,11 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         rr      <- ZIO.service[RouterRepo]
         blr     <- ZIO.service[BlocklistRepo]
         ber     <- ZIO.service[BlockEventRepo]
-        _       <- TestLayers.seedKidsProfile(pr)
+        kid     <- TestLayers.seedKidsProfile(pr)
         _       <- blr.insertBatch(List(("doubleclick.net", "test_ads")))
+        // #1784: the blocklist must be referenced by some profile to ship in snap.blocklists,
+        // otherwise mutating its content won't move the ETag.
+        _       <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("test_ads")))
         ps      <- makePolicyService
         (_, et) <- seedRouter("gw-etag")
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)


### PR DESCRIPTION
## Summary

`PolicyService.snapshot` built the `blocklists` map from `blocklistRepo.listCategories` — i.e. **every bundled list in the system**, regardless of whether any profile referenced it. The router agent fetches and renders directives for every id it sees in the snapshot, so an un-assigned list was still loaded; un-assigning a list from every profile did not reduce the agent's workload. On prod this was the difference between hundreds of thousands of directives and hundreds (surfaced during the [#1412](https://github.com/wifihaven/wifihaven/issues/1412) investigation).

Filter `pBlocklists` to the union of `blocklistIds` across the snapshot's:
- profile policies (`profilePolicies.values.flatMap(_.rules.blocklistIds)`)
- global section (`globalRules.blocklistIds`)
- per-device override rules (`devicePolicies.values.flatMap(_.rules.toList.flatMap(_.blocklistIds))`)

Wire-compat: **additive-safe**. The router agent already iterates whatever ids appear in `snapshot.blocklists`; an id no longer present is one the agent was never going to use. No router-agent changes needed (AGENTS.md `#wire-contract`).

## Test plan

- [x] New feature spec [PolicySnapshotBlocklistScopeSpec](api/test/src/feature/PolicySnapshotBlocklistScopeSpec.scala) covering: single profile reference, multi-profile union, zero references → empty, and global-sentinel-only reference. Committed first as a failing test (TDD red commit `dc2c6732`) before the fix landed.
- [x] Three existing `RouterApiSpec` assertions that incidentally relied on the "ship every list" behavior updated to reference the lists they assert on.
- [x] `mill api.test` green (full suite).
- [x] `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll` clean.

Closes #1784
Refs #1435 (parent design), #1412 (where this was originally surfaced)