### PR TITLE
feat(#1841): cut over canonical app host to app.wifihaven.net (installs + tooling)

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -14,7 +14,7 @@ name: Master API/UI CD
 #       ‖ deploy-spa-staging         (build + wrangler push to Cloudflare Pages — parallel
 #                                     with deploy-staging, gated on the same test chain)
 #     → smoke-staging                (lightweight curl checks against api-staging.wifihaven.net
-#                                     AND staging.wifihaven.net SPA)
+#                                     AND app-staging.wifihaven.net SPA)
 #     → api-smoke-staging            (Gate 1 — admin + router API contract smoke against staging)
 #     → gate-3b-api-staging          (Gate 3b — last-published qemu router + freshly-deployed
 #                                     staging API; #655)
@@ -331,7 +331,7 @@ jobs:
   # Runs in parallel with deploy-staging — SPA build doesn't depend on the
   # API image. Gated on the same test chain as build-image so a CI failure
   # blocks both surfaces. smoke-staging waits on this job, so the SPA is
-  # live at staging.wifihaven.net before the cross-origin CORS checks run.
+  # live at app-staging.wifihaven.net before the cross-origin CORS checks run.
   deploy-spa-staging:
     name: Deploy SPA to Cloudflare Pages (staging)
     if: github.ref == 'refs/heads/main'
@@ -436,12 +436,12 @@ jobs:
         run: |
           headers=$(curl --silent --show-error --max-time 10 -i \
             -X OPTIONS \
-            -H "Origin: https://staging.wifihaven.net" \
+            -H "Origin: https://app-staging.wifihaven.net" \
             -H "Access-Control-Request-Method: POST" \
             -H "Access-Control-Request-Headers: content-type,authorization" \
             "${STAGING_API_URL}/api/health")
           echo "$headers"
-          echo "$headers" | grep -i '^access-control-allow-origin: https://staging.wifihaven.net'
+          echo "$headers" | grep -i '^access-control-allow-origin: https://app-staging.wifihaven.net'
           # Allow-Headers must echo back the requested headers — empty value
           # is the #626 regression.
           allow=$(echo "$headers" | grep -i '^access-control-allow-headers:' || true)
@@ -450,19 +450,19 @@ jobs:
 
       - name: Staging SPA returns 200 and bakes the staging API URL
         # Confirms the Cloudflare Pages deploy aliased the new build to
-        # staging.wifihaven.net and the VITE_API_BASE_URL was wired
-        # correctly (a prod-API URL in a staging bundle would silently
-        # break cross-origin auth).
+        # app-staging.wifihaven.net (the canonical app host post-#1841) and
+        # the VITE_API_BASE_URL was wired correctly (a prod-API URL in a
+        # staging bundle would silently break cross-origin auth).
         run: |
           body=$(curl --fail --silent --show-error --max-time 10 \
-            https://staging.wifihaven.net/)
+            https://app-staging.wifihaven.net/)
           echo "$body" | head -c 500
           # The Vite-built index.html references the hashed JS bundle.
           # Pull it and grep for the staging API origin.
           js_path=$(echo "$body" | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -1)
           [[ -n "$js_path" ]] || { echo "could not find JS bundle path" >&2; exit 1; }
           curl --fail --silent --show-error --max-time 10 \
-            "https://staging.wifihaven.net${js_path}" \
+            "https://app-staging.wifihaven.net${js_path}" \
             | grep -q 'api-staging.wifihaven.net' \
             || { echo "staging bundle missing api-staging.wifihaven.net" >&2; exit 1; }
 
@@ -511,7 +511,8 @@ jobs:
           E2E_BASE_URL: ${{ env.STAGING_API_URL }}
           # Post-#613 the SPA is on Cloudflare Pages, not the API host —
           # so the `/blocked` SPA-route check has to hit the SPA host.
-          E2E_SPA_URL: https://staging.wifihaven.net
+          # #1841/#1832: app-staging.wifihaven.net is the canonical app host.
+          E2E_SPA_URL: https://app-staging.wifihaven.net
           ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}
           RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}
         run: scripts/e2e-router.sh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1170,8 +1170,8 @@ SPA hosting differs by environment:
 - **Self-hosted (local / dev / `deploy/install.sh`)**: the SPA is bundled
   with the API — `web/dist` is baked into the API container and served by
   the JVM on :8080. One deploy, one rollback.
-- **Staging and production cloud (`staging.wifihaven.net`,
-  `api.wifihaven.net`)**: the SPA deploys to **Cloudflare Pages**,
+- **Staging and production cloud (`app-staging.wifihaven.net`,
+  `app.wifihaven.net`; API at `api.wifihaven.net`)**: the SPA deploys to **Cloudflare Pages**,
   independent of the API. The API JVM serves only `/api/*`; the SPA is a
   static bundle that talks to the API over the network like any other
   client. Cloudflare config lives in-repo:

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -188,7 +188,8 @@ curl -sS -o /dev/null -w "%{http_code}\n" https://app-staging.wifihaven.net/
 curl -sS -o /dev/null -w "%{http_code}\n" https://staging.wifihaven.net/
 ```
 
-All should return 200. Inspect the prod SPA HTML (`view-source` on
+The two `/api/health` calls should report `"db":"ok"`; every SPA-host curl
+should print `200`. Inspect the prod SPA HTML (`view-source` on
 `https://app.wifihaven.net/`) and search for `api.wifihaven.net` to confirm
 the right `VITE_API_BASE_URL` got baked in.
 

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -16,15 +16,22 @@ Let's Encrypt issuance. Cloudflare Pages uses DNS-01 challenges, so the
 class of bug doesn't exist. CI is also already building the SPA, so
 having Render rebuild it was wasted work.
 
-Custom domain layout (unchanged from the pre-#613 setup):
+Custom domain layout:
 
 | Hostname                       | Where it lives                    |
 |--------------------------------|-----------------------------------|
-| `wifihaven.net` (apex)         | Cloudflare Pages: `wifihaven`     |
+| `app.wifihaven.net`            | Cloudflare Pages: `wifihaven` (canonical app host, #1832) |
+| `app-staging.wifihaven.net`    | Cloudflare Pages: `wifihaven-staging` (canonical staging app host) |
+| `wifihaven.net` (apex)         | Cloudflare Pages: `wifihaven` (legacy SPA host; becomes marketing in #1842, must keep serving `/blocked*` for pre-rename routers) |
 | `www.wifihaven.net`            | Cloudflare Pages: `wifihaven`     |
-| `staging.wifihaven.net`        | Cloudflare Pages: `wifihaven-staging` |
+| `staging.wifihaven.net`        | Cloudflare Pages: `wifihaven-staging` (legacy) |
 | `api.wifihaven.net`            | Render: `wifihaven-api-prod`      |
 | `api-staging.wifihaven.net`    | Render: `wifihaven-api-staging`   |
+
+`app.wifihaven.net` / `app-staging.wifihaven.net` are additional custom domains
+on the *same* Pages projects — the SPA bundle is identical, only the fronting
+host is canonical now. The apex/`www` keep serving the SPA until the marketing
+split (#1842); the API host (`api.wifihaven.net`) is unchanged.
 
 ---
 
@@ -54,8 +61,8 @@ DNS UI (proxy / orange-cloud status as noted):
 | CNAME | `api`          | shown in Render → `wifihaven-api-prod`    | DNS-only (grey) |
 | CNAME | `api-staging`  | shown in Render → `wifihaven-api-staging` | DNS-only (grey) |
 
-The Pages hostnames (apex, `www`, `staging`) are added through the Pages
-project's **Custom domains** tab (see §3) — Cloudflare wires the DNS
+The Pages hostnames (`app`, `app-staging`, apex, `www`, `staging`) are added
+through the Pages project's **Custom domains** tab (see §3) — Cloudflare wires the DNS
 records automatically when the apex zone is on the same account.
 
 API CNAMEs are intentionally **DNS-only** (grey cloud): proxying through
@@ -118,8 +125,8 @@ terraform apply
 ```
 
 This creates two Pages projects (`wifihaven`, `wifihaven-staging`,
-Direct Upload — CI pushes via Wrangler), three Pages custom domains
-(apex, `www`, `staging`), and the two API CNAMEs.
+Direct Upload — CI pushes via Wrangler), the Pages custom domains
+(`app`, `app-staging`, apex, `www`, `staging`), and the two API CNAMEs.
 
 Cloudflare auto-issues edge certs (DNS-01 challenge — no path
 interception). Cert status flips to **Active** in the dash within a
@@ -168,19 +175,22 @@ workflow → **Run workflow**).
 Verify:
 
 ```sh
-# Prod API + SPA
+# Prod API + SPA (app.wifihaven.net is the canonical app host; apex/www
+# still serve the SPA until the marketing split #1842)
 curl -sS https://api.wifihaven.net/api/health
+curl -sS -o /dev/null -w "%{http_code}\n" https://app.wifihaven.net/
 curl -sS -o /dev/null -w "%{http_code}\n" https://wifihaven.net/
 curl -sS -o /dev/null -w "%{http_code}\n" https://www.wifihaven.net/
 
 # Staging API + SPA
 curl -sS https://api-staging.wifihaven.net/api/health
+curl -sS -o /dev/null -w "%{http_code}\n" https://app-staging.wifihaven.net/
 curl -sS -o /dev/null -w "%{http_code}\n" https://staging.wifihaven.net/
 ```
 
-All five should return 200. Inspect the prod SPA HTML (`view-source`) and
-search for `api.wifihaven.net` to confirm the right `VITE_API_BASE_URL`
-got baked in.
+All should return 200. Inspect the prod SPA HTML (`view-source` on
+`https://app.wifihaven.net/`) and search for `api.wifihaven.net` to confirm
+the right `VITE_API_BASE_URL` got baked in.
 
 Login flow end-to-end on staging exercises the CORS allowlist from #612.
 
@@ -253,7 +263,7 @@ prod on the free PG tier (it expires after ~30 days).
 | `WifiHaven — Cloudflare API Token`     | The token written to `CLOUDFLARE_API_TOKEN` (Pages:Edit scope) |
 
 **First admin login**: the prod API ships with default `admin/changeme`,
-force-expired on first login (#586). Open `https://wifihaven.net/` in a
+force-expired on first login (#586). Open `https://app.wifihaven.net/` in a
 browser, log in, the UI redirects to `/account` to set a new password.
 Store it in 1Password immediately.
 

--- a/docs/design/blocklists.md
+++ b/docs/design/blocklists.md
@@ -149,7 +149,9 @@ device → blocked HTTP request
        ↓ DNAT (router nft)
 router uhttpd:8081  → returns HTML that redirects to
        ↓
-https://wifihaven.net/blocked?mac=<mac>&host=<dest>
+https://app.wifihaven.net/blocked?mac=<mac>&host=<dest>
+       (pre-rename routers DNAT to wifihaven.net/blocked, which 302-redirects
+        here via the apex compat shim #1842, preserving the query string)
        ↓
 SPA fetches GET /api/blocked?mac=<mac>&host=<dest>
        ↓ API resolves: profile, the BlockReason struct, category name if any

--- a/docs/install-flint2.md
+++ b/docs/install-flint2.md
@@ -234,7 +234,7 @@ Now follow **[`install-openwrt.md` §2](install-openwrt.md#2-install-with-the-on
 For a Flint 2 talking to the production cloud API, the prompt answers are:
 
 - API server URL: `https://api.wifihaven.net` (the default)
-- Enrollment token: the `et_…` value from `https://wifihaven.net → Routers → Add router`
+- Enrollment token: the `et_…` value from `https://app.wifihaven.net → Routers → Add router`
 - LAN prefix: auto-detected from `network.lan.ipaddr`; accept the default
   unless you've moved LAN off its first /24.
 

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -141,7 +141,7 @@ script the install into your own provisioning system.
   installed (see [§M1](#m1-download-the-matching-package) and
   [§M2](#m2-install)). The agent does **not** need to be started yet —
   enrollment runs first.
-- Admin access to the cloud SPA at `https://wifihaven.net`. If the cloud
+- Admin access to the cloud SPA at `https://app.wifihaven.net`. If the cloud
   side isn't deployed yet, see [`deploy-cloud.md`](deploy-cloud.md).
 
 ### Steps
@@ -164,7 +164,7 @@ script the install into your own provisioning system.
    every flow.
 
 3. **Generate an enrollment token in the admin UI.** Open
-   `https://wifihaven.net` → **Routers → Add router**. Enter a display name
+   `https://app.wifihaven.net` → **Routers → Add router**. Enter a display name
    for the router (e.g. `main-house`) and submit. The UI returns a one-time
    `enrollmentToken` (`et_…`); copy it.
 
@@ -198,7 +198,7 @@ script the install into your own provisioning system.
    ```
 
    You should see `[wifihaven] policy snapshot fetched, etag=…` within ~60s.
-   Then check `https://wifihaven.net` → **Routers** — the new router should
+   Then check `https://app.wifihaven.net` → **Routers** — the new router should
    appear with a recent `last_seen_at`. If you've never set up the local
    block page on this router, also walk [§M6](#m6-set-up-the-local-block-page).
 
@@ -210,7 +210,7 @@ Two routers in the same operator's environment will run with different
 
 | Role | `api_url` | Notes |
 |---|---|---|
-| Prod router (new main-house box) | `https://api.wifihaven.net` | Cloud-hosted API on Render; the SPA at `https://wifihaven.net` is what household admins use. |
+| Prod router (new main-house box) | `https://api.wifihaven.net` | Cloud-hosted API on Render; the SPA at `https://app.wifihaven.net` is what household admins use. |
 | Dev router (existing OpenWRT box) | `http://192.168.10.43:8080` | Points at the on-prem dev API behind the prod router. Used for shakeout and integration testing. |
 
 Each router enrolls independently against its own API — there is no shared

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -135,14 +135,18 @@ API_URL=${API_URL%/}
 
 # #1174: the block page redirects blocked clients to the public SPA that serves
 # the /blocked route. In the cloud deploy the SPA lives on a SEPARATE host
-# (Cloudflare Pages, e.g. https://wifihaven.net) from the API
+# (Cloudflare Pages, e.g. https://app.wifihaven.net) from the API
 # (api.wifihaven.net), so the redirect must target the SPA host, not the API.
 # Self-hosted installs bundle the SPA into the API image on the same host, so
-# the block-page URL is just the API URL there. Default to the known public SPA
+# the block-page URL is just the API URL there. Default to the canonical app
 # host when enrolling against the managed cloud API; otherwise default to the
 # API URL (correct for self-hosted).
+# #1841/#1832: new cloud installs point at app.wifihaven.net (the canonical app
+# host). Routers enrolled before the rename keep https://wifihaven.net in their
+# block_page_url UCI key and rely on the apex /blocked compat shim (#1842) to
+# redirect to app.wifihaven.net/blocked.
 case "$API_URL" in
-  *api.wifihaven.net*) block_page_default="https://wifihaven.net" ;;
+  *api.wifihaven.net*) block_page_default="https://app.wifihaven.net" ;;
   *)                   block_page_default="$API_URL" ;;
 esac
 prompt BLOCK_PAGE_URL   "Public SPA URL for the block page" "$block_page_default"

--- a/web/src/pages/BlockedPage.tsx
+++ b/web/src/pages/BlockedPage.tsx
@@ -5,8 +5,12 @@ import type { AccessRequestKind, BlockedInfoResponse } from '@/types/api'
 
 // #959: kid-side block page.
 //
-// Flow: router DNATs blocked traffic to wifihaven.net (#944 has the SPA hosts
-// in extraAllowed so this resolves), redirecting to /blocked?mac=...&host=....
+// Flow: router DNATs blocked traffic to app.wifihaven.net (#944 has the SPA
+// hosts in extraAllowed so this resolves), redirecting to /blocked?mac=...&host=....
+// (#1841/#1832: app.wifihaven.net is the canonical app host. Routers enrolled
+// before the rename DNAT to the apex wifihaven.net, which serves a /blocked
+// compat shim (#1842) that 302-redirects to app.wifihaven.net/blocked,
+// preserving the query string.)
 // We call GET /api/blocked to resolve the reason class and render kid-friendly
 // copy per the #952 design doc Q4 decisions.
 //


### PR DESCRIPTION
Fixes #1841. Relates to #1832 (app-host rename epic). Sub-issue 3 of 5 — see [`docs/design/app-host-rename.md`](docs/design/app-host-rename.md) §2.3/§2.5, §5.

## ⚠️ This is a deliberate canonical-host CUT-OVER — operator-gated

This PR makes **`app.wifihaven.net`** (`app-staging.wifihaven.net` for staging) the **canonical app host** for **new installs + tooling**. It is a user-facing cut-over; please **verify on staging before merging to prod** (see below). I have **not** enabled auto-merge.

**The API host (`api.wifihaven.net`) is unchanged** — only the *SPA/block-page* host becomes canonical. `web/src/api/client.ts` (`VITE_API_BASE_URL` → `api.wifihaven.net`) is intentionally left untouched.

**Existing routers are not affected by this PR.** They keep `https://wifihaven.net` in their per-router `block_page_url` UCI key (can't be pushed over the wire — it's not on the policy snapshot) and rely on the **apex `/blocked` compat shim** landing in the later sub-issue **#1842**. This PR only changes the default for *fresh* cloud enrollments.

## Changes
- **`openwrt/install.sh`** (~145): cloud-enrollment block-page default → `https://app.wifihaven.net` (self-hosted default — the API URL — unchanged).
- **`.github/workflows/master-api-ui.yml`**: retarget the smoke `Origin`/SPA-bundle checks, `E2E_SPA_URL`, and header/comment text → `app-staging.wifihaven.net`.
- **`web/src/pages/BlockedPage.tsx`** (~8): comment → `app.wifihaven.net` + note the apex `/blocked` compat shim (#1842).
- **Docs sweep**: `docs/deploy-cloud.md` (custom-domain table, §3 TF, verify curls, §9 first-login URL), `docs/architecture.md`, `docs/install-openwrt.md`, `docs/install-flint2.md`, `docs/design/blocklists.md` (block-page redirect flow).

## Verification (done before pushing)
The #1839 Pages domains are **live**, so the retargeted staging smoke will pass:
- `curl -I https://app-staging.wifihaven.net/` → **200**, bundle bakes `api-staging.wifihaven.net`.
- `curl -I https://app.wifihaven.net/` → **200**.
- CORS preflight `Origin: https://app-staging.wifihaven.net` → `api-staging.wifihaven.net/api/health` echoes `access-control-allow-origin: https://app-staging.wifihaven.net` (so #1840 CORS covers it).
- `web` vitest: `BlockedPage` suite 20/20 pass (node 22).
- `actionlint` clean on the workflow.

## Recommended operator gate before merge
Confirm staging smoke/e2e is green against `app-staging.wifihaven.net` on this branch's CI run, then merge to prod deliberately. This is a cut-over by nature — I am not merging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)