### PR TITLE
feat(#1890): add curated 'AI' category blocklist

### DIFF
--- a/api/resources/blocklists/_index.yml
+++ b/api/resources/blocklists/_index.yml
@@ -10,6 +10,7 @@ ids:
   - gambling
   - adult
   - games
+  - ai
   # URL-sourced lists fetched at startup; cached in-memory.
   - ads-extended
   - social-extended

--- a/api/resources/blocklists/ai.yml
+++ b/api/resources/blocklists/ai.yml
@@ -1,0 +1,82 @@
+# AI chatbots, assistants, and generators (#1890). Conservative, hand-curated
+# starter set of the consumer-facing AI services a household may want to block:
+# chat assistants, AI search, companion/roleplay bots, and image/video/audio/
+# text generators. Subdomains are matched at the router, so only apex hosts (and
+# the handful of product subdomains / dedicated CDNs each vendor uses) are
+# listed.
+#
+# Host-scoping note: entries are suffix-matched, not apex-constrained, so a
+# product subdomain like `gemini.google.com` blocks only that host (and deeper),
+# never the bare `google.com`. We deliberately list the product subdomain rather
+# than the shared vendor apex.
+#
+# Shared-infra caveat: Google's AI products (Gemini, AI Studio) and a few others
+# sit behind the vendor's shared front-end IP pool, so blocking the product
+# subdomain can incidentally affect other same-vendor services that resolve to
+# overlapping IPs — an inherent limitation of IP-layer enforcement, accepted
+# here because the product hostnames are the canonical block target. We still
+# avoid multi-tenant CDN/cloud apexes (cloudfront, fastly, amazonaws, akamai*)
+# that would drag unrelated tenants into the drop.
+#
+# Distinct from the *app* templates (which grant a daily time budget): this is a
+# category a profile subscribes to for an outright block.
+id: ai
+name: AI Tools
+description: AI chatbots, assistants, and content generators (ChatGPT/OpenAI, Claude, Gemini, Copilot, Perplexity, Character.AI, Midjourney, etc.). Hand-curated v1.
+source: curated
+hosts:
+  # OpenAI / ChatGPT / Sora
+  - openai.com
+  - chatgpt.com
+  - oaistatic.com
+  - oaiusercontent.com
+  - sora.com
+  # Anthropic / Claude
+  - anthropic.com
+  - claude.ai
+  - claudeusercontent.com
+  # Google Gemini (product subdomains only — never bare google.com)
+  - gemini.google.com
+  - bard.google.com
+  - aistudio.google.com
+  - ai.google.dev
+  - deepmind.com
+  # Microsoft Copilot
+  - copilot.microsoft.com
+  - githubcopilot.com
+  # xAI / Grok
+  - x.ai
+  - grok.com
+  # Perplexity
+  - perplexity.ai
+  - pplx.ai
+  # Other major chat assistants
+  - meta.ai
+  - deepseek.com
+  - mistral.ai
+  - poe.com
+  - you.com
+  - phind.com
+  - huggingface.co
+  # Companion / roleplay chatbots
+  - character.ai
+  - characterai.io
+  - janitorai.com
+  - replika.com
+  - pi.ai
+  - chai-research.com
+  # Image / video / audio generators
+  - midjourney.com
+  - stability.ai
+  - runwayml.com
+  - leonardo.ai
+  - ideogram.ai
+  - civitai.com
+  - lumalabs.ai
+  - elevenlabs.io
+  - suno.com
+  - udio.com
+  # Writing assistants
+  - jasper.ai
+  - copy.ai
+  - writesonic.com

--- a/api/test/src/feature/BundledBlocklistsSpec.scala
+++ b/api/test/src/feature/BundledBlocklistsSpec.scala
@@ -366,6 +366,28 @@ object BundledBlocklistsSpec
         assertTrue(hosts.contains(Hostname.unsafe("riotgames.com"))) &&
         assertTrue(hosts.contains(Hostname.unsafe("gimkitconnect.com")))
     },
+    test("ai: bundled list is loaded and includes the major AI services (#1890)") {
+      for {
+        bundled <- BundledBlocklists.loadAll()
+        ai    = bundled.find(_.id == BlocklistId.unsafe("ai"))
+        hosts = ai.toList.flatMap(_.content match {
+          case BundledBlocklistContent.Inline(hs) => hs
+          case _                                  => Nil
+        })
+      } yield assertTrue(ai.isDefined) &&
+        assertTrue(ai.exists(_.name == "AI Tools")) &&
+        assertTrue(hosts.contains(Hostname.unsafe("chatgpt.com"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("openai.com"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("claude.ai"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("gemini.google.com"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("copilot.microsoft.com"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("perplexity.ai"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("character.ai"))) &&
+        assertTrue(hosts.contains(Hostname.unsafe("midjourney.com"))) &&
+        // Never list the bare shared vendor apex (#1890 host-scoping note).
+        assertTrue(!hosts.contains(Hostname.unsafe("google.com"))) &&
+        assertTrue(!hosts.contains(Hostname.unsafe("microsoft.com")))
+    },
     test("refresh(): re-fetches a single bundled list and returns new host count") {
       for {
         _       <- cleanDb


### PR DESCRIPTION
## Summary
Adds a hand-curated **AI** category blocklist — consumer-facing AI chatbots, assistants, and generators a household may want to block (ChatGPT/OpenAI, Claude, Gemini, Copilot, Perplexity, Character.AI, Midjourney, image/video/audio/text generators, companion bots, etc.).

Distinct from *app* templates (which grant a daily time budget) — this is a category a profile subscribes to for an outright block.

## What changed
- **`api/resources/blocklists/ai.yml`** — new inline `hosts:` bundled blocklist, following the exact existing pattern (id/name/description/source + `hosts:`).
- **`api/resources/blocklists/_index.yml`** — registered `ai` in the manifest.
- **`BundledBlocklistsSpec.scala`** — new test mirroring the `games` list test: asserts the list loads, has the right name, contains the major services, and never lists a bare shared vendor apex (`google.com` / `microsoft.com`).

## Enforcement
No new mechanism. Seeded by the existing `BundledBlocklists` startup seeder into `blocklist_domains`; enforced via the existing per-(MAC, blocklistId) nftables ipset drop path.

## Host-set curation
Kept tight per the architecture rule — product apexes + each vendor's own dedicated CDN / product subdomains only. **Never** the bare shared vendor apex (entries are suffix-matched, so `gemini.google.com` blocks Gemini without touching `google.com`) and no multi-tenant CDN/cloud pools (cloudfront/fastly/amazonaws/akamai*). A comment in the YAML documents the inherent GFE shared-IP caveat for vendor product subdomains.

High-signal hosts validated against 30d prod traffic (READ-ONLY): `claude.ai`, `anthropic.com`, `claudeusercontent.com`, `chatgpt.com`, `openai.com`, `oaistatic.com`, `grok.com`, `x.ai`, `elevenlabs.io` all observed; remainder from web research. `.ai`-TLD ad-tech noise (bidbrain, rtbrain, programmaticx, mediayo, etc.) deliberately excluded.

## Tests
`mill api.test.testOnly 'wifihaven.api.feature.BundledBlocklistsSpec'` → 19 passed. `scalafmt --check` clean.

Fixes #1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)