### PR TITLE
feat(#1846): API /api/router/ws websocket transport — endpoint + {op,payload} demux + connection registry

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -299,6 +299,18 @@ object Main extends ZIOAppDefault {
       promPublisher  <- ZIO.service[PrometheusPublisher]
       routerAuth = new RouterAuthLive(routerRepo)
       routerMetrics <- RouterMetricsService.make
+      // #1846: the transport-agnostic ingest service shared by the REST ingest routes and the new
+      // websocket transport, plus the per-router ws connection registry.
+      routerIngest = new RouterIngestService(
+        routerRepo,
+        trafficRepo,
+        usageRepo,
+        deviceRepo,
+        connRepo,
+        alertRepo,
+        hsRepo,
+      )
+      wsRegistry <- RouterWsRegistry.make
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield {
       // #1177: split the route composition into typed chunks. A flat `++` chain across
@@ -401,16 +413,9 @@ object Main extends ZIOAppDefault {
         RouterRoutes.routes(routerRepo, policy, routerAuth, blockEvRepo) ++
           AdminRouterRoutes.routes(auth, routerRepo) ++
           RollupAdminRoutes.routes(auth, rollupRepo2) ++
-          RouterIngestRoutes.routes(
-            routerAuth,
-            routerRepo,
-            trafficRepo,
-            usageRepo,
-            deviceRepo,
-            connRepo,
-            alertRepo,
-            hsRepo,
-          ) ++
+          RouterIngestRoutes.routes(routerAuth, routerIngest) ++
+          // #1846: additive websocket transport. REST ingest/poll/metrics above stay fully live.
+          RouterWsRoutes.routes(routerAuth, wsRegistry, routerIngest, routerMetrics, routerRepo) ++
           RouterMetricsRoutes.routes(routerAuth, routerMetrics) ++
           AlertRoutes.routes(
             auth,

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -72,6 +72,10 @@ object MetricGuard {
       // stays specific — `id` would be a generic catch-all that future series
       // might mistakenly co-opt for unbounded entities.
       "blocklist_id",
+      // #1846 — websocket frame direction for `router_ws_frames_total`. A fixed
+      // 2-value enum (`in` agent→server / `out` server→agent); bounded, so it
+      // satisfies the §4 cardinality firewall.
+      "dir",
     )
 
   /**
@@ -186,6 +190,14 @@ object MetricGuard {
     "usage_post_total"                          -> Set("result", "router_id", "installation_id"),
     // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
     "router_metrics_batches_total"              -> Set("status"),
+    // #1846 — websocket router transport (server side). `router_ws_connections_active` is the live
+    // count of open channels (a household-scoped gauge, refreshed on every register/deregister so it
+    // ages out cleanly on disconnect). `router_ws_frames_total` counts every frame demuxed/sent:
+    // `op` ∈ {hello, usage, events, metrics, ping, pong, ack, unknown} (the fixed envelope
+    // vocabulary), `dir` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. All bounded enums — no
+    // per-mac / per-host dimension ever rides a ws metric.
+    "router_ws_connections_active"              -> Set.empty[String],
+    "router_ws_frames_total"                    -> Set("op", "dir", "result"),
     // #1718 — native OpenWRT OS-level metrics the agent collects from /proc/* and `iw dev`
     // and pushes through the existing #1205 batch transport. Gives operators the LuCI-style
     // view of router health (load / cpu / mem / bandwidth / conntrack / wifi clients) in
@@ -434,6 +446,24 @@ object AppMetrics {
 
   def recordRouterMetricsBatch(status: String): UIO[Unit] =
     MetricGuard.counter("router_metrics_batches_total", Map("status" -> status))
+
+  // ── Websocket router transport (#1846) ───────────────────────────────────────
+  // Set by RouterWsRegistry on every register/deregister: the live count of open
+  // ws channels. Refreshed to the recomputed total each time so a disconnect drives
+  // it back down (no stale high-water value). Unlabelled household-scoped gauge.
+
+  def setWsConnectionsActive(count: Int): UIO[Unit] =
+    MetricGuard.gauge("router_ws_connections_active", Map.empty, count.toDouble)
+
+  // Emitted from RouterWsRoutes for every frame demuxed (`dir=in`) or sent
+  // (`dir=out`). `op` is the envelope discriminator (a fixed enum), `dir` ∈
+  // {in, out}, `result` ∈ {ok, reject, unknown_op}. `unknown_op` is the
+  // forward-compat counter (design §1.3 — an unrecognized op is ignored + metered).
+  def recordWsFrame(op: String, dir: String, result: String): UIO[Unit] =
+    MetricGuard.counter(
+      "router_ws_frames_total",
+      Map("op" -> op, "dir" -> dir, "result" -> result),
+    )
 
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
   // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -75,7 +75,7 @@ object MetricGuard {
       // #1846 — websocket frame direction for `router_ws_frames_total`. A fixed
       // 2-value enum (`in` agent→server / `out` server→agent); bounded, so it
       // satisfies the §4 cardinality firewall.
-      "dir",
+      "direction",
     )
 
   /**
@@ -194,10 +194,10 @@ object MetricGuard {
     // count of open channels (a household-scoped gauge, refreshed on every register/deregister so it
     // ages out cleanly on disconnect). `router_ws_frames_total` counts every frame demuxed/sent:
     // `op` ∈ {hello, usage, events, metrics, ping, pong, ack, unknown} (the fixed envelope
-    // vocabulary), `dir` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. All bounded enums — no
-    // per-mac / per-host dimension ever rides a ws metric.
+    // vocabulary), `direction` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. All bounded enums —
+    // no per-mac / per-host dimension ever rides a ws metric.
     "router_ws_connections_active"              -> Set.empty[String],
-    "router_ws_frames_total"                    -> Set("op", "dir", "result"),
+    "router_ws_frames_total"                    -> Set("op", "direction", "result"),
     // #1718 — native OpenWRT OS-level metrics the agent collects from /proc/* and `iw dev`
     // and pushes through the existing #1205 batch transport. Gives operators the LuCI-style
     // view of router health (load / cpu / mem / bandwidth / conntrack / wifi clients) in
@@ -455,14 +455,14 @@ object AppMetrics {
   def setWsConnectionsActive(count: Int): UIO[Unit] =
     MetricGuard.gauge("router_ws_connections_active", Map.empty, count.toDouble)
 
-  // Emitted from RouterWsRoutes for every frame demuxed (`dir=in`) or sent
-  // (`dir=out`). `op` is the envelope discriminator (a fixed enum), `dir` ∈
-  // {in, out}, `result` ∈ {ok, reject, unknown_op}. `unknown_op` is the
+  // Emitted from RouterWsRoutes for every frame demuxed (`direction=in`) or sent
+  // (`direction=out`). `op` is the envelope discriminator (a fixed enum), `direction`
+  // ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. `unknown_op` is the
   // forward-compat counter (design §1.3 — an unrecognized op is ignored + metered).
-  def recordWsFrame(op: String, dir: String, result: String): UIO[Unit] =
+  def recordWsFrame(op: String, direction: String, result: String): UIO[Unit] =
     MetricGuard.counter(
       "router_ws_frames_total",
-      Map("op" -> op, "dir" -> dir, "result" -> result),
+      Map("op" -> op, "direction" -> direction, "result" -> result),
     )
 
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -1,17 +1,8 @@
 package wifihaven.api.routes
 
 import wifihaven.api.db.*
-import wifihaven.api.metrics.AppMetrics
-import wifihaven.api.observability.LogContext
-import wifihaven.api.policy.PolicyService
-import wifihaven.shared.*
-import wifihaven.shared.types.*
-import zio.{Clock as _, *}
+import zio.*
 import zio.http.*
-import zio.json.*
-import zio.json.ast.Json
-
-import java.time.{Duration, Instant}
 
 /**
  * Router-side ingest endpoints. See docs/architecture-openwrt.md §5.4 / §5.5.
@@ -19,9 +10,24 @@ import java.time.{Duration, Instant}
  *   - `POST /api/router/events` — DHCP lease + first-seen-MAC + connection_attempt events.
  *
  * Both require a router bearer token resolved via [[RouterAuth]].
+ *
+ * #1846: these handlers are now thin transport adapters. They authenticate, read the body, and
+ * delegate to the carrier-agnostic [[RouterIngestService]], which the websocket transport
+ * ([[RouterWsRoutes]]) shares — so the decode + per-record-skip + persistence logic lives in
+ * exactly one place (`AGENTS.md#single-source-of-truth`). The typed [[ApiError]] the service raises
+ * is mapped centrally by [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs
+ * (4xx WARN / 5xx ERROR) + meters each error. Per-record skip / per-batch debug logging now lives
+ * in the service (annotated with the same [[wifihaven.api.observability.LogContext]] router scope),
+ * so the debuggability #1017/#1334 relied on is preserved.
  */
 object RouterIngestRoutes {
 
+  /**
+   * Convenience overload that constructs the [[RouterIngestService]] from its repos. Kept so call
+   * sites that only need the REST ingest routes (and the existing test suite, which is the
+   * back-compat gate for the #1846 extraction) don't each have to build the service. Production
+   * (`Main`) builds ONE service and shares it with the websocket transport.
+   */
   def routes(
       auth: RouterAuth,
       routerRepo: RouterRepo,
@@ -32,579 +38,43 @@ object RouterIngestRoutes {
       alertRepo: AlertRepo,
       householdSettingsRepo: HouseholdSettingsRepo,
   ): Routes[Any, Response] =
+    routes(
+      auth,
+      new RouterIngestService(
+        routerRepo,
+        trafficRepo,
+        timeUsageRepo,
+        deviceRepo,
+        connEventRepo,
+        alertRepo,
+        householdSettingsRepo,
+      ),
+    )
+
+  def routes(
+      auth: RouterAuth,
+      ingest: RouterIngestService,
+  ): Routes[Any, Response] =
     Routes(
       Method.POST / "api" / "router" / "usage"  ->
         handler { (req: Request) =>
-          // #1570: fail with a typed ApiError; ErrorMapper.errorToResponse maps it and the
-          // ErrorBoundary logs (4xx WARN / 5xx ERROR) + meters. This subsumes the bespoke
-          // envelope/timestamp decode logging #1574 added for #1569 — the boundary now logs the 400
-          // once, with the response-body snippet (the zio-json error names the failing field), so
-          // the diagnostic gap stays closed without a second emitter.
-          //
-          // The per-RECORD skip path (below) is kept from #1574 and is NOT redundant with the
-          // boundary: a batch carrying a bad record still returns 200, so the boundary never sees
-          // it — the skip is logged + metered inline here.
-          // #602: route/method are on the MDC via LoggingMiddleware. We add
-          // `routerId` to the whole post-auth scope so every log emitted from
-          // here (per-record skip warn, per-batch debug, per-record debug dump)
-          // inherits the same router context without re-wrapping.
           val handle: ZIO[Any, ApiError, Response] =
-            auth.authenticate(req).flatMap { router =>
-              LogContext.annotate(LogContext.RouterId, router.id.toString) {
-                for {
-                  body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
-                  // #1569: decode the *envelope* (routerId, periodStart, periodEnd) + `records` as a
-                  // raw JSON array, deferring per-record validation. A genuinely unparseable
-                  // envelope (bad routerId/timestamps, not an object, `records` not an array,
-                  // truncated body) still 400s — logged by the boundary.
-                  raw       <- ZIO
-                    .fromEither(body.fromJson[RawUsageReport])
-                    .mapError(ApiError.DecodeFailure(_))
-                  _         <- ZIO
-                    .fail(ApiError.BadRequest("router_id mismatch"))
-                    .when(raw.routerId != router.id)
-                  ps        <- parseInstant(raw.periodStart)
-                  pe        <- parseInstant(raw.periodEnd)
-                  // #1569 / #1757: decode each record individually via the shared per-
-                  // record skip helper. A single malformed record (e.g. a host value
-                  // that fails Hostname validation — an Akamai/CDN CNAME target with
-                  // underscores, see #1572) used to fail the WHOLE batch, dropping
-                  // every valid record with it. Now bad records are skipped, logged
-                  // (bounded), and metered, and the valid ones ingest.
-                  decResult <- decodePerRecord[UsageRecord](
-                    raw.records,
-                    "router usage",
-                    "record",
-                    router.id,
-                    AppMetrics.recordUsageRecordsRejected(_),
-                  )
-                  (records, rejectedCount) = decResult
-                  _        <- LogContext.annotateAll(
-                    LogContext.BatchSize -> records.size.toString,
-                    LogContext.Rejected  -> rejectedCount.toString,
-                  ) {
-                    ZIO.logDebug(
-                      s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
-                        s"rejected=$rejectedCount",
-                    )
-                  }
-                  _        <- ZIO.foreachDiscard(records)(r =>
-                    ZIO.logDebug(
-                      s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
-                        s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
-                    ),
-                  )
-                  settings <- householdSettingsRepo.get.mapError(ApiError.Db(_))
-                  _        <- handleUsage(
-                    router.id,
-                    ps,
-                    pe,
-                    records,
-                    settings,
-                    trafficRepo,
-                    timeUsageRepo,
-                    deviceRepo,
-                    connEventRepo,
-                  )
-                  _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
-                } yield Response.ok
-              }
-            }
+            for {
+              router <- auth.authenticate(req)
+              body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+              _      <- ingest.ingestUsage(router, body)
+            } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "router" / "events" ->
         handler { (req: Request) =>
-          // #1570: typed errors + central mapping. The bespoke decode `logWarning`, the
-          // routerId-mismatch `logWarning`, and the trailing "returning status=" `logInfo` are
-          // gone — the ErrorBoundary now logs every 4xx (incl. this decode 400) at WARN with the
-          // response-body snippet, so logging is uniform with the usage route (the #1569 dedup:
-          // one emitter, not two).
-          // #602: route/method via LoggingMiddleware; `routerId` annotates the
-          // whole post-auth scope so every log here inherits it without re-wrapping.
           val handle: ZIO[Any, ApiError, Response] =
-            auth.authenticate(req).flatMap { router =>
-              LogContext.annotate(LogContext.RouterId, router.id.toString) {
-                for {
-                  body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
-                  // #1126: tolerate an empty/blank body as a no-op batch. A truncated
-                  // or empty POST (network blip, retry-queue edge) used to fail
-                  // RouterEventsRequest decoding with "Unexpected end of input" and
-                  // 400, spamming the warn log and dropping the (harmless) batch. An
-                  // empty events POST carries nothing to persist, so treat it as an
-                  // accepted no-op rather than an error. Genuinely malformed non-empty
-                  // bodies still 400 + warn (and the agent emitter no longer
-                  // produces them — see conntrack.encode_events_body).
-                  raw       <-
-                    if body.trim.isEmpty then
-                      ZIO.logDebug(
-                        s"router events: empty body from router=${router.id}; treating as no-op batch",
-                      ) *> ZIO.succeed(RawEventsReport(router.id, Nil))
-                    else
-                      ZIO
-                        .fromEither(body.fromJson[RawEventsReport])
-                        .mapError(ApiError.DecodeFailure(_))
-                  _         <- ZIO
-                    .fail(ApiError.BadRequest("router_id mismatch"))
-                    .when(raw.routerId != router.id)
-                  // #1757: decode each event individually via the shared per-record
-                  // skip helper. A single malformed RouterEvent (bad host/mac/ts/
-                  // unknown enum) used to fail the WHOLE batch — every valid
-                  // connection_attempt / dhcp_lease / first_seen_mac dropped with
-                  // it. Envelope itself (routerId, events-is-an-array) must still
-                  // parse or the request is a genuine 400.
-                  decResult <- decodePerRecord[RouterEvent](
-                    raw.events,
-                    "router events",
-                    "event",
-                    router.id,
-                    AppMetrics.recordEventsRecordsRejected(_),
-                  )
-                  (events, rejectedCount) = decResult
-                  _ <- LogContext.annotateAll(
-                    LogContext.BatchSize -> events.size.toString,
-                    LogContext.Rejected  -> rejectedCount.toString,
-                  ) {
-                    ZIO.logDebug(
-                      s"router events: router=${router.id} batchSize=${events.size} " +
-                        s"rejected=$rejectedCount",
-                    )
-                  }
-                  _ <- ZIO.foreachDiscard(events)(e =>
-                    ZIO.logDebug(
-                      s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +
-                        s"ip=${e.ip.getOrElse("-")} host=${e.host.map(_.value).orElse(e.hostname.map(_.value)).getOrElse("-")} " +
-                        s"destIp=${e.destIp.getOrElse("-")} allowed=${e.allowed.map(_.toString).getOrElse("-")} " +
-                        s"reason=${e.reason.getOrElse("-")} ts=${e.ts}",
-                    ),
-                  )
-                  _ <- handleEvents(router.id, events, deviceRepo, connEventRepo, alertRepo)
-                  _ <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
-                } yield Response.ok
-              }
-            }
+            for {
+              router <- auth.authenticate(req)
+              body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+              _      <- ingest.ingestEvents(router, body)
+            } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
     )
-
-  /**
-   * #1569: the wire-decode envelope for `POST /api/router/usage`. Identical field shape to
-   * [[UsageReport]] except `records` is held as a raw JSON array so each element can be decoded
-   * into a [[UsageRecord]] individually — a single malformed record (e.g. a host value that fails
-   * `Hostname` validation, see #1572) is then skipped + logged + metered instead of 400-ing the
-   * whole batch and dropping every valid record with it. The envelope itself (routerId, timestamps,
-   * records-is-an-array) must still parse or the request is a genuine 400. Decode-only; this is a
-   * server-side parse aid, NOT a wire-contract type — unknown fields are still ignored.
-   */
-  private case class RawUsageReport(
-      routerId: RouterId,
-      periodStart: String,
-      periodEnd: String,
-      records: List[Json],
-  ) derives JsonDecoder
-
-  /**
-   * #1757: the wire-decode envelope for `POST /api/router/events`, the `RouterEventsRequest` analog
-   * of [[RawUsageReport]]. Identical field shape to [[RouterEventsRequest]] except `events` is held
-   * as a raw JSON array so each element can be decoded into a [[RouterEvent]] individually — a
-   * single malformed event (bad host / mac / ts / unknown enum value) is then skipped + logged +
-   * metered instead of 400-ing the whole batch and dropping every valid connection_attempt /
-   * dhcp_lease / first_seen_mac with it. The envelope itself (routerId, events-is-an-array) must
-   * still parse or the request is a genuine 400. Decode-only; this is a server-side parse aid, NOT
-   * a wire-contract type — unknown fields are still ignored.
-   */
-  private case class RawEventsReport(
-      routerId: RouterId,
-      events: List[Json],
-  ) derives JsonDecoder
-
-  // #1570: a bad timestamp is a typed BadRequest (400) mapped centrally; the boundary logs it.
-  // (The bespoke per-call warn log #1574 added is subsumed by the boundary — single emitter.)
-  private def parseInstant(s: String): IO[ApiError, Instant] =
-    ZIO.attempt(Instant.parse(s)).orElseFail(ApiError.BadRequest(s"invalid timestamp: $s"))
-
-  /**
-   * #1569 / #1757: shared per-record skip helper used by both `/api/router/usage` (records →
-   * UsageRecord) and `/api/router/events` (events → RouterEvent). The two ingest paths used to
-   * carry hand-copied decode loops with a "// must mirror" coupling — extracted here so the single
-   * source of truth is enforced by the compiler. Decodes each `Json` element into `T` individually,
-   * logs each failure (bounded — one warn per bad slot, with the JSON index) and increments the
-   * supplied rejection metric, then returns the decoded list plus the rejected count for the
-   * caller's per-batch debug annotation. Bad records are skipped, NOT 400'd — the envelope itself
-   * must still parse upstream.
-   */
-  private def decodePerRecord[T](
-      raw: List[Json],
-      logPrefix: String,
-      itemNoun: String,
-      routerId: RouterId,
-      recordMetric: Int => UIO[Unit],
-  )(implicit decoder: JsonDecoder[T]): UIO[(List[T], Int)] = {
-    val decoded  = raw.zipWithIndex.map((j, i) => (i, j.as[T]))
-    val rejected = decoded.collect { case (i, Left(err)) => (i, err) }
-    val ok       = decoded.collect { case (_, Right(t)) => t }
-    ZIO.foreachDiscard(rejected) { (i, err) =>
-      ZIO.logWarning(
-        s"$logPrefix: skipping malformed $itemNoun[$i] for router=$routerId: $err",
-      )
-    } *> recordMetric(rejected.size).as((ok, rejected.size))
-  }
-
-  private def handleUsage(
-      routerId: RouterId,
-      periodStart: Instant,
-      periodEnd: Instant,
-      records: List[UsageRecord],
-      settings: HouseholdSettings,
-      trafficRepo: TrafficReportRepo,
-      timeUsageRepo: TimeUsageRepo,
-      deviceRepo: DeviceRepo,
-      connEventRepo: ConnectionEventRepo,
-  ): IO[ApiError, Unit] = {
-    // #1010: bucket usage by the household's logical "today" (TZ + non-midnight
-    // reset_time), matching the read-side date used by PolicyService.snapshot.
-    val date         = PolicyService.householdLocalDate(periodStart, settings)
-    // #864: a healthy agent never reports a row with no bytes and no active
-    // seconds. The read side already filters these (listRawInRange), so they're
-    // dead weight; count them here at ingest so a silent return of the #858 agent
-    // regression shows up as a rising rate rather than a per-request warn-log.
-    val zeroByteRows =
-      records.count(r => r.activeSeconds == 0L && r.bytesIn == 0L && r.bytesOut == 0L)
-    for {
-      _ <- AppMetrics.recordZeroByteFiltered(zeroByteRows)
-      // #1585: write-time FQDN backfill. The router's per-(mac, dst_ip)
-      // accumulator emits records whose host is the resolved fqdn when DNS
-      // attribution won the race, but ipv4/ipv6 when it lost (DoH, hard-coded
-      // IP, or just an ordering race). For each such race-loser we consult
-      // recent fqdn connection_events for the same (router_id, dest_ip) and
-      // rewrite the record to its resolved fqdn BEFORE inserting — so the
-      // traffic_reports row lands under the human-readable host and the
-      // read-side LATERAL join (#730 follow-up cleanup) can eventually go away.
-      // #1511: resolve the whole batch's race-loser dest_ips in one round trip,
-      // then rewrite each record in memory — collapses the per-record N+1 SELECT
-      // that dominated the handler's ~1 s p95.
-      candidateIps = records
-        .collect {
-          case r if r.host.isInstanceOf[HostId.IPv4] || r.host.isInstanceOf[HostId.IPv6] =>
-            r.destIp
-        }
-        .flatten
-        .distinct
-      fqdnMap <- connEventRepo
-        .findRecentFqdnForBatch(routerId, candidateIps, periodStart.minus(fqdnBackfillWindow))
-        .mapError(ApiError.Db(_))
-      rewritten <- ZIO.foreach(records)(r => backfillRecordWith(fqdnMap, r))
-      // After rewrite, two distinct (mac, dst_ip) records can collapse to the
-      // same (mac, host) at the same period — the existing primary key
-      // (router_id, period_start, mac, host_type, host_value) makes the second
-      // INSERT a silent no-op under ON CONFLICT DO NOTHING and the row's bytes
-      // would be dropped. Aggregate (sum bytes; max activeSeconds — same merge
-      // applyDelta uses below) before INSERT.
-      aggregated = aggregateForInsert(rewritten)
-      inserts    = aggregated.map(r =>
-        TrafficReportInsert(
-          routerId,
-          r.mac,
-          r.ip,
-          r.host,
-          date,
-          periodStart,
-          periodEnd,
-          r.activeSeconds.toInt,
-          r.bytesIn,
-          r.bytesOut,
-          r.destIp,
-        ),
-      )
-      // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
-      // Only those rows should drive time_usage / device updates; replays return 0.
-      newCount <- trafficRepo.insertBatch(inserts).mapError(ApiError.Db(_))
-      // applyDelta groups by (mac, host); pass the rewritten records so the
-      // time_usage credit lands under the resolved fqdn too. Unaggregated is
-      // fine — applyDelta already collapses duplicates with the same merge.
-      _        <- ZIO.when(newCount > 0)(
-        applyDelta(routerId, periodEnd, rewritten, settings, timeUsageRepo, deviceRepo),
-      )
-    } yield ()
-  }
-
-  /**
-   * #1585 + #1511: rewrite a race-loser ipv4/ipv6 UsageRecord to its resolved FQDN by consulting
-   * recent fqdn-typed connection_events for the same (router_id, dest_ip). #1585 introduced the
-   * write-time backfill; #1511 moved the per-record lookup off the wire — the resolved dest_ip →
-   * FQDN map is now built once per batch by [[ConnectionEventRepo.findRecentFqdnForBatch]] and
-   * consulted in memory here. Window symmetry with the events-side backfill (#720) is preserved via
-   * [[fqdnBackfillWindow]]: five minutes covers conntrack/dns-tail jitter without inviting
-   * attribution across reused-IP cloud endpoints. Emits `traffic_reports_backfill_total{result}`
-   * per record: `skip` (not a candidate — already fqdn, or no dest_ip), `filled` (rewritten), or
-   * `miss` (candidate, no fqdn found).
-   */
-  private def backfillRecordWith(
-      fqdnMap: Map[IpAddress, Hostname],
-      record: UsageRecord,
-  ): IO[ApiError, UsageRecord] =
-    (record.host, record.destIp) match {
-      case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
-        fqdnMap.get(destIp) match {
-          case Some(name) =>
-            AppMetrics.recordTrafficBackfill("filled").as(record.copy(host = HostId.Fqdn(name)))
-          case None       =>
-            AppMetrics.recordTrafficBackfill("miss").as(record)
-        }
-      case _                                               =>
-        AppMetrics.recordTrafficBackfill("skip").as(record)
-    }
-
-  /**
-   * #1585: collapse (mac, host) duplicates before INSERT so the traffic_reports primary key's `ON
-   * CONFLICT DO NOTHING` doesn't silently drop bytes from race-losers that the backfill just
-   * rewrote into a sibling record's bucket. Bytes sum; activeSeconds takes the max (the agent emits
-   * the bucket duration on every record, so summing would double-count the wall-clock); destIp / ip
-   * take the first non-null. Single-host batches (the common case) pass through unchanged.
-   */
-  private def aggregateForInsert(records: List[UsageRecord]): List[UsageRecord] =
-    records
-      .groupBy(r => (r.mac, r.host))
-      .view
-      .map { case (_, rs) =>
-        rs.reduce { (a, b) =>
-          a.copy(
-            ip = a.ip.orElse(b.ip),
-            activeSeconds = math.max(a.activeSeconds, b.activeSeconds),
-            bytesIn = a.bytesIn + b.bytesIn,
-            bytesOut = a.bytesOut + b.bytesOut,
-            destIp = a.destIp.orElse(b.destIp),
-          )
-        }
-      }
-      .toList
-
-  /**
-   * Apply seconds/byte deltas + device last_seen for a freshly-accepted batch. We only enter here
-   * when at least one row was inserted; for partial overlap (rare retry edge case) we accept that
-   * the new rows' increments fold in but already-stored ones don't double-count because the
-   * traffic_reports unique key blocked them.
-   *
-   * NOTE: a true partial-overlap retry would still double-count the *new* records' time_usage
-   * because we can't tell from the batch insert which sub-rows were new. This is acceptable: the
-   * agent's contract is to retry the whole batch unchanged, so partial overlap shouldn't happen in
-   * practice.
-   */
-  private def applyDelta(
-      @scala.annotation.unused routerId: RouterId,
-      periodEnd: Instant,
-      records: List[UsageRecord],
-      settings: HouseholdSettings,
-      timeUsageRepo: TimeUsageRepo,
-      deviceRepo: DeviceRepo,
-  ): IO[ApiError, Unit] = {
-    // #1010: bucket time_usage by the household's logical "today" so the
-    // cap-tracking read path (which uses the same household-local date) lines
-    // up with the rows we wrote.
-    val date       = PolicyService.householdLocalDate(periodEnd, settings)
-    // A batch carries one record per (mac, dst_ip) but time_usage is keyed
-    // by (mac, hostname, date), and activeSeconds is the bucket duration
-    // (the report window, ~60 s — same value on every record that saw bytes>0). Two
-    // records with the same (mac, hostname) describe the *same* window of
-    // active time, not two windows back-to-back, so the seconds delta is
-    // the max of activeSeconds, not the sum. Bytes still sum because they
-    // count distinct flows.
-    // Per-mac aggregates needed for #715 proportional attribution: bucket duration
-    // (one batch == one period, so max activeSeconds across the mac is the bucket
-    // duration) and total bytes across the mac in this batch (denominator for the
-    // bytes-share weight).
-    val perMacAgg  = records
-      .groupBy(_.mac)
-      .view
-      .mapValues { rs =>
-        val bucketSecs = rs.map(_.activeSeconds).maxOption.getOrElse(0L)
-        val totalBytes = rs.map(r => r.bytesIn + r.bytesOut).sum
-        (bucketSecs, totalBytes)
-      }
-      .toMap
-    val grouped    = records
-      .groupBy(r => (r.mac, r.host))
-      .view
-      .mapValues { rs =>
-        (
-          rs.map(_.activeSeconds).maxOption.getOrElse(0L),
-          rs.map(_.bytesIn).sum,
-          rs.map(_.bytesOut).sum,
-        )
-      }
-      .toList
-    // #1511: build the per-(mac, host) increments in memory and ship them as ONE batched upsert
-    // instead of N sequential round trips. Same `seconds_used` / `proportional_seconds` /
-    // `bytes_in` / `bytes_out` deltas as before — only the wire shape to PG changed.
-    val increments = grouped.map { case ((mac, host), (secs, bIn, bOut)) =>
-      // #715: bytes-share weighted attribution within the batch. `bucketSecs` is the wall-clock
-      // duration of the bucket; the share is this host's (bytes_in + bytes_out) over the mac's
-      // total bytes in the batch. When the mac has zero bytes (shouldn't happen — the agent only
-      // emits a record when it saw bytes>0), fall back to crediting full bucket seconds so the
-      // row still moves and matches `seconds_used`.
-      val (bucketSecs, totalBytes) = perMacAgg.getOrElse(mac, (secs, bIn + bOut))
-      val hostBytes                = bIn + bOut
-      val proportionalSecs         =
-        if (totalBytes > 0L) (bucketSecs.toDouble * hostBytes.toDouble / totalBytes.toDouble).round
-        else bucketSecs
-      TimeUsageIncrement(mac, host, date, secs, bIn, bOut, proportionalSecs)
-    }
-    timeUsageRepo
-      .incrementSecondsAndBytesBatch(increments)
-      .mapError(ApiError.Db(_)) *>
-      // #1511: one batched UPDATE for all (mac, ip) last-seen touches in the batch — was N round
-      // trips. Skips rows for unknown MACs the same way the per-row method did (UPDATE only).
-      deviceRepo
-        .touchLastSeenBatch(records.map(r => (r.mac, r.ip)).distinct, periodEnd)
-        .mapError(ApiError.Db(_))
-        .unit
-  }
-
-  /**
-   * #720: how far back the API will look for a sibling fqdn-typed event to attribute an
-   * ipv4/ipv6-typed event to. Matches the spirit of #583 Option 4 — a small race window, not a
-   * long-running IP→host cache. Five minutes covers the conntrack/dns-tail jitter (and any client
-   * DNS TTL skew) without inviting attribution across reused-IP cloud endpoints.
-   */
-  private val fqdnBackfillWindow: Duration = Duration.ofMinutes(5)
-
-  private def handleEvents(
-      routerId: RouterId,
-      events: List[RouterEvent],
-      deviceRepo: DeviceRepo,
-      connEventRepo: ConnectionEventRepo,
-      alertRepo: AlertRepo,
-  ): IO[ApiError, Unit] = {
-    val connInserts = events.collect {
-      case e if e.`type` == "connection_attempt" =>
-        for {
-          h    <- e.host.toRight("connection_attempt missing host")
-          ts   <- scala.util.Try(Instant.parse(e.ts)).toEither.left.map(_.getMessage)
-          allw <- e.allowed.toRight("connection_attempt missing allowed")
-          // #962: router still sends free-form text on the wire (no router-side
-          // change in this PR); convert to typed BlockReason at the API boundary.
-          rsn = BlockReason.fromWire(e.reason.getOrElse(if allw then "allow" else "blocked"))
-        } yield ConnectionEventInsert(routerId, e.mac, h, e.destIp, allw, rsn, ts, e.eventId)
-    }
-    for {
-      // Surface JSON validation errors as 400.
-      validated <- ZIO.foreach(connInserts)(e => ZIO.fromEither(e).mapError(ApiError.BadRequest(_)))
-      // #720: for each ipv4/ipv6-typed insert with a dest_ip, consult the
-      // existing connection_events for a sibling fqdn-typed event we can
-      // attribute it to. This handles the "fqdn observed first, ipv4 race-
-      // loser arrives later" arrival order at insert time.
-      enriched  <- ZIO.foreach(validated)(attachResolvedHost(_, connEventRepo))
-      // #338: ON CONFLICT DO NOTHING on event_id dedups replays from the
-      // retry queue (#330). Insert returns count of new rows; the diff is
-      // duplicates collapsed on conflict.
-      inserted  <- connEventRepo
-        .insertBatch(enriched)
-        .mapError(ApiError.Db(_))
-        .when(enriched.nonEmpty)
-        .map(_.getOrElse(0))
-      _         <- ZIO
-        .logInfo(
-          s"router events: router=$routerId dedup'd ${enriched.size - inserted} of " +
-            s"${enriched.size} connection_attempt events (replay)",
-        )
-        .when(inserted < enriched.size)
-      // #720: for each fqdn-typed event we just persisted, patch prior
-      // unresolved ipv4/ipv6 rows in the same window. This handles the
-      // reverse arrival order ("ipv4 race-loser observed first, fqdn lands
-      // moments later").
-      _         <- ZIO.foreachDiscard(enriched)(backfillFromFqdn(_, connEventRepo))
-      _         <- ZIO.foreachDiscard(events)(applyDhcpOrFirstSeen(_, deviceRepo, alertRepo))
-    } yield ()
-  }
-
-  private def attachResolvedHost(
-      ev: ConnectionEventInsert,
-      connEventRepo: ConnectionEventRepo,
-  ): IO[ApiError, ConnectionEventInsert] =
-    (ev.host, ev.destIp) match {
-      case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
-        connEventRepo
-          .findRecentFqdnFor(ev.routerId, destIp, ev.ts.minus(fqdnBackfillWindow))
-          .mapError(ApiError.Db(_))
-          .map(h => ev.copy(resolvedHost = h))
-      case _                                               => ZIO.succeed(ev)
-    }
-
-  private def backfillFromFqdn(
-      ev: ConnectionEventInsert,
-      connEventRepo: ConnectionEventRepo,
-  ): IO[ApiError, Unit] =
-    (ev.host, ev.destIp) match {
-      case (HostId.Fqdn(name), Some(destIp)) =>
-        connEventRepo
-          .backfillResolvedFor(ev.routerId, destIp, name, ev.ts.minus(fqdnBackfillWindow))
-          .mapError(ApiError.Db(_))
-          .unit
-      case _                                 => ZIO.unit
-    }
-
-  /**
-   * Default name for a device whose DHCP lease did not provide a hostname (option 12) — e.g. iOS
-   * Private Address clients. The last 3 octets of the MAC (lowercase, no separators) keeps the
-   * placeholder disambiguable in the admin UI rather than collapsing every such device into the
-   * literal string "unknown" (#249).
-   */
-  private[routes] def autoGeneratedName(mac: String): String = {
-    val hex = mac.toLowerCase.replace(":", "").replace("-", "")
-    "device-" + (if hex.length >= 6 then hex.takeRight(6) else hex)
-  }
-
-  /**
-   * DHCP lease + first-seen-MAC: upsert into devices. For a known MAC refresh last_seen_ip /
-   * last_seen_at (preserve profile) and, on a dhcp_lease with a real hostname, also upgrade the
-   * name if it is still an auto-generated placeholder (#249 race: first_seen_mac landed before
-   * dnsmasq wrote the lease, so the row got named "unknown" / "device-XXYYZZ"). For an unknown MAC,
-   * create a row with NULL profile_id and the supplied hostname (or autoGeneratedName(mac)).
-   */
-  private def applyDhcpOrFirstSeen(
-      e: RouterEvent,
-      deviceRepo: DeviceRepo,
-      alertRepo: AlertRepo,
-  ): IO[ApiError, Unit] =
-    if e.`type` != "dhcp_lease" && e.`type` != "first_seen_mac" then ZIO.unit
-    else
-      e.mac match {
-        case None      => ZIO.unit
-        case Some(mac) =>
-          for {
-            ts       <- ZIO
-              .attempt(Instant.parse(e.ts))
-              .orElseFail(ApiError.BadRequest(s"invalid ts: ${e.ts}"))
-            existing <- deviceRepo.findByMac(mac).mapError(ApiError.Db(_))
-            _        <- existing match {
-              case Some(_) =>
-                deviceRepo
-                  .touchLastSeen(mac, e.ip, ts)
-                  .mapError(ApiError.Db(_))
-                  .unit *>
-                  ZIO
-                    .foreachDiscard(e.hostname)(h =>
-                      deviceRepo
-                        .renameIfAutoGenerated(mac, h.value)
-                        .mapError(ApiError.Db(_)),
-                    )
-              case None    =>
-                // #711: a brand-new MAC. Insert the device row, then raise a
-                // notification for the admin. The alert repo is idempotent on
-                // `mac`, so a router replaying the same event won't resurrect
-                // a previously-dismissed alert.
-                deviceRepo
-                  .upsertUnknown(
-                    mac,
-                    e.hostname.map(_.value).getOrElse(autoGeneratedName(mac.value)),
-                    e.ip,
-                    ts,
-                  )
-                  .mapError(ApiError.Db(_))
-                  .unit *>
-                  alertRepo
-                    .raiseNewDevice(mac, ts)
-                    .mapError(ApiError.Db(_))
-            }
-          } yield ()
-      }
 }

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -1,0 +1,508 @@
+package wifihaven.api.routes
+
+import wifihaven.api.db.*
+import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.observability.LogContext
+import wifihaven.api.policy.PolicyService
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.{Clock as _, *}
+import zio.json.*
+import zio.json.ast.Json
+
+import java.time.{Duration, Instant}
+
+/**
+ * #1846: transport-agnostic router ingest. The decode + per-record skip + persistence logic for the
+ * `usage` and `events` flows used to live inline in [[RouterIngestRoutes]]'s handlers. It is
+ * extracted here so the REST endpoints (`POST /api/router/usage`, `POST /api/router/events`) and
+ * the new websocket transport (`/api/router/ws`, [[RouterWsRoutes]]) dispatch into ONE
+ * implementation — there is no second copy of the ingest behavior
+ * (`AGENTS.md#single-source-of-truth`). The methods take the already-resolved [[Router]] (both
+ * transports authenticate the same way via [[RouterAuth]] before calling in) and the raw JSON body
+ * / frame payload; they fail with a typed [[ApiError]] the caller maps to its transport's error
+ * shape (a `400`/`401` Response for REST, an `ack reject` frame for ws). Behavior is byte-for-byte
+ * what the routes did before the extraction.
+ */
+final class RouterIngestService(
+    routerRepo: RouterRepo,
+    trafficRepo: TrafficReportRepo,
+    timeUsageRepo: TimeUsageRepo,
+    deviceRepo: DeviceRepo,
+    connEventRepo: ConnectionEventRepo,
+    alertRepo: AlertRepo,
+    householdSettingsRepo: HouseholdSettingsRepo,
+) {
+  import RouterIngestService.*
+
+  /**
+   * Decode + persist a `POST /api/router/usage` body (or a `usage` ws frame payload) for an
+   * already-authenticated router. Mirrors the prior inline handler exactly: a genuinely unparseable
+   * envelope (bad routerId/timestamps, `records` not an array, truncated body) fails with a typed
+   * 400; individual malformed records are skipped + logged + metered (#1569/#1757) and the valid
+   * ones ingest. `last_seen_at` is touched on success.
+   */
+  def ingestUsage(router: Router, body: String): IO[ApiError, Unit] =
+    LogContext.annotate(LogContext.RouterId, router.id.toString) {
+      for {
+        raw       <- ZIO
+          .fromEither(body.fromJson[RawUsageReport])
+          .mapError(ApiError.DecodeFailure(_))
+        _         <- ZIO
+          .fail(ApiError.BadRequest("router_id mismatch"))
+          .when(raw.routerId != router.id)
+        ps        <- parseInstant(raw.periodStart)
+        pe        <- parseInstant(raw.periodEnd)
+        decResult <- decodePerRecord[UsageRecord](
+          raw.records,
+          "router usage",
+          "record",
+          router.id,
+          AppMetrics.recordUsageRecordsRejected(_),
+        )
+        (records, rejectedCount) = decResult
+        _        <- LogContext.annotateAll(
+          LogContext.BatchSize -> records.size.toString,
+          LogContext.Rejected  -> rejectedCount.toString,
+        ) {
+          ZIO.logDebug(
+            s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
+              s"rejected=$rejectedCount",
+          )
+        }
+        _        <- ZIO.foreachDiscard(records)(r =>
+          ZIO.logDebug(
+            s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
+              s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
+          ),
+        )
+        settings <- householdSettingsRepo.get.mapError(ApiError.Db(_))
+        _        <- handleUsage(router.id, ps, pe, records, settings)
+        _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
+      } yield ()
+    }
+
+  /**
+   * Decode + persist a `POST /api/router/events` body (or an `events` ws frame payload) for an
+   * already-authenticated router. Mirrors the prior inline handler: an empty/blank body is an
+   * accepted no-op batch (#1126); individual malformed events are skipped + metered (#1757); the
+   * envelope itself must parse or it is a typed 400. `last_seen_at` is touched on success.
+   */
+  def ingestEvents(router: Router, body: String): IO[ApiError, Unit] =
+    LogContext.annotate(LogContext.RouterId, router.id.toString) {
+      for {
+        raw       <-
+          if body.trim.isEmpty then
+            ZIO.logDebug(
+              s"router events: empty body from router=${router.id}; treating as no-op batch",
+            ) *> ZIO.succeed(RawEventsReport(router.id, Nil))
+          else
+            ZIO
+              .fromEither(body.fromJson[RawEventsReport])
+              .mapError(ApiError.DecodeFailure(_))
+        _         <- ZIO
+          .fail(ApiError.BadRequest("router_id mismatch"))
+          .when(raw.routerId != router.id)
+        decResult <- decodePerRecord[RouterEvent](
+          raw.events,
+          "router events",
+          "event",
+          router.id,
+          AppMetrics.recordEventsRecordsRejected(_),
+        )
+        (events, rejectedCount) = decResult
+        _ <- LogContext.annotateAll(
+          LogContext.BatchSize -> events.size.toString,
+          LogContext.Rejected  -> rejectedCount.toString,
+        ) {
+          ZIO.logDebug(
+            s"router events: router=${router.id} batchSize=${events.size} " +
+              s"rejected=$rejectedCount",
+          )
+        }
+        _ <- ZIO.foreachDiscard(events)(e =>
+          ZIO.logDebug(
+            s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +
+              s"ip=${e.ip.getOrElse("-")} host=${e.host.map(_.value).orElse(e.hostname.map(_.value)).getOrElse("-")} " +
+              s"destIp=${e.destIp.getOrElse("-")} allowed=${e.allowed.map(_.toString).getOrElse("-")} " +
+              s"reason=${e.reason.getOrElse("-")} ts=${e.ts}",
+          ),
+        )
+        _ <- handleEvents(router.id, events)
+        _ <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
+      } yield ()
+    }
+
+  private def handleUsage(
+      routerId: RouterId,
+      periodStart: Instant,
+      periodEnd: Instant,
+      records: List[UsageRecord],
+      settings: HouseholdSettings,
+  ): IO[ApiError, Unit] = {
+    // #1010: bucket usage by the household's logical "today" (TZ + non-midnight
+    // reset_time), matching the read-side date used by PolicyService.snapshot.
+    val date         = PolicyService.householdLocalDate(periodStart, settings)
+    // #864: a healthy agent never reports a row with no bytes and no active
+    // seconds. The read side already filters these (listRawInRange), so they're
+    // dead weight; count them here at ingest so a silent return of the #858 agent
+    // regression shows up as a rising rate rather than a per-request warn-log.
+    val zeroByteRows =
+      records.count(r => r.activeSeconds == 0L && r.bytesIn == 0L && r.bytesOut == 0L)
+    for {
+      _ <- AppMetrics.recordZeroByteFiltered(zeroByteRows)
+      // #1585: write-time FQDN backfill. The router's per-(mac, dst_ip)
+      // accumulator emits records whose host is the resolved fqdn when DNS
+      // attribution won the race, but ipv4/ipv6 when it lost (DoH, hard-coded
+      // IP, or just an ordering race). For each such race-loser we consult
+      // recent fqdn connection_events for the same (router_id, dest_ip) and
+      // rewrite the record to its resolved fqdn BEFORE inserting — so the
+      // traffic_reports row lands under the human-readable host and the
+      // read-side LATERAL join (#730 follow-up cleanup) can eventually go away.
+      // #1511: resolve the whole batch's race-loser dest_ips in one round trip,
+      // then rewrite each record in memory — collapses the per-record N+1 SELECT
+      // that dominated the handler's ~1 s p95.
+      candidateIps = records
+        .collect {
+          case r if r.host.isInstanceOf[HostId.IPv4] || r.host.isInstanceOf[HostId.IPv6] =>
+            r.destIp
+        }
+        .flatten
+        .distinct
+      fqdnMap <- connEventRepo
+        .findRecentFqdnForBatch(routerId, candidateIps, periodStart.minus(fqdnBackfillWindow))
+        .mapError(ApiError.Db(_))
+      rewritten <- ZIO.foreach(records)(r => backfillRecordWith(fqdnMap, r))
+      // After rewrite, two distinct (mac, dst_ip) records can collapse to the
+      // same (mac, host) at the same period — the existing primary key
+      // (router_id, period_start, mac, host_type, host_value) makes the second
+      // INSERT a silent no-op under ON CONFLICT DO NOTHING and the row's bytes
+      // would be dropped. Aggregate (sum bytes; max activeSeconds — same merge
+      // applyDelta uses below) before INSERT.
+      aggregated = aggregateForInsert(rewritten)
+      inserts    = aggregated.map(r =>
+        TrafficReportInsert(
+          routerId,
+          r.mac,
+          r.ip,
+          r.host,
+          date,
+          periodStart,
+          periodEnd,
+          r.activeSeconds.toInt,
+          r.bytesIn,
+          r.bytesOut,
+          r.destIp,
+        ),
+      )
+      // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
+      // Only those rows should drive time_usage / device updates; replays return 0.
+      newCount <- trafficRepo.insertBatch(inserts).mapError(ApiError.Db(_))
+      // applyDelta groups by (mac, host); pass the rewritten records so the
+      // time_usage credit lands under the resolved fqdn too. Unaggregated is
+      // fine — applyDelta already collapses duplicates with the same merge.
+      _        <- ZIO.when(newCount > 0)(
+        applyDelta(routerId, periodEnd, rewritten, settings),
+      )
+    } yield ()
+  }
+
+  /**
+   * #1585 + #1511: rewrite a race-loser ipv4/ipv6 UsageRecord to its resolved FQDN by consulting
+   * recent fqdn-typed connection_events for the same (router_id, dest_ip). Emits
+   * `traffic_reports_backfill_total{result}` per record: `skip` / `filled` / `miss`.
+   */
+  private def backfillRecordWith(
+      fqdnMap: Map[IpAddress, Hostname],
+      record: UsageRecord,
+  ): IO[ApiError, UsageRecord] =
+    (record.host, record.destIp) match {
+      case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
+        fqdnMap.get(destIp) match {
+          case Some(name) =>
+            AppMetrics.recordTrafficBackfill("filled").as(record.copy(host = HostId.Fqdn(name)))
+          case None       =>
+            AppMetrics.recordTrafficBackfill("miss").as(record)
+        }
+      case _                                               =>
+        AppMetrics.recordTrafficBackfill("skip").as(record)
+    }
+
+  /**
+   * #1585: collapse (mac, host) duplicates before INSERT so the traffic_reports primary key's `ON
+   * CONFLICT DO NOTHING` doesn't silently drop bytes from race-losers that the backfill just
+   * rewrote into a sibling record's bucket. Bytes sum; activeSeconds takes the max (the agent emits
+   * the bucket duration on every record, so summing would double-count the wall-clock); destIp / ip
+   * take the first non-null. Single-host batches (the common case) pass through unchanged.
+   */
+  private def aggregateForInsert(records: List[UsageRecord]): List[UsageRecord] =
+    records
+      .groupBy(r => (r.mac, r.host))
+      .view
+      .map { case (_, rs) =>
+        rs.reduce { (a, b) =>
+          a.copy(
+            ip = a.ip.orElse(b.ip),
+            activeSeconds = math.max(a.activeSeconds, b.activeSeconds),
+            bytesIn = a.bytesIn + b.bytesIn,
+            bytesOut = a.bytesOut + b.bytesOut,
+            destIp = a.destIp.orElse(b.destIp),
+          )
+        }
+      }
+      .toList
+
+  /**
+   * Apply seconds/byte deltas + device last_seen for a freshly-accepted batch. We only enter here
+   * when at least one row was inserted; for partial overlap (rare retry edge case) we accept that
+   * the new rows' increments fold in but already-stored ones don't double-count because the
+   * traffic_reports unique key blocked them.
+   */
+  private def applyDelta(
+      @scala.annotation.unused routerId: RouterId,
+      periodEnd: Instant,
+      records: List[UsageRecord],
+      settings: HouseholdSettings,
+  ): IO[ApiError, Unit] = {
+    // #1010: bucket time_usage by the household's logical "today" so the
+    // cap-tracking read path (which uses the same household-local date) lines
+    // up with the rows we wrote.
+    val date       = PolicyService.householdLocalDate(periodEnd, settings)
+    // Per-mac aggregates needed for #715 proportional attribution: bucket duration
+    // (one batch == one period, so max activeSeconds across the mac is the bucket
+    // duration) and total bytes across the mac in this batch (denominator for the
+    // bytes-share weight).
+    val perMacAgg  = records
+      .groupBy(_.mac)
+      .view
+      .mapValues { rs =>
+        val bucketSecs = rs.map(_.activeSeconds).maxOption.getOrElse(0L)
+        val totalBytes = rs.map(r => r.bytesIn + r.bytesOut).sum
+        (bucketSecs, totalBytes)
+      }
+      .toMap
+    val grouped    = records
+      .groupBy(r => (r.mac, r.host))
+      .view
+      .mapValues { rs =>
+        (
+          rs.map(_.activeSeconds).maxOption.getOrElse(0L),
+          rs.map(_.bytesIn).sum,
+          rs.map(_.bytesOut).sum,
+        )
+      }
+      .toList
+    // #1511: build the per-(mac, host) increments in memory and ship them as ONE batched upsert
+    // instead of N sequential round trips.
+    val increments = grouped.map { case ((mac, host), (secs, bIn, bOut)) =>
+      val (bucketSecs, totalBytes) = perMacAgg.getOrElse(mac, (secs, bIn + bOut))
+      val hostBytes                = bIn + bOut
+      val proportionalSecs         =
+        if (totalBytes > 0L) (bucketSecs.toDouble * hostBytes.toDouble / totalBytes.toDouble).round
+        else bucketSecs
+      TimeUsageIncrement(mac, host, date, secs, bIn, bOut, proportionalSecs)
+    }
+    timeUsageRepo
+      .incrementSecondsAndBytesBatch(increments)
+      .mapError(ApiError.Db(_)) *>
+      deviceRepo
+        .touchLastSeenBatch(records.map(r => (r.mac, r.ip)).distinct, periodEnd)
+        .mapError(ApiError.Db(_))
+        .unit
+  }
+
+  private def handleEvents(
+      routerId: RouterId,
+      events: List[RouterEvent],
+  ): IO[ApiError, Unit] = {
+    val connInserts = events.collect {
+      case e if e.`type` == "connection_attempt" =>
+        for {
+          h    <- e.host.toRight("connection_attempt missing host")
+          ts   <- scala.util.Try(Instant.parse(e.ts)).toEither.left.map(_.getMessage)
+          allw <- e.allowed.toRight("connection_attempt missing allowed")
+          // #962: router still sends free-form text on the wire (no router-side
+          // change in this PR); convert to typed BlockReason at the API boundary.
+          rsn = BlockReason.fromWire(e.reason.getOrElse(if allw then "allow" else "blocked"))
+        } yield ConnectionEventInsert(routerId, e.mac, h, e.destIp, allw, rsn, ts, e.eventId)
+    }
+    for {
+      // Surface JSON validation errors as 400.
+      validated <- ZIO.foreach(connInserts)(e => ZIO.fromEither(e).mapError(ApiError.BadRequest(_)))
+      // #720: for each ipv4/ipv6-typed insert with a dest_ip, consult the
+      // existing connection_events for a sibling fqdn-typed event we can
+      // attribute it to. This handles the "fqdn observed first, ipv4 race-
+      // loser arrives later" arrival order at insert time.
+      enriched  <- ZIO.foreach(validated)(attachResolvedHost)
+      // #338: ON CONFLICT DO NOTHING on event_id dedups replays from the
+      // retry queue (#330). Insert returns count of new rows; the diff is
+      // duplicates collapsed on conflict.
+      inserted  <- connEventRepo
+        .insertBatch(enriched)
+        .mapError(ApiError.Db(_))
+        .when(enriched.nonEmpty)
+        .map(_.getOrElse(0))
+      _         <- ZIO
+        .logInfo(
+          s"router events: router=$routerId dedup'd ${enriched.size - inserted} of " +
+            s"${enriched.size} connection_attempt events (replay)",
+        )
+        .when(inserted < enriched.size)
+      // #720: for each fqdn-typed event we just persisted, patch prior
+      // unresolved ipv4/ipv6 rows in the same window. This handles the
+      // reverse arrival order ("ipv4 race-loser observed first, fqdn lands
+      // moments later").
+      _         <- ZIO.foreachDiscard(enriched)(backfillFromFqdn)
+      _         <- ZIO.foreachDiscard(events)(applyDhcpOrFirstSeen)
+    } yield ()
+  }
+
+  private def attachResolvedHost(
+      ev: ConnectionEventInsert,
+  ): IO[ApiError, ConnectionEventInsert] =
+    (ev.host, ev.destIp) match {
+      case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
+        connEventRepo
+          .findRecentFqdnFor(ev.routerId, destIp, ev.ts.minus(fqdnBackfillWindow))
+          .mapError(ApiError.Db(_))
+          .map(h => ev.copy(resolvedHost = h))
+      case _                                               => ZIO.succeed(ev)
+    }
+
+  private def backfillFromFqdn(
+      ev: ConnectionEventInsert,
+  ): IO[ApiError, Unit] =
+    (ev.host, ev.destIp) match {
+      case (HostId.Fqdn(name), Some(destIp)) =>
+        connEventRepo
+          .backfillResolvedFor(ev.routerId, destIp, name, ev.ts.minus(fqdnBackfillWindow))
+          .mapError(ApiError.Db(_))
+          .unit
+      case _                                 => ZIO.unit
+    }
+
+  /**
+   * DHCP lease + first-seen-MAC: upsert into devices. For a known MAC refresh last_seen_ip /
+   * last_seen_at (preserve profile) and, on a dhcp_lease with a real hostname, also upgrade the
+   * name if it is still an auto-generated placeholder (#249). For an unknown MAC, create a row with
+   * NULL profile_id and the supplied hostname (or autoGeneratedName(mac)).
+   */
+  private def applyDhcpOrFirstSeen(
+      e: RouterEvent,
+  ): IO[ApiError, Unit] =
+    if e.`type` != "dhcp_lease" && e.`type` != "first_seen_mac" then ZIO.unit
+    else
+      e.mac match {
+        case None      => ZIO.unit
+        case Some(mac) =>
+          for {
+            ts       <- ZIO
+              .attempt(Instant.parse(e.ts))
+              .orElseFail(ApiError.BadRequest(s"invalid ts: ${e.ts}"))
+            existing <- deviceRepo.findByMac(mac).mapError(ApiError.Db(_))
+            _        <- existing match {
+              case Some(_) =>
+                deviceRepo
+                  .touchLastSeen(mac, e.ip, ts)
+                  .mapError(ApiError.Db(_))
+                  .unit *>
+                  ZIO
+                    .foreachDiscard(e.hostname)(h =>
+                      deviceRepo
+                        .renameIfAutoGenerated(mac, h.value)
+                        .mapError(ApiError.Db(_)),
+                    )
+              case None    =>
+                // #711: a brand-new MAC. Insert the device row, then raise a
+                // notification for the admin. The alert repo is idempotent on
+                // `mac`, so a router replaying the same event won't resurrect
+                // a previously-dismissed alert.
+                deviceRepo
+                  .upsertUnknown(
+                    mac,
+                    e.hostname.map(_.value).getOrElse(autoGeneratedName(mac.value)),
+                    e.ip,
+                    ts,
+                  )
+                  .mapError(ApiError.Db(_))
+                  .unit *>
+                  alertRepo
+                    .raiseNewDevice(mac, ts)
+                    .mapError(ApiError.Db(_))
+            }
+          } yield ()
+      }
+}
+
+object RouterIngestService {
+
+  /**
+   * #1569: the wire-decode envelope for `usage` ingest. Identical field shape to [[UsageReport]]
+   * except `records` is held as a raw JSON array so each element can be decoded into a
+   * [[UsageRecord]] individually — a single malformed record (e.g. a host value that fails
+   * `Hostname` validation, see #1572) is then skipped + logged + metered instead of failing the
+   * whole batch. Decode-only; NOT a wire-contract type — unknown fields are still ignored.
+   */
+  private case class RawUsageReport(
+      routerId: RouterId,
+      periodStart: String,
+      periodEnd: String,
+      records: List[Json],
+  ) derives JsonDecoder
+
+  /**
+   * #1757: the wire-decode envelope for `events` ingest, the [[RouterEventsRequest]] analog of
+   * [[RawUsageReport]]. `events` is held as a raw JSON array so a single malformed event is skipped
+   * + metered rather than failing the whole batch. Decode-only; unknown fields are still ignored.
+   */
+  private case class RawEventsReport(
+      routerId: RouterId,
+      events: List[Json],
+  ) derives JsonDecoder
+
+  // #1570: a bad timestamp is a typed BadRequest (400) mapped centrally; the boundary logs it.
+  private def parseInstant(s: String): IO[ApiError, Instant] =
+    ZIO.attempt(Instant.parse(s)).orElseFail(ApiError.BadRequest(s"invalid timestamp: $s"))
+
+  /**
+   * #1569 / #1757: shared per-record skip helper used by both the `usage` (records → UsageRecord)
+   * and `events` (events → RouterEvent) flows. Decodes each `Json` element into `T` individually,
+   * logs each failure (bounded — one warn per bad slot, with the JSON index) and increments the
+   * supplied rejection metric, then returns the decoded list plus the rejected count. Bad records
+   * are skipped, NOT failed — the envelope itself must still parse upstream.
+   */
+  private def decodePerRecord[T](
+      raw: List[Json],
+      logPrefix: String,
+      itemNoun: String,
+      routerId: RouterId,
+      recordMetric: Int => UIO[Unit],
+  )(implicit decoder: JsonDecoder[T]): UIO[(List[T], Int)] = {
+    val decoded  = raw.zipWithIndex.map((j, i) => (i, j.as[T]))
+    val rejected = decoded.collect { case (i, Left(err)) => (i, err) }
+    val ok       = decoded.collect { case (_, Right(t)) => t }
+    ZIO.foreachDiscard(rejected) { (i, err) =>
+      ZIO.logWarning(
+        s"$logPrefix: skipping malformed $itemNoun[$i] for router=$routerId: $err",
+      )
+    } *> recordMetric(rejected.size).as((ok, rejected.size))
+  }
+
+  /**
+   * #720: how far back the API will look for a sibling fqdn-typed event to attribute an
+   * ipv4/ipv6-typed event to. Five minutes covers the conntrack/dns-tail jitter without inviting
+   * attribution across reused-IP cloud endpoints.
+   */
+  private val fqdnBackfillWindow: Duration = Duration.ofMinutes(5)
+
+  /**
+   * Default name for a device whose DHCP lease did not provide a hostname (option 12) — e.g. iOS
+   * Private Address clients. The last 3 octets of the MAC (lowercase, no separators) keeps the
+   * placeholder disambiguable in the admin UI rather than collapsing every such device into the
+   * literal string "unknown" (#249).
+   */
+  private[routes] def autoGeneratedName(mac: String): String = {
+    val hex = mac.toLowerCase.replace(":", "").replace("-", "")
+    "device-" + (if hex.length >= 6 then hex.takeRight(6) else hex)
+  }
+}

--- a/api/src/routes/RouterWsRegistry.scala
+++ b/api/src/routes/RouterWsRegistry.scala
@@ -1,0 +1,76 @@
+package wifihaven.api.routes
+
+import wifihaven.api.metrics.AppMetrics
+import wifihaven.shared.types.RouterId
+import zio.*
+import zio.http.WebSocketChannel
+
+/**
+ * #1846: the per-router websocket connection registry. Tracks the live [[WebSocketChannel]]s open
+ * for each [[RouterId]] so a later push path (#1849 — policy pushed on change) can look up a
+ * router's socket(s) and fan a `policy` frame out to them, and so the server can expose a "is this
+ * router connected right now?" signal (§5.5).
+ *
+ * Single-process, in-memory (`Ref[Map[RouterId, Set[WebSocketChannel]]]`). This is the right shape
+ * for the single-household model; multi-tenant pub/sub fan-out across instances is explicitly out
+ * of scope (#1023, design §6.1). A router may hold more than one channel transiently (a reconnect
+ * whose old socket has not yet been deregistered), hence a `Set` per id.
+ *
+ * Every mutation refreshes the `router_ws_connections_active` gauge to the live total channel
+ * count, so the gauge ages out cleanly on disconnect (§7).
+ */
+trait RouterWsRegistry {
+
+  /** Record a freshly-upgraded channel for `id`. Refreshes the active-connections gauge. */
+  def register(id: RouterId, channel: WebSocketChannel): UIO[Unit]
+
+  /** Drop a closed/closing channel for `id`. Refreshes the active-connections gauge. */
+  def deregister(id: RouterId, channel: WebSocketChannel): UIO[Unit]
+
+  /** The live channels for `id` (empty if the router is not connected) — the #1849 push lookup. */
+  def channelsFor(id: RouterId): UIO[Set[WebSocketChannel]]
+
+  /** True iff `id` has at least one live channel right now (§5.5 link-up signal). */
+  def isConnected(id: RouterId): UIO[Boolean]
+
+  /** Total open channels across all routers — backs `router_ws_connections_active`. */
+  def activeCount: UIO[Int]
+}
+
+object RouterWsRegistry {
+
+  def make: UIO[RouterWsRegistry] =
+    Ref.make(Map.empty[RouterId, Set[WebSocketChannel]]).map(new RouterWsRegistryLive(_))
+}
+
+final class RouterWsRegistryLive(
+    state: Ref[Map[RouterId, Set[WebSocketChannel]]],
+) extends RouterWsRegistry {
+
+  // Recompute the live total and publish it. Called after every mutation so a deregister on
+  // disconnect drives the gauge back down rather than leaving a stale high-water value.
+  private def publishActive(m: Map[RouterId, Set[WebSocketChannel]]): UIO[Unit] =
+    AppMetrics.setWsConnectionsActive(m.valuesIterator.map(_.size).sum)
+
+  def register(id: RouterId, channel: WebSocketChannel): UIO[Unit] =
+    state
+      .updateAndGet(m => m.updated(id, m.getOrElse(id, Set.empty) + channel))
+      .flatMap(publishActive)
+
+  def deregister(id: RouterId, channel: WebSocketChannel): UIO[Unit] =
+    state
+      .updateAndGet { m =>
+        val remaining = m.getOrElse(id, Set.empty) - channel
+        if remaining.isEmpty then m.removed(id) else m.updated(id, remaining)
+      }
+      .flatMap(publishActive)
+
+  def channelsFor(id: RouterId): UIO[Set[WebSocketChannel]] =
+    state.get.map(_.getOrElse(id, Set.empty))
+
+  def isConnected(id: RouterId): UIO[Boolean] =
+    state.get.map(_.get(id).exists(_.nonEmpty))
+
+  def activeCount: UIO[Int] =
+    state.get.map(_.valuesIterator.map(_.size).sum)
+}

--- a/api/src/routes/RouterWsRoutes.scala
+++ b/api/src/routes/RouterWsRoutes.scala
@@ -147,8 +147,11 @@ object RouterWsRoutes {
                 )
             case other     =>
               // Forward-compat: ignore + meter an unrecognized op (design §1.3) so a future op
-              // (e.g. policy_diff) can ship without a flag day.
-              AppMetrics.recordWsFrame(opLabel(other), "in", "unknown_op") *>
+              // (e.g. policy_diff) can ship without a flag day. The arbitrary op string is collapsed
+              // to the bounded literal `unknown` for the metric label (an attacker-supplied op must
+              // never become a Prometheus label value — cardinality firewall); the real op goes to
+              // the log only.
+              AppMetrics.recordWsFrame("unknown", "in", "unknown_op") *>
                 ZIO.logDebug(s"router ws: ignoring unknown op '$other' from router=${router.id}")
           }
         }
@@ -219,7 +222,10 @@ object RouterWsRoutes {
       status: String,
       reason: Option[String],
   ): ZIO[Any, Throwable, Unit] =
-    send(channel, WsFrame("ack", Some(WsAck(op, seq, status, reason).toJsonAST.toOption.get))) *>
+    send(
+      channel,
+      WsFrame("ack", Some(WsAck(op, seq, status, reason).toJsonAST.getOrElse(Json.Obj()))),
+    ) *>
       AppMetrics.recordWsFrame("ack", "out", status match { case "ok" => "ok"; case _ => "reject" })
 
   /** Short, bounded reason string for an ack reject — never the raw (potentially large) body. */
@@ -234,13 +240,6 @@ object RouterWsRoutes {
       case ApiError.Internal(_)      => "internal"
       case ApiError.Wrapped(_)       => "rejected"
     }
-
-  /**
-   * Collapse an unknown op string to a bounded metric label. An arbitrary string from a misbehaving
-   * client must NOT become a Prometheus label value (cardinality firewall) — every unrecognized op
-   * is reported under the single `unknown` label, while the actual op string goes to the log.
-   */
-  private def opLabel(op: String): String = "unknown"
 
   /**
    * The `{op, payload, seq}` frame envelope (design §1.2). `payload`/`seq` optional (e.g. ping).

--- a/api/src/routes/RouterWsRoutes.scala
+++ b/api/src/routes/RouterWsRoutes.scala
@@ -1,0 +1,256 @@
+package wifihaven.api.routes
+
+import wifihaven.api.db.RouterRepo
+import wifihaven.api.metrics.{AppMetrics, RouterMetricsService}
+import wifihaven.api.observability.LogContext
+import wifihaven.shared.{Router, RouterMetricsBatch}
+import zio.*
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.json.*
+import zio.json.ast.Json
+
+/**
+ * #1846: the persistent-websocket router transport, `GET /api/router/ws`. This is sub-issue A of
+ * the websocket-transport epic
+ * ([`docs/design/websocket-transport.md`](../../../docs/design/websocket-transport.md)) — the
+ * SERVER endpoint + `{op, payload}` envelope demux + per-router connection registry. It is purely
+ * additive: the REST ingest/poll/metrics endpoints stay fully live (design §3), and a router may
+ * use either transport. Capability negotiation (`hello`/`ready`, #1847), the agent ws client
+ * (#1848), and policy push-on-change (#1849) build on this and are explicitly out of scope here.
+ *
+ * Auth (design §4.1): the upgrade request carries the existing per-router bearer token; we call the
+ * SAME [[RouterAuth.authenticate]] the REST routes use, BEFORE completing the upgrade. A
+ * bad/missing token → the upgrade is rejected with the usual 401 Response (no 101) — no second auth
+ * surface (`AGENTS.md#single-source-of-truth`). The resolved [[Router]] is captured once at upgrade
+ * and carried for the connection's lifetime; every ingest is dispatched under it.
+ *
+ * Demux (design §1.2/§1.3): each frame is one JSON text message `{op, payload, seq?}`. `op` selects
+ * the logical channel and we dispatch into the SAME [[RouterIngestService]] /
+ * [[RouterMetricsService]] the REST routes call — there is no second copy of ingest logic. An
+ * unrecognized `op` is ignored + metered (`unknown_op`), the forward-compat rule that lets a future
+ * op ship without a flag day.
+ *
+ * Out of scope for #1846, with a clear seam: the `hello` op is logged + metered but NOT negotiated
+ * here — the `hello`→`ready` capability handshake and the first-policy-on-connect push land in
+ * #1847 / #1849. The agent does not yet open this socket (the Lua client is #1848); the endpoint is
+ * exercisable by a test ws client today.
+ */
+object RouterWsRoutes {
+
+  def routes(
+      auth: RouterAuth,
+      registry: RouterWsRegistry,
+      ingest: RouterIngestService,
+      metricsSvc: RouterMetricsService,
+      routerRepo: RouterRepo,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "router" / "ws" ->
+        handler { (req: Request) =>
+          // Auth at upgrade time. On failure, return the SAME 401 Response the REST routes produce
+          // (no 101) — the agent treats a ws-401 exactly like a REST-401 (drop, do not hammer).
+          auth
+            .authenticate(req)
+            .foldZIO(
+              err => ZIO.succeed(ErrorMapper.errorToResponse(err)),
+              router => socketApp(router, registry, ingest, metricsSvc, routerRepo).toResponse,
+            )
+        },
+    )
+
+  private def socketApp(
+      router: Router,
+      registry: RouterWsRegistry,
+      ingest: RouterIngestService,
+      metricsSvc: RouterMetricsService,
+      routerRepo: RouterRepo,
+  ): WebSocketApp[Any] =
+    Handler.webSocket { channel =>
+      // Register once the upgrade handshake completes; deregister unconditionally on exit (normal
+      // close, error, or interruption) so the registry + active-connections gauge never leak a dead
+      // channel. deregister is idempotent, so the explicit Unregistered handler below is harmless
+      // belt-and-suspenders.
+      channel
+        .receiveAll {
+          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            registry.register(router.id, channel) *>
+              ZIO.logInfo(s"router ws: connected router=${router.id}")
+          case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
+            // A dispatch failure (e.g. a send error) tears this frame's handling down; log the cause
+            // so a transport-level fault is debuggable, then let it surface (the socket closes and
+            // the agent reconnects per the design's reconnect-is-the-throttle rule).
+            dispatch(router, channel, text, ingest, metricsSvc, routerRepo)
+              .tapErrorCause(c =>
+                ZIO.logErrorCause(s"router ws: dispatch failed router=${router.id}", c),
+              )
+          case ChannelEvent.Unregistered                                    =>
+            registry.deregister(router.id, channel)
+          case _                                                            =>
+            ZIO.unit
+        }
+        .ensuring(
+          registry.deregister(router.id, channel) *>
+            ZIO.logInfo(s"router ws: disconnected router=${router.id}"),
+        )
+    }
+
+  /**
+   * Demux one inbound text frame. A frame that does not parse as the envelope, or carries an
+   * unrecognized `op`, is metered + logged and otherwise ignored (forward-compat, design §1.3).
+   * Data ops (`usage`/`events`/`metrics`) run through the shared ingest services and reply with an
+   * `ack` frame (`ok`/`reject`). `ping` is answered with `pong`. `hello` is the #1847 handshake
+   * seam — it is logged + metered but not yet negotiated. Every recognized frame touches
+   * `routers.last_seen_at` for uniform liveness with the REST path (design §3.1/§5.5).
+   */
+  private def dispatch(
+      router: Router,
+      channel: WebSocketChannel,
+      text: String,
+      ingest: RouterIngestService,
+      metricsSvc: RouterMetricsService,
+      routerRepo: RouterRepo,
+  ): ZIO[Any, Throwable, Unit] =
+    text.fromJson[WsFrame] match {
+      case Left(err)    =>
+        AppMetrics.recordWsFrame("unknown", "in", "reject") *>
+          ZIO.logWarning(s"router ws: undecodable frame from router=${router.id}: $err")
+      case Right(frame) =>
+        LogContext.annotate(LogContext.RouterId, router.id.toString) {
+          frame.op match {
+            case "usage"   =>
+              ingestFrame("usage", frame, channel, payload => ingest.ingestUsage(router, payload))
+            case "events"  =>
+              ingestFrame("events", frame, channel, payload => ingest.ingestEvents(router, payload))
+            case "metrics" =>
+              ingestFrame(
+                "metrics",
+                frame,
+                channel,
+                payload => ingestMetrics(router, payload, metricsSvc),
+              )
+            case "ping"    =>
+              touch(routerRepo, router) *>
+                AppMetrics.recordWsFrame("ping", "in", "ok") *>
+                send(channel, WsFrame("pong", Some(Json.Obj()))) *>
+                AppMetrics.recordWsFrame("pong", "out", "ok")
+            case "pong"    =>
+              touch(routerRepo, router) *> AppMetrics.recordWsFrame("pong", "in", "ok")
+            case "hello"   =>
+              // #1847 seam: the capability handshake (hello→ready + snapshotVersion negotiation) is
+              // NOT implemented here. Acknowledge receipt in the logs/metrics so the frame is
+              // observable, but do not negotiate or reply `ready` yet.
+              touch(routerRepo, router) *>
+                AppMetrics.recordWsFrame("hello", "in", "ok") *>
+                ZIO.logInfo(
+                  s"router ws: hello from router=${router.id} (handshake deferred to #1847)",
+                )
+            case other     =>
+              // Forward-compat: ignore + meter an unrecognized op (design §1.3) so a future op
+              // (e.g. policy_diff) can ship without a flag day.
+              AppMetrics.recordWsFrame(opLabel(other), "in", "unknown_op") *>
+                ZIO.logDebug(s"router ws: ignoring unknown op '$other' from router=${router.id}")
+          }
+        }
+    }
+
+  /**
+   * Run a data-frame payload through `ingestF` (one of the shared ingest services) and reply with
+   * an `ack` frame. On a typed [[ApiError]] we ack `reject` with a short reason (mirroring the REST
+   * 4xx/5xx the same body would have produced) rather than tearing the socket down — the agent
+   * drops the frame on a reject exactly as it drops a 4xx POST.
+   */
+  private def ingestFrame(
+      op: String,
+      frame: WsFrame,
+      channel: WebSocketChannel,
+      ingestF: String => IO[ApiError, Unit],
+  ): ZIO[Any, Throwable, Unit] = {
+    val payload = frame.payload.map(_.toString).getOrElse("")
+    ingestF(payload).foldZIO(
+      err =>
+        AppMetrics.recordWsFrame(op, "in", "reject") *>
+          ZIO.logWarning(s"router ws: $op frame rejected: ${rejectReason(err)}") *>
+          sendAck(channel, op, frame.seq, "reject", Some(rejectReason(err))),
+      _ =>
+        AppMetrics.recordWsFrame(op, "in", "ok") *>
+          sendAck(channel, op, frame.seq, "ok", None),
+    )
+  }
+
+  /**
+   * Decode + ingest a `metrics` frame payload. Mirrors `POST /api/router/metrics`
+   * ([[RouterMetricsRoutes]]): a malformed batch or a `routerId` that doesn't match the token's
+   * router is a typed error (so the ws path acks `reject`); a good batch folds through the shared
+   * [[RouterMetricsService]].
+   */
+  private def ingestMetrics(
+      router: Router,
+      payload: String,
+      metricsSvc: RouterMetricsService,
+  ): IO[ApiError, Unit] =
+    for {
+      batch <- ZIO
+        .fromEither(payload.fromJson[RouterMetricsBatch])
+        .mapError(ApiError.DecodeFailure(_))
+        .tapError(_ => AppMetrics.recordRouterMetricsBatch("malformed"))
+      _     <- (AppMetrics.recordRouterMetricsBatch("router_mismatch") *>
+        ZIO.fail(ApiError.BadRequest("router_id mismatch")))
+        .when(batch.routerId != router.id)
+      _     <- metricsSvc.ingest(batch)
+      _     <- AppMetrics.recordRouterMetricsBatch("ok")
+    } yield ()
+
+  private def touch(routerRepo: RouterRepo, router: Router): UIO[Unit] =
+    routerRepo
+      .touch(router.id, None, None)
+      .catchAll(e =>
+        ZIO.logWarning(s"router ws: last_seen touch failed for router=${router.id}: $e"),
+      )
+      .unit
+
+  private def send(channel: WebSocketChannel, frame: WsFrame): ZIO[Any, Throwable, Unit] =
+    channel.send(ChannelEvent.read(WebSocketFrame.text(frame.toJson)))
+
+  private def sendAck(
+      channel: WebSocketChannel,
+      op: String,
+      seq: Option[Int],
+      status: String,
+      reason: Option[String],
+  ): ZIO[Any, Throwable, Unit] =
+    send(channel, WsFrame("ack", Some(WsAck(op, seq, status, reason).toJsonAST.toOption.get))) *>
+      AppMetrics.recordWsFrame("ack", "out", status match { case "ok" => "ok"; case _ => "reject" })
+
+  /** Short, bounded reason string for an ack reject — never the raw (potentially large) body. */
+  private def rejectReason(err: ApiError): String =
+    err match {
+      case ApiError.BadRequest(m)    => s"bad_request: $m".take(200)
+      case ApiError.DecodeFailure(m) => s"decode_error: $m".take(200)
+      case ApiError.Unauthorized(_)  => "unauthorized"
+      case ApiError.Forbidden(_)     => "forbidden"
+      case ApiError.NotFound(_)      => "not_found"
+      case ApiError.Db(_)            => "db_error"
+      case ApiError.Internal(_)      => "internal"
+      case ApiError.Wrapped(_)       => "rejected"
+    }
+
+  /**
+   * Collapse an unknown op string to a bounded metric label. An arbitrary string from a misbehaving
+   * client must NOT become a Prometheus label value (cardinality firewall) — every unrecognized op
+   * is reported under the single `unknown` label, while the actual op string goes to the log.
+   */
+  private def opLabel(op: String): String = "unknown"
+
+  /**
+   * The `{op, payload, seq}` frame envelope (design §1.2). `payload`/`seq` optional (e.g. ping).
+   */
+  private case class WsFrame(op: String, payload: Option[Json] = None, seq: Option[Int] = None)
+      derives JsonCodec
+
+  /**
+   * The `ack` frame payload (design §1.3): which data frame, its seq, ok/reject, optional reason.
+   */
+  private case class WsAck(op: String, seq: Option[Int], status: String, reason: Option[String])
+      derives JsonCodec
+}

--- a/api/test/src/feature/RouterWsSpec.scala
+++ b/api/test/src/feature/RouterWsSpec.scala
@@ -1,7 +1,9 @@
 package wifihaven.api.feature
 
+import wifihaven.api.{ErrorBoundary, Readiness}
 import wifihaven.api.db.*
-import wifihaven.api.metrics.RouterMetricsService
+import wifihaven.api.metrics.{HttpMetrics, RouterMetricsService}
+import wifihaven.api.observability.LoggingMiddleware
 import wifihaven.api.routes.*
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -64,7 +66,17 @@ object RouterWsSpec
       reg     <- RouterWsRegistry.make
       auth   = new RouterAuthLive(rRepo)
       ingest = new RouterIngestService(rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr)
-      routes = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo)
+      // Mount the ws route through the SAME aspect stack `Main` wraps the router routes in
+      // (HttpMetrics.instrument → LoggingMiddleware.annotate → Readiness.gate → ErrorBoundary.observe)
+      // so the test proves the HTTP/1.1 upgrade survives the production middleware, not just the raw
+      // route. These aspects are response-transparent for a websocket Response, but pinning it here
+      // closes the gap between the test path and the assembled prod path.
+      raw    = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo)
+      routes = HttpMetrics.instrument(
+        LoggingMiddleware.annotate(
+          Readiness.gate(ErrorBoundary.observe(raw), ZIO.succeed(true)),
+        ),
+      )
     } yield (routes, reg)
 
   /**

--- a/api/test/src/feature/RouterWsSpec.scala
+++ b/api/test/src/feature/RouterWsSpec.scala
@@ -1,0 +1,179 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.metrics.RouterMetricsService
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import doobie.Transactor
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.json.*
+import zio.test.*
+
+import java.time.{Instant, LocalDateTime}
+
+/**
+ * #1846: server-side websocket transport. Exercises the real `/api/router/ws` endpoint end to end —
+ * a real [[Server]] on an ephemeral port and a real ws [[Client]] — to prove upgrade-time auth, the
+ * `{op, payload}` demux dispatching into the shared ingest service, the per-router connection
+ * registry, and the heartbeat (`ping`→`pong`). The REST ingest path stays covered by
+ * [[RouterIngestSpec]], which is the back-compat gate for the transport-agnostic ingest extraction.
+ */
+object RouterWsSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
+
+  private val testClockAt: LocalDateTime = LocalDateTime.of(2026, 5, 7, 14, 0, 0)
+
+  override val bootstrap = TestDatabase.layer ++ TestLayers.withClock(testClockAt)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val periodStart = Instant.parse("2026-05-07T14:00:00Z")
+  private val periodEnd   = Instant.parse("2026-05-07T14:05:00Z")
+  private val knownMac    = "aa:bb:cc:11:22:33"
+
+  private def seedRouter(rRepo: RouterRepo): Task[(RouterId, String)] = {
+    val token = "ROUTER_TOKEN_PLAIN"
+    val hash  = Sha256Hex.unsafe(RouterAuth.sha256Hex(token))
+    for {
+      id <- rRepo.create("test-router", Sha256Hex.unsafe("m" * 64))
+      _  <- rRepo.completeEnrollment(id, hash)
+    } yield (id, token)
+  }
+
+  private def seedKnownDevice(dRepo: DeviceRepo, profileRepo: ProfileRepo): Task[Unit] =
+    for {
+      pid <- profileRepo.create("Kids", List(BlocklistId.unsafe("adult")))
+      _   <- dRepo.upsert(MacAddress.unsafe(knownMac), "kid-ipad", Some(pid), "192.168.1.10")
+    } yield ()
+
+  private def buildWsRoutes =
+    for {
+      rRepo   <- ZIO.service[RouterRepo]
+      tRepo   <- ZIO.service[TrafficReportRepo]
+      tu      <- ZIO.service[TimeUsageRepo]
+      dRepo   <- ZIO.service[DeviceRepo]
+      cRepo   <- ZIO.service[ConnectionEventRepo]
+      aRepo   <- ZIO.service[AlertRepo]
+      hsr     <- ZIO.service[HouseholdSettingsRepo]
+      metrics <- RouterMetricsService.make
+      reg     <- RouterWsRegistry.make
+      auth   = new RouterAuthLive(rRepo)
+      ingest = new RouterIngestService(rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr)
+      routes = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo)
+    } yield (routes, reg)
+
+  /**
+   * Open a ws connection to the bound server, run `clientBehavior` (which drives the channel and
+   * resolves `firstServerText` with the first text frame the server sends back), and return that
+   * frame. Connects with the given bearer header.
+   */
+  private def connectAndCapture[B](
+      port: Int,
+      bearer: Option[String],
+      send: WebSocketChannel => ZIO[Any, Throwable, Unit],
+      probe: ZIO[Any, Throwable, B],
+  ): ZIO[Client, Throwable, (String, B)] =
+    Promise.make[Nothing, String].flatMap { firstServerText =>
+      val app     = Handler.webSocket { channel =>
+        channel.receiveAll {
+          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            send(channel)
+          case ChannelEvent.Read(WebSocketFrame.Text(t))                    =>
+            firstServerText.succeed(t).unit
+          case _                                                            =>
+            ZIO.unit
+        }
+      }
+      val headers = bearer.fold(Headers.empty)(t => Headers(Header.Authorization.Bearer(t)))
+      // Drive the connection in a LOCAL scope closed as soon as we have the server's reply, so the
+      // ws fiber is interrupted promptly and the test does not wait on connection teardown. `probe`
+      // runs INSIDE the scope (connection still open) so a registry-liveness check observes the live
+      // channel rather than racing the post-scope deregister.
+      ZIO.scoped {
+        for {
+          _ <- app.connect(s"ws://localhost:$port/api/router/ws", headers).forkScoped
+          t <- firstServerText.await
+            .timeoutFail(new RuntimeException("no server frame within 30s"))(30.seconds)
+          b <- probe
+        } yield (t, b)
+      }
+    }
+
+  def spec = suite("Router websocket /api/router/ws")(
+    test("rejects the upgrade with 401 when the bearer token is missing or invalid") {
+      for {
+        _           <- cleanDb
+        (routes, _) <- buildWsRoutes
+        noToken     <- routes.runZIO(
+          Request.get(URL.decode("/api/router/ws").toOption.get),
+        )
+        badToken    <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/ws").toOption.get)
+            .addHeader(Header.Authorization.Bearer("not-a-real-token")),
+        )
+      } yield assertTrue(noToken.status == Status.Unauthorized) &&
+        assertTrue(badToken.status == Status.Unauthorized)
+    },
+    test("a usage frame ingests through the shared service and the server acks ok") {
+      (for {
+        _             <- cleanDb
+        rRepo         <- ZIO.service[RouterRepo]
+        pRepo         <- ZIO.service[ProfileRepo]
+        dRepo         <- ZIO.service[DeviceRepo]
+        tRepo         <- ZIO.service[TrafficReportRepo]
+        _             <- seedKnownDevice(dRepo, pRepo)
+        (id, tk)      <- seedRouter(rRepo)
+        (routes, reg) <- buildWsRoutes
+        port          <- Server.install(routes)
+        rec       = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          Some(IpAddress.unsafe("192.168.1.10")),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          240L,
+          1000L,
+          500L,
+        )
+        usageBody = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        frame     = s"""{"op":"usage","seq":7,"payload":$usageBody}"""
+        result <- connectAndCapture(
+          port,
+          Some(tk),
+          ch => ch.send(ChannelEvent.read(WebSocketFrame.text(frame))),
+          reg.isConnected(id),
+        )
+        (ack, connected) = result
+        rows <- tRepo.listForRouter(id, 100)
+      } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
+        assertTrue(ack.contains("\"status\":\"ok\"")) &&
+        assertTrue(ack.contains("\"seq\":7")) &&
+        assertTrue(rows.size == 1) &&
+        assertTrue(connected)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    test("a ping frame is answered with a pong") {
+      (for {
+        _           <- cleanDb
+        rRepo       <- ZIO.service[RouterRepo]
+        (id, tk)    <- seedRouter(rRepo)
+        (routes, _) <- buildWsRoutes
+        port        <- Server.install(routes)
+        result      <- connectAndCapture(
+          port,
+          Some(tk),
+          ch => ch.send(ChannelEvent.read(WebSocketFrame.text("""{"op":"ping"}"""))),
+          ZIO.unit,
+        )
+        pong = result._1
+      } yield assertTrue(pong.contains("\"op\":\"pong\""))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.timeout(90.seconds)
+}

--- a/deploy/grafana/dashboards/router-ws-transport.json
+++ b/deploy/grafana/dashboards/router-ws-transport.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven websocket router transport (#1846, epic #1023): server-side health for the persistent /api/router/ws endpoint. Panels target only the series the API actually emits today \u2014 router_ws_connections_active (RouterWsRegistry) and router_ws_frames_total{op,dir,result} (RouterWsRoutes demux). The REST transport stays the fallback; until the agent ws client (#1848) ships these read 0/flat. Push-on-change health (router_ws_policy_push_total) lands with #1849. Labels are bounded enums only per the \u00a74 cardinality firewall. datasource/env are templated for per-environment view.",
+  "description": "WifiHaven websocket router transport (#1846, epic #1023): server-side health for the persistent /api/router/ws endpoint. Panels target only the series the API actually emits today \u2014 router_ws_connections_active (RouterWsRegistry) and router_ws_frames_total{op,direction,result} (RouterWsRoutes demux). The REST transport stays the fallback; until the agent ws client (#1848) ships these read 0/flat. Push-on-change health (router_ws_policy_push_total) lands with #1849. Labels are bounded enums only per the \u00a74 cardinality firewall. datasource/env are templated for per-environment view.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -84,8 +84,8 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "title": "Websocket frame rate by op/dir/result (#1846)",
-      "description": "sum by (op, dir, result) (rate(router_ws_frames_total[5m])) \u2014 frame throughput across the {op,payload} demux. dir \u2208 {in,out}; result \u2208 {ok,reject,unknown_op}. A rising result=reject share means agents are sending frames the server rejects (the ws analog of a REST 4xx); result=unknown_op is the forward-compat counter for frames whose op the server does not recognize (design \u00a71.3).",
+      "title": "Websocket frame rate by op/direction/result (#1846)",
+      "description": "sum by (op, direction, result) (rate(router_ws_frames_total[5m])) \u2014 frame throughput across the {op,payload} demux. dir \u2208 {in,out}; result \u2208 {ok,reject,unknown_op}. A rising result=reject share means agents are sending frames the server rejects (the ws analog of a REST 4xx); result=unknown_op is the forward-compat counter for frames whose op the server does not recognize (design \u00a71.3).",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -134,8 +134,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (op, dir, result) (rate(router_ws_frames_total{env=\"$env\"}[5m]))",
-          "legendFormat": "{{op}} {{dir}} {{result}}",
+          "expr": "sum by (op, direction, result) (rate(router_ws_frames_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}} {{direction}} {{result}}",
           "refId": "A"
         }
       ]

--- a/deploy/grafana/dashboards/router-ws-transport.json
+++ b/deploy/grafana/dashboards/router-ws-transport.json
@@ -1,0 +1,324 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "WifiHaven websocket router transport (#1846, epic #1023): server-side health for the persistent /api/router/ws endpoint. Panels target only the series the API actually emits today \u2014 router_ws_connections_active (RouterWsRegistry) and router_ws_frames_total{op,dir,result} (RouterWsRoutes demux). The REST transport stays the fallback; until the agent ws client (#1848) ships these read 0/flat. Push-on-change health (router_ws_policy_push_total) lands with #1849. Labels are bounded enums only per the \u00a74 cardinality firewall. datasource/env are templated for per-environment view.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Websocket connections active (#1846)",
+      "description": "router_ws_connections_active \u2014 live count of open /api/router/ws channels, refreshed on every register/deregister so it ages out cleanly on disconnect. The single \"how many routers are on the ws transport right now?\" signal; 0 while REST ingest flows means no agent has migrated yet (the Lua ws client is #1848).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "router_ws_connections_active{env=\"$env\"}",
+          "legendFormat": "active channels",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Websocket frame rate by op/dir/result (#1846)",
+      "description": "sum by (op, dir, result) (rate(router_ws_frames_total[5m])) \u2014 frame throughput across the {op,payload} demux. dir \u2208 {in,out}; result \u2208 {ok,reject,unknown_op}. A rising result=reject share means agents are sending frames the server rejects (the ws analog of a REST 4xx); result=unknown_op is the forward-compat counter for frames whose op the server does not recognize (design \u00a71.3).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (op, dir, result) (rate(router_ws_frames_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}} {{dir}} {{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Websocket frames by op (rate)",
+      "description": "sum by (op) (rate(router_ws_frames_total[5m])) \u2014 total frame rate per logical channel (hello/usage/events/metrics/ping/pong/ack). Lets an operator see which flows dominate the socket and confirm heartbeats (ping/pong) are ticking.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (op) (rate(router_ws_frames_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Websocket reject + unknown_op rate",
+      "description": "sum by (op) (rate(router_ws_frames_total{result=~\"reject|unknown_op\"}[5m])) \u2014 the error surface of the transport isolated. Steady non-zero here is the first sign agents and server disagree on the wire (a bad payload, or an op one side hasn't shipped yet).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (op, result) (rate(router_ws_frames_total{env=\"$env\",result=~\"reject|unknown_op\"}[5m]))",
+          "legendFormat": "{{op}} {{result}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wifihaven",
+    "router",
+    "websocket"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "prod",
+          "value": "prod"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [
+          {
+            "selected": true,
+            "text": "prod",
+            "value": "prod"
+          },
+          {
+            "selected": false,
+            "text": "staging",
+            "value": "staging"
+          }
+        ],
+        "query": "prod,staging",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-wifihaven-prom",
+          "value": "grafanacloud-prom"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "WifiHaven \u2014 Router WS transport",
+  "uid": "wifihaven-router-ws-transport",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -81,7 +81,7 @@ provider "grafana" {
 
 locals {
   folder     = var.folder_uid != "" ? var.folder_uid : null
-  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health", "db-health", "data-quality-ingest", "enforcement"]
+  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health", "db-health", "data-quality-ingest", "enforcement", "router-ws-transport"]
   dashfiles  = { for name in local.dashboards : name => "${path.module}/../../deploy/grafana/dashboards/${name}.json" }
 }
 

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -349,9 +349,12 @@ done
 pass "REST usage/events/metrics accepted (200)"
 
 # ws leg — send all three frames over one connection; every reply must be ack ok.
+# `|| true` so a ws_send.py failure doesn't abort under `set -e` before we can
+# surface it: on error the helper prints `{"error":…}` to stdout, which the
+# ACKS_OK parse below reports verbatim in the fail message.
 WS_REPLIES=$(printf '%s' "$PARITY" \
   | _py "import json,sys; print(json.dumps(json.load(sys.stdin)['ws_frames']))" \
-  | python3 "$WS_SEND" --url "$WS_URL" --token "$RTOK")
+  | python3 "$WS_SEND" --url "$WS_URL" --token "$RTOK" || true)
 ACKS_OK=$(printf '%s' "$WS_REPLIES" | _py "
 import json, sys
 replies = json.load(sys.stdin)

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -274,6 +274,122 @@ curl -fsS -X POST "$BASE/api/router/events" "${RAUTH[@]}" \
   -d "$EVTS" >/dev/null
 pass "dhcp_lease + 3 connection_attempt shapes posted"
 
+# ── 4b. #1846: WS↔REST ingest-transport demux parity ──────────────────────
+#
+# The websocket transport (GET /api/router/ws) demuxes {op,payload} frames into
+# the SAME RouterIngestService / RouterMetricsService the REST endpoints call.
+# Prove that end-to-end against the real API — this script runs against both the
+# in-docker compose stack and deployed staging — by sending identical payloads
+# over REST and over ws frames and asserting:
+#   (a) the ws upgrade authenticates exactly like REST (bad/missing → 401, valid → 101),
+#   (b) every usage/events/metrics frame is acked ok, and
+#   (c) the connection events land identically whether posted via REST or ws
+#       (read back through the public /api/logs surface — staging has no
+#        /api/debug/*, so this uses the same endpoint the #1122 step does).
+# Usage/metrics are validated at acceptance granularity (REST 200 == ws ack ok)
+# since neither exposes a per-mac public readback on staging; the events leg is
+# the deep parity proof of the shared ingest path.
+step "#1846: websocket transport demux parity with REST"
+
+WS_SEND="$E2E_LIB/ws_send.py"
+WS_URL="$(printf '%s' "$BASE" | sed -e 's#^http#ws#')/api/router/ws"
+ws_status() { python3 "$WS_SEND" --url "$WS_URL" "$@" --expect-upgrade-status \
+  | _py 'import json,sys; print(json.load(sys.stdin)["status"])'; }
+
+st_none=$(ws_status)
+st_bad=$(ws_status --token bogus-token)
+st_ok=$(ws_status --token "$RTOK")
+{ [ "$st_none" = 401 ] && [ "$st_bad" = 401 ]; } \
+  || fail "ws upgrade not 401 for missing/bad token (none=$st_none bad=$st_bad)"
+[ "$st_ok" = 101 ] || fail "ws upgrade not 101 for valid token (got $st_ok)"
+pass "ws upgrade auth parity: missing/bad → 401, valid → 101"
+
+# Disjoint MACs so the REST and ws connection-event rows compare side by side.
+PARITY_TS="$(_py 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+MAC_REST="e2:e2:e3:${mac_suffix:0:2}:${mac_suffix:2:2}:${mac_suffix:4:2}"
+MAC_WS="e2:e2:e4:${mac_suffix:0:2}:${mac_suffix:2:2}:${mac_suffix:4:2}"
+
+# Build the REST bodies + the ws frame array together so payloads are identical
+# bar the MAC. usage/events carry routerId=$RID (the authed router); the ws
+# frames wrap the same bodies under {op,payload,seq}.
+PARITY=$(_py "
+import json, uuid
+rid, ts = '$RID', '$PARITY_TS'
+def events(mac):
+    return {'routerId': rid, 'events': [
+        {'type':'connection_attempt','mac':mac,'host':{'type':'fqdn','value':'youtube.com'},
+         'destIp':'203.0.113.51','allowed':False,'reason':'category:adult','ts':ts,'eventId':str(uuid.uuid4())},
+        {'type':'connection_attempt','mac':mac,'host':{'type':'fqdn','value':'khanacademy.org'},
+         'destIp':'203.0.113.52','allowed':True,'reason':'allow','ts':ts,'eventId':str(uuid.uuid4())},
+    ]}
+def usage(mac):
+    return {'routerId': rid, 'periodStart': ts, 'periodEnd': ts,
+            'records': [{'mac':mac,'ip':'192.168.50.10','host':{'type':'fqdn','value':'youtube.com'},
+                         'activeSeconds':240,'bytesIn':100000,'bytesOut':50000}]}
+def metrics():
+    return {'routerId': rid, 'agentVersion':'ws-parity-e2e','agentStartedAt':ts,'sampledAt':ts,
+            'gauges':[{'name':'agent_uptime_seconds','value':4242.0}]}
+print(json.dumps({
+  'rest_events': events('$MAC_REST'), 'rest_usage': usage('$MAC_REST'), 'rest_metrics': metrics(),
+  'ws_frames': [
+    {'op':'events','seq':1,'payload': events('$MAC_WS')},
+    {'op':'usage','seq':2,'payload': usage('$MAC_WS')},
+    {'op':'metrics','seq':3,'payload': metrics()},
+  ],
+}))
+")
+
+# REST legs — each must 200.
+for kind in events usage metrics; do
+  body=$(printf '%s' "$PARITY" | _py "import json,sys; print(json.dumps(json.load(sys.stdin)['rest_$kind']))")
+  code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/api/router/$kind" "${RAUTH[@]}" \
+    -H 'content-type: application/json' -d "$body")
+  [ "$code" = 200 ] || fail "REST /api/router/$kind returned $code (expected 200)"
+done
+pass "REST usage/events/metrics accepted (200)"
+
+# ws leg — send all three frames over one connection; every reply must be ack ok.
+WS_REPLIES=$(printf '%s' "$PARITY" \
+  | _py "import json,sys; print(json.dumps(json.load(sys.stdin)['ws_frames']))" \
+  | python3 "$WS_SEND" --url "$WS_URL" --token "$RTOK")
+ACKS_OK=$(printf '%s' "$WS_REPLIES" | _py "
+import json, sys
+replies = json.load(sys.stdin)
+ok = (isinstance(replies, list) and len(replies) == 3
+      and all(r.get('op') == 'ack' and (r.get('payload') or {}).get('status') == 'ok' for r in replies))
+print('ok' if ok else 'bad: ' + json.dumps(replies))
+")
+[ "$ACKS_OK" = ok ] || fail "ws frames not all acked ok: $ACKS_OK"
+pass "ws usage/events/metrics frames each acked ok"
+
+# (c) Deep parity — the connection events land identically whether posted over
+# REST or ws. Read both MACs via the public /api/logs and compare the
+# (host, allowed, reason-kind) projection.
+proj_for() { # $1 = mac → sorted JSON projection of that mac's youtube/khan events
+  curl -fsS "${AUTH[@]}" "$BASE/api/logs?mac=$1&hours=1" | _py "
+import json, sys
+rows = json.load(sys.stdin).get('rows', [])
+def host(r):
+    h = r.get('host') or {}
+    return h.get('value','') if h.get('type') == 'fqdn' else ''
+print(json.dumps(sorted(
+    (host(r), bool(r.get('allowed')), (r.get('reason') or {}).get('kind'))
+    for r in rows if host(r) in ('youtube.com', 'khanacademy.org'))))
+"
+}
+REST_PROJ=""; WS_PROJ=""
+deadline=$(( $(date +%s) + 15 ))
+while (( $(date +%s) < deadline )); do
+  REST_PROJ=$(proj_for "$MAC_REST"); WS_PROJ=$(proj_for "$MAC_WS")
+  n=$(printf '%s' "$REST_PROJ" | _py 'import json,sys; print(len(json.load(sys.stdin)))')
+  { [ "$n" = 2 ] && [ "$REST_PROJ" = "$WS_PROJ" ]; } && break
+  sleep 1
+done
+[ "$REST_PROJ" = "$WS_PROJ" ] || fail "ws/REST event parity mismatch: rest=$REST_PROJ ws=$WS_PROJ"
+[ "$(printf '%s' "$REST_PROJ" | _py 'import json,sys; print(len(json.load(sys.stdin)))')" = 2 ] \
+  || fail "expected 2 events per transport, got rest=$REST_PROJ"
+pass "ws and REST connection events landed identically via /api/logs"
+
 # ── 5a. #1122: nflog-synthesized blocked-MAC events end-to-end ────────────
 #
 # Server-side half of #1122 (router-side half lives in

--- a/scripts/e2e/lib/ws_send.py
+++ b/scripts/e2e/lib/ws_send.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Stdlib-only websocket client for the router→API transport e2e (#1846).
+
+Drives the API's `/api/router/ws` endpoint the way a fake router agent would,
+using ONLY the Python standard library (socket + ssl + hashlib) so it runs in
+the bare e2e shells (`scripts/e2e-router.sh`) against both the in-docker stack
+(`ws://`) and deployed staging (`wss://`) without any pip install.
+
+Usage:
+    echo '[{"op":"events","seq":1,"payload":{…}}, …]' \
+        | ws_send.py --url ws://127.0.0.1:8080/api/router/ws --token "$RTOK"
+
+Reads a JSON array of `{op,payload,seq}` frames on stdin, sends each over one
+authenticated connection, and prints a JSON array of the server's reply frames
+(one per sent frame — the `ack`/`pong`) on stdout. Exit non-zero (with a JSON
+`{"error":…}` on stdout) if the upgrade is rejected or the socket dies.
+
+A standalone `--expect-upgrade-status` mode just performs the upgrade and prints
+the HTTP status (101 on success, 401 on a bad/missing bearer) — used to assert
+auth-at-upgrade parity with the REST 401 without sending any frame.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import ssl
+import struct
+import sys
+from urllib.parse import urlparse
+
+_OPCODE_TEXT = 0x1
+_OPCODE_CLOSE = 0x8
+_OPCODE_PING = 0x9
+_OPCODE_PONG = 0xA
+
+
+class UpgradeRejected(Exception):
+    def __init__(self, status: int, detail: str = ""):
+        super().__init__(f"ws upgrade rejected: HTTP {status} {detail}".strip())
+        self.status = status
+
+
+def _open(url: str, token: str | None, timeout: float):
+    u = urlparse(url)
+    if u.scheme not in ("ws", "wss"):
+        raise ValueError(f"url must be ws:// or wss://, got {url!r}")
+    host = u.hostname
+    port = u.port or (443 if u.scheme == "wss" else 80)
+    path = u.path or "/"
+    if u.query:
+        path += "?" + u.query
+
+    sock: socket.socket = socket.create_connection((host, port), timeout=timeout)
+    if u.scheme == "wss":
+        ctx = ssl.create_default_context()
+        sock = ctx.wrap_socket(sock, server_hostname=host)
+
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    lines = [
+        f"GET {path} HTTP/1.1",
+        f"Host: {host}:{port}",
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        f"Sec-WebSocket-Key: {key}",
+        "Sec-WebSocket-Version: 13",
+    ]
+    if token:
+        lines.append(f"Authorization: Bearer {token}")
+    sock.sendall(("\r\n".join(lines) + "\r\n\r\n").encode("ascii"))
+
+    # Read the handshake response (headers end at the first blank line).
+    buf = bytearray()
+    while b"\r\n\r\n" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise RuntimeError("connection closed during ws handshake")
+        buf += chunk
+    head, _, rest = bytes(buf).partition(b"\r\n\r\n")
+    status_line = head.split(b"\r\n", 1)[0].decode("latin1")
+    try:
+        status = int(status_line.split()[1])
+    except (IndexError, ValueError) as e:
+        raise RuntimeError(f"malformed ws handshake status line: {status_line!r}") from e
+    if status != 101:
+        raise UpgradeRejected(status, status_line)
+    return sock, bytearray(rest)
+
+
+def _send_text(sock: socket.socket, text: str) -> None:
+    payload = text.encode("utf-8")
+    n = len(payload)
+    header = bytearray([0x80 | _OPCODE_TEXT])  # FIN + text opcode
+    mask_flag = 0x80  # client frames MUST be masked (RFC 6455 §5.3)
+    if n < 126:
+        header.append(mask_flag | n)
+    elif n < 65536:
+        header.append(mask_flag | 126)
+        header += struct.pack(">H", n)
+    else:
+        header.append(mask_flag | 127)
+        header += struct.pack(">Q", n)
+    mask = os.urandom(4)
+    header += mask
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    sock.sendall(bytes(header) + masked)
+
+
+def _recv_frame(sock: socket.socket, buf: bytearray) -> tuple[int, bytes]:
+    def need(total: int) -> None:
+        # buf.extend (in-place) not `buf += chunk`: an augmented assignment would
+        # rebind `buf` as a local of this nested function → UnboundLocalError.
+        while len(buf) < total:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise RuntimeError("connection closed mid-frame")
+            buf.extend(chunk)
+
+    need(2)
+    b0, b1 = buf[0], buf[1]
+    opcode = b0 & 0x0F
+    masked = b1 & 0x80
+    length = b1 & 0x7F
+    idx = 2
+    if length == 126:
+        need(4)
+        length = struct.unpack(">H", bytes(buf[2:4]))[0]
+        idx = 4
+    elif length == 127:
+        need(10)
+        length = struct.unpack(">Q", bytes(buf[2:10]))[0]
+        idx = 10
+    mask = b""
+    if masked:  # servers don't mask, but handle it for completeness
+        need(idx + 4)
+        mask = bytes(buf[idx:idx + 4])
+        idx += 4
+    need(idx + length)
+    data = bytes(buf[idx:idx + length])
+    if masked:
+        data = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+    del buf[:idx + length]
+    return opcode, data
+
+
+def _close(sock: socket.socket) -> None:
+    try:
+        # Masked close frame, no payload.
+        mask = os.urandom(4)
+        sock.sendall(bytes([0x80 | _OPCODE_CLOSE, 0x80]) + mask)
+        sock.close()
+    except OSError:
+        pass
+
+
+def send_frames(url: str, token: str | None, frames: list[dict], timeout: float) -> list[dict]:
+    sock, buf = _open(url, token, timeout)
+    sock.settimeout(timeout)
+    replies: list[dict] = []
+    try:
+        for frame in frames:
+            _send_text(sock, json.dumps(frame))
+            # Read the next data (text) frame, answering any control frames.
+            while True:
+                opcode, data = _recv_frame(sock, buf)
+                if opcode == _OPCODE_TEXT:
+                    replies.append(json.loads(data.decode("utf-8")))
+                    break
+                if opcode == _OPCODE_PING:
+                    continue  # benign; server-initiated control ping
+                if opcode == _OPCODE_CLOSE:
+                    raise RuntimeError("server closed the socket before replying")
+                # ignore pong / continuation
+    finally:
+        _close(sock)
+    return replies
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True, help="ws:// or wss:// URL of /api/router/ws")
+    ap.add_argument("--token", default=None, help="router bearer token (omit to test the 401 path)")
+    ap.add_argument("--timeout", type=float, default=15.0)
+    ap.add_argument(
+        "--expect-upgrade-status",
+        action="store_true",
+        help="just attempt the upgrade and print the HTTP status (101/401)",
+    )
+    args = ap.parse_args()
+
+    if args.expect_upgrade_status:
+        try:
+            sock, _ = _open(args.url, args.token, args.timeout)
+            _close(sock)
+            print(json.dumps({"status": 101}))
+            return 0
+        except UpgradeRejected as e:
+            print(json.dumps({"status": e.status}))
+            return 0
+
+    try:
+        frames = json.load(sys.stdin)
+        if not isinstance(frames, list):
+            raise ValueError("stdin must be a JSON array of frames")
+        replies = send_frames(args.url, args.token, frames, args.timeout)
+        print(json.dumps(replies))
+        return 0
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e/lib/ws_send.py
+++ b/scripts/e2e/lib/ws_send.py
@@ -56,6 +56,10 @@ def _open(url: str, token: str | None, timeout: float):
     sock: socket.socket = socket.create_connection((host, port), timeout=timeout)
     if u.scheme == "wss":
         ctx = ssl.create_default_context()
+        # Pin a TLS 1.2 floor — create_default_context() otherwise still permits
+        # TLSv1/1.1 (CodeQL py/insecure-protocol). Staging terminates modern TLS,
+        # so this only forbids the obsolete versions.
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         sock = ctx.wrap_socket(sock, server_hostname=host)
 
     key = base64.b64encode(os.urandom(16)).decode("ascii")


### PR DESCRIPTION
## What & why

Sub-issue **A** of the websocket-transport epic ([#1023](https://github.com/wifihaven/wifihaven/issues/1023); design [`docs/design/websocket-transport.md`](https://github.com/wifihaven/wifihaven/blob/main/docs/design/websocket-transport.md), spike [#1845](https://github.com/wifihaven/wifihaven/issues/1845) GO). This is the **server side** of the transport — the foundation the capability handshake ([#1847](https://github.com/wifihaven/wifihaven/issues/1847)), agent ws client ([#1848](https://github.com/wifihaven/wifihaven/issues/1848)), and push-on-change ([#1849](https://github.com/wifihaven/wifihaven/issues/1849)) build on.

**Purely additive** — the REST ingest/poll/metrics endpoints stay fully live (design §3); a router may use either transport. No wire-visible change to existing endpoints.

## Changes

- **`RouterWsRoutes`** — `GET /api/router/ws` via zio-http `Handler.webSocket`. Auth at upgrade time through the **existing** `RouterAuth.authenticate` (bad/missing token → 401, no 101 — same semantics as the REST 401, design §4.1); the resolved `Router` is captured once and carried for the connection. The `{op, payload, seq?}` envelope (§1.2) is demuxed on `op`:
  - `usage` / `events` / `metrics` → dispatch into the **shared** ingest services, reply with an `ack` (`ok`/`reject`).
  - `ping` → `pong` (heartbeat).
  - `hello` → logged + metered **seam** for #1847 (no `ready` negotiation here).
  - unknown `op` → ignored + metered (`unknown_op`) — forward-compat (§1.3).
  - Every frame touches `routers.last_seen_at` for uniform liveness with REST (§5.5).
- **`RouterIngestService`** — extracted the `usage`/`events` decode + per-record-skip + persistence logic out of `RouterIngestRoutes` with **no behavior change**, so REST and ws share **one** implementation (`AGENTS.md#single-source-of-truth`). REST routes are now thin adapters; a convenience overload keeps existing call sites/tests unchanged.
- **`RouterWsRegistry`** — per-router connection registry (`Ref[Map[RouterId, Set[WebSocketChannel]]]`), concurrency-safe, keyed by `RouterId`, clean connect/disconnect lifecycle. The lookup a later push path (#1849) needs + the §5.5 "router connected?" signal. Single-process (household model); multi-tenant pub/sub explicitly out of scope.
- **Metrics** (bounded labels only, via `MetricGuard`): `router_ws_connections_active` (gauge, refreshed on every register/deregister so it ages out on disconnect) and `router_ws_frames_total{op,dir,result}` (+ new bounded `dir` label key). Dedicated Grafana dashboard `router-ws-transport.json` wired into `infra/grafana/main.tf`.

> Scoped to #1846. `router_ws_policy_push_total` (push fan-out health) is deferred to #1849 with the push path that emits it, per the dashboards-match-emitted-metrics rule.

## Tests

`RouterWsSpec` — a real `Server` (ephemeral port) + real ws `Client` round trip:
- upgrade auth: missing/invalid token → 401 (no 101),
- `usage` frame → shared ingest → `traffic_reports` row + `ack ok` + registry shows the router connected,
- `ping` → `pong`.

The existing `RouterIngestSpec` (and `BlockedMacEventIngestSpec`, `DbFailureSpec`, `ErrorBoundarySpec`) act as the back-compat gate for the ingest extraction. Full `mill api.test` green; `MetricCardinalityGuardSpec` confirms the new series/label pass the cardinality firewall.

Fixes #1846
Relates to #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)