### PR TITLE
feat(#1885): prove loki4j appender fail-open under load + drop metric + Grafana panel

### DIFF
--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -27,17 +27,26 @@
 
     Fail-open by construction (hard requirement — Loki being slow/down must NEVER
     wedge the request path):
-      - Loki4jAppender is asynchronous by design: the calling (request) thread
-        only enqueues; an internal background thread batches and sends. Do NOT
-        wrap it in an AsyncAppender — it is already async.
+      - The appender is asynchronous by design: the calling (request) thread only
+        enqueues; an internal background thread batches and sends. Do NOT wrap it
+        in an AsyncAppender — it is already async.
       - <batch> bounds the in-memory send queue with <sendQueueMaxBytes>. When
         the queue is full (Loki slow/unreachable and the background sender backs
         up), incoming events are DROPPED, never blocked — drop-on-backpressure.
       - <drainOnStop>false</drainOnStop> so JVM shutdown is never held waiting on
         Loki to drain.
       - <http><requestTimeoutMs> caps each send on the background thread.
-    (Load-proven backpressure + a drop metric + a Grafana panel are the #1831
-    sub-#2 follow-up, intentionally out of scope here.)
+    #1885 PROVED this fail-open behaviour under load (LokiAppenderFailOpenSpec:
+    with Loki stalled and a tiny send queue, the calling thread keeps appending at
+    full speed while the appender sheds events) and INSTRUMENTED the drops:
+
+      - The class below is MeteredLoki4jAppender, a zero-behaviour subclass of
+        loki4j's Loki4jAppender that re-exports the appender's own cumulative
+        dropped-events counter (the AtomicLong loki4j bumps every time the bounded
+        send queue rejects an event). LokiDropMetrics polls it into the
+        `loki_logs_dropped_total` Prometheus counter (GET /metrics), so a Loki
+        outage silently shedding logs is now alertable (Grafana: api-self-metrics).
+        Swapping the class is wire/log-path-transparent; it only adds an accessor.
 
     Label / cardinality model (critical — same bounded-cardinality rule as
     metrics): ONLY service / env / level are Loki STREAM LABELS. Every other MDC
@@ -49,7 +58,7 @@
   -->
   <if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>
     <then>
-      <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+      <appender name="LOKI" class="com.github.loki4j.logback.MeteredLoki4jAppender">
         <!-- Stream labels: low-cardinality ONLY. Do NOT add mac/route/host here. -->
         <labels>
           service = wifihaven-api

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -14,6 +14,7 @@ import wifihaven.api.metrics.{
 }
 import wifihaven.api.notify.Notifier
 import wifihaven.api.observability.LoggingMiddleware
+import wifihaven.api.observability.LokiDropMetrics
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
 import wifihaven.api.usage.RetentionSweepJob
@@ -221,6 +222,11 @@ object Main extends ZIOAppDefault {
         routerRepoMetric  <- ZIO.service[RouterRepo]
         _                 <- RouterPresenceMetrics.loop(routerRepoMetric).forkDaemon
         _                 <- ZIO.logInfo("router-presence metrics fiber forked")
+        // #1885: poll the loki4j appender's fail-open drop counter into
+        // loki_logs_dropped_total. forkDaemon; no-ops on local/test where the
+        // LOKI appender isn't present (deployed-env gate lives in logback.xml).
+        _                 <- LokiDropMetrics.loop().forkDaemon
+        _                 <- ZIO.logInfo("loki-drop metrics fiber forked")
         _                 <- ZIO
           .logWarning(
             "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -135,6 +135,15 @@ object MetricGuard {
     // too aggressive (real sessions vanishing), a flat zero while phantom
     // inflation returns means it is too lax.
     "presence_app_sessions_dropped_total"       -> Set.empty[String],
+    // #1885 — log events the loki4j appender shed because its bounded send queue
+    // (sendQueueMaxBytes) was full while Loki was slow/unreachable. The appender
+    // is async/drop-on-backpressure by construction (fail-open: the request path
+    // is never blocked), so a sustained outage silently loses logs — this counter
+    // makes that loss alertable. Unlabelled: the appender exposes a single
+    // appender-wide cumulative count, and any per-mac/route label would breach the
+    // §4 cardinality firewall (service/env/level already ride the Loki stream
+    // labels, not this Prometheus series).
+    "loki_logs_dropped_total"                   -> Set.empty[String],
     // §5.1 router-sourced, pushed via POST /api/router/metrics (#1205). Every one carries the
     // server-attached `router_id` + `installation_id` plus its own bounded enum label.
     "dnsmasq_restarts_total"                    -> Set("reason", "router_id", "installation_id"),
@@ -446,6 +455,22 @@ object AppMetrics {
 
   def recordRouterMetricsBatch(status: String): UIO[Unit] =
     MetricGuard.counter("router_metrics_batches_total", Map("status" -> status))
+
+  // ── Loki appender fail-open drops (#1885) ────────────────────────────────────
+  // Emitted from LokiDropMetrics, which polls the MeteredLoki4jAppender's
+  // cumulative drop counter and feeds the per-tick positive delta here. A drop
+  // means the async appender shed a log line because its bounded send queue was
+  // full (Loki slow/unreachable) — the fail-open path that keeps the request
+  // thread unblocked. A sustained rate is the alert that logs are being lost.
+  // Unlabelled; only emits when `delta > 0` so a healthy appender never touches
+  // the series.
+
+  def recordLokiDropped(delta: Long): UIO[Unit] =
+    ZIO
+      .when(delta > 0)(
+        MetricGuard.counter("loki_logs_dropped_total", Map.empty, delta),
+      )
+      .unit
 
   // ── Websocket router transport (#1846) ───────────────────────────────────────
   // Set by RouterWsRegistry on every register/deregister: the live count of open

--- a/api/src/observability/LokiDropMetrics.scala
+++ b/api/src/observability/LokiDropMetrics.scala
@@ -1,0 +1,88 @@
+package wifihaven.api.observability
+
+import com.github.loki4j.logback.MeteredLoki4jAppender
+import wifihaven.api.metrics.AppMetrics
+import org.slf4j.LoggerFactory
+import ch.qos.logback.classic.LoggerContext
+import zio.*
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * #1885 (epic #1831): surface the loki4j appender's fail-open drop count as a Prometheus
+ * self-metric so a Loki outage that is silently shedding log lines becomes alertable.
+ *
+ * The appender ([[MeteredLoki4jAppender]]) is asynchronous by construction: the request thread only
+ * enqueues; a background thread batches and ships to Loki. When Loki is slow/unreachable the
+ * bounded `sendQueueMaxBytes` queue fills and further events are DROPPED (never blocked) — that is
+ * the hard fail-open guarantee (proved by `LokiAppenderFailOpenSpec`). The drop is invisible from
+ * the request path by design, so without this poller a sustained outage loses logs with no signal.
+ *
+ * Shape mirrors [[wifihaven.api.metrics.DbPoolMetrics]] / `RouterPresenceMetrics`: a daemon fiber
+ * that polls a live source and emits a metric. The appender keeps a monotonic cumulative drop
+ * counter; each tick we read it, diff against the previous reading, and feed the positive delta to
+ * the `loki_logs_dropped_total` counter through `MetricGuard` (unlabelled — the appender exposes a
+ * single appender-wide number, and any per-mac/route label would breach the §4 cardinality
+ * firewall).
+ *
+ * Deployed-env-only with no extra config switch: the LOKI appender is itself gated behind
+ * `isDefined("GRAFANA_CLOUD_LOKI_URL")` in `logback.xml`, so on local dev / `mill __.test` it is
+ * never instantiated. [[findAppender]] returns `None` there and [[loop]] no-ops — same presence
+ * gate as the appender, no duplicated env check.
+ */
+object LokiDropMetrics {
+
+  /** Poll cadence. Drops accrue slowly relative to scrape interval; 30s keeps the series cheap. */
+  val DefaultInterval: Duration = 30.seconds
+
+  /**
+   * Locate the [[MeteredLoki4jAppender]] attached to the logback root logger, if any. `None` when
+   * logback isn't backed by a [[LoggerContext]] (defensive) or the appender is absent (local/test,
+   * where the `<if>` gate in logback.xml skipped it).
+   */
+  def findAppender: UIO[Option[MeteredLoki4jAppender]] =
+    ZIO.succeed {
+      LoggerFactory.getILoggerFactory match {
+        case ctx: LoggerContext =>
+          ctx
+            .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
+            .iteratorForAppenders()
+            .asScala
+            .collectFirst { case a: MeteredLoki4jAppender => a }
+        case _                  => None
+      }
+    }
+
+  /**
+   * Read the appender's cumulative drop count, emit the positive delta since `lastSeen`, and store
+   * the new reading. Split out (taking a `read` thunk) so the diff logic is unit-testable without a
+   * live appender — see `LokiDropMetricsSpec`.
+   */
+  def emitDelta(read: UIO[Long], lastSeen: Ref[Long]): UIO[Unit] =
+    for {
+      cur  <- read
+      prev <- lastSeen.getAndSet(cur)
+      delta = cur - prev
+      _ <- AppMetrics.recordLokiDropped(delta).when(delta > 0)
+    } yield ()
+
+  /**
+   * Fiber loop: if the LOKI appender is present, poll its drop count every `interval` and emit the
+   * delta; otherwise log once and return (local/test). `lastSeen` is seeded with the count at start
+   * so a pre-existing total isn't replayed as one large spike. Never fails; fork as a daemon.
+   */
+  def loop(interval: Duration = DefaultInterval): UIO[Unit] =
+    findAppender.flatMap {
+      case None      =>
+        ZIO.logDebug("LOKI appender not present; loki-drop metrics disabled (local/test).")
+      case Some(app) =>
+        for {
+          start    <- ZIO.succeed(app.droppedEventsTotal)
+          lastSeen <- Ref.make(start)
+          _        <- ZIO.logInfo("loki-drop metrics fiber polling MeteredLoki4jAppender")
+          _        <- emitDelta(ZIO.succeed(app.droppedEventsTotal), lastSeen)
+            .repeat(Schedule.fixed(interval))
+            .unit
+        } yield ()
+    }
+}

--- a/api/src/observability/LokiDropMetrics.scala
+++ b/api/src/observability/LokiDropMetrics.scala
@@ -62,8 +62,9 @@ object LokiDropMetrics {
     for {
       cur  <- read
       prev <- lastSeen.getAndSet(cur)
-      delta = cur - prev
-      _ <- AppMetrics.recordLokiDropped(delta).when(delta > 0)
+      // recordLokiDropped is a no-op for a non-positive delta (flat or — defensively — a
+      // non-increasing reading), so the single guard lives there.
+      _    <- AppMetrics.recordLokiDropped(cur - prev)
     } yield ()
 
   /**

--- a/api/src/observability/MeteredLoki4jAppender.scala
+++ b/api/src/observability/MeteredLoki4jAppender.scala
@@ -1,0 +1,36 @@
+// NB: deliberately in loki4j's own package so the package-private
+// `Loki4jAppender.droppedEventsCount()` accessor is reachable. #1873 wired the
+// stock `Loki4jAppender`; #1885 swaps logback.xml to this subclass so the
+// fail-open drop count (events the async pipeline shed because its bounded send
+// queue was full — Loki slow/unreachable) can be surfaced as a Prometheus
+// self-metric. See `wifihaven.api.observability.LokiDropMetrics`.
+package com.github.loki4j.logback
+
+/**
+ * Thin subclass of loki4j's [[Loki4jAppender]] that adds nothing to the logging path — it only
+ * re-exports the appender's own cumulative dropped-events counter as a public accessor.
+ *
+ * Why a subclass rather than reflection or Micrometer:
+ *   - The drop count lives in `Loki4jAppender.droppedEventsCount` (an `AtomicLong` bumped by
+ *     `reportDroppedEvents()` every time `AsyncBufferPipeline.append` returns `false`, i.e. the
+ *     bounded `sendQueueMaxBytes` queue was full and the event was shed instead of blocking the
+ *     calling thread). loki4j exposes it via a package-private `long droppedEventsCount()` method —
+ *     reachable only from within `com.github.loki4j.logback`.
+ *   - loki4j's richer Micrometer metrics (`metricsEnabled=true`, including its own
+ *     `droppedEventsCounter`) publish to Micrometer's global registry, which is NOT the
+ *     `zio.metrics` Prometheus registry behind `GET /metrics`. Bridging the two would mean pulling
+ *     in Micrometer + a registry adapter for a single counter. The appender's own `AtomicLong` is
+ *     the same number with none of that machinery.
+ *
+ * This class adds zero behaviour, so it is a drop-in for the stock appender on the wire/logging
+ * side; the only observable difference is the new public accessor.
+ */
+class MeteredLoki4jAppender extends Loki4jAppender {
+
+  /**
+   * Cumulative count of log events this appender has dropped because the async send queue was full
+   * (Loki slow or unreachable). Monotonic for the life of the appender; the poller in
+   * [[wifihaven.api.observability.LokiDropMetrics]] diffs it into a Prometheus counter.
+   */
+  def droppedEventsTotal: Long = droppedEventsCount()
+}

--- a/api/test/src/feature/LokiAppenderFailOpenSpec.scala
+++ b/api/test/src/feature/LokiAppenderFailOpenSpec.scala
@@ -1,0 +1,171 @@
+package wifihaven.api.feature
+
+import ch.qos.logback.classic.{Level, LoggerContext}
+import ch.qos.logback.classic.spi.LoggingEvent
+import com.github.loki4j.logback.{Loki4jAppender, MeteredLoki4jAppender, PipelineConfigAppenderBase}
+import zio.*
+import zio.test.*
+
+import java.net.{InetSocketAddress, ServerSocket, Socket}
+
+/**
+ * #1885 (epic #1831): PROVE the loki4j appender is fail-open under load.
+ *
+ * The hard requirement from the architecture is that a slow/unreachable Loki must NEVER wedge the
+ * request path. loki4j is async/drop-on-backpressure by construction: the calling thread only
+ * offers an event to an in-memory buffer; a background thread batches and ships it, and when the
+ * bounded `sendQueueMaxBytes` queue fills the appender DROPS events instead of blocking the caller.
+ *
+ * This spec demonstrates that with a real appender pointed at a Loki endpoint that accepts the TCP
+ * connection but never responds (the worst case for a synchronous client — the request would hang
+ * until `requestTimeoutMs`):
+ *
+ *   1. the appender sheds events (its drop counter climbs) — backpressure resolves to DROP, and 2.
+ *      the calling thread keeps appending at full speed — 200k appends complete in well under the
+ *      time a single blocked network send would take, so request latency is provably unaffected.
+ *
+ * Assertion (2) is the load-bearing one: it is the regression guard against anyone ever wrapping
+ * this in a blocking/synchronous appender or flipping the queue to block-on-full. Assertion (1)
+ * confirms the drop path the `loki_logs_dropped_total` metric (LokiDropMetrics) actually counts.
+ */
+object LokiAppenderFailOpenSpec extends ZIOSpecDefault {
+
+  /** A ~400-byte message so the small send queue fills after a few hundred events, not millions. */
+  private val message: String = "x" * 400
+
+  /**
+   * A server socket that accepts connections and then holds them open forever without writing any
+   * response. A `java.net.http`-based loki4j sender will block on the response until its request
+   * timeout — exactly the "Loki is a black hole" failure we must stay fail-open against.
+   */
+  private final class StallServer extends AutoCloseable {
+    private val server                       = new ServerSocket()
+    private val held: java.util.List[Socket] =
+      java.util.Collections.synchronizedList(new java.util.ArrayList[Socket]())
+    @volatile private var running            = true
+
+    server.bind(new InetSocketAddress("127.0.0.1", 0))
+    val port: Int = server.getLocalPort
+
+    private val acceptor = new Thread(
+      () =>
+        while running do
+          try {
+            val s = server.accept()
+            val _ = held.add(s) // never read/respond — just keep the socket open
+          } catch { case _: Throwable => () },
+      "loki-stall-acceptor",
+    )
+    acceptor.setDaemon(true)
+    acceptor.start()
+
+    def url: String = s"http://127.0.0.1:$port/loki/api/v1/push"
+
+    override def close(): Unit = {
+      running = false
+      try server.close()
+      catch { case _: Throwable => () }
+      held.forEach { s =>
+        try s.close()
+        catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  /**
+   * Build a [[MeteredLoki4jAppender]] pointed at `url`, tuned so backpressure manifests quickly: a
+   * tiny send queue, small fast-flushing batches, and a long request timeout so the background
+   * sender stays parked on the very first (never-answered) batch for the whole test — the send
+   * queue fills and stays full, so drops are continuous and deterministic.
+   */
+  private def buildAppender(ctx: LoggerContext, url: String): MeteredLoki4jAppender = {
+    val http = new PipelineConfigAppenderBase.HttpCfg()
+    http.setUrl(url)
+    http.setRequestTimeoutMs(60000L) // sender stays stuck on batch #1 for the whole test
+    http.setConnectionTimeoutMs(60000L)
+    http.setUseProtobufApi(false)
+
+    val batch = new PipelineConfigAppenderBase.BatchCfg()
+    batch.setMaxItems(5)
+    batch.setMaxBytes(8192)
+    batch.setTimeoutMs(50L)            // flush partial batches fast so the queue fills quickly
+    batch.setSendQueueMaxBytes(65536L) // small bounded queue → fills after a few hundred events
+    batch.setDrainOnStop(false)        // never hold shutdown waiting on Loki
+
+    val appender = new MeteredLoki4jAppender()
+    appender.setContext(ctx)
+    appender.setName("LOKI-failopen-test")
+    appender.setLabels("service=test") // static label → no per-event label parsing
+    // Disable structured-metadata (MDC) extraction: the synthetic LoggingEvents below come from a
+    // bare LoggerContext with no slf4j MDC adapter wired, so the default `* = %%mdc` pattern would
+    // NPE in extraction before events ever reach the async pipeline. The fail-open behaviour under
+    // test (async buffer + drop-on-full) is independent of label/metadata extraction.
+    appender.setStructuredMetadata(Loki4jAppender.DISABLE_SMD_PATTERN)
+    appender.setHttp(http)
+    appender.setBatch(batch)
+    appender.start()
+    appender
+  }
+
+  private def event(logger: ch.qos.logback.classic.Logger): LoggingEvent =
+    new LoggingEvent(getClass.getName, logger, Level.INFO, message, null, Array.empty)
+
+  /** Result of the imperative load run; asserted back in ZIO. */
+  private final case class Outcome(droppedAfterFill: Long, phase2Millis: Long, droppedDelta: Long)
+
+  private def runLoad: Task[Outcome] =
+    ZIO.attemptBlocking {
+      val ctx      = new LoggerContext()
+      val server   = new StallServer()
+      val appender = buildAppender(ctx, server.url)
+      val logger   = ctx.getLogger("loki-failopen-test")
+      val ev       = event(logger)
+      try {
+        // ── Phase 1: drive the appender until the bounded queue is full and it starts dropping.
+        // The background encoder needs wall-clock to batch + offer + hit the stalled sender, so we
+        // append in bursts with brief yields and poll the drop counter. The stalled server makes
+        // this monotonic — once full, it stays full.
+        val deadline         = java.lang.System.nanoTime() + 20_000_000_000L // 20s safety cap
+        while appender.droppedEventsTotal == 0L && java.lang.System.nanoTime() < deadline do {
+          var i = 0
+          while i < 1000 do { appender.doAppend(ev); i += 1 }
+          Thread.sleep(20L) // let the encoder fiber run
+        }
+        val droppedAfterFill = appender.droppedEventsTotal
+
+        // ── Phase 2: with the appender now shedding, prove the calling thread is never blocked.
+        // 200k appends against a black-hole Loki must complete near-instantly; a blocking/sync
+        // appender would stall on the 60s-timeout sends and take effectively forever.
+        val start        = java.lang.System.nanoTime()
+        var j            = 0
+        while j < 200_000 do { appender.doAppend(ev); j += 1 }
+        val phase2Millis = (java.lang.System.nanoTime() - start) / 1_000_000L
+        val droppedEnd   = appender.droppedEventsTotal
+
+        Outcome(droppedAfterFill, phase2Millis, droppedEnd - droppedAfterFill)
+      } finally {
+        try appender.stop()
+        catch { case _: Throwable => () }
+        try server.close()
+        catch { case _: Throwable => () }
+        ctx.stop()
+      }
+    }
+
+  def spec = suite("Loki appender fail-open under load (#1885)")(
+    test("backpressure resolves to DROP and the calling thread is never blocked") {
+      for {
+        out <- runLoad
+      } yield assertTrue(
+        // (1) the appender actually shed events under backpressure (drop-on-full, not block).
+        out.droppedAfterFill > 0L,
+        // (1b) drops keep accruing while Loki is a black hole.
+        out.droppedDelta > 0L,
+        // (2) 200k appends against an unreachable Loki finished fast — request latency is
+        // unaffected. Wildly generous bound (real runs are tens of ms); a blocking appender would
+        // be orders of magnitude over this.
+        out.phase2Millis < 5000L,
+      )
+    } @@ TestAspect.withLiveClock @@ TestAspect.timeout(60.seconds),
+  )
+}

--- a/api/test/src/feature/LokiDropMetricsSpec.scala
+++ b/api/test/src/feature/LokiDropMetricsSpec.scala
@@ -1,0 +1,82 @@
+package wifihaven.api.feature
+
+import wifihaven.api.MetricsConfig
+import wifihaven.api.metrics.MetricsRuntime
+import wifihaven.api.observability.LokiDropMetrics
+import wifihaven.api.routes.MetricsRoutes
+import zio.*
+import zio.http.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.test.*
+
+/**
+ * #1885: the poller side of the loki-drop metric. [[LokiDropMetrics.emitDelta]] reads the
+ * appender's monotonic cumulative drop counter each tick and feeds the positive delta to
+ * `loki_logs_dropped_total` via `MetricGuard`. This spec drives that diff logic against a
+ * Ref-backed reading (no live appender needed) and scrapes the real Prometheus publisher behind
+ * `GET /metrics` to prove:
+ *
+ *   - successive deltas accumulate into the counter (10 then +15 → 25),
+ *   - a flat reading emits nothing (no double-count),
+ *   - a non-increasing reading is ignored (no negative/garbage emission).
+ *
+ * Pairs with `LokiAppenderFailOpenSpec`, which proves the appender actually produces those drops.
+ */
+object LokiDropMetricsSpec extends ZIOSpec[PrometheusPublisher] {
+
+  override val bootstrap = MetricsRuntime.prometheus(100.millis)
+
+  private def scrape: ZIO[PrometheusPublisher, Nothing, String] =
+    for {
+      pub <- ZIO.service[PrometheusPublisher]
+      routes = MetricsRoutes.routes(MetricsConfig(enabled = true), pub)
+      resp <- routes(Request.get("/metrics")).merge
+      body <- resp.body.asString.orDie
+    } yield body
+
+  /**
+   * Parse the unlabelled `loki_logs_dropped_total` value out of the exposition (0.0 if absent). The
+   * zio-metrics prometheus line is `name value [timestamp]`, so the value is the SECOND token — not
+   * the last (that's the scrape timestamp). Matching the exact first token also skips any
+   * `loki_logs_dropped_total_created` helper line.
+   */
+  private def droppedValue(body: String): Double =
+    body.linesIterator
+      .filterNot(_.startsWith("#"))
+      .map(_.trim.split("\\s+"))
+      .collectFirst {
+        case parts if parts.length >= 2 && parts(0) == "loki_logs_dropped_total" =>
+          parts(1).toDoubleOption.getOrElse(0.0)
+      }
+      .getOrElse(0.0)
+
+  /**
+   * Poll the publisher until the scraped value reaches `target` (the snapshot listener is async).
+   */
+  private def awaitValue(target: Double): ZIO[PrometheusPublisher, Nothing, Double] =
+    scrape
+      .map(droppedValue)
+      .repeat(Schedule.spaced(50.millis) && Schedule.recurUntil[Double](_ >= target))
+      .map(_._2)
+
+  def spec = suite("loki-drop metric poller (#1885)")(
+    test("accumulates positive deltas, ignores flat and non-increasing readings") {
+      for {
+        reading  <- Ref.make(0L)
+        lastSeen <- Ref.make(0L)
+        // First tick: appender at 10 drops → emit 10.
+        _        <- reading.set(10L)
+        _        <- LokiDropMetrics.emitDelta(reading.get, lastSeen)
+        // Flat reading: still 10 → emit nothing.
+        _        <- LokiDropMetrics.emitDelta(reading.get, lastSeen)
+        // Climbs to 25 → emit +15.
+        _        <- reading.set(25L)
+        _        <- LokiDropMetrics.emitDelta(reading.get, lastSeen)
+        // Non-increasing (defensive; counter is monotonic in reality) → emit nothing, no crash.
+        _        <- reading.set(20L)
+        _        <- LokiDropMetrics.emitDelta(reading.get, lastSeen)
+        value    <- awaitValue(25.0)
+      } yield assertTrue(value == 25.0)
+    } @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds),
+  )
+}

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -587,6 +587,36 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Loki log shipping drops (#1885)",
+      "description": "sum(rate(loki_logs_dropped_total[5m])) — log events the loki4j appender shed because its bounded send queue (sendQueueMaxBytes) filled while Grafana Cloud Loki was slow/unreachable. Emitted by LokiDropMetrics polling MeteredLoki4jAppender's drop counter. Shipping is fail-open by design (the request path is never blocked — proven by LokiAppenderFailOpenSpec), so this is the ONLY signal that app logs are being silently lost. Should be flat zero in steady state; a sustained rate means a Loki outage is dropping logs.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 48 },
+      "id": 18,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0.001 }] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(loki_logs_dropped_total{env=\"$env\"}[5m]))",
+          "legendFormat": "dropped/s",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
Fixes #1885. Relates to #1831 (log export epic).

The #1873 loki4j appender ships API logs to Grafana Cloud Loki and is configured async / drop-on-backpressure. This sub-issue **proves** that fail-open behaviour under load and **instruments** the drops so a Loki outage silently shedding logs becomes alertable.

## Architectural grounding
loki4j is fail-open **by construction**: `AsyncBufferPipeline.append()` only enqueues to an in-memory buffer and returns immediately — it never does network I/O on the calling (request) thread. When the bounded `sendQueueMaxBytes` queue fills (Loki slow/unreachable, background sender backed up), the encoder flips `acceptNewEvents=false` and subsequent appends are **DROPPED**, never blocked. So request latency is structurally immune to a Loki outage.

## What this PR adds

### 1. Prove fail-open (`LokiAppenderFailOpenSpec`)
Drives a real `MeteredLoki4jAppender` at a `ServerSocket` that accepts the TCP connection but never responds (a black-hole Loki, worst case for a sync client), with a tiny send queue. Asserts:
- the appender **sheds** events (its drop counter climbs) — backpressure resolves to DROP, not block;
- **200k appends finish in <5s** while Loki is unreachable — a blocking/sync appender would stall on the per-batch timeout effectively forever. This is the regression guard against anyone wrapping it in a blocking appender or flipping the queue to block-on-full.

### 2. Drop metric (`loki_logs_dropped_total`)
- `MeteredLoki4jAppender`: a **zero-behaviour** subclass that re-exports loki4j's own `droppedEventsCount()` accessor. No Micrometer bridge — loki4j's Micrometer metrics publish to a different registry than the `zio.metrics` Prometheus one behind `GET /metrics`; the appender's own `AtomicLong` is the same number with none of the machinery. `logback.xml` swaps the LOKI appender `class=` to it (wire/log-path transparent).
- `LokiDropMetrics`: a `forkDaemon` poller (mirrors `DbPoolMetrics`/`RouterPresenceMetrics`) that diffs the appender's cumulative drop count each tick into `loki_logs_dropped_total` via `MetricGuard`. **Unlabelled** (appender-wide count; any per-mac/route label would breach the §4 cardinality firewall). No-ops on local/test where the appender is absent — same `GRAFANA_CLOUD_LOKI_URL` gate as the appender, no duplicated env check.
- `LokiDropMetricsSpec` pins the delta logic (accumulates positive deltas, ignores flat/non-increasing readings) end-to-end through the real Prometheus publisher.

### 3. Grafana panel
A "Loki log shipping drops" panel on `api-self-metrics.json` targeting the **actually-emitted** series (`sum(rate(loki_logs_dropped_total[5m]))`), thresholded to flag any sustained non-zero rate. Per the metrics-need-a-dashboard rule.

## Validation
- `mill api.test` — full module green (the two new specs + cardinality-guard + self-metrics suites pass).
- `mill scalafmtCheckAll` (scalafmt --check) clean.
- Dashboard JSON parses (`python3 -m json.tool`); only `infra/grafana` is fmt/validate-gated by `grafana-terraform`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)