### PR TITLE
test(#1877): auto-discover openwrt specs in run_tests.sh (no more hand-maintained list)

### DIFF
--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -8,49 +8,29 @@
 set -e
 cd "$(dirname "$0")/.."
 
+# RED step for #1877: the spec lists are still hand-maintained (replaced by
+# auto-discovery in the green commit). zzz_canary_spec.lua is on disk but absent
+# here, so the coverage guard fails — that is the gap this issue closes.
+LUA_SPECS="test/conntrack_spec.lua test/render_spec.lua test/policy_spec.lua test/usage_spec.lua test/clock_spec.lua test/failover_spec.lua test/blocklists_spec.lua test/block_page_spec.lua test/contract_spec.lua test/selfheal_spec.lua test/version_spec.lua test/update_spec.lua test/metrics_spec.lua test/log_spec.lua test/dns_log_spec.lua test/dns_tail_sets_spec.lua test/sni_spec.lua test/sni_reassembly_spec.lua test/quic_spec.lua test/nft_drops_spec.lua test/nflog_spec.lua test/host_norm_spec.lua test/lan_warn_spec.lua test/eb_refresh_spec.lua test/static_ip_labels_spec.lua test/host_metrics_spec.lua test/ws_frame_spec.lua"
+
+SHELL_SPECS="test/init_spec.sh test/init_boot_spec.sh test/boot_skeleton_spec.sh test/update_spec.sh test/update_multi_pkg_spec.sh test/install_spec.sh test/lua_module_paths_spec.sh test/nft_log_dep_spec.sh test/agent_spec.sh test/rotate_dnsmasq_log_spec.sh test/nflog_tail_bounded_spec.sh test/init_sni_toggle_spec.sh"
+
+# List mode (WH_LIST_SPECS=1): print the specs this script would run, one per
+# line, and exit without running anything. spec_coverage_spec.test.sh reads this
+# to verify discovery is complete.
+if [ "${WH_LIST_SPECS:-}" = "1" ]; then
+  for f in $LUA_SPECS $SHELL_SPECS; do printf '%s\n' "$f"; done
+  exit 0
+fi
+
+# shellcheck disable=SC2086 # word-splitting LUA_SPECS into separate args is intentional
 LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./spike/ws-1845/?.lua;./test/shim/?.lua;./test/shim/?/init.lua;$(lua -e 'print(package.path)')" \
-  busted test/conntrack_spec.lua \
-         test/render_spec.lua \
-         test/policy_spec.lua \
-         test/usage_spec.lua \
-         test/clock_spec.lua \
-         test/failover_spec.lua \
-         test/blocklists_spec.lua \
-         test/block_page_spec.lua \
-         test/contract_spec.lua \
-         test/selfheal_spec.lua \
-         test/version_spec.lua \
-         test/update_spec.lua \
-         test/metrics_spec.lua \
-         test/log_spec.lua \
-         test/dns_log_spec.lua \
-         test/dns_tail_sets_spec.lua \
-         test/sni_spec.lua \
-         test/sni_reassembly_spec.lua \
-         test/quic_spec.lua \
-         test/nft_drops_spec.lua \
-         test/nflog_spec.lua \
-         test/host_norm_spec.lua \
-         test/lan_warn_spec.lua \
-         test/eb_refresh_spec.lua \
-         test/static_ip_labels_spec.lua \
-         test/host_metrics_spec.lua \
-         test/ws_frame_spec.lua \
-         "$@"
+  busted $LUA_SPECS "$@"
 
 echo ""
-sh test/init_spec.sh
-sh test/init_boot_spec.sh
-sh test/boot_skeleton_spec.sh
-sh test/update_spec.sh
-sh test/update_multi_pkg_spec.sh
-sh test/install_spec.sh
-sh test/lua_module_paths_spec.sh
-sh test/nft_log_dep_spec.sh
-sh test/agent_spec.sh
-sh test/rotate_dnsmasq_log_spec.sh
-sh test/nflog_tail_bounded_spec.sh
-sh test/init_sni_toggle_spec.sh
+for f in $SHELL_SPECS; do
+  sh "$f"
+done
 # ws-client e2e (#1845): runs ws://+wss:// round-trips through the real client;
 # self-skips (exit 0) when lua-cqueues/lua-luaossl aren't installed.
 sh spike/ws-1845/e2e_test.sh

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -5,15 +5,36 @@
 # LUA_PATH is set so that:
 #   require("render")            →  files/usr/lib/lua/wifihaven/render.lua    (short form, used in tests)
 #   require("wifihaven.render")  →  files/usr/lib/lua/wifihaven/render.lua    (qualified form, used in modules)
+#
+# Specs are AUTO-DISCOVERED, not hand-listed (#1877): every test/*_spec.lua runs
+# under busted and every test/*_spec.sh runs as a shell spec, so dropping a new
+# spec into test/ gates it with no edit here. The only carve-out is the
+# documented exclude allowlist in test/spec_exclude.txt (today: jsonc_shim_spec,
+# which needs the real luci.jsonc C module and runs in CI's Contract Tests job).
+# spec_coverage_spec.test.sh enforces that this discovery stays complete.
+# Note: test/*_spec.test.sh files are a different suffix owned by CI's
+# "Discover and run *.test.sh" job — the *_spec.sh glob does not match them.
 set -e
 cd "$(dirname "$0")/.."
 
-# RED step for #1877: the spec lists are still hand-maintained (replaced by
-# auto-discovery in the green commit). zzz_canary_spec.lua is on disk but absent
-# here, so the coverage guard fails — that is the gap this issue closes.
-LUA_SPECS="test/conntrack_spec.lua test/render_spec.lua test/policy_spec.lua test/usage_spec.lua test/clock_spec.lua test/failover_spec.lua test/blocklists_spec.lua test/block_page_spec.lua test/contract_spec.lua test/selfheal_spec.lua test/version_spec.lua test/update_spec.lua test/metrics_spec.lua test/log_spec.lua test/dns_log_spec.lua test/dns_tail_sets_spec.lua test/sni_spec.lua test/sni_reassembly_spec.lua test/quic_spec.lua test/nft_drops_spec.lua test/nflog_spec.lua test/host_norm_spec.lua test/lan_warn_spec.lua test/eb_refresh_spec.lua test/static_ip_labels_spec.lua test/host_metrics_spec.lua test/ws_frame_spec.lua"
+# shellcheck source=test/spec_discovery.sh
+. ./test/spec_discovery.sh
 
-SHELL_SPECS="test/init_spec.sh test/init_boot_spec.sh test/boot_skeleton_spec.sh test/update_spec.sh test/update_multi_pkg_spec.sh test/install_spec.sh test/lua_module_paths_spec.sh test/nft_log_dep_spec.sh test/agent_spec.sh test/rotate_dnsmasq_log_spec.sh test/nflog_tail_bounded_spec.sh test/init_sni_toggle_spec.sh"
+# Discover busted specs: test/*_spec.lua minus the exclude allowlist. Shell glob
+# expansion is sorted, so the runlist is deterministic.
+LUA_SPECS=""
+for f in test/*_spec.lua; do
+  [ -e "$f" ] || continue
+  wh_spec_is_excluded "${f#test/}" && continue
+  LUA_SPECS="$LUA_SPECS $f"
+done
+
+# Discover shell specs: test/*_spec.sh (does not match *_spec.test.sh).
+SHELL_SPECS=""
+for f in test/*_spec.sh; do
+  [ -e "$f" ] || continue
+  SHELL_SPECS="$SHELL_SPECS $f"
+done
 
 # List mode (WH_LIST_SPECS=1): print the specs this script would run, one per
 # line, and exit without running anything. spec_coverage_spec.test.sh reads this

--- a/openwrt/test/spec_coverage_spec.test.sh
+++ b/openwrt/test/spec_coverage_spec.test.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Coverage guard for run_tests.sh spec auto-discovery (#1877).
+#
+# This is a *.test.sh, so CI's "Discover and run *.test.sh" job gates it
+# automatically — which means the guard gates ITSELF with no list to maintain.
+#
+# It fails if any test/*_spec.lua or test/*_spec.sh on disk is neither
+#   (a) in run_tests.sh's actual runlist (queried via WH_LIST_SPECS=1), nor
+#   (b) documented in test/spec_exclude.txt with a reason.
+#
+# That catches the whole #1877 failure class:
+#   - a newly-added spec that silently never runs (root cause behind #1870),
+#   - an exclusion that hides a spec without being written down,
+#   - the discovery globs being quietly reverted to a hand-maintained list.
+#
+# The runlist is read from run_tests.sh's *behavior* (list mode), not its text,
+# so a revert to a static list that drops a spec is caught the moment the spec
+# exists on disk; the literal glob-token checks below add belt-and-suspenders so
+# a revert is caught even before the next spec lands.
+set -eu
+
+cd "$(dirname "$0")/.."   # → openwrt/
+
+# shellcheck source=test/spec_discovery.sh
+. ./test/spec_discovery.sh   # provides wh_spec_excludes / wh_spec_is_excluded
+
+RUN_TESTS="test/run_tests.sh"
+FAIL=0
+report() { printf "  FAIL: %s\n" "$1"; FAIL=1; }
+
+printf "spec_coverage_spec: run_tests.sh spec auto-discovery is complete (#1877)\n"
+
+# Actual list of specs run_tests.sh would execute (no suite is run in list mode).
+RUNLIST=$(WH_LIST_SPECS=1 sh "$RUN_TESTS")
+
+# 1. Every on-disk spec must be either run or explicitly excluded.
+for f in test/*_spec.lua test/*_spec.sh; do
+  [ -e "$f" ] || continue
+  base=${f#test/}
+  if printf '%s\n' "$RUNLIST" | grep -Fxq "$f"; then continue; fi
+  if wh_spec_is_excluded "$base"; then continue; fi
+  report "$f exists on disk but run_tests.sh neither runs it nor excludes it in $WH_SPEC_EXCLUDE_FILE"
+done
+
+# 2. Every exclude entry must still exist on disk (no stale excludes).
+EXCL=$(wh_spec_excludes)
+for base in $EXCL; do
+  [ -e "test/$base" ] || report "$WH_SPEC_EXCLUDE_FILE lists '$base' but test/$base does not exist (stale exclude)"
+done
+
+# 3. *_spec.test.sh files are owned by the *.test.sh discovery job — run_tests.sh
+#    must not pick them up via the *_spec.sh glob.
+if printf '%s\n' "$RUNLIST" | grep -q '_spec\.test\.sh$'; then
+  report "run_tests.sh runlist includes a *_spec.test.sh file (owned by the *.test.sh job)"
+fi
+
+# 4. Belt-and-suspenders: run_tests.sh must still discover via glob, not a list.
+grep -q 'test/\*_spec\.lua' "$RUN_TESTS" \
+  || report "$RUN_TESTS no longer globs test/*_spec.lua (reverted to a static list?)"
+grep -q 'test/\*_spec\.sh' "$RUN_TESTS" \
+  || report "$RUN_TESTS no longer globs test/*_spec.sh (reverted to a static list?)"
+
+if [ "$FAIL" -eq 0 ]; then
+  printf "  PASS: every test/*_spec.{lua,sh} is discovered or documented-excluded\n"
+fi
+exit "$FAIL"

--- a/openwrt/test/spec_discovery.sh
+++ b/openwrt/test/spec_discovery.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Shared spec-discovery helpers for the OpenWrt test harness (#1877).
+#
+# Sourced by both run_tests.sh (which skips excluded specs during discovery) and
+# spec_coverage_spec.test.sh (which fails if an on-disk spec is neither run nor
+# excluded), so the exclude allowlist — both its DATA (test/spec_exclude.txt) and
+# the parse that reads it — lives in exactly one place. Callers cd to openwrt/
+# before sourcing, so the default relative path resolves.
+#
+# Not executable on its own; it only defines functions.
+
+WH_SPEC_EXCLUDE_FILE="${WH_SPEC_EXCLUDE_FILE:-test/spec_exclude.txt}"
+
+# Print the documented exclude basenames, one per line (comment + blank lines
+# stripped). Empty output (no exclusions) is fine.
+wh_spec_excludes() {
+  grep -v '^[[:space:]]*#' "$WH_SPEC_EXCLUDE_FILE" | grep -v '^[[:space:]]*$' || true
+}
+
+# True if basename $1 is on the exclude allowlist.
+wh_spec_is_excluded() {
+  wh_spec_excludes | grep -Fxq "$1"
+}

--- a/openwrt/test/spec_exclude.txt
+++ b/openwrt/test/spec_exclude.txt
@@ -1,0 +1,17 @@
+# Specs EXCLUDED from run_tests.sh's busted auto-discovery (#1877).
+#
+# Single source of truth for the exclude allowlist: both run_tests.sh (which
+# skips these during discovery) and spec_coverage_spec.test.sh (which fails if
+# any on-disk spec is neither discovered nor listed here) read this file.
+#
+# One basename per line (matching test/<basename>). Blank lines and lines
+# starting with '#' are ignored. Every entry MUST exist on disk and carry the
+# reason it is excluded and where it runs instead — the coverage guard fails on
+# a stale entry.
+#
+# jsonc_shim_spec.lua — fidelity contract for the REAL luci.jsonc C module.
+#   run_tests.sh puts the Lua shim (test/shim/luci/jsonc.lua) on LUA_PATH, so
+#   running it here would test the shim against itself (a tautology). It runs in
+#   CI's "Contract Tests" job with the shim dropped and LUA_CPATH pointed at the
+#   built luci-lib-jsonc .so — see .github/workflows/ci.yml.
+jsonc_shim_spec.lua

--- a/openwrt/test/zzz_canary_spec.lua
+++ b/openwrt/test/zzz_canary_spec.lua
@@ -1,9 +1,0 @@
--- TEMPORARY canary for #1877 — REMOVED in the green commit.
--- A static-list run_tests.sh never runs this file, so the coverage guard
--- (spec_coverage_spec.test.sh) fails on it; once discovery globs test/*_spec.lua
--- the canary runs automatically and the guard passes. It must NOT ship.
-describe("zzz_canary (#1877 discovery proof)", function()
-  it("runs only when run_tests.sh auto-discovers test/*_spec.lua", function()
-    assert.is_true(true)
-  end)
-end)

--- a/openwrt/test/zzz_canary_spec.lua
+++ b/openwrt/test/zzz_canary_spec.lua
@@ -1,0 +1,9 @@
+-- TEMPORARY canary for #1877 — REMOVED in the green commit.
+-- A static-list run_tests.sh never runs this file, so the coverage guard
+-- (spec_coverage_spec.test.sh) fails on it; once discovery globs test/*_spec.lua
+-- the canary runs automatically and the guard passes. It must NOT ship.
+describe("zzz_canary (#1877 discovery proof)", function()
+  it("runs only when run_tests.sh auto-discovers test/*_spec.lua", function()
+    assert.is_true(true)
+  end)
+end)


### PR DESCRIPTION
## What & why

`openwrt/test/run_tests.sh` hand-maintained **two** spec lists — an explicit `busted test/<a>_spec.lua …` invocation and an explicit `sh test/<x>_spec.sh` block. Adding a new `test/*_spec.lua` or `test/*_spec.sh` did nothing until someone also edited the list, so forgotten specs silently never gated — a green ✓ that proves nothing. This is the **root cause behind #1870** (the CI list and run_tests.sh drifted), and why #1845's `ws_frame_spec.lua` and #1870's `quic_spec`/`sni_spec`/etc. went ungated.

#1872 (merged) re-synced the static list and collapsed CI's *OpenWrt Lua Tests* job onto `run_tests.sh` — but the list is **still hand-maintained**, so the underlying "add a file ≠ it runs" gap remains. This PR closes that gap.

Fixes #1877.

## Changes

1. **Auto-discovery** — `run_tests.sh` now globs `test/*_spec.lua` (busted) and `test/*_spec.sh` (shell), sorted/deterministic, instead of two static lists. `"$@"` passthrough and `set -e` semantics preserved (a failing shell spec still fails the run). The `*_spec.test.sh` suffix is **not** matched by the `*_spec.sh` glob, so those stay owned by CI's existing "Discover and run *.test.sh" job.
2. **Single-source exclude allowlist** — `test/spec_exclude.txt` (data) + `test/spec_discovery.sh` (the parse), sourced by both `run_tests.sh` and the guard. Its only member is `jsonc_shim_spec.lua`: `run_tests.sh` puts the Lua `luci.jsonc` shim on `LUA_PATH`, so running that spec here would test the shim against itself — its real fidelity check runs in CI's *Contract Tests* job against the built `.so`.
3. **Coverage guard** — `test/spec_coverage_spec.test.sh` (a `*.test.sh`, auto-gated by CI's discovery job). Fails if any `test/*_spec.{lua,sh}` on disk is neither in `run_tests.sh`'s actual runlist (queried via a new `WH_LIST_SPECS=1` list mode — behavior, not text) nor documented in `spec_exclude.txt`. It also greps `run_tests.sh` for the glob tokens, so a silent revert to a static list is caught even before the next spec lands.

Since #1872 pointed CI's *OpenWrt Lua Tests* job at `sh test/run_tests.sh`, this auto-discovery is exercised directly by CI, and the guard self-gates via the *.test.sh job.

## TDD (red → green in history)

- **RED**: guard + canary `test/zzz_canary_spec.lua` against the still-static list — guard fails (canary not run; no glob).
- **GREEN**: glob discovery; canary removed; guard passes. Full suite: 865 successes / 1 pending, exit 0.

## Validation

- `sh test/run_tests.sh` → exit 0, 865 successes / 0 failures / 1 pending, all shell specs pass, ws e2e self-skips locally (runs in CI, which installs cqueues/luaossl).
- `shellcheck --severity=warning -x` clean on all shell files; guard passes under `sh` and `bash`; `actionlint` clean (ci.yml untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
