### PR TITLE
fix(#1865): never drop traffic to the block-page listener (+ verify reachability)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1152,6 +1152,28 @@ function M.nft(snapshot, opts)
 
   ind("chain wifihaven_block {")
   ind2("type filter hook forward priority 0; policy accept;")
+  -- #1865: the block page must NEVER be dropped, for any reason. The block-page
+  -- DNAT chain (wifihaven_block_nat, prerouting) rewrites a blocked device's
+  -- HTTP/HTTPS destination to the local block-page listener so the user sees
+  -- *why* they are blocked. With route_localnet (v4 → 127.0.0.1) / redirect
+  -- (v6 → br-lan addr) that packet is delivered locally and normally never
+  -- reaches this forward chain — but if it ever does (a transient routing edge,
+  -- a future DNAT target, or route_localnet not yet applied) the per-MAC / eb_
+  -- / bl_ / blockIpOnly / global drops below would kill it and the user would
+  -- get a hung connection instead of the block page (the original bug: a
+  -- Schedule-blocked v6 device DNAT'd to ::1, then dropped — DST=::1:8443).
+  -- One accept guard for router-local destinations encodes the invariant in a
+  -- SINGLE place: every block-page DNAT/redirect target is a router-local
+  -- address (`fib daddr type local`), whereas normal forwarded traffic is
+  -- destined to an external host, so the guard matches only block-page traffic
+  -- and never widens who is blocked. Threading a per-rule carve-out suffix
+  -- instead would be one missed rule away from re-introducing the bug.
+  -- `accept` is a per-chain verdict — the priority-1 accounting chains still
+  -- see the packet, so block-page bytes are still counted. This changes no
+  -- existing drop rule: the forward hook never governed traffic to the router
+  -- itself (that is the input hook), so router-local destinations were never
+  -- dropped here regardless.
+  ind2("fib daddr type local counter accept comment \"wh_block_page:never-drop:#1865\"")
   -- #1122: the family-agnostic @blocked_macs drop is replaced by per-MAC
   -- rules so each can carry its own `wh_drop:<mac>:<reason>` comment. The
   -- set is still declared (used by the DNAT chain below) but no longer
@@ -1283,9 +1305,20 @@ function M.nft(snapshot, opts)
       ind2(predicate .. " tcp dport 80 dnat ip to 127.0.0.1:8081")
       ind2(predicate .. " tcp dport 443 dnat ip to 127.0.0.1:8443")
     end
+    -- #1865: IPv6 has no `route_localnet` equivalent, and ::1 must never appear
+    -- on the wire (RFC 4291), so DNAT'ing forwarded v6 traffic to ::1 never
+    -- delivers — the routing decision treats ::1 as non-local and forwards the
+    -- packet out the WAN instead (observed live: DST=::1:8443 OUT=eth1). Use
+    -- `redirect` instead: it rewrites the destination to the inbound interface's
+    -- (br-lan) own address, which IS router-local, so the packet is delivered to
+    -- the local uhttpd block-page listener. uhttpd binds [::]:8081 / [::]:8443
+    -- (see setup-uhttpd-block-page.sh) so the redirected packet — now destined
+    -- to a br-lan v6 address rather than ::1 — lands on a live listener. (The v4
+    -- path keeps DNAT-to-127.0.0.1: route_localnet makes loopback deliverable on
+    -- v4, and that path already works on prod — leave it untouched.)
     local function dnat6(predicate)
-      ind2(predicate .. " tcp dport 80 dnat ip6 to ::1:8081")
-      ind2(predicate .. " tcp dport 443 dnat ip6 to ::1:8443")
+      ind2(predicate .. " tcp dport 80 redirect to :8081")
+      ind2(predicate .. " tcp dport 443 redirect to :8443")
     end
     if #blocked_macs_list > 0 then
       dnat4("ether saddr @blocked_macs")
@@ -1325,9 +1358,12 @@ function M.nft(snapshot, opts)
       dnat4(string.format("ether saddr %s ip daddr != @%s",
         mac, resolved_set_name(mac)))
     end
-    -- #411: v6 siblings. uhttpd also binds [::1]:8081 + [::1]:8443.
-    -- `ip6 daddr != ::1` guards against self-DNAT recursion if the block
-    -- page itself ever issues an outbound v6 request.
+    -- #411/#1865: v6 siblings, delivered via `redirect` (see dnat6 above).
+    -- uhttpd binds [::]:8081 + [::]:8443 so the redirected packet (now destined
+    -- to the br-lan v6 address) lands on a live listener. The retained
+    -- `ip6 daddr != ::1` guard keeps us from redirecting traffic literally
+    -- addressed to loopback (also avoids any self-redirect if the block page
+    -- ever issues an outbound v6 request).
     if #blocked_macs_list > 0 then
       dnat6("ether saddr @blocked_macs ip6 daddr != ::1")
     end

--- a/openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh
+++ b/openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Configure the uhttpd block-page listener on 127.0.0.1:8081 (v4) + [::1]:8081
-# (v6) with the lua handler at /www/wifihaven/handler.lua.
+# Configure the uhttpd block-page listener on 127.0.0.1:8081 (v4) + [::]:8081
+# (v6, #1865 — wildcard so nft `redirect`'d forwarded v6 traffic lands on it)
+# with the lua handler at /www/wifihaven/handler.lua.
 #
 # Called from:
 #   - openwrt/Makefile  Package/wifihaven/postinst (package installs)
@@ -46,11 +47,23 @@ else
   uhttpd_changed=1
 fi
 
-# v6 sibling (#411).
-if ! uci -q get "uhttpd.${uhttpd_section}.listen_http" \
+# v6 sibling (#411). #1865: bind the wildcard [::] rather than loopback [::1].
+# Forwarded IPv6 block-page traffic is delivered by render.lua's nft `redirect`
+# to the br-lan address (::1 is non-routable for forwarded traffic, RFC 4291),
+# so the listener must accept on the router's real v6 address, not just
+# loopback. Migrate any legacy [::1]:8081 entry to [::]:8081 — binding BOTH
+# would fail (the [::] wildcard already covers ::1, so the second bind hits
+# "address already in use").
+if uci -q get "uhttpd.${uhttpd_section}.listen_http" \
     | tr ' ' '\n' | grep -qx '\[::1\]:8081'; then
-  log "adding v6 block-page uhttpd listener on [::1]:8081"
-  uci add_list "uhttpd.${uhttpd_section}.listen_http=[::1]:8081"
+  log "migrating v6 block-page listener [::1]:8081 -> [::]:8081"
+  uci del_list "uhttpd.${uhttpd_section}.listen_http=[::1]:8081"
+  uhttpd_changed=1
+fi
+if ! uci -q get "uhttpd.${uhttpd_section}.listen_http" \
+    | tr ' ' '\n' | grep -qx '\[::\]:8081'; then
+  log "adding v6 block-page uhttpd listener on [::]:8081"
+  uci add_list "uhttpd.${uhttpd_section}.listen_http=[::]:8081"
   uhttpd_changed=1
 fi
 
@@ -65,10 +78,17 @@ if ! uci -q get "uhttpd.${uhttpd_section}.listen_https" \
   uci add_list "uhttpd.${uhttpd_section}.listen_https=127.0.0.1:8443"
   uhttpd_changed=1
 fi
-if ! uci -q get "uhttpd.${uhttpd_section}.listen_https" \
+# #1865: wildcard [::] for v6 TLS, same rationale as listen_http above.
+if uci -q get "uhttpd.${uhttpd_section}.listen_https" \
     | tr ' ' '\n' | grep -qx '\[::1\]:8443'; then
-  log "adding v6 TLS block-page uhttpd listener on [::1]:8443"
-  uci add_list "uhttpd.${uhttpd_section}.listen_https=[::1]:8443"
+  log "migrating v6 TLS block-page listener [::1]:8443 -> [::]:8443"
+  uci del_list "uhttpd.${uhttpd_section}.listen_https=[::1]:8443"
+  uhttpd_changed=1
+fi
+if ! uci -q get "uhttpd.${uhttpd_section}.listen_https" \
+    | tr ' ' '\n' | grep -qx '\[::\]:8443'; then
+  log "adding v6 TLS block-page uhttpd listener on [::]:8443"
+  uci add_list "uhttpd.${uhttpd_section}.listen_https=[::]:8443"
   uhttpd_changed=1
 fi
 current_cert=$(uci -q get "uhttpd.${uhttpd_section}.cert" || echo "")

--- a/openwrt/files/www/wifihaven/handler.lua
+++ b/openwrt/files/www/wifihaven/handler.lua
@@ -1,4 +1,4 @@
--- uhttpd-mod-lua handler for the block-page listener (127.0.0.1:8081 / [::1]:8081).
+-- uhttpd-mod-lua handler for the block-page listener (127.0.0.1:8081 / [::]:8081).
 --
 -- Wired in install.sh via:
 --   option lua_prefix '/'

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -132,10 +132,20 @@ grep -q "listen_https=127.0.0.1:8443" "$UHTTPD_HELPER" \
   || check "#383 helper configures TLS listener on 127.0.0.1:8443" \
            "missing listen_https=127.0.0.1:8443 wiring"
 
-grep -q "listen_https=\[::1\]:8443" "$UHTTPD_HELPER" \
-  && check "#383 helper configures TLS listener on [::1]:8443" ok \
-  || check "#383 helper configures TLS listener on [::1]:8443" \
-           "missing listen_https=[::1]:8443 wiring"
+# #1865: v6 TLS listener binds the wildcard [::] (not loopback [::1]) so the
+# nft `redirect` of forwarded v6 traffic to the br-lan address lands on a live
+# listener — ::1 is non-routable for forwarded traffic (RFC 4291).
+grep -q "listen_https=\[::\]:8443" "$UHTTPD_HELPER" \
+  && check "#1865 helper configures TLS listener on [::]:8443" ok \
+  || check "#1865 helper configures TLS listener on [::]:8443" \
+           "missing listen_https=[::]:8443 wiring"
+
+# #1865: legacy [::1]:8443 must be migrated away (binding both [::] and [::1]
+# fails — the wildcard already covers loopback).
+grep -q "del_list .*listen_https=\[::1\]:8443" "$UHTTPD_HELPER" \
+  && check "#1865 helper migrates legacy [::1]:8443 listener" ok \
+  || check "#1865 helper migrates legacy [::1]:8443 listener" \
+           "missing del_list for legacy listen_https=[::1]:8443"
 
 grep -q "/etc/wifihaven/block_page.crt" "$UHTTPD_HELPER" \
   && check "#383 helper wires cert=/etc/wifihaven/block_page.crt" ok \

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -641,23 +641,27 @@ describe("render.nft nat chain", function()
     assert.is_nil(nft:find("wifihaven_block_nat", 1, true))
   end)
 
-  -- #411: v6 block-page DNAT mirrors v4. uhttpd also binds [::1]:8081 so the
-  -- redirect lands on a live listener (see install.sh). Each v4 DNAT line
-  -- gets a parallel v6 sibling targeting the eb6_/bl6_ sets and ::1:8081.
-  it("emits a v6 DNAT rule scoped to @blocked_macs (#411)", function()
+  -- #411/#1865: v6 block-page delivery mirrors v4 but uses `redirect` rather
+  -- than DNAT-to-::1. IPv6 has no route_localnet and ::1 is non-routable for
+  -- forwarded traffic (RFC 4291), so DNAT-to-::1 forwarded out the WAN instead
+  -- of delivering. `redirect` rewrites the destination to the inbound (br-lan)
+  -- address, which is router-local; uhttpd binds [::]:8081 so it lands on a
+  -- live listener (see setup-uhttpd-block-page.sh). Each v4 DNAT line gets a
+  -- parallel v6 sibling targeting the eb6_/bl6_ sets via `redirect to :8081`.
+  it("emits a v6 redirect rule scoped to @blocked_macs (#411/#1865)", function()
     local s = snap_one()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 dnat ip6 to ::1:8081",
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 redirect to :8081",
       1, true))
   end)
 
-  it("DNATs v6 HTTP/80 from a MAC to the block page when daddr ∈ eb6_<host> (#411)", function()
+  it("redirects v6 HTTP/80 from a MAC to the block page when daddr ∈ eb6_<host> (#411/#1865)", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 80 dnat ip6 to ::1:8081",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 80 redirect to :8081",
       1, true))
   end)
 
@@ -677,18 +681,110 @@ describe("render.nft nat chain", function()
       "ether saddr @blocked_macs tcp dport 443 dnat ip to 127.0.0.1:8443",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 443 dnat ip6 to ::1:8443",
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 443 redirect to :8443",
       1, true))
   end)
 
-  it("emits a parallel HTTPS/443 DNAT for per-MAC extraBlocked (#383)", function()
+  it("emits a parallel HTTPS/443 DNAT/redirect for per-MAC extraBlocked (#383/#1865)", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com tcp dport 443 dnat ip to 127.0.0.1:8443",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 443 dnat ip6 to ::1:8443",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 443 redirect to :8443",
       1, true))
+  end)
+
+end)
+
+-- ── #1865: the block page must NEVER be dropped, and v6 must deliver ───────
+--
+-- Operator directive: a blocked device must always reach the local block-page
+-- listener so it sees *why* it is blocked, never a hung connection. Two
+-- confirmed failure modes:
+--   1. The block-page DNAT (wifihaven_block_nat, prerouting) rewrote a blocked
+--      device's HTTP/HTTPS to the local listener, but the per-MAC blocked drop
+--      in wifihaven_block (forward) then killed the redirected packet — it
+--      carved out ea_/@global_allow but NOT the block-page destination.
+--   2. v6 DNAT'd to ::1 (loopback). IPv6 has no route_localnet and ::1 is
+--      non-routable for forwarded traffic (RFC 4291), so the packet forwarded
+--      out the WAN (`DST=::1:8443 OUT=eth1`) instead of delivering.
+
+describe("render.nft #1865 block page is never dropped", function()
+
+  local function filter_chain_body(nft)
+    local start = nft:find("chain wifihaven_block {", 1, true)
+    if not start then return nil end
+    local open  = nft:find("{", start, true)
+    local close = nft:find("\n  }", open, true)
+    return nft:sub(open + 1, close - 1)
+  end
+
+  it("wifihaven_block accepts router-local (block-page DNAT) traffic before any drop", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    local nft  = render.nft(s)
+    local body = filter_chain_body(nft)
+    assert.truthy(body)
+    -- A single accept guard for router-local destinations (every block-page
+    -- DNAT/redirect target is a local address; normal forwarded traffic is
+    -- destined to an external host) — must be an accept, never a drop.
+    local guard = body:find("fib daddr type local counter accept", 1, true)
+    assert.truthy(guard, "expected a `fib daddr type local counter accept` guard")
+    -- It must precede every drop so the block page wins over all of them.
+    local first_drop = body:find("counter drop", 1, true)
+    assert.truthy(first_drop, "expected at least one drop rule")
+    assert.is_true(guard < first_drop,
+      "block-page accept guard must precede every drop rule")
+  end)
+
+  it("the guard is present even when only extraBlocked / category / blockIpOnly drops apply", function()
+    local s = snap_one()  -- snap_one has extraBlocked + blocklistIds, no MAC-wide block
+    s.profiles["3"].rules.blockIpOnly = true
+    local body = filter_chain_body(render.nft(s))
+    assert.truthy(body)
+    assert.truthy(body:find("fib daddr type local counter accept", 1, true))
+    -- And it still precedes the blockIpOnly drop.
+    local guard = body:find("fib daddr type local counter accept", 1, true)
+    local drop  = body:find("counter drop", 1, true)
+    assert.is_true(drop ~= nil and guard < drop)
+  end)
+
+  it("no v6 block-page DNAT to loopback (::1) survives — that path never delivered", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    local nft = render.nft(s)
+    assert.is_nil(nft:find("dnat ip6 to ::1", 1, true))
+  end)
+
+  it("v6 block-page uses redirect for @blocked_macs, extraBlocked and category", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 redirect to :8081", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 443 redirect to :8443", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_ads tcp dport 80 redirect to :8081", 1, true))
+  end)
+
+  it("v4 block-page path is unchanged (DNAT to 127.0.0.1; route_localnet delivers loopback)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs tcp dport 80 dnat ip to 127.0.0.1:8081", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs tcp dport 443 dnat ip to 127.0.0.1:8443", 1, true))
   end)
 
 end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1533,7 +1533,7 @@ describe("render blocklist enforcement (#352)", function()
   it("DNATs v6 HTTP/80 from a MAC to the block page when daddr ∈ bl6_<id> (#411)", function()
     local nft = render.nft(snap_bl())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads tcp dport 80 dnat ip6 to ::1:8081",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads tcp dport 80 redirect to :8081",
       1, true))
   end)
 
@@ -1750,7 +1750,7 @@ describe("render blockIpOnly enforcement (#353)", function()
   it("DNATs v6 HTTP/80 to the block page for daddrs NOT in resolved6_<mac> (#411)", function()
     local nft = render.nft(snap_bio())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != ::1 ip6 daddr != @resolved6_aa_bb_cc_11_22_33 tcp dport 80 dnat ip6 to ::1:8081",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != ::1 ip6 daddr != @resolved6_aa_bb_cc_11_22_33 tcp dport 80 redirect to :8081",
       1, true))
   end)
 
@@ -2062,7 +2062,7 @@ describe("render extraAllowed enforcement (#421)", function()
   it("appends `ip6 daddr != @ea6_<m>_<a>` to the eb6_<host> DNAT for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip6 to ::1:8081",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 redirect to :8081",
       1, true))
   end)
 
@@ -2171,7 +2171,7 @@ describe("render extraAllowed enforcement (#421)", function()
       "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip to 127.0.0.1:8081",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != ::1 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip6 to ::1:8081",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != ::1 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 redirect to :8081",
       1, true))
   end)
 

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -96,6 +96,8 @@ case "${ONLY}" in
   usage)        MARK="usage" ;;
   blocked-page|blocked_page)
                 MARK="blocked_page" ;;
+  block-page-v6|block_page_v6)
+                MARK="block_page_v6" ;;
   pause)        MARK="pause" ;;
   extra-blocked|extra_blocked)
                 MARK="extra_blocked" ;;
@@ -117,7 +119,7 @@ case "${ONLY}" in
                 MARK="v6_usage_attribution" ;;
   *) echo "unknown --only: ${ONLY}" >&2
      echo "valid: enrollment, allowed-browsing, blocked-domain, daily-limit, usage, blocked-page," >&2
-     echo "       pause, extra-blocked, schedule, time-limit, reassignment, unknown-device," >&2
+     echo "       block-page-v6, pause, extra-blocked, schedule, time-limit, reassignment, unknown-device," >&2
      echo "       install-health, sni-attribution, v6-link-local, v6-attribution, v6-usage-attribution" >&2
      exit 2 ;;
 esac

--- a/scripts/e2e/gate3/test_smoke.py
+++ b/scripts/e2e/gate3/test_smoke.py
@@ -20,7 +20,7 @@ import logging
 import time
 
 from lib.traffic import http_get
-from lib.wait import wait_until
+from lib.wait import wait_for_etag_change, wait_until
 
 log = logging.getLogger(__name__)
 
@@ -105,6 +105,34 @@ def test_gate3_smoke(admin, enrolled_router, client_vm, scratch_profile_and_devi
         f"saw {len(summaries)} summaries across {len(statuses)} profile(s)"
     )
     log.info("gate3: time_status summary present for %s: %s", mac, matched[0])
+
+    # ── whole-MAC block → block page is reachable (#1865) ─────────────────
+    # Regression for #1865 ("the block page must NEVER be blocked"). A
+    # *whole-MAC* block (pause / schedule / time-limit / manual — exercised
+    # here via pause) DNATs ALL of the device's HTTP to the local block page.
+    # The bug: the per-MAC blocked drop killed the DNAT'd packet (notably v6,
+    # which DNAT'd to ::1 and forwarded out the WAN), so the user saw a hung
+    # connection instead of the block page. After the fix the block page must
+    # load for the whole-MAC-blocked device. We probe a NEUTRAL host (not
+    # allowed_host: a Paused MAC keeps its extraAllowed carve-out per #1413,
+    # so the allowed host stays reachable even while paused). The block-page
+    # DNAT for a whole-MAC block is not gated on a resolved ipset, so any
+    # HTTP/80 from the paused MAC lands on the page.
+    neutral_host = "example.com"  # client_vm fixture already gated its DNS
+    admin.set_profile_paused(profile_id, True)
+    try:
+        wait_for_etag_change(admin, enrolled_router["router_id"], timeout_s=180)
+        blocked_probe = wait_until(
+            lambda: _block_page_probe(client_vm, neutral_host),
+            timeout_s=120, interval_s=3,
+            description=f"block page for whole-MAC-blocked {neutral_host}",
+        )
+        assert blocked_probe.http_code == 200
+        log.info("gate3: whole-MAC-block block page hit for %s (%d bytes)",
+                 neutral_host, len(blocked_probe.body))
+    finally:
+        # Restore so teardown (and any retry of this run) starts unpaused.
+        admin.set_profile_paused(profile_id, False)
 
 
 # ── probes ───────────────────────────────────────────────────────────────

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -9,6 +9,7 @@ markers =
     daily_limit: scenario 4 — per-app daily limit enforced
     usage: scenario 5 — usage reflected in /api/logs and /api/time/status
     blocked_page: scenario 6 — block page rendered for blocked HTTP traffic
+    block_page_v6: #1865 — whole-MAC-blocked device reaches the block page over IPv6 (redirect delivery + never-drop guard)
     pause: suite A (#428) — pause enforcement
     extra_blocked: suite B (#429) — extraBlocked Truth-1 + scoping
     schedule: suite C (#430) — schedule enforcement

--- a/scripts/e2e/scenarios_fake/test_v6_block_page.py
+++ b/scripts/e2e/scenarios_fake/test_v6_block_page.py
@@ -1,0 +1,144 @@
+"""IPv6 block-page reachability for a whole-MAC-blocked device (#1865).
+
+Regression for #1865 ("the block page must NEVER be blocked, for any reason").
+
+The bug: a whole-MAC-blocked device's IPv6 HTTP was DNAT'd to ``::1``. IPv6 has
+no ``route_localnet`` equivalent and ``::1`` must never appear on the wire
+(RFC 4291), so the routing decision treated ``::1`` as non-local and forwarded
+the packet out the WAN (observed live: ``wh_drop:…:Schedule … DST=::1:8443
+OUT=eth1``) instead of delivering it to the local block-page listener — the
+user saw a hung connection instead of *why* they were blocked.
+
+The fix (render.lua + setup-uhttpd-block-page.sh):
+  * the v6 block-page path DNATs via nft ``redirect`` (→ the router's br-lan v6
+    address, which IS router-local and deliverable) instead of ``dnat … ::1``;
+  * uhttpd binds ``[::]:8081`` / ``[::]:8443`` (wildcard) so the redirected
+    packet lands on a live listener;
+  * a ``fib daddr type local`` accept guard at the top of ``wifihaven_block``
+    ensures the redirected (now router-local) packet is never dropped.
+
+Why this is exercisable in the qemu harness even though SLIRP is v4-only
+(cf. test_v6_link_local): the block-page redirect terminates **locally** on the
+router — it never needs WAN forwarding. The client's v6 SYN to a blocked
+destination is intercepted in prerouting, redirected to the router's own uhttpd,
+and the block page comes back over IPv6 entirely on the LAN bridge.
+
+The ``client`` fixture already gates v6 readiness (``_assert_v6_link_local_ready``
+in lib/vm.py: a v6 default route via eth0 + a global-scope ULA), so a v6 request
+from the client routes to the router.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib.traffic import http_get
+from lib.vm import router_nft_set, router_ssh
+from lib.wait import wait_until
+
+from .snapshot_builder import snapshot_with_assigned_device
+
+pytestmark = pytest.mark.block_page_v6
+
+BLOCKED_MACS_SET = "blocked_macs"
+
+# RFC 3849 documentation address — same target test_v6_link_local proves the
+# client routes toward the router. The address itself is unreachable on the WAN
+# (and SLIRP is v4-only anyway); the point is the SYN reaches the router, where
+# the block-page redirect intercepts it before it can be forwarded.
+V6_BLOCKED_DEST = "2001:db8::10"
+
+
+def _norm(mac: str) -> str:
+    return mac.lower().strip()
+
+
+def _wait_mac_blocked(mac: str, *, timeout_s: float = 180) -> None:
+    wait_until(
+        lambda: True
+        if _norm(mac) in {_norm(m) for m in router_nft_set(BLOCKED_MACS_SET)}
+        else None,
+        timeout_s=timeout_s,
+        interval_s=2,
+        description=f"{mac} present in {BLOCKED_MACS_SET}",
+    )
+
+
+def _v6_block_page_probe(client):
+    """Return the HttpProbe iff a v6 request to a blocked dest yields the block
+    page (200 + marker). None otherwise — caller polls. The bracketed v6 literal
+    forces curl onto IPv6."""
+    p = http_get(client, f"http://[{V6_BLOCKED_DEST}]/", timeout_s=8)
+    if p.http_code != 200 or not p.body:
+        return None
+    body_lc = p.body.lower()
+    if "wifihaven" in body_lc or "blocked" in body_lc:
+        return p
+    return None
+
+
+@pytest.mark.smoke
+def test_whole_mac_block_serves_block_page_over_v6(router, client, fake_api):
+    mac = client.mac
+
+    # Whole-MAC block (paused → rules.blocked=true) for this device.
+    paused = snapshot_with_assigned_device(
+        etag='"sha256:fake-v6-blockpage-v1"', mac=mac, paused=True,
+    )
+    etag = fake_api.serve_snapshot(paused)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+    _wait_mac_blocked(mac, timeout_s=180)
+
+    # The fix's shape on the live router: the v6 block-page DNAT must be a
+    # `redirect` (not the broken `dnat … ::1`), and the never-drop guard must be
+    # present. Pins the regression at the ruleset level before the round-trip.
+    nat_chain = router_ssh(
+        "nft list chain inet wifihaven wifihaven_block_nat 2>&1",
+        check=False, timeout=15,
+    ).stdout or ""
+    # The v6 block-page path must use `redirect` (deliverable to the local
+    # listener), and the old broken DNAT-to-loopback targets must be gone.
+    # (Substring `redirect`/`::1:8081` rather than the full input syntax — nft's
+    # list form can normalize differently, and `::1` still legitimately appears
+    # in the retained `ip6 daddr != ::1` predicate, so we match on the old DNAT
+    # *target* ::1:<port>, which only the removed rules carried.)
+    assert "redirect" in nat_chain, (
+        "v6 block-page redirect missing from wifihaven_block_nat — "
+        f"chain was:\n{nat_chain}"
+    )
+    assert "::1:8081" not in nat_chain and "::1:8443" not in nat_chain, (
+        f"broken v6 DNAT-to-::1 target still present (the #1865 bug):\n{nat_chain}"
+    )
+    block_chain = router_ssh(
+        "nft list chain inet wifihaven wifihaven_block 2>&1",
+        check=False, timeout=15,
+    ).stdout or ""
+    assert "fib daddr type local" in block_chain, (
+        "never-drop block-page guard missing from wifihaven_block — "
+        f"chain was:\n{block_chain}"
+    )
+
+    # The round-trip the bug broke: a v6 request from the whole-MAC-blocked
+    # client must render the block page (delivered locally via redirect), not
+    # hang. dnsmasq restarts on PolicyApply (#341) and the agent's apply lags
+    # the etag flip, so poll.
+    try:
+        probe = wait_until(
+            lambda: _v6_block_page_probe(client),
+            timeout_s=120, interval_s=3,
+            description=f"v6 block page for whole-MAC-blocked {mac}",
+        )
+    except AssertionError:
+        # Full diagnostics on failure: was the SYN redirected, or did it leak
+        # to FORWARD / get dropped?
+        dump = router_ssh(
+            "echo '=== block_nat ==='; nft list chain inet wifihaven wifihaven_block_nat 2>&1; "
+            "echo '=== block ==='; nft list chain inet wifihaven wifihaven_block 2>&1 | head -30; "
+            "echo '=== uhttpd listeners ==='; netstat -ltn 2>/dev/null | grep -E ':8081|:8443' || true; "
+            "echo '=== ip -6 ==='; ip -6 addr show br-lan 2>&1",
+            check=False, timeout=20,
+        ).stdout or ""
+        pytest.fail(f"v6 block page never rendered for {mac}.\n{dump}")
+
+    assert probe.http_code == 200
+    body_lc = probe.body.lower()
+    assert "blocked" in body_lc or "wifihaven" in body_lc


### PR DESCRIPTION
## Problem
**The block page must NEVER be blocked, for any reason.** A whole-MAC-blocked device (paused / schedule / time-limit / manual) could not reach the local block-page listener — it saw a hung connection instead of *why* it was blocked. Two confirmed root causes (see #1865 for the live diagnosis):

1. **Drop carve-out missing.** The block-page DNAT chain (`wifihaven_block_nat`, prerouting) rewrites a blocked device's HTTP/HTTPS to the local listener, but the per-MAC / `eb_` / `bl_` / `blockIpOnly` / global drops in `wifihaven_block` (forward) then killed the redirected packet — they carved out `ea_`/`@global_allow` but **not** the block-page destination. Live: `wh_drop:…:Schedule … DST=::1:8443`.
2. **v6 never delivered.** IPv6 has no `route_localnet` equivalent and `::1` must never appear on the wire (RFC 4291), so DNAT'ing *forwarded* v6 traffic to `::1` never delivered — the routing decision forwarded it out the WAN (`DST=::1:8443 OUT=eth1`).

## Fix
1. **Single never-drop guard.** Add `fib daddr type local counter accept` at the **top** of `wifihaven_block`. Every block-page DNAT/redirect target is a router-local address; normal forwarded traffic is destined to an external host, so the guard matches *only* block-page traffic and never widens who is blocked. One rule encodes the invariant — versus threading a carve-out suffix through every drop rule (one missed rule away from re-introducing the bug). `accept` is a per-chain verdict, so the priority-1 accounting chains still count the bytes. The forward hook never governed router-local destinations (that's the input hook), so no existing drop rule changes.
2. **v6 via `redirect`.** Switch the v6 block-page path from `dnat ip6 to ::1:PORT` to nft `redirect to :PORT` (→ br-lan local address, deliverable). Bind uhttpd to `[::]:8081` / `[::]:8443` (wildcard) instead of loopback `[::1]` so the redirected packet lands on a live listener; `setup-uhttpd-block-page.sh` migrates any legacy `[::1]` entry (binding both fails — the wildcard already covers loopback). **The v4 path (DNAT → `127.0.0.1`, `route_localnet`) is untouched — it already works.**

## Validation
- `busted` (openwrt/): all green (614 passing). New `render_spec` cases assert the never-drop guard precedes every drop and the v6 path uses `redirect` (no surviving `dnat ip6 to ::1`). `install_spec` asserts the `[::]` listener wiring + legacy `[::1]` migration.
- **Rendered ruleset validated with `nft -c -f -` on a real OpenWRT target (nftables v1.1.6)** for both normal and failover snapshots — `redirect` + `fib daddr type local` syntax accepted. (KVM Gate 2/3a can't run locally; relying on PR CI for full boot.)
- **Gate 3a smoke extended**: asserts a whole-MAC-blocked (paused) device still renders the block page end-to-end.

Fixes #1865

🤖 Generated with [Claude Code](https://claude.com/claude-code)