### PR TITLE
feat(#1889): add Feeling Great app template

### DIFF
--- a/api/resources/app_templates/_index.yml
+++ b/api/resources/app_templates/_index.yml
@@ -37,3 +37,6 @@ slugs:
   - x
   # #1815: traffic-driven catalog pass (see evidence/classification-1815.md)
   - lego
+  # #1889: Feeling Great CBT app (distinctive host only; shared
+  # elevenlabs/launchdarkly deferred to #1888)
+  - feeling-great

--- a/api/resources/app_templates/feeling-great.yml
+++ b/api/resources/app_templates/feeling-great.yml
@@ -1,0 +1,28 @@
+slug: feeling-great
+name: Feeling Great
+icon: "https://icons.duckduckgo.com/ip3/feelinggreat.com.ico"
+icon_type: url
+# Feeling Great — AI-powered CBT/therapy app (David Burns' T.E.A.M. approach),
+# built around an AI chatbot. Authored from prod evidence (#1889): 90d traffic
+# across 5 human devices showed every feelinggreat.com hit landing on exactly
+# ONE subdomain — `app.feelinggreat.com` (the web/app + API surface; 23 MB / 445
+# hits on the heaviest device). No separate api./cdn. feelinggreat apex appears
+# in traffic, so the single sub-experience host covers the whole app. Scoped to
+# `app.feelinggreat.com` rather than the `feelinggreat.com` apex so the
+# marketing/www site stays OUT of this app's time-limit budget — dnsmasq's
+# `nftset=/<host>/` suffix-matches `app.feelinggreat.com` and its subtree but
+# not `www.feelinggreat.com` (same deliberate sub-experience scoping as lego.yml).
+#
+# SHARED HOSTS — deferred to #1888 (do NOT add as distinctive hosts here):
+#   * elevenlabs.io   — TTS API powering the AI chat voice
+#   * launchdarkly.com — feature flags
+# Both are backends shared by MANY apps. The prod evidence proves it:
+# launchdarkly.com shows meaningful traffic on devices that hit feelinggreat
+# ZERO bytes (every device in the 90d sample), so listing it here would
+# mis-attribute its bytes to Feeling Great. They are the motivating case for the
+# shared-host attribution mechanism (#1888) — once that lands they'll be added
+# here marked `shared` (credited to Feeling Great only when app.feelinggreat.com
+# is also active for the same device/window). TODO(#1888): add elevenlabs.io and
+# launchdarkly.com as `shared` hosts once the mechanism ships.
+hosts:
+  - app.feelinggreat.com

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -121,6 +121,8 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           "x",
           // #1815: traffic-driven catalog pass
           "lego",
+          // #1889: Feeling Great CBT app
+          "feeling-great",
         )
         val slugs    = templates.map(_.slug.value).toSet
         assertTrue(slugs == expected) &&


### PR DESCRIPTION
## What

Adds the **Feeling Great** app template (`api/resources/app_templates/feeling-great.yml`), the AI-powered CBT/therapy app, and registers it in `_index.yml`.

## Distinctive host-set (traffic-driven)

Pulled 90d of prod traffic across 5 human devices that use the app. **Every** `feelinggreat.com` hit lands on exactly one subdomain — `app.feelinggreat.com` (the web/app + API surface; 23 MB / 445 hits on the heaviest device). No separate `api.`/`cdn.`/`www.` apex carries app traffic, so a single host covers the whole app.

Scoped to `app.feelinggreat.com` (not the `feelinggreat.com` apex) so the marketing/`www` site stays out of the app's time-limit budget — `dnsmasq`'s `nftset=/<host>/` suffix-matches the subdomain subtree but not `www.feelinggreat.com` (same deliberate sub-experience scoping as `lego.yml`).

## Shared hosts deferred to #1888

`elevenlabs.io` (TTS for the AI chat voice) and `launchdarkly.com` (feature flags) are **not** added as distinctive hosts. Prod evidence: `launchdarkly.com` shows meaningful traffic on every device in the sample that hit feelinggreat **zero** bytes — proving it's a shared backend. Listing it here would mis-attribute its bytes to Feeling Great. Left a `TODO(#1888)` in the template to add them marked `shared` once that mechanism ships.

## Tests

`mill api.test.testOnly wifihaven.api.feature.AppTemplatesSpec` → 29 passed (includes manifest-in-sync, parse, icon-url, and seeding checks; updated the expected-slugs set). `scalafmt --check` clean.

Fixes #1889
Relates to #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)