### PR TITLE
fix(#1871): poll the time-used display so it can't lag enforcement

### DIFF
--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -11,14 +11,15 @@ vi.mock('@/api/client', () => ({
   api: {
     profiles: { list: vi.fn() },
     devices: { list: vi.fn() },
-    time: { statusAll: vi.fn(), statusAllWeek: vi.fn() },
+    time: { statusAll: vi.fn(), statusAllWeek: vi.fn(), summaryAll: vi.fn() },
     dashboard: { now: vi.fn() },
   },
 }))
 
 import { api } from '@/api/client'
 import {
-  useProfiles, useDevices, useTimeStatusToday, useInvalidators, qk,
+  useProfiles, useDevices, useTimeStatusToday, useTimeStatusSummary,
+  useTimeStatusProfileToday, useInvalidators, qk, TIME_STATUS_REFETCH_MS,
 } from './queries'
 
 function makeWrapper(client: QueryClient) {
@@ -46,6 +47,7 @@ beforeEach(() => {
   ;(api.profiles.list  as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
   ;(api.devices.list   as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
   ;(api.time.statusAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
   ;(api.dashboard.now  as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ asOf: '', profiles: [] })
 })
 
@@ -101,5 +103,63 @@ describe('SWR caching (#803)', () => {
     // After the invalidation completes, data is still present — the
     // hook never exposes `undefined` for a query that has loaded once.
     expect(hook.result.current.data?.[0]?.profile.name).toBe('Kids')
+  })
+})
+
+// #1871: the live time-used surfaces must poll in the foreground so the
+// displayed "minutes left" can't lag enforcement (the router blocks within
+// seconds of the cap, but a query with only a staleTime never refetches on its
+// own). Each 'today' hook must carry a bounded refetchInterval; the immutable
+// 'past'/'week' hooks must NOT poll.
+describe('time-used live polling (#1871)', () => {
+  it('exposes a bounded refetch interval constant', () => {
+    expect(TIME_STATUS_REFETCH_MS).toBeGreaterThan(0)
+    expect(TIME_STATUS_REFETCH_MS).toBeLessThanOrEqual(30_000)
+  })
+
+  // Drive a hook with fake timers and prove it refetches after the interval.
+  // freshClient's long staleTime means an interval-driven refetch is the ONLY
+  // thing that can produce a second network call, so a missing/false
+  // refetchInterval makes the second assertion fail.
+  async function expectLivePolling(
+    render: () => void,
+    fetchSpy: ReturnType<typeof vi.fn>,
+  ): Promise<void> {
+    vi.useFakeTimers()
+    try {
+      render()
+      // Let the initial fetch resolve.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      // One interval later, it polls again on its own.
+      await vi.advanceTimersByTimeAsync(TIME_STATUS_REFETCH_MS)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  }
+
+  it('useTimeStatusToday refetches on the live interval', async () => {
+    const wrapper = makeWrapper(freshClient())
+    await expectLivePolling(
+      () => renderHook(() => useTimeStatusToday(), { wrapper }),
+      api.time.statusAll as unknown as ReturnType<typeof vi.fn>,
+    )
+  })
+
+  it('useTimeStatusSummary refetches on the live interval', async () => {
+    const wrapper = makeWrapper(freshClient())
+    await expectLivePolling(
+      () => renderHook(() => useTimeStatusSummary(), { wrapper }),
+      api.time.summaryAll as unknown as ReturnType<typeof vi.fn>,
+    )
+  })
+
+  it('useTimeStatusProfileToday refetches on the live interval', async () => {
+    const wrapper = makeWrapper(freshClient())
+    await expectLivePolling(
+      () => renderHook(() => useTimeStatusProfileToday(1), { wrapper }),
+      api.time.statusAll as unknown as ReturnType<typeof vi.fn>,
+    )
   })
 })

--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -19,7 +19,8 @@ vi.mock('@/api/client', () => ({
 import { api } from '@/api/client'
 import {
   useProfiles, useDevices, useTimeStatusToday, useTimeStatusSummary,
-  useTimeStatusProfileToday, useInvalidators, qk, TIME_STATUS_REFETCH_MS,
+  useTimeStatusProfileToday, useInvalidators, qk,
+  timeStatusRefetchMs, TIME_STATUS_REFETCH_MAX_MS,
 } from './queries'
 
 function makeWrapper(client: QueryClient) {
@@ -109,57 +110,108 @@ describe('SWR caching (#803)', () => {
 // #1871: the live time-used surfaces must poll in the foreground so the
 // displayed "minutes left" can't lag enforcement (the router blocks within
 // seconds of the cap, but a query with only a staleTime never refetches on its
-// own). Each 'today' hook must carry a bounded refetchInterval; the immutable
-// 'past'/'week' hooks must NOT poll.
-describe('time-used live polling (#1871)', () => {
-  it('exposes a bounded refetch interval constant', () => {
-    expect(TIME_STATUS_REFETCH_MS).toBeGreaterThan(0)
-    expect(TIME_STATUS_REFETCH_MS).toBeLessThanOrEqual(30_000)
+// own). The cadence is ADAPTIVE — fast near a profile's cap, slow with lots of
+// time left. The immutable 'past'/'week' hooks must NOT poll.
+describe('time-used adaptive poll cadence (#1871)', () => {
+  // The ladder the operator asked for: ≤5m → 10s, ≤10m → 1m, ≤30m → 5m,
+  // beyond that (or no daily limit) → the 5m baseline.
+  it('maps remaining minutes to the poll interval', () => {
+    expect(timeStatusRefetchMs(0)).toBe(10_000)
+    expect(timeStatusRefetchMs(3)).toBe(10_000)
+    expect(timeStatusRefetchMs(5)).toBe(10_000)
+    expect(timeStatusRefetchMs(6)).toBe(60_000)
+    expect(timeStatusRefetchMs(10)).toBe(60_000)
+    expect(timeStatusRefetchMs(11)).toBe(300_000)
+    expect(timeStatusRefetchMs(30)).toBe(300_000)
+    expect(timeStatusRefetchMs(31)).toBe(TIME_STATUS_REFETCH_MAX_MS)
+    expect(timeStatusRefetchMs(120)).toBe(TIME_STATUS_REFETCH_MAX_MS)
   })
 
-  // Drive a hook with fake timers and prove it refetches after the interval.
-  // freshClient's long staleTime means an interval-driven refetch is the ONLY
-  // thing that can produce a second network call, so a missing/false
-  // refetchInterval makes the second assertion fail.
-  async function expectLivePolling(
+  it('treats no-daily-limit and past-cap edges sensibly', () => {
+    // No limit in force (null/undefined remaining) → slow baseline, not a tight poll.
+    expect(timeStatusRefetchMs(null)).toBe(TIME_STATUS_REFETCH_MAX_MS)
+    expect(timeStatusRefetchMs(undefined)).toBe(TIME_STATUS_REFETCH_MAX_MS)
+    // At/over the cap (a blocked profile) → fastest bucket, so a time extension
+    // or unblock surfaces within seconds.
+    expect(timeStatusRefetchMs(-5)).toBe(10_000)
+  })
+
+  // Behavioural: with fake timers, a hook fetched with a near-cap profile polls
+  // again after the fast 10s bucket. freshClient's long staleTime means an
+  // interval-driven refetch is the ONLY thing that can produce a second network
+  // call, so a missing/false refetchInterval makes the assertion fail.
+  const nearCap = [{ profileId: 1, dailyLimitMins: 60, usedMins: 58, remainingMins: 2 }]
+
+  async function expectFastPoll(
+    seed: (v: unknown) => void,
     render: () => void,
     fetchSpy: ReturnType<typeof vi.fn>,
   ): Promise<void> {
+    seed(nearCap)
     vi.useFakeTimers()
     try {
       render()
-      // Let the initial fetch resolve.
-      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(0) // initial fetch resolves
       expect(fetchSpy).toHaveBeenCalledTimes(1)
-      // One interval later, it polls again on its own.
-      await vi.advanceTimersByTimeAsync(TIME_STATUS_REFETCH_MS)
+      await vi.advanceTimersByTimeAsync(10_000) // one fast-bucket interval
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
   }
 
-  it('useTimeStatusToday refetches on the live interval', async () => {
+  it('useTimeStatusToday polls fast near the cap', async () => {
+    const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
     const wrapper = makeWrapper(freshClient())
-    await expectLivePolling(
+    await expectFastPoll(
+      v => statusAll.mockResolvedValue(v),
       () => renderHook(() => useTimeStatusToday(), { wrapper }),
-      api.time.statusAll as unknown as ReturnType<typeof vi.fn>,
+      statusAll,
     )
   })
 
-  it('useTimeStatusSummary refetches on the live interval', async () => {
+  it('useTimeStatusSummary polls fast near the cap', async () => {
+    const summaryAll = api.time.summaryAll as unknown as ReturnType<typeof vi.fn>
     const wrapper = makeWrapper(freshClient())
-    await expectLivePolling(
+    await expectFastPoll(
+      v => summaryAll.mockResolvedValue(v),
       () => renderHook(() => useTimeStatusSummary(), { wrapper }),
-      api.time.summaryAll as unknown as ReturnType<typeof vi.fn>,
+      summaryAll,
     )
   })
 
-  it('useTimeStatusProfileToday refetches on the live interval', async () => {
+  it('useTimeStatusProfileToday polls fast near the cap', async () => {
+    const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
     const wrapper = makeWrapper(freshClient())
-    await expectLivePolling(
+    await expectFastPoll(
+      // single-row shape (the hook takes rows[0])
+      v => statusAll.mockResolvedValue(v),
       () => renderHook(() => useTimeStatusProfileToday(1), { wrapper }),
-      api.time.statusAll as unknown as ReturnType<typeof vi.fn>,
+      statusAll,
     )
+  })
+
+  // Adaptivity: with lots of time left, the hook does NOT poll on the fast
+  // cadence — it stays quiet until the slow baseline elapses.
+  it('backs off to the slow baseline with lots of time left', async () => {
+    const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
+    statusAll.mockResolvedValue([
+      { profileId: 1, dailyLimitMins: 240, usedMins: 10, remainingMins: 230 },
+    ])
+    const wrapper = makeWrapper(freshClient())
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useTimeStatusToday(), { wrapper })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(statusAll).toHaveBeenCalledTimes(1)
+      // Fast-bucket interval elapses — still no refetch, because we're far from the cap.
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(statusAll).toHaveBeenCalledTimes(1)
+      // The slow baseline elapses — now it polls.
+      await vi.advanceTimersByTimeAsync(TIME_STATUS_REFETCH_MAX_MS)
+      expect(statusAll).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -75,12 +75,14 @@ export function timeStatusRefetchMs(remainingMins: number | null | undefined): n
   return TIME_STATUS_REFETCH_MAX_MS
 }
 
+// The cadence-relevant slice of a time-status row — both ProfileTimeStatus and
+// ProfileTimeSummary carry these, and they're all we read to pick a poll rate.
+type CadenceRow = { dailyLimitMins?: number | null; remainingMins?: number | null }
+
 // The most-urgent (least remaining) capped profile across a freshly-fetched
 // time-status payload — `null` when no row has a daily limit. A row without a
 // `dailyLimitMins` isn't counting down, so it never drives the cadence.
-function minRemainingMins(
-  rows: ReadonlyArray<{ dailyLimitMins?: number | null; remainingMins?: number | null }>,
-): number | null {
+function minRemainingMins(rows: ReadonlyArray<CadenceRow>): number | null {
   let min: number | null = null
   for (const row of rows) {
     if (row.dailyLimitMins == null) continue
@@ -93,10 +95,7 @@ function minRemainingMins(
 // react-query refetchInterval callback: normalize the query data (single row,
 // array of rows, or not-yet-loaded) and pick the adaptive interval.
 function timeStatusRefetchInterval(data: unknown): number {
-  const rows = (Array.isArray(data) ? data : data ? [data] : []) as ReadonlyArray<{
-    dailyLimitMins?: number | null
-    remainingMins?: number | null
-  }>
+  const rows = (Array.isArray(data) ? data : data ? [data] : []) as ReadonlyArray<CadenceRow>
   return timeStatusRefetchMs(minRemainingMins(rows))
 }
 

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -44,9 +44,61 @@ const STALE = {
 // with only a staleTime never refetches on its own — it stays frozen from page
 // load until a manual trigger (reload / window refocus). Without a background
 // poll the UI shows minutes remaining while the profile is already blocked.
-// Match useDashboardNow's 10s cadence; foreground-only (refetchIntervalInBackground:
-// false) so hidden tabs don't poll.
-export const TIME_STATUS_REFETCH_MS = 10_000
+//
+// The cadence is *adaptive*: we only need a tight poll when a profile is close
+// to its daily cap (where a stale display would visibly disagree with
+// enforcement). With lots of time left, a fast poll is wasted load — so we slow
+// down. The ladder is keyed on the *most-urgent* profile's remaining minutes
+// (the one closest to its cap drives the whole list's cadence). Foreground-only
+// (refetchIntervalInBackground: false) so hidden tabs don't poll.
+//
+// `[thresholdMins, intervalMs]`, evaluated low-to-high — first row whose
+// threshold the remaining time is at/under wins.
+export const TIME_STATUS_REFETCH_LADDER: ReadonlyArray<readonly [number, number]> = [
+  [5, 10_000],   // ≤5m left  → poll every 10s
+  [10, 60_000],  // ≤10m left → poll every 1m
+  [30, 300_000], // ≤30m left → poll every 5m
+] as const
+// >30m left, or no daily limit at all (nothing counting down) → slow baseline.
+export const TIME_STATUS_REFETCH_MAX_MS = 300_000
+
+// Map a profile's remaining minutes to its poll interval. `null`/`undefined`
+// remaining means no daily limit is in force → baseline cadence. A profile at
+// or past its cap (remaining ≤ 0) lands in the fastest bucket so a time
+// extension / unblock shows up within seconds.
+export function timeStatusRefetchMs(remainingMins: number | null | undefined): number {
+  if (remainingMins == null) return TIME_STATUS_REFETCH_MAX_MS
+  const remaining = Math.max(0, remainingMins)
+  for (const [thresholdMins, intervalMs] of TIME_STATUS_REFETCH_LADDER) {
+    if (remaining <= thresholdMins) return intervalMs
+  }
+  return TIME_STATUS_REFETCH_MAX_MS
+}
+
+// The most-urgent (least remaining) capped profile across a freshly-fetched
+// time-status payload — `null` when no row has a daily limit. A row without a
+// `dailyLimitMins` isn't counting down, so it never drives the cadence.
+function minRemainingMins(
+  rows: ReadonlyArray<{ dailyLimitMins?: number | null; remainingMins?: number | null }>,
+): number | null {
+  let min: number | null = null
+  for (const row of rows) {
+    if (row.dailyLimitMins == null) continue
+    const remaining = row.remainingMins ?? 0
+    if (min == null || remaining < min) min = remaining
+  }
+  return min
+}
+
+// react-query refetchInterval callback: normalize the query data (single row,
+// array of rows, or not-yet-loaded) and pick the adaptive interval.
+function timeStatusRefetchInterval(data: unknown): number {
+  const rows = (Array.isArray(data) ? data : data ? [data] : []) as ReadonlyArray<{
+    dailyLimitMins?: number | null
+    remainingMins?: number | null
+  }>
+  return timeStatusRefetchMs(minRemainingMins(rows))
+}
 
 export const qk = {
   profiles: () => ['profiles'] as const,
@@ -221,7 +273,7 @@ export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]>) {
     queryKey: qk.timeStatusToday(),
     queryFn: () => api.time.statusAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: TIME_STATUS_REFETCH_MS,
+    refetchInterval: q => timeStatusRefetchInterval(q.state.data),
     refetchIntervalInBackground: false,
     ...opts,
   })
@@ -255,7 +307,7 @@ export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]>) {
     queryKey: qk.timeStatusSummaryToday(),
     queryFn: () => api.time.summaryAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: TIME_STATUS_REFETCH_MS,
+    refetchInterval: q => timeStatusRefetchInterval(q.state.data),
     refetchIntervalInBackground: false,
     ...opts,
   })
@@ -283,7 +335,7 @@ export function useTimeStatusProfileToday(
     queryKey: qk.timeStatusProfileToday(profileId),
     queryFn: () => api.time.statusAll(undefined, profileId).then(rows => rows[0]),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: TIME_STATUS_REFETCH_MS,
+    refetchInterval: q => timeStatusRefetchInterval(q.state.data),
     refetchIntervalInBackground: false,
     ...opts,
   })

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -38,6 +38,16 @@ const STALE = {
   devices: 5 * MIN,
 } as const
 
+// #1871 — live time-used surfaces must poll in the foreground so the displayed
+// "minutes left" can't lag enforcement. The router recomputes block state on
+// every ~5s snapshot poll and blocks within seconds of the cap, but a query
+// with only a staleTime never refetches on its own — it stays frozen from page
+// load until a manual trigger (reload / window refocus). Without a background
+// poll the UI shows minutes remaining while the profile is already blocked.
+// Match useDashboardNow's 10s cadence; foreground-only (refetchIntervalInBackground:
+// false) so hidden tabs don't poll.
+export const TIME_STATUS_REFETCH_MS = 10_000
+
 export const qk = {
   profiles: () => ['profiles'] as const,
   devices: () => ['devices'] as const,
@@ -211,6 +221,8 @@ export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]>) {
     queryKey: qk.timeStatusToday(),
     queryFn: () => api.time.statusAll(),
     staleTime: STALE.timeStatusToday,
+    refetchInterval: TIME_STATUS_REFETCH_MS,
+    refetchIntervalInBackground: false,
     ...opts,
   })
 }
@@ -243,6 +255,8 @@ export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]>) {
     queryKey: qk.timeStatusSummaryToday(),
     queryFn: () => api.time.summaryAll(),
     staleTime: STALE.timeStatusToday,
+    refetchInterval: TIME_STATUS_REFETCH_MS,
+    refetchIntervalInBackground: false,
     ...opts,
   })
 }
@@ -269,6 +283,8 @@ export function useTimeStatusProfileToday(
     queryKey: qk.timeStatusProfileToday(profileId),
     queryFn: () => api.time.statusAll(undefined, profileId).then(rows => rows[0]),
     staleTime: STALE.timeStatusToday,
+    refetchInterval: TIME_STATUS_REFETCH_MS,
+    refetchIntervalInBackground: false,
     ...opts,
   })
 }


### PR DESCRIPTION
Fixes #1871

## Problem
The per-profile time-used display lagged reality: a profile could be **blocked** (enforcement) while the UI still showed **a few minutes left**; reloading then showed time fully used. Enforcement is fresh — `PolicyService` recomputes block state on every ~5s router snapshot poll — but the SWR hooks driving the live time-used display in `web/src/api/queries.ts` carried only a `staleTime` and **no `refetchInterval`**, so they never refetched on their own. The displayed value was frozen from page load until a reload or window refocus.

This is a **freshness** bug, not a divergent computation — enforcement and the UI share the same `TimeStatusService.ProfileDayState` SSOT (#1104). That computation is untouched; we only poll the same source more proactively.

## Fix — adaptive poll cadence
Add an `refetchInterval` to the three live **"today"** time-status hooks (`useTimeStatusToday`, `useTimeStatusSummary`, `useTimeStatusProfileToday`), scaled to how close the **most-urgent** profile is to its daily cap (a fixed fast poll is wasted load when a profile has hours left):

| remaining time | poll every |
|---|---|
| ≤ 5m | 10s |
| ≤ 10m | 1m |
| ≤ 30m | 5m |
| > 30m / no daily limit | 5m (baseline) |

- Implemented via react-query's function-form `refetchInterval`, reading the just-fetched `remainingMins` (`timeStatusRefetchMs` — a pure, unit-tested mapping). The least-remaining capped profile drives the whole list's cadence; an at/over-cap (blocked) profile lands in the fast bucket so a time extension / unblock surfaces within seconds. `refetchIntervalInBackground: false` so hidden tabs don't poll.
- The immutable `past`/`week` variants are left on their long staleTime — they do not poll.
- Tests: a ladder-edge unit test over `timeStatusRefetchMs` (including null-limit and past-cap edges) plus fake-timer render tests proving the fast bucket near the cap and the slow-baseline back-off with lots of time left.

## Scope
- Web-only (TS/vitest). No Scala.
- **Not** changing the API-side `TimeStatusCache.todayTtl` (issue part 3) — it trades freshness for DB load (the cache exists to avoid recomputing presence rollups per poll). Possible separate follow-up if the residual ≤30s cache staleness proves noticeable; the dominant cause (no UI poll) is fixed here.

### Deliberately not polled
`useUsageSeriesProfileToday` and `useProfileUsageByApp` also key on `STALE.timeStatusToday` and render on the profile-today surfaces, but were left non-polling on purpose — they're the hourly chart and per-app rollup, not the "minutes left" display that lags enforcement.

## Validation
- `npm run type-check`, `npm run lint`, full `npm run test` (405 tests) all green on node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
