### PR TITLE
feat(#1840): add app.* origins to CORS allowlist + UI-allowed-hosts (additive)

### DIFF
--- a/api/test/src/feature/CorsSpec.scala
+++ b/api/test/src/feature/CorsSpec.scala
@@ -144,6 +144,38 @@ object CorsSpec extends ZIOSpecDefault {
         resp.header(Header.ETag).isDefined,
       )
     },
+    test("additive prod allowlist accepts both apex and app.* origins (#1840)") {
+      // #1840 (#1832 rename): the prod CORS allowlist gains app.wifihaven.net
+      // additively — the existing apex/www origins must keep working while the
+      // new app host is also accepted. Mirror the render.yaml prod value.
+      val prodCfg                   = CorsConfig(
+        allowedOrigins =
+          "https://wifihaven.net,https://www.wifihaven.net,https://app.wifihaven.net",
+      )
+      val prodRoutes                = Cors.wrap(Routes(loginEcho), prodCfg)
+      def preflight(origin: String) =
+        Request
+          .options("/api/auth/login")
+          .addHeader(Header.Origin.parse(origin).toOption.get)
+          .addHeader(Header.AccessControlRequestMethod(Method.POST))
+      def echoed(origin: String)    =
+        prodRoutes(preflight(origin)).merge.map { resp =>
+          resp
+            .header(Header.AccessControlAllowOrigin)
+            .contains(
+              Header.AccessControlAllowOrigin.Specific(
+                Header.Origin.parse(origin).toOption.get,
+              ),
+            )
+        }
+      for {
+        apex <- echoed("https://wifihaven.net")
+        www  <- echoed("https://www.wifihaven.net")
+        app  <- echoed("https://app.wifihaven.net")
+        evil <- prodRoutes(preflight("https://evil.example")).merge
+          .map(_.header(Header.AccessControlAllowOrigin).isEmpty)
+      } yield assertTrue(apex, www, app, evil)
+    },
     test("empty allowedOrigins disables middleware entirely") {
       val bare =
         Cors.wrap(Routes(loginEcho), CorsConfig(allowedOrigins = ""))

--- a/render.yaml
+++ b/render.yaml
@@ -97,13 +97,16 @@ services:
       - key: WIFIHAVEN_DEBUG
         value: ""
       # #612: SPA on https://staging.wifihaven.net calls this API cross-origin.
+      # #1840: app-staging.wifihaven.net added additively (#1832 rename) — the
+      # SPA now also fronts on app-staging.*; old origin kept through transition.
       - key: WIFIHAVEN_ALLOWED_ORIGINS
-        value: "https://staging.wifihaven.net"
+        value: "https://staging.wifihaven.net,https://app-staging.wifihaven.net"
       # #944: union into every profile's snapshot extraAllowed so a paused
       # operator can still reach the admin UI on staging. Staging-only —
       # MUST NOT include prod hosts (router would let them through too).
+      # #1840: app-staging.wifihaven.net added additively (#1832 rename).
       - key: WIFIHAVEN_UI_ALLOWED_HOSTS
-        value: "staging.wifihaven.net,api-staging.wifihaven.net"
+        value: "staging.wifihaven.net,api-staging.wifihaven.net,app-staging.wifihaven.net"
       # #614: SPA is served by the wifihaven-spa-staging Static Site (CDN).
       # The JVM still bundles a copy as a self-hosted fallback, but the API
       # origin must not serve it here — non-/api/* paths return 404.
@@ -200,13 +203,16 @@ services:
       - key: WIFIHAVEN_DEBUG
         value: ""
       # #612: SPA on https://wifihaven.net (apex + www) calls this API cross-origin.
+      # #1840: app.wifihaven.net added additively (#1832 rename) — the SPA now
+      # also fronts on app.*; apex + www kept through transition (no cut-over).
       - key: WIFIHAVEN_ALLOWED_ORIGINS
-        value: "https://wifihaven.net,https://www.wifihaven.net"
+        value: "https://wifihaven.net,https://www.wifihaven.net,https://app.wifihaven.net"
       # #944: union into every profile's snapshot extraAllowed so a paused
       # operator can still reach the admin UI on prod. Prod-only — MUST NOT
       # include staging hosts (router would let them through too).
+      # #1840: app.wifihaven.net added additively (#1832 rename).
       - key: WIFIHAVEN_UI_ALLOWED_HOSTS
-        value: "wifihaven.net,www.wifihaven.net,api.wifihaven.net"
+        value: "wifihaven.net,www.wifihaven.net,api.wifihaven.net,app.wifihaven.net"
       # #614: SPA is served by the wifihaven-spa-prod Static Site (CDN).
       # The JVM still bundles a copy as a self-hosted fallback, but the API
       # origin must not serve it here — non-/api/* paths return 404.


### PR DESCRIPTION
## What

Makes `app.wifihaven.net` (prod) and `app-staging.wifihaven.net` (staging) usable for auth by adding them to the API's CORS allowlist (`WIFIHAVEN_ALLOWED_ORIGINS`) and the [#944](https://github.com/wifihaven/wifihaven/issues/944) UI-allowed-hosts (`WIFIHAVEN_UI_ALLOWED_HOSTS`) in `render.yaml`, per sub-issue 2 of [#1832](https://github.com/wifihaven/wifihaven/issues/1832) (`docs/design/app-host-rename.md` §2.2, §5).

## Additive — no cut-over

This is **purely additive**. The existing prod apex/www and staging origins keep working unchanged. No canonical-host cut-over, no redirects, no JWT-audience change — those are [#1841](https://github.com/wifihaven/wifihaven/issues/1841) and later sub-issues. Rollback is just reverting the env + redeploy (removing an additive set can't break the canonical apex).

## Why no code change

Per the RFC §2.2: auth is a localStorage bearer token with **no cookie, no `aud`, no `iss`**, so the only origin-coupled surfaces are the CORS allowlist and the UI-allowed-hosts. `api/src/Cors.scala` is config-driven (exact-match against `WIFIHAVEN_ALLOWED_ORIGINS`) and needs no change.

`WIFIHAVEN_UI_ALLOWED_HOSTS` is security-relevant — it's unioned into every profile's snapshot `extraAllowed` so a paused/blocked device can still reach the admin UI — so prod and staging hosts are kept strictly separate (prod gets `app.wifihaven.net`, staging gets `app-staging.wifihaven.net`, never mixed).

## Changes

- `render.yaml` prod: `WIFIHAVEN_ALLOWED_ORIGINS` += `https://app.wifihaven.net`; `WIFIHAVEN_UI_ALLOWED_HOSTS` += `app.wifihaven.net`
- `render.yaml` staging: `WIFIHAVEN_ALLOWED_ORIGINS` += `https://app-staging.wifihaven.net`; `WIFIHAVEN_UI_ALLOWED_HOSTS` += `app-staging.wifihaven.net`
- `CorsSpec`: new test asserting the additive prod allowlist echoes apex, www, **and** app.* origins while still rejecting a disallowed origin.

## Verification

`mill api.test.testOnly 'wifihaven.api.feature.CorsSpec'` → 8 passed. `scalafmt --check` clean.

Post-deploy (per issue): `curl -H 'Origin: https://app-staging.wifihaven.net' -I https://api-staging.wifihaven.net/api/health` returns matching `access-control-allow-origin`; `app.*` appears in a fresh policy snapshot's `extraAllowed`.

Fixes #1840
Relates to #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)