### PR TITLE
fix(#1829): fix empty-ruleset v6 e2e test to unblock Gate 2

### DIFF
--- a/scripts/e2e/scenarios_fake/test_v6_usage_attribution.py
+++ b/scripts/e2e/scenarios_fake/test_v6_usage_attribution.py
@@ -331,15 +331,32 @@ def test_v6_usage_attributes_to_fqdn_and_aggregates_with_v4(router, client, fake
         # the loaded ruleset. Pre-#1802 they do not (the regression's root
         # cause), so this is a cheap, deterministic #1796 guard independent of
         # the traffic round-trip. ──────────────────────────────────────────
-        sets = router_ssh(
-            "nft list sets inet wifihaven 2>/dev/null || true",
-            check=False, timeout=10,
-        ).stdout or ""
-        for s in ("mac_ip6_tracking", "ip_pair6_tracking_rx"):
-            assert s in sets, (
-                f"nft ruleset is missing the v6 accounting set {s!r} — "
-                f"pre-#1802 IPv4-only accounting plane regressed?\n{sets!r}"
-            )
+        #
+        # NB: dump the whole table (`nft list table inet wifihaven`), NOT
+        # `nft list sets inet wifihaven` — the latter is malformed (`list sets`
+        # takes only an optional FAMILY token, so the trailing table name makes
+        # nft error out; the `2>/dev/null` then swallowed it and the assert ran
+        # against an empty string, which is why this gate was red on every run
+        # since #1808 merged, see #1829). The table dump includes each set's
+        # `set <name> { ... }` declaration, so the membership check still holds.
+        # Poll briefly to absorb the fetch→apply gap (the etag is *served*
+        # before the agent finishes rendering the ruleset).
+        _required_sets = ("mac_ip6_tracking", "ip_pair6_tracking_rx")
+
+        def _v6_sets_present():
+            out = router_ssh(
+                "nft list table inet wifihaven 2>/dev/null || true",
+                check=False, timeout=10,
+            ).stdout or ""
+            return out if all(s in out for s in _required_sets) else None
+
+        wait_until(
+            _v6_sets_present, timeout_s=60, interval_s=3,
+            description=(
+                "nft table inet wifihaven contains the v6 accounting sets "
+                f"{_required_sets} (#1802 / #1796 regression guard)"
+            ),
+        )
 
         url = f"http://{LEAF_HOST}/"
         _wait_origin_reachable(client, url=url, family_flag="-6")


### PR DESCRIPTION
## Root cause
Master Router CD Gate 2 (router fake-API e2e) has been RED on `main` since #1808 merged. `scenarios_fake/test_v6_usage_attribution.py` fails deterministically at its real-nft regression guard:

```
AssertionError: nft ruleset is missing the v6 accounting set 'mac_ip6_tracking'
assert 'mac_ip6_tracking' in ''
```

The asserted-against ruleset string is **empty**. The cause is a **test/harness bug, not a product regression**: the guard ran

```
nft list sets inet wifihaven
```

which is **malformed** — `nft list sets` takes only an optional *family* token (`inet`/`ip`/`ip6`/…), so the trailing table name `wifihaven` makes nft error out. With `2>/dev/null || true` the stderr was swallowed and stdout came back `''`, so the assertion always ran against an empty string. The test has therefore **never been green on main** and provided **zero real coverage**.

(`mac_ip6_tracking` / `ip_pair6_tracking_rx` are rendered **unconditionally** in `render.lua` ~827/835 and covered by passing busted unit tests — the product is fine.)

## What I did (correct fix, not quarantine)
- Switched the read to `nft list table inet wifihaven` — the exact form `scenarios_fake/_observers.py` already uses successfully. The table dump includes each set's `set <name> { ... }` declaration, so the `in` membership check still holds.
- Wrapped it in a short `wait_until` poll (60s) to absorb the fetch→apply gap — the fake serves the etag *before* the agent finishes rendering the ruleset, so a single immediate read could race. This preserves (in fact strengthens) the #1796/#1802 regression-guard value instead of discarding it.

No quarantine needed — this is a clean, high-confidence harness fix, so no follow-up issue is required.

## Validation
Cannot run Gate 2 locally (no KVM on macOS). `python3 -m py_compile` passes. CI **Master Router CD → Gate 2** validates end-to-end against the plex KVM runner (~44 min). The VM-networking log noise (`Cannot find device eth1`, `udhcpc: no lease`) is incidental — the failing assertion was deterministic on the malformed command, and `wait_until` now also tolerates a slow apply.

Fixes #1829