### PR TITLE
fix(#1826): rate-limit nftables wh_drop logging to survive retry-storms

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/nflog.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/nflog.lua
@@ -9,11 +9,15 @@
 -- confirmed, never emit IPCT_NEW, and the conntrack watcher never sees
 -- them. The Logs page therefore goes silent for blocked traffic — #1103.
 --
--- Fix: every per-MAC drop rule emitted by render.lua now carries
---   `log prefix "wh_drop:<mac>:<reason> " counter drop comment "wh_drop:…"`
--- (#1126 switched the read channel from NFLOG `log group` — which had no stock
--- userspace consumer — to a `log prefix` that lands in the kernel ring buffer,
--- readable straight off `logread`). This module tails the resulting stream
+-- Fix: every per-MAC drop emitted by render.lua now carries a
+--   `log prefix "wh_drop:<mac>:<reason> "`
+-- statement (#1126 switched the read channel from NFLOG `log group` — which had
+-- no stock userspace consumer — to a `log prefix` that lands in the kernel ring
+-- buffer, readable straight off `logread`). Post-#1826 that log prefix lives on
+-- its own rate-limited rule (`limit rate …/second`), separate from the
+-- unconditional `counter drop comment "wh_drop:…"`, so a retry storm can't flood
+-- the ring buffer — the kernel log line this module parses is unchanged in
+-- shape, just rate-bounded. This module tails the resulting stream
 -- (via the wifihaven-nflog-tail spool) + synthesizes a
 -- `connection_attempt` event for each dropped packet with allowed=false
 -- and reason set from the comment. The event then takes the same ingest

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1079,8 +1079,13 @@ function M.nft(snapshot, opts)
     end
   end
 
-  -- #1122/#1126: each drop rule carries
-  --   `log prefix "wh_drop:<mac>:<reason> " counter drop comment "wh_drop:<mac>:<reason>"`.
+  -- #1122/#1126: each drop is rendered as a pair of rules sharing one predicate
+  -- (see #1826 / `emit_drop` below):
+  --   `<predicate> limit rate 10/second burst 20 packets log prefix "wh_drop:<mac>:<reason> "`
+  --   `<predicate> counter drop comment "wh_drop:<mac>:<reason>"`
+  -- (pre-#1826 this was a single `… log prefix … counter drop` rule; the LOG is
+  -- now on its own rate-limited rule so a retry storm can't flood the kernel
+  -- ring buffer, while the drop stays unconditional).
   -- The `log prefix` form writes to the kernel ring buffer (the LOG backend),
   -- so the wifihaven-nflog-tail sidecar can read the dropped-packet records
   -- straight off `logread -f` on stock OpenWRT — no NFLOG netlink consumer
@@ -1104,10 +1109,38 @@ function M.nft(snapshot, opts)
   -- whole-MAC drop carries the MacBlockReason that the API server resolved
   -- (Paused / Schedule / TimeLimit / Manual / Unmanaged). See
   -- PolicySnapshotMacDropAttributionSpec for the wire-string contract.
+  -- #1826: a Schedule-blocked device that retry-storms 443 made the old
+  -- single-rule form (`… log prefix … counter drop`) emit one kernel-log line
+  -- per dropped packet — a ring-buffer flood that pegged wifihaven-agent and
+  -- wifihaven-dns-tail (load 4.3). We rate-limit the LOG, but the drop MUST
+  -- stay unconditional. An inline `limit rate … log … drop` would NOT achieve
+  -- that: in nftables a `limit` statement is a *match*, so packets exceeding the
+  -- rate fail the rule and fall through to `policy accept` — silently leaking
+  -- the block over budget. So each drop is split into TWO rules with the same
+  -- predicate: a rate-limited log rule (no verdict — over-budget packets just
+  -- skip the log and continue to the next rule) immediately followed by an
+  -- unconditional `counter drop`. The `log prefix` (the agent's nflog read
+  -- channel, parsed by nflog.lua off `logread`) lives on the log rule; the
+  -- `counter` + `wh_drop:` comment (ops view via `nft list ruleset` and the
+  -- nft_drops.lua attribution path, which sums only commented+countered rules)
+  -- live on the drop rule, so drop counts stay exact and unaffected by the rate
+  -- limit. 10/second burst 20 is per-rule, so each blocked MAC gets its own
+  -- budget — ample for ops visibility, bounded against a retry storm.
+  local DROP_LOG_LIMIT = "limit rate 10/second burst 20 packets"
+  local function log_suffix(mac, reason)
+    return string.format(" %s log prefix \"wh_drop:%s:%s \"",
+                         DROP_LOG_LIMIT, mac, reason)
+  end
   local function drop_suffix(mac, reason)
-    return string.format(
-      " log prefix \"wh_drop:%s:%s \" counter drop comment \"wh_drop:%s:%s\"",
-      mac, reason, mac, reason)
+    return string.format(" counter drop comment \"wh_drop:%s:%s\"",
+                         mac, reason)
+  end
+  -- Emit the rate-limited log rule then the unconditional drop rule for one
+  -- predicate. `predicate` is everything up to (but excluding) the log/drop
+  -- suffix; both rules share it verbatim so they match the same packets.
+  local function emit_drop(predicate, mac, reason)
+    ind2(predicate .. log_suffix(mac, reason))
+    ind2(predicate .. drop_suffix(mac, reason))
   end
   local blocked_reason_by_mac = {}
   for mac, dev in pairs(snapshot.devices or {}) do
@@ -1126,18 +1159,18 @@ function M.nft(snapshot, opts)
   -- family-agnostic per-MAC drop; MACs with extraAllowed get per-family
   -- rules carrying the ea exception (same shape as pre-#1122).
   for _, mac in ipairs(blocked_macs_list) do
-    ind2(string.format("ether saddr %s%s", mac,
-                       drop_suffix(mac, blocked_reason_by_mac[mac] or "blocked")))
+    emit_drop(string.format("ether saddr %s", mac),
+              mac, blocked_reason_by_mac[mac] or "blocked")
   end
   -- #1319: each per-MAC blocked rule also carries the `!= @global_allow`
   -- carve-out (ga_suffix), so a globally-allowed host stays reachable for a
   -- blocked MAC. ea_suffix (per-MAC allow) comes first, then ga_suffix.
   for _, mac in ipairs(blocked_ea_macs) do
     local reason = blocked_reason_by_mac[mac] or "blocked"
-    ind2(string.format("ether saddr %s%s%s%s", mac, ea_suffix(mac, "ip"),
-                       ga_suffix("ip"), drop_suffix(mac, reason)))
-    ind2(string.format("ether saddr %s%s%s%s", mac, ea_suffix(mac, "ip6"),
-                       ga_suffix("ip6"), drop_suffix(mac, reason)))
+    emit_drop(string.format("ether saddr %s%s%s", mac, ea_suffix(mac, "ip"),
+                            ga_suffix("ip")), mac, reason)
+    emit_drop(string.format("ether saddr %s%s%s", mac, ea_suffix(mac, "ip6"),
+                            ga_suffix("ip6")), mac, reason)
   end
   -- v4 drops first, then v6 (#392). One ipset directive populates both sets
   -- at DNS time; here we gate on whichever family the destination matched.
@@ -1157,36 +1190,36 @@ function M.nft(snapshot, opts)
   -- parser sees a partial host; for now we accept that gracefully (the
   -- drop still fires correctly — only the label is lossy).
   for _, p in ipairs(eb_pairs) do
-    ind2(string.format("ether saddr %s ip daddr @%s%s%s%s",
-                       p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip"),
-                       ga_suffix("ip"), drop_suffix(p.mac, "host:" .. p.host)))
+    emit_drop(string.format("ether saddr %s ip daddr @%s%s%s",
+                            p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip"),
+                            ga_suffix("ip")), p.mac, "host:" .. p.host)
   end
   for _, p in ipairs(eb_pairs) do
-    ind2(string.format("ether saddr %s ip6 daddr @%s%s%s%s",
-                       p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6"),
-                       ga_suffix("ip6"), drop_suffix(p.mac, "host:" .. p.host)))
+    emit_drop(string.format("ether saddr %s ip6 daddr @%s%s%s",
+                            p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6"),
+                            ga_suffix("ip6")), p.mac, "host:" .. p.host)
   end
   for _, p in ipairs(bl_pairs) do
-    ind2(string.format("ether saddr %s ip daddr @%s%s%s%s",
-                       p.mac, bl_set_name(p.id), ea_suffix(p.mac, "ip"),
-                       ga_suffix("ip"), drop_suffix(p.mac, "category:" .. tostring(p.id))))
+    emit_drop(string.format("ether saddr %s ip daddr @%s%s%s",
+                            p.mac, bl_set_name(p.id), ea_suffix(p.mac, "ip"),
+                            ga_suffix("ip")), p.mac, "category:" .. tostring(p.id))
   end
   for _, p in ipairs(bl_pairs) do
-    ind2(string.format("ether saddr %s ip6 daddr @%s%s%s%s",
-                       p.mac, bl6_set_name(p.id), ea_suffix(p.mac, "ip6"),
-                       ga_suffix("ip6"), drop_suffix(p.mac, "category:" .. tostring(p.id))))
+    emit_drop(string.format("ether saddr %s ip6 daddr @%s%s%s",
+                            p.mac, bl6_set_name(p.id), ea_suffix(p.mac, "ip6"),
+                            ga_suffix("ip6")), p.mac, "category:" .. tostring(p.id))
   end
   -- #353: blockIpOnly drop. Predicate `ip daddr != @resolved_<mac>` matches
   -- any v4 destination the device did not DNS-resolve via our resolver in
   -- the last 5 minutes — i.e. DoH / DoT / hard-coded IPs / stale cache
   -- entries past the set timeout.
   for _, mac in ipairs(bio_macs) do
-    ind2(string.format("ether saddr %s ip daddr != @%s%s",
-                       mac, resolved_set_name(mac), drop_suffix(mac, "ip_only")))
+    emit_drop(string.format("ether saddr %s ip daddr != @%s",
+                            mac, resolved_set_name(mac)), mac, "ip_only")
   end
   for _, mac in ipairs(bio_macs) do
-    ind2(string.format("ether saddr %s ip6 daddr != @%s%s",
-                       mac, resolved6_set_name(mac), drop_suffix(mac, "ip_only")))
+    emit_drop(string.format("ether saddr %s ip6 daddr != @%s",
+                            mac, resolved6_set_name(mac)), mac, "ip_only")
   end
   -- #1319: global block (hosts ∪ categories) → drop for every managed MAC on
   -- @global_block, carved out ONLY by @global_allow (a per-MAC extraAllowed
@@ -1194,14 +1227,14 @@ function M.nft(snapshot, opts)
   -- one v6 rule per managed MAC.
   if has_global_block then
     for _, mac in ipairs(managed_macs) do
-      ind2(string.format("ether saddr %s ip daddr @%s%s%s",
-                         mac, GLOBAL_BLOCK4, ga_suffix("ip"),
-                         drop_suffix(mac, "global_block")))
+      emit_drop(string.format("ether saddr %s ip daddr @%s%s",
+                              mac, GLOBAL_BLOCK4, ga_suffix("ip")),
+                mac, "global_block")
     end
     for _, mac in ipairs(managed_macs) do
-      ind2(string.format("ether saddr %s ip6 daddr @%s%s%s",
-                         mac, GLOBAL_BLOCK6, ga_suffix("ip6"),
-                         drop_suffix(mac, "global_block")))
+      emit_drop(string.format("ether saddr %s ip6 daddr @%s%s",
+                              mac, GLOBAL_BLOCK6, ga_suffix("ip6")),
+                mac, "global_block")
     end
   end
   -- #1319: global lockdown (global.blocked) → whole-network kill switch. Drop
@@ -1214,17 +1247,17 @@ function M.nft(snapshot, opts)
     if has_global_allow then
       -- Per-family so each can carry its family-specific @global_allow carve-out.
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format("ether saddr %s%s%s",
-                           mac, ga_suffix("ip"), drop_suffix(mac, g_block_reason)))
+        emit_drop(string.format("ether saddr %s%s", mac, ga_suffix("ip")),
+                  mac, g_block_reason)
       end
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format("ether saddr %s%s%s",
-                           mac, ga_suffix("ip6"), drop_suffix(mac, g_block_reason)))
+        emit_drop(string.format("ether saddr %s%s", mac, ga_suffix("ip6")),
+                  mac, g_block_reason)
       end
     else
       -- No global allow → one family-agnostic unconditional drop per MAC.
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format("ether saddr %s%s", mac, drop_suffix(mac, g_block_reason)))
+        emit_drop(string.format("ether saddr %s", mac), mac, g_block_reason)
       end
     end
   end

--- a/openwrt/test/failover_spec.lua
+++ b/openwrt/test/failover_spec.lua
@@ -166,11 +166,11 @@ describe("render.nft — #385/#422 three-mode failover", function()
     s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
     local nft_no_signal = render.nft(s)
     assert.truthy(nft_no_signal:find(
-      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com log prefix \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com\"", 1, true),
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com\"", 1, true),
       "AllowAll must enforce normally when no failover signal is present")
     local nft_ok = render.nft(s, { poll_failed = false })
     assert.truthy(nft_ok:find(
-      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com log prefix \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com\"", 1, true),
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com\"", 1, true),
       "AllowAll must enforce normally when the most-recent poll succeeded")
   end)
 
@@ -184,15 +184,15 @@ describe("render.nft — #385/#422 three-mode failover", function()
     local nft = render.nft(s, { poll_failed = true })
     -- Block-all kid keeps its extraBlocked drop.
     assert.truthy(nft:find(
-      "ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example log prefix \"wh_drop:aa:aa:aa:00:00:01:host:kidblocked.example \" counter drop comment \"wh_drop:aa:aa:aa:00:00:01:host:kidblocked.example\"",
+      "ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example counter drop comment \"wh_drop:aa:aa:aa:00:00:01:host:kidblocked.example\"",
       1, true))
     -- LastKnownGood adult keeps its extraBlocked drop.
     assert.truthy(nft:find(
-      "ether saddr bb:bb:bb:00:00:02 ip daddr @eb_adultblocked_example log prefix \"wh_drop:bb:bb:bb:00:00:02:host:adultblocked.example \" counter drop comment \"wh_drop:bb:bb:bb:00:00:02:host:adultblocked.example\"",
+      "ether saddr bb:bb:bb:00:00:02 ip daddr @eb_adultblocked_example counter drop comment \"wh_drop:bb:bb:bb:00:00:02:host:adultblocked.example\"",
       1, true))
     -- AllowAll guest does NOT have its extraBlocked drop.
     assert.is_nil(nft:find(
-      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_guestblocked_example log prefix \"wh_drop:cc:cc:cc:00:00:03:host:guestblocked.example \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:guestblocked.example\"",
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_guestblocked_example counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:guestblocked.example\"",
       1, true))
   end)
 

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -459,7 +459,7 @@ describe("render.nft extraBlocked enforcement", function()
   it("emits a drop rule `ether saddr <mac> ip daddr @eb_<host> drop` for each (mac, host) pair", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
   end)
 
   -- #392: v6 drop rule mirrors the v4 one. Without it a dual-stack host
@@ -467,7 +467,7 @@ describe("render.nft extraBlocked enforcement", function()
   it("emits a v6 drop rule `ether saddr <mac> ip6 daddr @eb6_<host> drop` (#392)", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
   end)
 
   it("does NOT drop traffic from MACs in OTHER profiles (no global leakage — the bug #351 fixes)", function()
@@ -485,10 +485,10 @@ describe("render.nft extraBlocked enforcement", function()
     local nft = render.nft(s)
     -- Kids MAC still has the drop.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
     -- Adults MAC must NOT appear paired with eb_tiktok_com.
     assert.is_nil(nft:find(
-      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com log prefix \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com\"", 1, true))
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com\"", 1, true))
   end)
 
   it("two MACs sharing the same extraBlocked host produce ONE ipset and TWO MAC-scoped drops", function()
@@ -507,9 +507,9 @@ describe("render.nft extraBlocked enforcement", function()
     local _, set_count = nft:gsub("set eb_tiktok_com {", "")
     assert.equal(1, set_count)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
     assert.truthy(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr @eb_tiktok_com log prefix \"wh_drop:11:22:33:44:55:66:host:tiktok.com \" counter drop comment \"wh_drop:11:22:33:44:55:66:host:tiktok.com\"", 1, true))
+      "ether saddr 11:22:33:44:55:66 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:11:22:33:44:55:66:host:tiktok.com\"", 1, true))
   end)
 
   it("emits no extraBlocked sets or drop rules when no device has extraBlocked", function()
@@ -546,10 +546,10 @@ describe("render.nft extraBlocked enforcement", function()
     }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_override_example log prefix \"wh_drop:aa:bb:cc:11:22:33:host:override.example \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:override.example\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_override_example counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:override.example\"", 1, true))
     -- Sibling under the same profile must NOT inherit the override.
     assert.is_nil(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr @eb_override_example log prefix \"wh_drop:11:22:33:44:55:66:host:override.example \" counter drop comment \"wh_drop:11:22:33:44:55:66:host:override.example\"", 1, true))
+      "ether saddr 11:22:33:44:55:66 ip daddr @eb_override_example counter drop comment \"wh_drop:11:22:33:44:55:66:host:override.example\"", 1, true))
   end)
 
 end)
@@ -614,7 +614,7 @@ describe("render.nft nat chain", function()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
-    assert.truthy(nft:find("ether saddr aa:bb:cc:11:22:33 log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"", 1, true))
+    assert.truthy(nft:find("ether saddr aa:bb:cc:11:22:33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"", 1, true))
   end)
 
   -- #351: a connection-layer block to an extraBlocked host on HTTP/80 should
@@ -724,7 +724,7 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     s.profiles["3"].rules.blockReason = "TimeLimit"
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 log prefix \"wh_drop:aa:bb:cc:11:22:33:TimeLimit \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
+      "ether saddr aa:bb:cc:11:22:33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
       1, true))
     -- The family-agnostic @blocked_macs drop is gone — per-MAC rules supersede.
     assert.is_nil(nft:find("@blocked_macs drop", 1, true))
@@ -737,10 +737,10 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     s.profiles["3"].rules.extraAllowed = { "school.example" }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_school_example log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_school_example counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_school_example log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_school_example counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
   end)
 
@@ -757,7 +757,7 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     local nft = render.nft(s)
     -- The per-MAC drop spares the allowed host via the ea_ exception (allow wins).
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
     -- The MAC is pulled out of the family-agnostic @blocked_macs set (it has a
     -- per-MAC carve-out rule instead), so general traffic drops via that rule.
@@ -781,7 +781,7 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     end
   end)
 
-  it("every drop rule in wifihaven_block carries `log prefix` + `counter drop`", function()
+  it("every drop rule carries `counter drop` + comment and is preceded by its rate-limited log rule (#1826)", function()
     local s = snap_one()
     -- Force every kind of drop to appear.
     s.profiles["3"].rules.blocked      = true
@@ -793,21 +793,37 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     local nft  = render.nft(s)
     local body = filter_chain_body(nft)
     assert.truthy(body)
-    -- For every `drop` token in the body, the surrounding line must contain
-    -- `log prefix "wh_drop:…" counter drop`. We scan line-by-line so a missing
-    -- `log prefix` (the agent's read channel) on any drop fails the assertion.
+    -- Post-#1826 each drop is two rules: a rate-limited log rule (the agent's
+    -- read channel) immediately followed by an unconditional `counter drop`
+    -- carrying the `wh_drop:` comment. We scan line-by-line: every `counter
+    -- drop` line must carry the comment, and the line directly above it must be
+    -- the matching rate-limited `log prefix "wh_drop:…"` rule with the same
+    -- predicate (so the log can never be unbounded and the drop is never gated
+    -- by the limit).
+    local prev = nil
     for line in body:gmatch("[^\n]+") do
-      if line:find(" drop", 1, true)
-         and not (line:find("counter drop", 1, true) and line:find("log prefix \"wh_drop:", 1, true)) then
-        assert(false, "drop without log prefix / counter: " .. line)
+      if line:find("counter drop", 1, true) then
+        assert(line:find("comment \"wh_drop:", 1, true),
+               "counter drop without wh_drop comment: " .. line)
+        -- The drop must NOT itself carry a limit/log (else it gates the drop).
+        assert(not line:find("limit rate ", 1, true),
+               "drop rule gated by limit rate: " .. line)
+        assert(not line:find("log prefix", 1, true),
+               "drop rule still logs (flood risk): " .. line)
+        -- The matching log rule is the line directly above, same predicate.
+        local predicate = line:gsub(" counter drop.*$", "")
+        assert(prev and prev:find(predicate, 1, true)
+               and prev:find("limit rate 10/second burst 20 packets log prefix \"wh_drop:", 1, true),
+               "drop not preceded by its rate-limited log rule: " .. line)
       end
+      prev = line
     end
   end)
 
   it("eb_ drop comment is wh_drop:<mac>:host:<host> (#1645)", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
+      "ip daddr @eb_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
@@ -817,7 +833,7 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ip daddr @bl_ads log prefix \"wh_drop:aa:bb:cc:11:22:33:category:ads \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:ads\"",
+      "ip daddr @bl_ads counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:ads\"",
       1, true))
   end)
 
@@ -826,8 +842,89 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     s.profiles["3"].rules.blockIpOnly = true
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
+  end)
+end)
+
+-- ── wh_drop LOG rate-limiting (#1826) ─────────────────────────────────────
+--
+-- Incident (2026-06-22): a Schedule-blocked device retry-stormed HTTPS/QUIC
+-- (port 443) against the whole-MAC drop. The old single-rule form emitted one
+-- kernel-log line per dropped packet — a ring-buffer flood that pegged
+-- wifihaven-agent + wifihaven-dns-tail (load 4.3). The drop is correct; the
+-- unbounded LOG action is the defect.
+--
+-- The fix rate-limits the LOG with an nft `limit rate`, but the drop MUST stay
+-- unconditional. Crucially this CANNOT be a single `… limit rate … log … drop`
+-- rule: in nftables a `limit` statement is a *match*, so packets that exceed the
+-- rate fail the rule and fall through to `policy accept` — that would leak the
+-- block over budget. So each drop is split into two rules with the same
+-- predicate: a rate-limited log rule (no verdict) followed by an unconditional
+-- `counter drop`.
+
+describe("render.nft rate-limits wh_drop logging (#1826)", function()
+
+  local function filter_chain_body(nft)
+    local start = nft:find("chain wifihaven_block {", 1, true)
+    if not start then return nil end
+    local open  = nft:find("{", start, true)
+    local close = nft:find("\n  }", open, true)
+    return nft:sub(open + 1, close - 1)
+  end
+
+  it("whole-MAC Schedule drop rate-limits the LOG on a separate rule", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked     = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    local nft = render.nft(s)
+    -- Rate-limited log rule for this MAC/reason (limit precedes log prefix).
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 limit rate 10/second burst 20 packets log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \"",
+      1, true), "expected rate-limited wh_drop log rule")
+    -- Unconditional drop rule (counter + comment), with NO limit/log.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
+      1, true), "expected unconditional counter drop rule")
+  end)
+
+  it("every wh_drop LOG line carries a limit rate clause", function()
+    local s = snap_one()
+    -- Force every kind of drop to appear.
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Schedule"
+    s.profiles["3"].rules.blockIpOnly  = true
+    s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    local nft  = render.nft(s)
+    local body = filter_chain_body(nft)
+    assert.truthy(body)
+    for line in body:gmatch("[^\n]+") do
+      if line:find("log prefix \"wh_drop:", 1, true)
+         and not line:find("limit rate ", 1, true) then
+        assert(false, "unbounded wh_drop log line: " .. line)
+      end
+    end
+  end)
+
+  it("the drop verdict is never gated by the rate limit (no `limit … drop` on one line)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Schedule"
+    s.profiles["3"].rules.blockIpOnly  = true
+    s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    local nft  = render.nft(s)
+    local body = filter_chain_body(nft)
+    for line in body:gmatch("[^\n]+") do
+      -- A line that both rate-limits and drops would let over-budget packets
+      -- escape the drop. The two must live on separate rules.
+      if line:find("limit rate ", 1, true) and line:find(" drop", 1, true) then
+        assert(false, "limit and drop on same rule (block leaks over budget): " .. line)
+      end
+    end
   end)
 end)
 
@@ -1273,14 +1370,14 @@ describe("render blocklist enforcement (#352)", function()
     local nft = render.nft(snap_bl())
     -- Only kid mac references test_ads; parent does not.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads log prefix \"wh_drop:aa:bb:cc:11:22:33:category:test_ads \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"", 1, true))
   end)
 
   -- #392: v6 drop rule mirrors the v4 one for blocklists.
   it("emits v6 drop 'ether saddr <mac> ip6 daddr @bl6_<id> drop' (#392)", function()
     local nft = render.nft(snap_bl())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads log prefix \"wh_drop:aa:bb:cc:11:22:33:category:test_ads \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"", 1, true))
   end)
 
   it("does NOT emit v6 drop for MACs whose profile has no blocklistIds (#392)", function()
@@ -1292,7 +1389,7 @@ describe("render blocklist enforcement (#352)", function()
   it("does NOT emit drop for MACs whose profile has blocklistIds = {}", function()
     local nft = render.nft(snap_bl())
     assert.is_nil(nft:find(
-      "ether saddr de:ad:be:ef:00:01 ip daddr @bl_test_ads log prefix \"wh_drop:de:ad:be:ef:00:01:category:test_ads \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:category:test_ads\"", 1, true),
+      "ether saddr de:ad:be:ef:00:01 ip daddr @bl_test_ads counter drop comment \"wh_drop:de:ad:be:ef:00:01:category:test_ads\"", 1, true),
       "adults MAC must not get a bl_test_ads drop rule")
   end)
 
@@ -1303,9 +1400,9 @@ describe("render blocklist enforcement (#352)", function()
     local _, set_count = nft:gsub("set bl_test_ads {", "")
     assert.equal(1, set_count, "exactly one set declaration")
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads log prefix \"wh_drop:aa:bb:cc:11:22:33:category:test_ads \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"", 1, true))
     assert.truthy(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr @bl_test_ads log prefix \"wh_drop:11:22:33:44:55:66:category:test_ads \" counter drop comment \"wh_drop:11:22:33:44:55:66:category:test_ads\"", 1, true))
+      "ether saddr 11:22:33:44:55:66 ip daddr @bl_test_ads counter drop comment \"wh_drop:11:22:33:44:55:66:category:test_ads\"", 1, true))
   end)
 
   it("blocklistId referenced by profile but absent from snapshot.blocklists → silently skipped", function()
@@ -1534,14 +1631,14 @@ describe("render blockIpOnly enforcement (#353)", function()
   it("emits `ether saddr <mac> ip daddr != @resolved_<mac> drop` in wifihaven_block", function()
     local nft = render.nft(snap_bio())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
   end)
 
   it("emits the v6 sibling drop `ip6 daddr != @resolved6_<mac> drop`", function()
     local nft = render.nft(snap_bio())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @resolved6_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @resolved6_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
   end)
 
@@ -1587,11 +1684,11 @@ describe("render blockIpOnly enforcement (#353)", function()
     local nft = render.nft(s)
     -- Override MAC has the rule.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
     -- Sibling under same profile must NOT inherit.
     assert.is_nil(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr != @resolved_11_22_33_44_55_66 log prefix \"wh_drop:11:22:33:44:55:66:ip_only \" counter drop comment \"wh_drop:11:22:33:44:55:66:ip_only\"",
+      "ether saddr 11:22:33:44:55:66 ip daddr != @resolved_11_22_33_44_55_66 counter drop comment \"wh_drop:11:22:33:44:55:66:ip_only\"",
       1, true))
     assert.is_nil(nft:find("set resolved_11_22_33_44_55_66", 1, true))
   end)
@@ -1603,9 +1700,9 @@ describe("render blockIpOnly enforcement (#353)", function()
     assert.truthy(nft:find("set resolved_aa_bb_cc_11_22_33",  1, true))
     assert.truthy(nft:find("set resolved_11_22_33_44_55_66",  1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"", 1, true))
     assert.truthy(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr != @resolved_11_22_33_44_55_66 log prefix \"wh_drop:11:22:33:44:55:66:ip_only \" counter drop comment \"wh_drop:11:22:33:44:55:66:ip_only\"", 1, true))
+      "ether saddr 11:22:33:44:55:66 ip daddr != @resolved_11_22_33_44_55_66 counter drop comment \"wh_drop:11:22:33:44:55:66:ip_only\"", 1, true))
   end)
 
   -- ── failover allow-all suppression (mirrors eb_/bl_ pattern) ────────────
@@ -1618,10 +1715,10 @@ describe("render blockIpOnly enforcement (#353)", function()
     -- the dnsmasq tag is still wired). But forward-chain drops and DNAT for
     -- these MACs must be gone.
     assert.is_nil(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
     assert.is_nil(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @resolved6_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @resolved6_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
     assert.is_nil(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 tcp dport 80",
@@ -1638,9 +1735,9 @@ describe("render blockIpOnly enforcement (#353)", function()
     -- rules, so a packet matching the eb_ rule is dropped regardless of the
     -- blockIpOnly rule's predicate.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
   end)
 
@@ -1801,28 +1898,28 @@ describe("render extraAllowed enforcement (#421)", function()
   it("appends `ip daddr != @ea_<m>_<a>` to the eb_<host> drop for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
   it("appends `ip6 daddr != @ea6_<m>_<a>` to the eb6_<host> drop for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
   it("appends `ip daddr != @ea_<m>_<a>` to the bl_<id> drop for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:category:test_ads \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"",
       1, true))
   end)
 
   it("appends `ip6 daddr != @ea6_<m>_<a>` to the bl6_<id> drop for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:category:test_ads \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:category:test_ads\"",
       1, true))
   end)
 
@@ -1832,7 +1929,7 @@ describe("render extraAllowed enforcement (#421)", function()
     local nft = render.nft(s)
     -- Both clauses present in the same eb_ drop rule, in sorted order.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
@@ -1842,7 +1939,7 @@ describe("render extraAllowed enforcement (#421)", function()
     -- Adult MAC has the same eb_tiktok_com drop but extraAllowed={}, so no
     -- ea_ suffix on its rule.
     assert.truthy(nft:find(
-      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com log prefix \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com\"", 1, true))
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com\"", 1, true))
     -- And specifically not carrying the kid's ea set.
     assert.is_nil(nft:find(
       "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com",
@@ -1854,7 +1951,7 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.extraAllowed = {}
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
   end)
 
   -- ── DNAT chain: same suffix applied ─────────────────────────────────────
@@ -1893,7 +1990,7 @@ describe("render extraAllowed enforcement (#421)", function()
     local nft = render.nft(s)
     -- The bio drop is unchanged — no `!= @ea_...` clause appended.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
     -- And no spurious mixed rule like
     -- "ip daddr != @resolved_... ip daddr != @ea_..." either.
@@ -1907,11 +2004,11 @@ describe("render extraAllowed enforcement (#421)", function()
     local nft = render.nft(s)
     -- eb drop has ea suffix:
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
     -- bio drop has no ea suffix:
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
   end)
 
@@ -1962,10 +2059,10 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
   end)
 
@@ -1999,7 +2096,7 @@ describe("render extraAllowed enforcement (#421)", function()
     assert.truthy(blk:find("de:ad:be:ef:00:01", 1, true))
     -- And the per-MAC drop with logging fires for adult.
     assert.truthy(nft:find(
-      "ether saddr de:ad:be:ef:00:01 log prefix \"wh_drop:de:ad:be:ef:00:01:Paused \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:Paused\"",
+      "ether saddr de:ad:be:ef:00:01 counter drop comment \"wh_drop:de:ad:be:ef:00:01:Paused\"",
       1, true))
   end)
 
@@ -2038,7 +2135,7 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.extraAllowed = { "music.tiktok.com", "khanacademy.org" }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
   end)
 
@@ -2060,10 +2157,10 @@ describe("render extraAllowed enforcement (#421)", function()
     assert.is_nil(blk:find("aa:bb:cc:11:22:33", 1, true))
     -- Per-MAC v4 + v6 drops carry the ea exception and the TimeLimit reason.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com log prefix \"wh_drop:aa:bb:cc:11:22:33:TimeLimit \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_mathacademy_com log prefix \"wh_drop:aa:bb:cc:11:22:33:TimeLimit \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_mathacademy_com counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
       1, true))
     -- And the block-page DNAT for the allowed host is likewise carved out.
     assert.truthy(nft:find(
@@ -2387,10 +2484,10 @@ describe("render.nft global composition (#1319)", function()
     local nft = render.nft(s)
     -- The blocked-MAC drop must carry the global-allow exception on both families.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
       1, true))
   end)
 
@@ -2400,7 +2497,7 @@ describe("render.nft global composition (#1319)", function()
     s.global.extraAllowed = { "wifihaven.local" }
     local nft = render.nft(s) -- snap_one has extraBlocked = { "tiktok.com" }
     assert.truthy(nft:find(
-      "ip daddr @eb_tiktok_com ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
+      "ip daddr @eb_tiktok_com ip daddr != @global_allow counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
@@ -2417,13 +2514,13 @@ describe("render.nft global composition (#1319)", function()
     }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block log prefix \"wh_drop:aa:bb:cc:11:22:33:global_block \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr de:ad:be:ef:00:01 ip daddr @global_block log prefix \"wh_drop:de:ad:be:ef:00:01:global_block \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:global_block\"",
+      "ether saddr de:ad:be:ef:00:01 ip daddr @global_block counter drop comment \"wh_drop:de:ad:be:ef:00:01:global_block\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @global_block6 log prefix \"wh_drop:aa:bb:cc:11:22:33:global_block \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @global_block6 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
       1, true))
   end)
 
@@ -2436,7 +2533,7 @@ describe("render.nft global composition (#1319)", function()
     s.profiles["3"].rules.extraAllowed = { "school.example" }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block log prefix \"wh_drop:aa:bb:cc:11:22:33:global_block \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
       1, true))
     -- No ea exception spliced into the global-block drop line.
     assert.is_nil(nft:find(
@@ -2453,10 +2550,10 @@ describe("render.nft global composition (#1319)", function()
     s.global.extraAllowed = { "wifihaven.local" }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow counter drop comment \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 log prefix \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny\"",
       1, true))
   end)
 
@@ -2467,7 +2564,7 @@ describe("render.nft global composition (#1319)", function()
     local nft = render.nft(s)
     assert.truthy(nft:find("set resolved_aa_bb_cc_11_22_33 {", 1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
   end)
 
@@ -2486,7 +2583,7 @@ describe("render.nft global composition (#1319)", function()
 
   -- Every drop in wifihaven_block — including the new global drops — must
   -- carry the nflog attribution prefix (the #1122 invariant).
-  it("every global drop carries `log prefix` + `counter drop`", function()
+  it("every global drop carries `counter drop` + comment, preceded by its rate-limited log rule (#1826)", function()
     local s = snap_global()
     s.global.blocked      = true
     s.global.blockReason  = "DefaultDeny"
@@ -2497,11 +2594,24 @@ describe("render.nft global composition (#1319)", function()
     local block_start = nft:find("chain wifihaven_block {", 1, true)
     local next_chain  = nft:find("\n%s*chain ", block_start + 1)
     local body = nft:sub(block_start, (next_chain or #nft + 1) - 1)
+    -- Post-#1826: each drop is a `counter drop` + comment rule preceded by its
+    -- own rate-limited `log prefix` rule with the same predicate (see the
+    -- per-MAC equivalent above). The drop itself never logs or rate-limits.
+    local prev = nil
     for line in body:gmatch("[^\n]+") do
-      if line:find(" drop", 1, true)
-         and not (line:find("counter drop", 1, true) and line:find("log prefix \"wh_drop:", 1, true)) then
-        assert(false, "drop without log prefix / counter: " .. line)
+      if line:find("counter drop", 1, true) then
+        assert(line:find("comment \"wh_drop:", 1, true),
+               "counter drop without wh_drop comment: " .. line)
+        assert(not line:find("limit rate ", 1, true),
+               "drop rule gated by limit rate: " .. line)
+        assert(not line:find("log prefix", 1, true),
+               "drop rule still logs (flood risk): " .. line)
+        local predicate = line:gsub(" counter drop.*$", "")
+        assert(prev and prev:find(predicate, 1, true)
+               and prev:find("limit rate 10/second burst 20 packets log prefix \"wh_drop:", 1, true),
+               "drop not preceded by its rate-limited log rule: " .. line)
       end
+      prev = line
     end
   end)
 end)
@@ -2524,10 +2634,10 @@ describe("render.nft global composition — precedence compositions (#1322)", fu
     -- The drop matches @global_block but is suppressed for any IP also in
     -- @global_allow — i.e. evil.example's resolved IPs survive.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:global_block \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block ip daddr != @global_allow counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @global_block6 ip6 daddr != @global_allow6 log prefix \"wh_drop:aa:bb:cc:11:22:33:global_block \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @global_block6 ip6 daddr != @global_allow6 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
       1, true))
   end)
 
@@ -2550,12 +2660,12 @@ describe("render.nft global composition — precedence compositions (#1322)", fu
     local nft = render.nft(s)
     -- 1) whole-MAC block, carved out by the per-MAC ea exception, DefaultDeny reason
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_pbskids_org log prefix \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_pbskids_org counter drop comment \"wh_drop:aa:bb:cc:11:22:33:DefaultDeny\"",
       1, true))
     -- 2) the independent strict-IP drop on resolved_<m>
     assert.truthy(nft:find("set resolved_aa_bb_cc_11_22_33 {", 1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
   end)
 
@@ -2571,7 +2681,7 @@ describe("render.nft global composition — precedence compositions (#1322)", fu
     local nft = render.nft(s)
     -- the resolved_ drop line is exactly the bare strict-IP predicate
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
     -- no `@global_allow` spliced onto the resolved_ line
     assert.is_nil(nft:find(
@@ -2605,7 +2715,7 @@ describe("render.nft global composition — precedence compositions (#1322)", fu
     -- But the global block still drops for this managed MAC, carved out only by
     -- @global_allow (its own empty extraAllowed cannot loosen a global block).
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:global_block \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @global_block ip daddr != @global_allow counter drop comment \"wh_drop:aa:bb:cc:11:22:33:global_block\"",
       1, true))
   end)
 end)
@@ -2632,10 +2742,10 @@ describe("render.nft #1174 schedule-block + ui-host allow", function()
   it("schedule-blocked MAC's per-MAC drop carries `!= @global_allow` (v4 + v6)", function()
     local nft = render.nft(snap_174())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
       1, true))
   end)
 


### PR DESCRIPTION
Fixes #1826

## Incident
router.lan CPU spiked at ~06:00 MDT (2026-06-22). Load avg **4.3**;
`wifihaven-agent` **26%** and `wifihaven-dns-tail` **24%**, both pinned `R`.
Both are kids' devices on a bedtime **Schedule** (≈19:30–06:30 MDT), so the
whole-MAC block was active **all night** — it did not "engage at 6am". The ~06:00
spike is when the **retry-storm** against that already-active block (TCP+UDP 443,
v4+v6, Apple push/iCloud/relay endpoints) was observed pegging CPU, ~30 min before
the 06:30 schedule end.

## Root cause
`render.lua` rendered each per-MAC drop as a single rule with **no `limit rate`**:

```
ether saddr <mac> … log prefix "wh_drop:<mac>:<reason> " counter drop comment "wh_drop:…"
```

So a retry storm = **one kernel-ring-buffer line per dropped packet** (dozens/sec),
flooding `logread` and pegging the agent + dns-tail. The drop is working
correctly — the **unbounded LOG action** is the defect.

## Fix
Rate-limit the LOG with an nft `limit rate 10/second burst 20 packets`, keeping
the drop **unconditional and unchanged**.

> ⚠️ This is deliberately **not** the single-rule form `… limit rate … log … drop`.
> In nftables a `limit` statement is a **match**: packets that *exceed* the rate
> fail the rule and fall through to `policy accept`. Putting `limit` before `drop`
> in one rule would silently **leak the block over budget** (a schedule/manual/
> category block would let >10 pkt/s through). That violates "keep enforcement
> identical", so instead `emit_drop` renders **two rules sharing one predicate**:

```
ether saddr <mac> … limit rate 10/second burst 20 packets log prefix "wh_drop:<mac>:<reason> "
ether saddr <mac> … counter drop comment "wh_drop:<mac>:<reason>"
```

- The **log prefix** (the agent's nflog read channel, parsed off `logread` by
  `nflog.lua`) lives on the rate-limited rule.
- The **counter + `wh_drop:` comment** (ops view via `nft list ruleset` and the
  `nft_drops.lua` attribution path, which sums only commented+countered rules)
  live on the unconditional drop rule, so **drop counts stay exact**.
- Per-rule budget (10/s) → each blocked MAC gets its own; two storming devices
  cap at ~20 logged lines/s instead of unbounded.

Applied uniformly to **all** wh_drop emission sites: whole-MAC blocked,
blocked+extraAllowed, extraBlocked host (v4/v6), category blocklist (v4/v6),
blockIpOnly (v4/v6), global block (v4/v6), global lockdown.

**Enforcement behavior is identical** — only the LOG is now bounded. Drop
*visibility* becomes rate-sampled (≤10 logged records/s per rule) rather than
one-record-per-packet, which is itself part of relieving the agent-side load.

## Tests (TDD)
`render_spec.lua` gains a `#1826` block (written failing first):
- whole-MAC Schedule drop rate-limits the LOG on a **separate** rule;
- **every** wh_drop log line carries a `limit rate` clause (no unbounded log);
- the drop verdict is **never** gated by the limit (no `limit … drop` on one line).

The two existing "every drop carries `log prefix` + `counter drop`" contract
tests are rewritten to the new pairing (each `counter drop`+comment rule is
immediately preceded by its matching rate-limited `log prefix` rule, same
predicate). Existing combined-form assertions across `render_spec`/`failover_spec`
updated to the split drop-line shape.

Local `busted` is green: **713 passing** (the `nft -c` syntax check is `pending`
locally — no `nft` binary on macOS).

## Validation
Router-agent change. The `nft -c` ruleset-syntax check and the **KVM Gate 2/3
e2e cannot run on macOS** — they run on the self-hosted CI runner and validate
the rendered ruleset / live apply end-to-end. Relying on CI for that gate.

## Secondary (issue's "assess")
The issue also flags `dns-tail` CPU from the DNS-query volume of the storm and
`dnsmasq.log` outrunning the 10-min rotate. The rate-limit addresses the
**agent/kernel-log** flood (the dominant pegging source). The DNS-side items are
a **distinct** fix and are filed separately as #1828 rather than expanding
this PR.

