### PR TITLE
docs(skills): add self-updating app-catalog-pass + ads-blocklist-pass skills

### DIFF
--- a/.claude/skills/ads-blocklist-pass/SKILL.md
+++ b/.claude/skills/ads-blocklist-pass/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: ads-blocklist-pass
+description: Do a traffic-driven WifiHaven ads-blocklist pass — pull real device traffic from prod, find ad/RTB/tracker hostnames devices are hitting that the curated ads blocklists don't yet cover, and add the genuine gaps to api/resources/blocklists/ads.yml. Invoke whenever the operator says "update the ads blocklist", "do an ads-blocklist pass", "what ad traffic isn't blocked", "review traffic for unblocked ads", or wants new ad-category blocklist entries. Self-updating: records new learnings back into this file on every run.
+---
+
+# WifiHaven ads-blocklist pass
+
+Repeatable process for turning **observed ad/tracker traffic** into curated
+**ads blocklist** entries (`api/resources/blocklists/ads.yml`, with the bulk of
+coverage in the URL-sourced `ads-extended`). Sibling to the `app-catalog-pass`
+skill — same evidence-driven method, same validation + review gate — but the
+target is the **ad/RTB/tracker** category, not brand apps.
+
+This file is the **process**. The **data + conventions** live elsewhere and are
+read live — do not duplicate them here:
+
+- The curated ads lists + index → [`api/resources/blocklists/ads.yml`](../../../api/resources/blocklists/ads.yml),
+  [`api/resources/blocklists/_index.yml`](../../../api/resources/blocklists/_index.yml).
+- Blocklist design (inline vs URL-sourced, refresh cadence) → [`docs/design/blocklists.md`](../../../docs/design/blocklists.md).
+- Enforcement model (per-(mac,host) nftset drops; DNS never enforces) →
+  [`AGENTS.md`](../../../AGENTS.md) + [`docs/architecture.md`](../../../docs/architecture.md).
+- Host-scoping mechanics (host entries are suffix-matched, not apex-constrained)
+  → the sibling [`app-catalog-pass`](../app-catalog-pass/SKILL.md) Step 3.
+- The merge-gating independent review → [`docs/pr-review-checklist.md`](../../../docs/pr-review-checklist.md).
+
+When this skill and those docs disagree, **those docs win** — update this skill
+if the process itself changed (see Step 5).
+
+---
+
+## Step 0 — Pull active traffic (READ-ONLY prod)
+
+Same source + auth as `app-catalog-pass` Step 0. Prod `https://api.wifihaven.net`;
+admin password in local memory (`prod_api_admin_password.md`) — read, never
+echo/commit. Pull per-apex bytes/hits across **all** devices (ad traffic is
+everywhere, not just kid devices):
+
+```bash
+PW=$(grep -oE 'is `[^`]+`' ~/.claude/projects/*wifihaven*/memory/prod_api_admin_password.md | head -1 | sed 's/^is `//; s/`$//')
+TOKEN=$(curl -sS -X POST https://api.wifihaven.net/api/auth/login -H 'Content-Type: application/json' \
+  -d "{\"username\":\"admin\",\"password\":\"$PW\"}" | jq -r '.token')
+MACS=$(curl -sS -H "Authorization: Bearer $TOKEN" https://api.wifihaven.net/api/devices | jq -r '.[].mac')
+for mac in $MACS; do
+  curl -sS -H "Authorization: Bearer $TOKEN" \
+    "https://api.wifihaven.net/api/devices/$mac/recent-apexes?windowDays=30&limit=500" > /tmp/apex_$mac.json
+done
+jq -r '.items[] | "\(.apex)\t\(.bytes)\t\(.hits)"' /tmp/apex_*.json \
+  | awk -F'\t' '{b[$1]+=$2; h[$1]+=$3} END{for(a in b) printf "%d\t%d\t%s\n", b[a], h[a], a}' \
+  | sort -rn
+rm -f /tmp/apex_*.json
+```
+
+> IPv4-bias caveat applies (#1796) — see `app-catalog-pass`. Re-confirm at run time.
+
+## Step 1 — Identify unblocked ad/RTB/tracker traffic
+
+An apex is an **ads-blocklist candidate** if it is an advertising exchange,
+RTB/SSP/DSP, tracker, data broker, attribution/measurement, or tag network — and
+is NOT already covered by `ads.yml` / `ads-extended`. The signal: many distinct
+subdomains, high hit count, served to many devices, and a name that maps to no
+app or content category. Apexes seen unblocked in the #1815 traffic sample that
+look like classic ad/RTB infra (verify each before adding):
+
+```
+flashtalking innovid adsrvr doubleverify adsafeprotected pubmatic casalemedia
+media.net sharethrough onetag-sys 3lift seedtag richaudience adnxs rubiconproject
+smartadserver 33across rlcdn openx criteo adform teads outbrain bidswitch
+pubmatic mathtag agkn adkernel sitescout rfihub bidr 360yield smaato …
+```
+
+**Cross-check before adding** — web-search the apex; many are obvious, but verify
+it's ad-dedicated. Be conservative:
+
+- **Skip dual-use / shared infra** that also carries legitimate product traffic.
+  Known traps to LEAVE OUT: `google-analytics.com`, `googleadservices.com`,
+  `googlesyndication.com` parents that share Google pools; `app-measurement.com`
+  (Firebase); `sentry.io` / `bugsnag.com` (error reporting); `cloudflare.com`,
+  `amazonaws.com`, `akamai*` (multi-tenant). Same collateral rule as app
+  host-sets — a shared pool drags non-ad traffic into the drop.
+- **`ads.yml` is hand-curated apex hosts** for clearly ad-dedicated domains; the
+  heavy lifting is the URL-sourced `ads-extended` feed. If the gap is really
+  "the public feed is stale / not catching this", say so rather than
+  hand-maintaining hundreds of apexes — a handful of high-traffic, clearly-ad
+  apexes per pass is the right scale.
+
+## Step 2 — Verify the gap is real
+
+Before adding `X`, confirm it isn't already blocked: load `ads.yml` (and, if
+fetchable, the `ads-extended` source) and check membership. Only add genuine
+gaps. Record per-apex hits + a one-line "what it is" for each addition.
+
+## Step 3 — Author
+
+- Add apexes to `api/resources/blocklists/ads.yml` under a dated comment block
+  (`# traffic-driven additions (#<issue>): observed but unblocked ad/RTB infra`).
+  Subdomains are suffix-matched at the router, so list apexes.
+- No `_index.yml` change unless adding a NEW list file.
+- `BundledBlocklistsSpec` asserts *presence* of representative hosts, not an
+  exact count — additions are safe; optionally pin one representative new host
+  in the spec's presence assertions.
+- Keep an evidence doc under `evidence/ads-classification-<issue>.md` (per-apex
+  hit table + what-it-is + why-it-was-a-gap).
+
+## Step 4 — Validate + ship
+
+```bash
+mill api.test.testOnly 'wifihaven.api.feature.BundledBlocklistsSpec'
+scalafmt --check --non-interactive   # only if any .scala changed (usually none)
+```
+
+Worktree off `origin/main`; file/identify a tracking issue; open a PR ("Relates
+to #<issue>"); run `/pr-review`, address BLOCKERs + cheap SHOULD-FIX, push,
+re-run until no BLOCKER; monitor CI through green. Do **not** `gh pr merge` /
+enable auto-merge (operator's call). Post a summary on the issue: apexes added +
+what each is + why it was a gap.
+
+## Step 5 — Self-update (MANDATORY, every run)
+
+Reflect on what THIS run taught you that the steps didn't capture — a new
+dual-use host to skip, a better ad-apex detection signal, a changed caveat, a
+stale-public-feed finding. **Append it to the Learnings log below and include
+that edit in the same PR.** If a step above is now wrong, fix the step too.
+
+---
+
+## Learnings log (newest first)
+
+- **2026-06-21** — Skill seeded from the `app-catalog-pass` method. Reuse the
+  same `recent-apexes` pull; the difference is the classification target
+  (ad/RTB/tracker infra) and that the bulk of coverage belongs in the
+  URL-sourced `ads-extended` feed — reserve hand-curated `ads.yml` for a handful
+  of clearly ad-dedicated high-traffic apexes per pass.
+- **2026-06-21** — Dual-use guard: do NOT blocklist hosts that also front
+  product traffic — `google-analytics.com`, `googleadservices.com`,
+  `app-measurement.com`, `sentry.io`, `bugsnag.com`, and multi-tenant clouds
+  (`cloudflare.com`, `amazonaws.com`, `akamai*`). Same collateral rule as app
+  host-sets.

--- a/.claude/skills/app-catalog-pass/SKILL.md
+++ b/.claude/skills/app-catalog-pass/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: app-catalog-pass
+description: Do a traffic-driven WifiHaven app-catalog pass — pull real device traffic from prod, find high-volume hostname clusters no existing app covers, and author new app templates (and/or curated-blocklist entries) for them. Invoke whenever the operator says "do an app-catalog pass", "update the apps", "author app templates from traffic", "what apps are we missing", "add a <brand> app", or wants new entries in api/resources/app_templates/. Self-updating: records new learnings back into this file on every run.
+---
+
+# WifiHaven app-catalog pass
+
+Repeatable process for turning **observed device traffic** into **app templates**
+(`api/resources/app_templates/*.yml`) and, where appropriate, **curated
+blocklist** entries (`api/resources/blocklists/*.yml`). The point is
+consistency: the same evidence-driven method, the same host-set discipline, the
+same validation + review gate every time.
+
+Apps are **template-authored only** (UI app editing is being removed, #1798) —
+this is repo YAML work, not DB/UI edits.
+
+This file is the **process**. The **data + conventions** live elsewhere and are
+read live — do not duplicate them here:
+
+- Host-set authoring rules, icon fields, shared-CDN/collateral guidance →
+  [`api/resources/app_templates/_README.yml`](../../../api/resources/app_templates/_README.yml).
+- The registry the loader validates against →
+  [`api/resources/app_templates/_index.yml`](../../../api/resources/app_templates/_index.yml).
+- Enforcement/attribution model (DNS never enforces; per-(mac,host) nftset
+  drops) → [`AGENTS.md`](../../../AGENTS.md) + [`docs/architecture.md`](../../../docs/architecture.md).
+- The merge-gating independent review → [`docs/pr-review-checklist.md`](../../../docs/pr-review-checklist.md).
+
+When this skill and those docs disagree, **those docs win** — update this skill
+if the process itself changed (see Step 6).
+
+---
+
+## Step 0 — Pull active traffic (READ-ONLY prod)
+
+Prod cloud API `https://api.wifihaven.net`. The admin password lives in **local
+Claude memory** (`prod_api_admin_password.md`) — read it, never echo/commit it.
+
+```bash
+# read the password WITHOUT printing it, log in, cache the JWT
+PW=$(grep -oE 'is `[^`]+`' ~/.claude/projects/*wifihaven*/memory/prod_api_admin_password.md | head -1 | sed 's/^is `//; s/`$//')
+TOKEN=$(curl -sS -X POST https://api.wifihaven.net/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"admin\",\"password\":\"$PW\"}" | jq -r '.token')
+curl -sS -H "Authorization: Bearer $TOKEN" https://api.wifihaven.net/api/devices \
+  | jq -r '.[] | "\(.mac)\t\(.name)\t\(.profileId)"'
+```
+
+Then pull **per-apex bytes per device** over a recent window. The
+`recent-apexes` endpoint already groups FQDNs by apex and returns
+`subdomains[]` — exactly what you need:
+
+```bash
+# focus on the kid devices (the app catalog is about kid-facing apps)
+for mac in <kid-macs>; do
+  curl -sS -H "Authorization: Bearer $TOKEN" \
+    "https://api.wifihaven.net/api/devices/$mac/recent-apexes?windowDays=30&limit=500" \
+    > /tmp/apex_$mac.json
+done
+# aggregate across devices, ranked by bytes
+jq -r '.items[] | "\(.apex)\t\(.bytes)\t\(.hits)"' /tmp/apex_*.json \
+  | awk -F'\t' '{b[$1]+=$2; h[$1]+=$3} END{for(a in b) printf "%d\t%d\t%s\n", b[a], h[a], a}' \
+  | sort -rn | head -120
+# inspect a candidate's real subdomains (drives host-set scoping):
+jq '.items[] | select(.apex=="<apex>")' /tmp/apex_*.json
+rm -f /tmp/wh_token.txt   # don't leave creds on disk
+```
+
+> **CAVEAT — the sample is IPv4-biased.** IPv6 host attribution has been broken
+> on prod (v6 recorded as bare literals / dropped — #1796, fixes #1807/#1802).
+> Do **not** conclude "no traffic" from a quiet apex; many sites (lego.com et al)
+> serve heavily over v6. **Cross-check every candidate with web research**, not
+> byte counts alone. Re-confirm whether this caveat still holds at run time
+> (check #1796/#1807/#1802 state) and update this note.
+
+## Step 1 — Gap-check against existing apps
+
+List `_index.yml` slugs and the `*.yml` host-sets. For each high-byte apex in
+"Other", decide: already covered? adjacent to an existing app (extend that app's
+host-set instead of duplicating)? or a genuine gap?
+
+## Step 2 — Classify each cluster: app, blocklist, or skip
+
+- **New app template** — a brand-specific apex/sub-experience a kid actually
+  uses, worth a per-app **time limit / allow / block** surface. Tinkercad,
+  Duolingo, LEGO Builder, etc.
+- **Curated blocklist entry** — a whole **category** the operator blocks
+  wholesale (`api/resources/blocklists/games.yml`, `social-media.yml`,
+  `adult.yml`, …). "Unblocked games" / proxy / filter-bypass portals belong in
+  `games.yml`. The two surfaces are **complementary**, not exclusive: a
+  browser-game portal can be BOTH an app (time-limit) and a games.yml entry
+  (category block) — duplicates dedupe at the router (precedent: roblox,
+  crazygames, poki are both).
+- **Skip** — ad/RTB networks (flashtalking, adsrvr, pubmatic…), shared
+  service/CDN pools (icloud-content, apple-dns, fastly, akadns, googleapis),
+  shared corporate infra (adobe.com, autodesk.com), and below-engagement-bar
+  incidental hosts. When in doubt, skip and say so.
+
+## Step 3 — Author tight, correct host-sets
+
+Follow `_README.yml`. Key discipline:
+
+- **Host entries are NOT limited to registrable apexes.** You can scope an app
+  to a **sub-experience** by listing the building/feature subdomains and leaving
+  the rest of the brand's apex untouched. This is verified end-to-end:
+  - `Hostname.parse` ([`shared/src/types/Hostname.scala`](../../../shared/src/types/Hostname.scala))
+    accepts any valid multi-label host — no apex requirement.
+  - Nothing in the API→agent path reduces a host to its apex; app `_.hosts` flow
+    verbatim into `extraAllowed/extraBlocked`/exempt/attribution sets
+    ([`api/src/policy/ProfileAppDispositions.scala`](../../../api/src/policy/ProfileAppDispositions.scala)).
+  - The agent emits **one verbatim `nftset=/<host>/...` per host**
+    ([`openwrt/files/usr/lib/lua/wifihaven/render.lua`](../../../openwrt/files/usr/lib/lua/wifihaven/render.lua), ~L559).
+  - **Both enforcement AND attribution suffix-match the host's own subtree.**
+    `HostMatch.matchesApex(host, x) = host == x || host.endsWith("." + x)`
+    ([`shared/src/types/HostMatch.scala`](../../../shared/src/types/HostMatch.scala)).
+    So a host entry of `services.lego.com` covers `appconfig.services.lego.com`
+    for **both** the drop set and the per-app time budget, and never
+    `www.lego.com`. (Worked example: the `lego` app is scoped to
+    `cobuild.i.lego.com` / `dbix.i.lego.com` / `services.lego.com` /
+    `apps.lego.com` — the LEGO Builder building experience — excluding the shop.)
+  - The `_README.yml` "list apex hostnames" line is the **default** convention,
+    not a constraint. Deviate only with a clear reason, and document it inline.
+- **Keep it tight:** apex + the app's real branded subdomains/CDNs you actually
+  observed. Don't pin rotating shared-CDN artifacts; don't pull in a shared
+  vendor-API anycast host (collateral — see `_README.yml` shared-pool section).
+- **Only template what you've seen used** (or web-confirmed as the app's real
+  domains). Don't add marketing apexes with no observed kid traffic.
+
+## Step 4 — Register + keep the pinned test in sync
+
+- Add the slug to `api/resources/app_templates/_index.yml`.
+- **Update the hardcoded expected slug set** in
+  [`api/test/src/feature/AppTemplatesSpec.scala`](../../../api/test/src/feature/AppTemplatesSpec.scala)
+  (the `expected` set ~L90-122) — it pins the full slug list and WILL fail
+  otherwise. This is an additive edit, not a weakening.
+- New blocklist entries: edit the `*.yml`; `BundledBlocklistsSpec` asserts
+  *presence* of representative hosts, not an exact count, so additions are safe.
+- Keep a short evidence doc under `evidence/classification-<issue>.md` with the
+  per-apex byte table + disposition + host-set coverage check.
+
+## Step 5 — Validate + ship
+
+```bash
+mill api.test.testOnly 'wifihaven.api.feature.AppTemplatesSpec'
+mill api.test.testOnly 'wifihaven.api.feature.BundledBlocklistsSpec'   # if you touched blocklists
+scalafmt --check --non-interactive                                     # only if any .scala changed
+```
+
+- Worktree off `origin/main` (`git worktree add .claude/worktrees/<slug> -b <branch> origin/main`).
+- Open a PR. Use "Relates to #<issue>" (don't auto-close unless fully covered).
+- Run `/pr-review`, address BLOCKERs + cheap SHOULD-FIX, push, re-run until no
+  BLOCKER. Monitor CI through green; do **not** `gh pr merge` / enable
+  auto-merge (operator's call).
+- Post a brief summary on the issue: new apps (slug + host-set + rationale) and
+  any app-vs-blocklist / sub-experience-scoping decisions.
+
+## Step 6 — Self-update (MANDATORY, every run)
+
+Before you finish, reflect on what THIS run taught you that the steps above
+didn't already capture — a new endpoint, a new shared-CDN to skip, a host-set
+gotcha, a changed caveat (e.g. #1796 fixed), a new blocklist category, a
+classification judgment call. **Append it to the Learnings log below and include
+that edit in the same PR** (or, if the pass shipped no code PR, a tiny
+skill-only PR). Keep entries one or two lines, newest first, dated. If a step
+above is now wrong, fix the step too — don't just log around it.
+
+---
+
+## Learnings log (newest first)
+
+- **2026-06-21 (#1815)** — Host entries can be subdomains; enforcement AND
+  attribution both suffix-match the entry's own subtree (`HostMatch.matchesApex`),
+  so you can scope an app to a sub-experience (LEGO Builder → `*.i.lego.com` +
+  `services`/`apps.lego.com`) and exclude the brand's shop. Verified verbatim
+  host flow through `Hostname.parse` → `ProfileAppDispositions` → `render.lua`
+  `nftset=/<host>/`.
+- **2026-06-21 (#1815)** — `recent-apexes?windowDays=&limit=` is the right traffic
+  source: pre-grouped by apex with a `subdomains[]` list. Aggregate across kid
+  devices by bytes with the awk one-liner in Step 0.
+- **2026-06-21 (#1815)** — "Unblocked games" / filter-bypass portals (e.g.
+  duckmath.org) go in `blocklists/games.yml` for the category-block surface, AND
+  optionally as an app for the time-limit surface — they're complementary and
+  dedupe at the router.
+- **2026-06-21 (#1815)** — Prod v6 host attribution is broken (#1796); the byte
+  sample is IPv4-biased. Always web-cross-check candidates; never infer "no
+  traffic" from a quiet apex.

--- a/.claude/skills/app-catalog-pass/SKILL.md
+++ b/.claude/skills/app-catalog-pass/SKILL.md
@@ -85,11 +85,14 @@ host-set instead of duplicating)? or a genuine gap?
   Duolingo, LEGO Builder, etc.
 - **Curated blocklist entry** — a whole **category** the operator blocks
   wholesale (`api/resources/blocklists/games.yml`, `social-media.yml`,
-  `adult.yml`, …). "Unblocked games" / proxy / filter-bypass portals belong in
-  `games.yml`. The two surfaces are **complementary**, not exclusive: a
-  browser-game portal can be BOTH an app (time-limit) and a games.yml entry
-  (category block) — duplicates dedupe at the router (precedent: roblox,
-  crazygames, poki are both).
+  `adult.yml`, …). A legit browser-game portal can be BOTH an app (time-limit)
+  and a games.yml entry (category block) — duplicates dedupe at the router
+  (precedent: roblox, crazygames, poki are both). **But a filter-bypass /
+  "unblocked games" / web-proxy site (duckmath.org, holyunblocker.org, now.gg,
+  the TitaniumNetwork stack) is blocklist-ONLY — never an app.** There's no
+  reason to give a kid a daily time *budget* for a filter-evasion tool; it's a
+  block target, full stop (operator decision, #1815). Put it in `games.yml` and
+  do NOT author an app template for it.
 - **Skip** — ad/RTB networks (flashtalking, adsrvr, pubmatic…), shared
   service/CDN pools (icloud-content, apple-dns, fastly, akadns, googleapis),
   shared corporate infra (adobe.com, autodesk.com), and below-engagement-bar
@@ -176,10 +179,12 @@ above is now wrong, fix the step too — don't just log around it.
 - **2026-06-21 (#1815)** — `recent-apexes?windowDays=&limit=` is the right traffic
   source: pre-grouped by apex with a `subdomains[]` list. Aggregate across kid
   devices by bytes with the awk one-liner in Step 0.
-- **2026-06-21 (#1815)** — "Unblocked games" / filter-bypass portals (e.g.
-  duckmath.org) go in `blocklists/games.yml` for the category-block surface, AND
-  optionally as an app for the time-limit surface — they're complementary and
-  dedupe at the router.
+- **2026-06-21 (#1815)** — "Unblocked games" / filter-bypass / web-proxy portals
+  (duckmath.org, holyunblocker.org, invisiproxy.com, titaniumnetwork.org, now.gg)
+  go in `blocklists/games.yml` ONLY — they are block targets, NOT apps. Don't
+  give a filter-evasion tool a daily time budget (operator decision). Harvest the
+  proxy ecosystem a portal embeds (TitaniumNetwork: Holy Unblocker, InvisiProxy,
+  Rammerhead, Ultraviolet/Scramjet) into the same list.
 - **2026-06-21 (#1815)** — Prod v6 host attribution is broken (#1796); the byte
   sample is IPv4-biased. Always web-cross-check candidates; never infer "no
   traffic" from a quiet apex.


### PR DESCRIPTION
## Summary
Adds two project skills that encode the repeatable, evidence-driven processes for turning observed device traffic into curated WifiHaven config — extracted from the #1815 catalog pass so future runs are consistent instead of re-improvised.

- `.claude/skills/app-catalog-pass/SKILL.md` — author **app templates** from traffic.
- `.claude/skills/ads-blocklist-pass/SKILL.md` — grow the **ads blocklist** from traffic.

Both are directory-discovered like the existing `epic-prioritization` / `incident-investigation` skills; no registry to update.

## app-catalog-pass
Pull per-apex bytes per device from prod's read-only `recent-apexes` endpoint (password from local memory, never echoed; IPv4-bias caveat #1796) → gap-check vs `_index.yml` → classify each cluster as **app** / **curated blocklist** / **skip** → author tight host-sets → keep the pinned `AppTemplatesSpec` slug set in sync → validate → ship via `/pr-review`.

Captures the key #1815 learnings:
- **Host entries aren't limited to registrable apexes.** Both enforcement (`nftset=/<host>/`) and attribution (`HostMatch.matchesApex`) suffix-match the entry's own subtree, so an app can be scoped to a sub-experience (LEGO Builder → `*.i.lego.com` + `services`/`apps.lego.com`) and exclude the brand's shop. Verified verbatim host flow through `Hostname.parse` → `ProfileAppDispositions` → `render.lua`.
- **Filter-bypass / "unblocked games" / web-proxy portals are blocklist-ONLY, never apps** — a block target shouldn't get a daily time budget.

## ads-blocklist-pass
Pull `recent-apexes` across all devices → find ad/RTB/tracker apexes not covered by `ads.yml` / `ads-extended` → **skip dual-use shared infra** (`google-analytics.com`, `googleadservices.com`, `app-measurement.com`, `sentry.io`, `bugsnag.com`, multi-tenant clouds) per the collateral rule → add genuine gaps to `ads.yml` → validate → ship via `/pr-review`.

## Self-updating
Per the operator's request, each skill ends with a **mandatory Self-update step**: every run appends new learnings to the in-file **Learnings log** and includes that edit in the same PR. The logs are seeded with the #1815 findings.

These two skills are intended to run weekly (scheduled separately).

Relates to #1815

🤖 Generated with [Claude Code](https://claude.com/claude-code)