### PR TITLE
fix(#1864): nice agent below dnsmasq + bound wh_drop logging to stop DNS starvation

### DIFF
--- a/openwrt/files/etc/init.d/wifihaven
+++ b/openwrt/files/etc/init.d/wifihaven
@@ -5,10 +5,22 @@ USE_PROCD=1
 START=95
 STOP=10
 
+# #1864: nice the agent and its tail sidecars BELOW dnsmasq so DNS resolution
+# always wins the CPU under contention. On a busy household the agent runs hot
+# (~28% CPU steady, R state) and spikes under traffic bursts (e.g. a schedule-
+# block retry-storm, #1826); sharing the CPU with dnsmasq at equal priority let
+# those spikes starve dnsmasq, producing transient name-resolution failures for
+# EVERY device on the router (broken page loads) — none of them actually blocked.
+# dnsmasq keeps its package default (nice 0); we run the wifihaven stack at a
+# positive nice so the scheduler de-prioritises it whenever dnsmasq is runnable.
+# procd applies this on (re)start, so it is idempotent and survives respawns.
+WIFIHAVEN_NICE=10
+
 start_service() {
     procd_open_instance "agent"
     procd_set_param command /usr/sbin/wifihaven-agent
     procd_set_param respawn 3600 5 5
+    procd_set_param nice "$WIFIHAVEN_NICE"
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance
@@ -18,6 +30,7 @@ start_service() {
     procd_open_instance "dns-tail"
     procd_set_param command /usr/sbin/wifihaven-dns-tail
     procd_set_param respawn 3600 5 5
+    procd_set_param nice "$WIFIHAVEN_NICE"
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance
@@ -39,6 +52,7 @@ start_service() {
         procd_open_instance "sni-tail"
         procd_set_param command /usr/sbin/wifihaven-sni-tail
         procd_set_param respawn 3600 5 5
+        procd_set_param nice "$WIFIHAVEN_NICE"
         procd_set_param stdout 1
         procd_set_param stderr 1
         procd_close_instance
@@ -52,6 +66,7 @@ start_service() {
     procd_open_instance "nflog-tail"
     procd_set_param command /usr/sbin/wifihaven-nflog-tail
     procd_set_param respawn 3600 5 5
+    procd_set_param nice "$WIFIHAVEN_NICE"
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1081,7 +1081,7 @@ function M.nft(snapshot, opts)
 
   -- #1122/#1126: each drop is rendered as a pair of rules sharing one predicate
   -- (see #1826 / `emit_drop` below):
-  --   `<predicate> limit rate 10/second burst 20 packets log prefix "wh_drop:<mac>:<reason> "`
+  --   `<predicate> limit rate 2/second burst 10 packets log prefix "wh_drop:<mac>:<reason> "`
   --   `<predicate> counter drop comment "wh_drop:<mac>:<reason>"`
   -- (pre-#1826 this was a single `… log prefix … counter drop` rule; the LOG is
   -- now on its own rate-limited rule so a retry storm can't flood the kernel
@@ -1124,9 +1124,19 @@ function M.nft(snapshot, opts)
   -- `counter` + `wh_drop:` comment (ops view via `nft list ruleset` and the
   -- nft_drops.lua attribution path, which sums only commented+countered rules)
   -- live on the drop rule, so drop counts stay exact and unaffected by the rate
-  -- limit. 10/second burst 20 is per-rule, so each blocked MAC gets its own
-  -- budget — ample for ops visibility, bounded against a retry storm.
-  local DROP_LOG_LIMIT = "limit rate 10/second burst 20 packets"
+  -- limit. The limit is per-rule, so each blocked MAC gets its own budget.
+  -- #1864: the original 10/second budget was still enough to dominate the
+  -- shared `logread` ring buffer when several MACs retry-storm at once — the
+  -- aggregate (10/s × N drop rules) evicted wifihaven-agent and dnsmasq lines
+  -- from the ring buffer, leaving the router undiagnosable during an incident.
+  -- Throttle the LOG harder: 2/second with a burst of 10 still captures the
+  -- distinct flows the agent's nflog tail needs to label blocked-flow events
+  -- (the labels are deduped per (mac, reason, dst), so a retry storm to one
+  -- endpoint needs only a single sample), but cuts the steady-state ring-buffer
+  -- footprint ~5×. The burst absorbs the initial flurry of distinct hosts; the
+  -- low sustained rate keeps the ring buffer usable for everything else. The
+  -- `counter drop` rule is unchanged, so enforcement and drop counts are exact.
+  local DROP_LOG_LIMIT = "limit rate 2/second burst 10 packets"
   local function log_suffix(mac, reason)
     return string.format(" %s log prefix \"wh_drop:%s:%s \"",
                          DROP_LOG_LIMIT, mac, reason)

--- a/openwrt/test/init_spec.sh
+++ b/openwrt/test/init_spec.sh
@@ -61,6 +61,21 @@ grep -q 'procd_set_param respawn' "$INIT" \
   && check "sets procd_set_param respawn" ok \
   || check "sets procd_set_param respawn" "not found"
 
+# 6b. #1864: every instance must be niced BELOW dnsmasq (positive nice) so DNS
+# resolution wins the CPU under contention. There are four instances (agent,
+# dns-tail, sni-tail, nflog-tail); each carries one `procd_set_param nice`.
+NICE_COUNT=$(grep -c 'procd_set_param nice' "$INIT")
+[ "$NICE_COUNT" -eq 4 ] \
+  && check "all four instances set procd_set_param nice (count=$NICE_COUNT)" ok \
+  || check "all four instances set procd_set_param nice" "expected 4, got $NICE_COUNT"
+
+# 6c. The nice value must be a POSITIVE integer (lower priority than dnsmasq's
+# default nice 0). A zero/negative value would not de-prioritise the agent.
+WH_NICE=$(sed -n 's/^WIFIHAVEN_NICE=\([0-9-]*\).*/\1/p' "$INIT")
+{ [ -n "$WH_NICE" ] && [ "$WH_NICE" -gt 0 ]; } \
+  && check "WIFIHAVEN_NICE is a positive integer ($WH_NICE)" ok \
+  || check "WIFIHAVEN_NICE is a positive integer" "got '$WH_NICE'"
+
 # 7. Must define service_triggers() for UCI-triggered reload
 grep -q 'service_triggers()' "$INIT" \
   && check "defines service_triggers()" ok \

--- a/openwrt/test/init_spec.test.sh
+++ b/openwrt/test/init_spec.test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Thin shim: auto-discovered by the CI shell-tests job (*.test.sh pattern in
+# .github/workflows/ci.yml) and delegates to init_spec.sh, the canonical home
+# for openwrt/files/etc/init.d/wifihaven assertions. Added with #1864 so the
+# `procd_set_param nice` checks (agent niced below dnsmasq) gate merges in CI,
+# not just `run_tests.sh` locally.
+set -euo pipefail
+OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+sh "${OPENWRT_DIR}/test/init_spec.sh"

--- a/openwrt/test/nflog_tail_bounded_spec.sh
+++ b/openwrt/test/nflog_tail_bounded_spec.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Shell-level checks for openwrt/files/usr/sbin/wifihaven-nflog-tail.
+#
+# #1864 / AGENTS.md#bounded-tmp-writes: the nflog-tail sidecar appends every
+# `wh_drop:` line it reads off `logread -f` to a tmpfs spool. On OpenWRT /tmp is
+# tmpfs (RAM), and under a retry-storm the drop-log volume is unbounded — so the
+# spool MUST be capped and truncated in place. This is the agent's read channel
+# for blocked-flow visibility events; it is bounded by the sidecar itself
+# (truncate-on-cap), NOT by the wifihaven-rotate-dnsmasq-log cron (the cron
+# rotates the dnsmasq/SNI logs, whose writers hold the fd open). This spec
+# pins that the cap + truncate path stays present.
+#
+# Run from the openwrt/ directory:  sh test/nflog_tail_bounded_spec.sh
+set -e
+
+PASS=0; FAIL=0
+TAIL="$(cd "$(dirname "$0")/.." && pwd)/files/usr/sbin/wifihaven-nflog-tail"
+
+check() {
+  if [ "$2" = "ok" ]; then
+    printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s — %s\n" "$1" "$2"; FAIL=$((FAIL + 1))
+  fi
+}
+
+[ -f "$TAIL" ] || { printf "MISSING: %s\n" "$TAIL"; exit 1; }
+
+# 1. Must read a positive byte cap for the spool (defaulted, UCI-overridable).
+grep -q 'nflog_spool_max_bytes' "$TAIL" \
+  && check "reads a spool byte cap (nflog_spool_max_bytes)" ok \
+  || check "reads a spool byte cap (nflog_spool_max_bytes)" "not found"
+
+# 2. Must compare the spool size against the cap (bounded-write guard).
+grep -q 'cap_bytes' "$TAIL" \
+  && check "compares spool size against cap_bytes" ok \
+  || check "compares spool size against cap_bytes" "not found"
+
+# 3. Must truncate in place when over cap — reopen with mode "w" zeroes the
+#    file on the same path (the agent detects the shrink and rewinds). A rename
+#    would orphan the writer's fd; "w" is the correct in-place truncation.
+grep -q 'io.open(out_path, "w")' "$TAIL" \
+  && check "truncates the spool in place when over cap" ok \
+  || check "truncates the spool in place when over cap" "not found"
+
+# 4. The default cap must be a sane, small positive value (tmpfs is RAM). The
+#    default is 262144 (256 KiB); assert a non-zero numeric default is present.
+grep -Eq 'nflog_spool_max_bytes",[[:space:]]*"[1-9][0-9]+"' "$TAIL" \
+  && check "default cap is a non-zero positive integer" ok \
+  || check "default cap is a non-zero positive integer" "not found / not positive"
+
+printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/openwrt/test/nflog_tail_bounded_spec.test.sh
+++ b/openwrt/test/nflog_tail_bounded_spec.test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Thin shim: auto-discovered by the CI shell-tests job (*.test.sh pattern in
+# .github/workflows/ci.yml) and delegates to nflog_tail_bounded_spec.sh, the
+# canonical home for the wifihaven-nflog-tail bounded-write assertions (#1864).
+set -euo pipefail
+OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+sh "${OPENWRT_DIR}/test/nflog_tail_bounded_spec.sh"

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -813,7 +813,7 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
         -- The matching log rule is the line directly above, same predicate.
         local predicate = line:gsub(" counter drop.*$", "")
         assert(prev and prev:find(predicate, 1, true)
-               and prev:find("limit rate 10/second burst 20 packets log prefix \"wh_drop:", 1, true),
+               and prev:find("limit rate 2/second burst 10 packets log prefix \"wh_drop:", 1, true),
                "drop not preceded by its rate-limited log rule: " .. line)
       end
       prev = line
@@ -880,7 +880,7 @@ describe("render.nft rate-limits wh_drop logging (#1826)", function()
     local nft = render.nft(s)
     -- Rate-limited log rule for this MAC/reason (limit precedes log prefix).
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 limit rate 10/second burst 20 packets log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \"",
+      "ether saddr aa:bb:cc:11:22:33 limit rate 2/second burst 10 packets log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \"",
       1, true), "expected rate-limited wh_drop log rule")
     -- Unconditional drop rule (counter + comment), with NO limit/log.
     assert.truthy(nft:find(
@@ -925,6 +925,31 @@ describe("render.nft rate-limits wh_drop logging (#1826)", function()
         assert(false, "limit and drop on same rule (block leaks over budget): " .. line)
       end
     end
+  end)
+
+  -- #1864: even rate-limited at 10/second, the aggregate across many
+  -- simultaneously-storming drop rules dominated the shared `logread` ring
+  -- buffer and evicted agent/dnsmasq lines, leaving the router undiagnosable.
+  -- The LOG is throttled harder (≤ 2/second sustained) to keep the ring buffer
+  -- usable; the drop verdict is unaffected (asserted above). Guard against a
+  -- regression that bumps the sustained rate back up.
+  it("throttles the wh_drop LOG to ≤ 2/second sustained (#1864)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked     = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    local nft  = render.nft(s)
+    local body = filter_chain_body(nft)
+    assert.truthy(body)
+    local saw_log = false
+    for line in body:gmatch("[^\n]+") do
+      local rate = line:match("limit rate (%d+)/second")
+      if rate and line:find("log prefix \"wh_drop:", 1, true) then
+        saw_log = true
+        assert(tonumber(rate) <= 2,
+               "wh_drop LOG rate too high (ring-buffer flood risk): " .. line)
+      end
+    end
+    assert.truthy(saw_log, "expected at least one rate-limited wh_drop log rule")
   end)
 end)
 
@@ -2608,7 +2633,7 @@ describe("render.nft global composition (#1319)", function()
                "drop rule still logs (flood risk): " .. line)
         local predicate = line:gsub(" counter drop.*$", "")
         assert(prev and prev:find(predicate, 1, true)
-               and prev:find("limit rate 10/second burst 20 packets log prefix \"wh_drop:", 1, true),
+               and prev:find("limit rate 2/second burst 10 packets log prefix \"wh_drop:", 1, true),
                "drop not preceded by its rate-limited log rule: " .. line)
       end
       prev = line

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -45,4 +45,5 @@ sh test/lua_module_paths_spec.sh
 sh test/nft_log_dep_spec.sh
 sh test/agent_spec.sh
 sh test/rotate_dnsmasq_log_spec.sh
+sh test/nflog_tail_bounded_spec.sh
 sh test/init_sni_toggle_spec.sh


### PR DESCRIPTION
Fixes #1864.

## Problem
On the busy prod router, devices saw transient DNS resolution failures (broken page loads, "can't reach calendar.google.com") that self-recovered in minutes — **not** a policy block (confirmed via live recon: not in `@blocked_macs`, no `wh_drop`, `blockIpOnly` off, DNS resolving). Root cause: the `wifihaven-agent` stack runs hot (~28% CPU steady, R state) and **shares the CPU with dnsmasq at equal priority**, so a traffic burst (e.g. the schedule-block retry-storm in #1826) starves dnsmasq and every device on the router briefly loses name resolution. dnsmasq itself is stable (0 restarts) — it's CPU starvation, not a reload.

This is **resource isolation + observability, not a policy change** — enforcement behavior is identical.

## Changes
**1. PRIMARY — process priority (the fix).** `nice` the agent and all three tail sidecars (`dns-tail`, `sni-tail`, `nflog-tail`) to **+10** via `procd_set_param nice`, leaving dnsmasq at its package default (nice 0). procd applies this on (re)start → idempotent, survives respawns. dnsmasq now wins the CPU under contention.

**2. Observability — throttle the `wh_drop` LOG harder** (`10/s burst 20` → `2/s burst 10` per rule). Even rate-limited (#1826), the aggregate across many simultaneously-storming drop rules dominated the shared `logread` ring buffer and evicted agent/dnsmasq lines, leaving the router undiagnosable during an incident. The burst still captures the distinct flows the agent's nflog tail needs to label blocked-flow events (labels dedupe per `(mac, reason, dst)`); the unconditional `counter drop` rule is **unchanged**, so enforcement and drop counts stay exact. Note the agent already consumes `wh_drop` from a **bounded /tmp spool** (`wifihaven-nflog-tail`, self-truncating at 256 KiB) rather than relying on ring-buffer retention — so its read channel is already off the ring buffer; this change reduces the residual ring-buffer pressure on operator diagnosis.

**3. ASSESS → follow-up #1866.** The ~28% steady-state CPU itself is left out of this PR per scope. The clearest separable win: `wifihaven-dns-tail` re-serializes the **entire** DNS cache + alias map to /tmp on **every** ingested query line (`flush_every = 1`) — O(N) per line over the firehose. Filed as #1866 (assigned, in-progress, Epic: Router Agent & Release) with the #472 correctness constraint documented; not implemented here.

## Tests
- `init_spec` asserts all four procd instances carry a **positive** `nice` (count == 4, value > 0).
- `render_spec` pins the throttled LOG rate (≤ 2/s sustained, #1864) and the unchanged split log/drop rule shape.
- New `nflog_tail_bounded_spec` pins the nflog spool cap + in-place truncation (AGENTS.md#bounded-tmp-writes).
- Added thin `.test.sh` shims (`init_spec.test.sh`, `nflog_tail_bounded_spec.test.sh`) so the init `nice` checks and the bounded-write spec gate in CI's `shell-tests` job, not just `run_tests.sh` locally.

All busted + shell specs pass locally (the 4 pre-existing `nft_log_dep_spec` build-ipk/apk failures are on `main` too, untouched here).

## Validation note
Router-agent change. Validated locally via `busted` + shell specs; **Gate 2/3 KVM e2e runs on CI's self-hosted runner — cannot run on macOS**. The `nice` change should also be sanity-checked on a real busy router (`top` showing dnsmasq winning CPU while the agent is busy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)