### PR TITLE
feat(#1873): ship API app logs to Grafana Cloud Loki via loki4j (deployed envs only)

### DIFF
--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -76,6 +76,15 @@
             <password>${GRAFANA_CLOUD_LOKI_PASSWORD}</password>
           </auth>
           <requestTimeoutMs>10000</requestTimeoutMs>
+          <!--
+            Pin the JSON push API explicitly. The protobuf path needs loki-protobuf
+            + snappy on the classpath, which we deliberately do NOT depend on (the
+            loki4j jar resolves standalone). If a future loki4j default flipped this
+            to protobuf, shipping would ClassNotFound on the background sender thread
+            and silently drop every log line (fail-open hides it — the #1334 trap).
+            Keeping it false makes the dep-free contract explicit and flip-proof.
+          -->
+          <useProtobufApi>false</useProtobufApi>
         </http>
         <batch>
           <maxItems>1000</maxItems>

--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -5,12 +5,89 @@
         #602: %mdc renders the SLF4J MDC map populated by zio-logging annotations
         (see api/src/observability/LogContext.scala). One-line-per-log locally;
         keys like route=, mac=, op=, etag=, status= appear at the tail so they
-        can be grep'd without parsing the message text. A structured (JSON)
-        appender for deployed environments is tracked separately under #602.
+        can be grep'd without parsing the message text. Deployed environments
+        additionally ship every log line to Grafana Cloud Loki via the LOKI
+        appender below (#1873) — that is the searchable structured sink #602
+        called for; the console line stays human-readable for `docker logs`.
       -->
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %mdc%n</pattern>
     </encoder>
   </appender>
+
+  <!--
+    #1873 (epic #1831, folds in #602): push API application logs straight to
+    Grafana Cloud Loki's push API with basic auth, DEPLOYED ENVIRONMENTS ONLY.
+
+    Gating: the whole appender — and its root attachment below — is wrapped in
+    `<if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>` (logback + janino).
+    Local dev and `mill __.test` never set GRAFANA_CLOUD_LOKI_URL, so the
+    appender is never instantiated there; it activates only where Render injects
+    the GRAFANA_CLOUD_LOKI_* secrets (staging + prod web services, see
+    render.yaml). No code-level env switch — presence of the secret IS the gate.
+
+    Fail-open by construction (hard requirement — Loki being slow/down must NEVER
+    wedge the request path):
+      - Loki4jAppender is asynchronous by design: the calling (request) thread
+        only enqueues; an internal background thread batches and sends. Do NOT
+        wrap it in an AsyncAppender — it is already async.
+      - <batch> bounds the in-memory send queue with <sendQueueMaxBytes>. When
+        the queue is full (Loki slow/unreachable and the background sender backs
+        up), incoming events are DROPPED, never blocked — drop-on-backpressure.
+      - <drainOnStop>false</drainOnStop> so JVM shutdown is never held waiting on
+        Loki to drain.
+      - <http><requestTimeoutMs> caps each send on the background thread.
+    (Load-proven backpressure + a drop metric + a Grafana panel are the #1831
+    sub-#2 follow-up, intentionally out of scope here.)
+
+    Label / cardinality model (critical — same bounded-cardinality rule as
+    metrics): ONLY service / env / level are Loki STREAM LABELS. Every other MDC
+    key (mac, route, op, status, etag, profileId, routerId, trace ids, …) is
+    routed to Loki STRUCTURED METADATA via the `* = %%mdc` bulk pattern — indexed
+    for filtering WITHOUT exploding stream cardinality. `mac` as a label would be
+    a per-device cardinality explosion and is forbidden; keeping it in structured
+    metadata is how "show everything device X hit" stays queryable cheaply.
+  -->
+  <if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>
+    <then>
+      <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <!-- Stream labels: low-cardinality ONLY. Do NOT add mac/route/host here. -->
+        <labels>
+          service = wifihaven-api
+          env = ${WIFIHAVEN_ENV:-unknown}
+          level = %level
+        </labels>
+        <!--
+          All MDC keys -> structured metadata (not labels). `* = %%mdc` is loki4j's
+          bulk pattern that expands every MDC entry. thread/logger added explicitly
+          so they are searchable too without becoming stream labels.
+        -->
+        <structuredMetadata>
+          thread = %thread
+          logger = %logger
+          * = %%mdc
+        </structuredMetadata>
+        <message>
+          <pattern>%-5level [%thread] %logger{36} - %msg%n</pattern>
+        </message>
+        <http>
+          <url>${GRAFANA_CLOUD_LOKI_URL}</url>
+          <auth>
+            <username>${GRAFANA_CLOUD_LOKI_USER}</username>
+            <password>${GRAFANA_CLOUD_LOKI_PASSWORD}</password>
+          </auth>
+          <requestTimeoutMs>10000</requestTimeoutMs>
+        </http>
+        <batch>
+          <maxItems>1000</maxItems>
+          <maxBytes>4194304</maxBytes>
+          <timeoutMs>10000</timeoutMs>
+          <!-- Bounded send queue: when full, events are DROPPED, not blocked. -->
+          <sendQueueMaxBytes>33554432</sendQueueMaxBytes>
+          <drainOnStop>false</drainOnStop>
+        </batch>
+      </appender>
+    </then>
+  </if>
 
   <!--
     WIFIHAVEN_LOG_LEVEL controls verbosity of the wifihaven.* loggers.
@@ -20,6 +97,12 @@
   -->
   <root level="WARN">
     <appender-ref ref="STDOUT" />
+    <!-- #1873: attach LOKI only where the secret is present (same gate as above). -->
+    <if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>
+      <then>
+        <appender-ref ref="LOKI" />
+      </then>
+    </if>
   </root>
 
   <logger name="wifihaven" level="${WIFIHAVEN_LOG_LEVEL:-INFO}" />

--- a/api/test/src/unit/LokiAppenderConfigSpec.scala
+++ b/api/test/src/unit/LokiAppenderConfigSpec.scala
@@ -1,0 +1,117 @@
+package wifihaven.api.unit
+
+import zio.test.*
+
+import java.nio.file.{Files, Paths}
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.{Element, Node}
+
+/**
+ * #1873 (epic #1831): pins the structural contract of the Grafana Cloud Loki appender in
+ * `api/resources/logback.xml`. Logback `<if>` conditions resolve against the JVM environment, which
+ * a test cannot mutate, so we assert on the *config shape* rather than a live appender instance.
+ *
+ *   - DEPLOYED-ENV GATING: the LOKI appender, and its root attachment, are wrapped in `<if
+ *     condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>`. Local dev and `mill __.test` never set
+ *     that secret, so the appender is never instantiated there; it activates only where Render
+ *     injects GRAFANA_CLOUD_LOKI_*.
+ *   - LABEL WHITELIST: Loki STREAM LABELS are exactly {service, env, level}. `mac` (and any other
+ *     per-device/per-host MDC key) as a label would be a cardinality explosion, forbidden by the
+ *     same bounded-cardinality rule as metrics. All other MDC keys must ride STRUCTURED METADATA
+ *     via the `* = %%mdc` bulk pattern instead.
+ *   - FAIL-OPEN: the <batch> bounds the send queue (drop-on-backpressure) and does not drain on
+ *     stop, so Loki being slow/down can never wedge the request path or JVM shutdown.
+ */
+object LokiAppenderConfigSpec extends ZIOSpecDefault {
+
+  private val LokiGate = "GRAFANA_CLOUD_LOKI_URL"
+
+  private val doc = {
+    // Prefer the checked-in source file; fall back to the classpath copy if the layout changes.
+    val srcPath = Paths.get("api/resources/logback.xml")
+    val bytes   =
+      if (Files.exists(srcPath)) Files.readAllBytes(srcPath)
+      else
+        Option(getClass.getClassLoader.getResourceAsStream("logback.xml"))
+          .getOrElse(throw new IllegalStateException("logback.xml not found on classpath"))
+          .readAllBytes()
+    val factory = DocumentBuilderFactory.newInstance()
+    factory.newDocumentBuilder().parse(new java.io.ByteArrayInputStream(bytes))
+  }
+
+  private def elements(parent: Node, tag: String): List[Element] = {
+    val nodes = parent match {
+      case e: Element => e.getElementsByTagName(tag)
+      case _          => doc.getElementsByTagName(tag)
+    }
+    (0 until nodes.getLength).map(nodes.item).collect { case e: Element => e }.toList
+  }
+
+  /** True iff `node` has an `<if>` ancestor whose condition references GRAFANA_CLOUD_LOKI_URL. */
+  private def gatedByLokiSecret(node: Node): Boolean = {
+    var cur   = node.getParentNode
+    var found = false
+    while (cur != null && !found) {
+      cur match {
+        case e: Element if e.getTagName == "if" =>
+          val cond = e.getAttribute("condition")
+          if (cond.contains(LokiGate)) found = true
+        case _                                  => ()
+      }
+      cur = cur.getParentNode
+    }
+    found
+  }
+
+  /** Parse a logback labels/structuredMetadata block (`key = value` lines) into its key set. */
+  private def keysOf(blockText: String): Set[String] =
+    blockText
+      .split("\n")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .flatMap(line => line.split("=", 2).headOption.map(_.trim))
+      .filter(_.nonEmpty)
+      .toSet
+
+  private def lokiAppender: Element =
+    elements(doc, "appender")
+      .find(_.getAttribute("name") == "LOKI")
+      .getOrElse(throw new AssertionError("no <appender name=\"LOKI\"> in logback.xml"))
+
+  def spec = suite("LokiAppenderConfigSpec")(
+    test("the LOKI appender is gated on the GRAFANA_CLOUD_LOKI_URL secret (deployed envs only)") {
+      assertTrue(gatedByLokiSecret(lokiAppender))
+    },
+    test("the root attaches LOKI only behind the same secret gate") {
+      val lokiRefs = elements(doc, "appender-ref").filter(_.getAttribute("ref") == "LOKI")
+      assertTrue(lokiRefs.nonEmpty) &&
+      assertTrue(lokiRefs.forall(gatedByLokiSecret))
+    },
+    test("stream labels are whitelisted to exactly service/env/level") {
+      val labelsEl = elements(lokiAppender, "labels").head
+      val keys     = keysOf(labelsEl.getTextContent)
+      assertTrue(keys == Set("service", "env", "level"))
+    },
+    test("mac (and other high-cardinality MDC keys) are NOT stream labels") {
+      val labelsEl = elements(lokiAppender, "labels").head
+      val keys     = keysOf(labelsEl.getTextContent)
+      assertTrue(!keys.contains("mac")) &&
+      assertTrue(!keys.contains("route")) &&
+      assertTrue(!keys.contains("op")) &&
+      assertTrue(!keys.contains("host"))
+    },
+    test("all MDC keys are routed to structured metadata via the bulk pattern") {
+      val smEl = elements(lokiAppender, "structuredMetadata").head
+      // `* = %%mdc` expands every MDC entry into structured metadata, not labels.
+      assertTrue(smEl.getTextContent.replaceAll("\\s", "").contains("*=%%mdc"))
+    },
+    test("fail-open: bounded send queue (drop-on-backpressure) and no drain-on-stop") {
+      val batchEl     = elements(lokiAppender, "batch").head
+      val sendQueue   = elements(batchEl, "sendQueueMaxBytes").headOption.map(_.getTextContent.trim)
+      val drainOnStop = elements(batchEl, "drainOnStop").headOption.map(_.getTextContent.trim)
+      assertTrue(sendQueue.exists(_.toLong > 0L)) &&
+      assertTrue(drainOnStop.contains("false"))
+    },
+    // The shared DOM `Document` is not thread-safe; run these checks serially.
+  ) @@ TestAspect.sequential
+}

--- a/build.mill
+++ b/build.mill
@@ -45,6 +45,12 @@ val jwtVersion         = "10.0.1"
 val bcryptVersion      = "0.10.2"
 val postgresVersion    = "42.7.4"
 val logbackVersion     = "1.5.8"
+// #1873: loki4j ships API app logs straight to Grafana Cloud Loki via a
+// logback appender (deployed envs only). 2.0.x requires logback 1.5.x — matches
+// `logbackVersion` above. janino backs the `<if>` conditional in logback.xml that
+// gates the appender on the GRAFANA_CLOUD_LOKI_* secrets being present.
+val loki4jVersion      = "2.0.3"
+val janinoVersion      = "3.1.12"
 val embeddedPgVersion  = "2.1.0"
 val flywayPgVersion    = "10.17.3"
 val caffeineVersion    = "3.1.8"
@@ -121,6 +127,9 @@ object api extends CommonModule {
     mvn"at.favre.lib:bcrypt:$bcryptVersion",
     mvn"org.postgresql:postgresql:$postgresVersion",
     mvn"ch.qos.logback:logback-classic:$logbackVersion",
+    // #1873: deployed-env-only Loki appender + janino for the logback `<if>` gate.
+    mvn"com.github.loki4j:loki-logback-appender:$loki4jVersion",
+    mvn"org.codehaus.janino:janino:$janinoVersion",
     mvn"dev.zio::zio-interop-cats:23.1.0.3",
     mvn"com.github.ben-manes.caffeine:caffeine:$caffeineVersion",
     mvn"org.yaml:snakeyaml:$snakeYamlVersion",

--- a/docs/ops/grafana-cloud.md
+++ b/docs/ops/grafana-cloud.md
@@ -30,7 +30,7 @@ JVM pushes directly.
   enqueues); a bounded `<sendQueueMaxBytes>` drops on backpressure and
   `<drainOnStop>false` keeps shutdown from blocking on Loki. Loki being
   slow/down can never wedge the request path. (Load-proof + a drop metric +
-  panel are the #1831 sub-#2 follow-up.)
+  panel are the #1831 follow-up, tracked in #1879.)
 - **Label / cardinality model.** Loki **stream labels** are whitelisted to
   exactly `service` / `env` / `level`. Every other MDC key (`mac`, `route`,
   `op`, `status`, `etag`, …) rides Loki **structured metadata** via the

--- a/docs/ops/grafana-cloud.md
+++ b/docs/ops/grafana-cloud.md
@@ -12,3 +12,33 @@ deploy annotations (POSTed by `.github/workflows/master-api-ui.yml` via
 annotation POSTs are `GRAFANA_CLOUD_URL` +
 `GRAFANA_CLOUD_ANNOTATION_TOKEN`. Operator runbook in
 [`docs/deploy-cloud.md`](../deploy-cloud.md) §11.
+
+## App logs → Grafana Cloud Loki (#1873, epic #1831)
+
+In **deployed environments only**, the API ships its application logs
+straight to Grafana Cloud Loki's push API via the
+[loki4j](https://loki4j.github.io/loki-logback-appender/) `loki-logback-appender`
+configured in [`api/resources/logback.xml`](../../api/resources/logback.xml).
+There is **no** table-tailing pipeline and **no** Alloy `loki.write` hop — the
+JVM pushes directly.
+
+- **Deployed-env gate.** The appender (and its root attachment) is wrapped in a
+  logback `<if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>` (janino-backed).
+  Presence of the secret IS the gate: local dev and `mill __.test` never set it,
+  so the appender is never instantiated there.
+- **Fail-open.** Loki4jAppender is async by design (request thread only
+  enqueues); a bounded `<sendQueueMaxBytes>` drops on backpressure and
+  `<drainOnStop>false` keeps shutdown from blocking on Loki. Loki being
+  slow/down can never wedge the request path. (Load-proof + a drop metric +
+  panel are the #1831 sub-#2 follow-up.)
+- **Label / cardinality model.** Loki **stream labels** are whitelisted to
+  exactly `service` / `env` / `level`. Every other MDC key (`mac`, `route`,
+  `op`, `status`, `etag`, …) rides Loki **structured metadata** via the
+  `* = %%mdc` bulk pattern — same bounded-cardinality rule as metrics; `mac` as
+  a label would be a per-device explosion and is forbidden.
+- **Secrets.** `GRAFANA_CLOUD_LOKI_URL` (push API, `.../loki/api/v1/push`),
+  `GRAFANA_CLOUD_LOKI_USER` (numeric instance id), `GRAFANA_CLOUD_LOKI_PASSWORD`
+  (API token, logs-push scope) are Render-managed `sync:false` secrets on the
+  staging + prod API web services in [`render.yaml`](../../render.yaml) —
+  mirroring the `GRAFANA_CLOUD_PROM_*` pattern. `WIFIHAVEN_ENV` (`staging` /
+  `production`) supplies the `env` label. Never committed.

--- a/render.yaml
+++ b/render.yaml
@@ -116,6 +116,22 @@ services:
       # bearer token. Generated ONCE on first apply; share with the scraper.
       - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN
         generateValue: true
+      # #1873: env label for the Loki appender (logback.xml reads ${WIFIHAVEN_ENV}).
+      - key: WIFIHAVEN_ENV
+        value: staging
+      # #1873: Grafana Cloud Loki push endpoint + basic-auth creds for the
+      # loki-logback-appender (api/resources/logback.xml). Render-managed secrets
+      # set out of band — same sync:false pattern as GRAFANA_CLOUD_PROM_* on the
+      # alloy worker below. Presence of GRAFANA_CLOUD_LOKI_URL is also the gate
+      # that activates the appender (deployed envs only). URL is the Loki push API
+      # (.../loki/api/v1/push); USER is the numeric instance id; PASSWORD is a
+      # Grafana Cloud API token with logs-push scope. NEVER commit values.
+      - key: GRAFANA_CLOUD_LOKI_URL
+        sync: false
+      - key: GRAFANA_CLOUD_LOKI_USER
+        sync: false
+      - key: GRAFANA_CLOUD_LOKI_PASSWORD
+        sync: false
 
   # ── Production API ─────────────────────────────────────────────────────────
   - type: web
@@ -219,6 +235,22 @@ services:
       # bearer token. Generated ONCE on first apply; share with the scraper.
       - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN
         generateValue: true
+      # #1873: env label for the Loki appender (logback.xml reads ${WIFIHAVEN_ENV}).
+      - key: WIFIHAVEN_ENV
+        value: production
+      # #1873: Grafana Cloud Loki push endpoint + basic-auth creds for the
+      # loki-logback-appender (api/resources/logback.xml). Render-managed secrets
+      # set out of band — same sync:false pattern as GRAFANA_CLOUD_PROM_* on the
+      # alloy worker below. Presence of GRAFANA_CLOUD_LOKI_URL is also the gate
+      # that activates the appender (deployed envs only). URL is the Loki push API
+      # (.../loki/api/v1/push); USER is the numeric instance id; PASSWORD is a
+      # Grafana Cloud API token with logs-push scope. NEVER commit values.
+      - key: GRAFANA_CLOUD_LOKI_URL
+        sync: false
+      - key: GRAFANA_CLOUD_LOKI_USER
+        sync: false
+      - key: GRAFANA_CLOUD_LOKI_PASSWORD
+        sync: false
 
   # ── Metrics collector: Grafana Alloy → Grafana Cloud ─────────────────────────
   # #1208: the cloud APP-metrics path. Alloy (Prometheus agent-mode) scrapes


### PR DESCRIPTION
First foundation bit of **#1831** (API application logs → Grafana Cloud Loki). **Option B accepted** — app-side loki4j appender. Folds in **#602** (structured deployed-env sink).

## What
Adds the [loki4j](https://loki4j.github.io/loki-logback-appender/) `loki-logback-appender` to `api/resources/logback.xml` so deployed API instances push their application logs straight to Grafana Cloud Loki's push API with basic auth. No table-tailing pipeline, no Alloy `loki.write` hop — the JVM pushes directly.

## How the hard requirements are met
- **Deployed-env gate.** The appender *and* its root attachment are wrapped in a logback `<if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>` (janino-backed). Local dev and `mill __.test` never set the secret, so the appender is never instantiated there — presence of the secret IS the gate (no code-level env switch).
- **Fail-open by construction.** `Loki4jAppender` is async by design (the request thread only enqueues; a background thread batches + sends — *not* wrapped in `AsyncAppender`, it's already async). A bounded `<sendQueueMaxBytes>` (32 MiB) **drops on backpressure** rather than blocking, `<drainOnStop>false` keeps JVM shutdown from waiting on Loki, and `<requestTimeoutMs>` caps each send. Loki being slow/down can never wedge the request path. Smoke-tested by running a suite with the appender **active** against a dead endpoint (`127.0.0.1:1`) — no hang, no errors.
- **Label / cardinality whitelist (critical).** Loki **stream labels** are exactly `service` / `env` / `level`. Every other MDC key (`mac`, `route`, `op`, `status`, `etag`, …) rides Loki **structured metadata** via the `* = %%mdc` bulk pattern — same bounded-cardinality rule as metrics. `mac` as a label would be a per-device explosion — forbidden.
- **Secrets, declaratively.** `GRAFANA_CLOUD_LOKI_{URL,USER,PASSWORD}` as Render `sync:false` secrets on the staging + prod API web services in `render.yaml`, mirroring `GRAFANA_CLOUD_PROM_*`. `WIFIHAVEN_ENV` (`staging`/`production`) supplies the `env` label. **No creds committed.**

## Tests
`api/test/src/unit/LokiAppenderConfigSpec.scala` pins the structural contract: deployed-env gate, the `service/env/level` label whitelist (and that `mac`/`route`/`op`/`host` are NOT labels), the `* = %%mdc` structured-metadata routing, and the fail-open batch config. `mill api.test` (full suite) + `scalafmt --check` green.

## Out of scope (separate #1831 sub-#2)
Load-proven backpressure + a drop metric + a Grafana panel — tracked in #1879.

Fixes #1873
Relates to #1831, #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)
