### PR TITLE
feat(#1895): add app_hosts.shared column (schema-only)

### DIFF
--- a/api/resources/db/migration/V60__app_hosts_shared.sql
+++ b/api/resources/db/migration/V60__app_hosts_shared.sql
@@ -1,0 +1,31 @@
+-- #1895 (shared-hosts S1a): mark an app_hosts row as a SHARED host.
+--
+-- Foundation for the shared-host allocation mechanism — see the design doc
+-- docs/design/shared-host-allocation.md (PR #1894) and parent #1888.
+--
+-- A SHARED host is a multi-tenant vendor backend/CDN (e.g. api.elevenlabs.io,
+-- app.launchdarkly.com) that several unrelated apps legitimately list. Its
+-- traffic must be credited to an app only while that app's DISTINCTIVE
+-- (non-shared) hosts have a live session on the same device — the co-presence
+-- rule. Distinctive hosts (shared = FALSE) keep their current unconditional
+-- minBy(appId) attribution.
+--
+-- The flag is stored per-(app_id, host) for enforcement flexibility, even
+-- though distinctiveness is globally consistent across the catalog (a host
+-- shared on any template must be shared on every template that lists it —
+-- enforced by the directory-wide validation test in S1b).
+--
+-- DEFAULT FALSE: every existing app_hosts row is "distinctive", which is the
+-- pre-#1895 behavior (all hosts attribute unconditionally). The next image
+-- after this migration deploys is backward-compatible — code that doesn't read
+-- this column behaves exactly as before. The flag is stored and ignored until
+-- the consuming PRs (S1b parser/seed #1896, then S2/S3/S4) adopt it.
+--
+-- app_hosts is a small, bounded table (one row per app/host pair from the
+-- template catalog), so this ADD COLUMN is fast at prod scale.
+--
+-- Schema-only per AGENTS.md §migrations-back-compat. Code adoption follows in
+-- a separate PR (#1896).
+
+ALTER TABLE app_hosts
+  ADD COLUMN shared BOOLEAN NOT NULL DEFAULT FALSE;

--- a/docs/design/shared-host-allocation.md
+++ b/docs/design/shared-host-allocation.md
@@ -315,11 +315,14 @@ app's host-set into distinctive vs shared. This is the plumbing in sub-issue
 Ordered foundation-first; each ships with tests per [TDD](../process/tdd.md) and
 runs `/pr-review` before merge.
 
-- **S1a — Migration: `app_hosts.shared` column** (schema-only PR per
-  [migrations](../process/migrations.md#migrations-back-compat)).
+- **S1a — Migration: `app_hosts.shared` column** ✅ shipped
+  ([#1895](https://github.com/wifihaven/wifihaven/issues/1895),
+  `V60__app_hosts_shared.sql`) — schema-only PR per
+  [migrations](../process/migrations.md#migrations-back-compat).
   `ALTER TABLE app_hosts ADD COLUMN shared BOOLEAN NOT NULL DEFAULT FALSE;`
   Existing rows default distinctive. No source/test in this PR — the existing
-  suite is the back-compat gate.
+  suite is the back-compat gate. The flag is stored and ignored until S1b
+  adopts it.
 
 - **S1b — Template syntax + parser + seeder + validation** (depends on S1a).
   Add `sharedHosts: List[Hostname]` to `AppTemplate`


### PR DESCRIPTION
## What

Adds the `app_hosts.shared` BOOLEAN column — the per-`(app_id, host)` flag marking a host as **shared across apps** — as the schema foundation for the shared-host allocation mechanism.

```sql
ALTER TABLE app_hosts ADD COLUMN shared BOOLEAN NOT NULL DEFAULT FALSE;
```

(`V60__app_hosts_shared.sql`)

## Why

Per the merged design [`docs/design/shared-host-allocation.md`](docs/design/shared-host-allocation.md) (#1894), some hosts are multi-tenant vendor backends/CDNs (e.g. `api.elevenlabs.io`, `app.launchdarkly.com`) that several unrelated apps legitimately list. Their traffic must be credited to an app only while that app's **distinctive** (non-shared) hosts have a live session on the same device (the co-presence rule). This column distinguishes the two. Distinctive hosts (`shared = FALSE`) keep their current unconditional `minBy(appId)` attribution.

## Schema-only PR

Per [`docs/process/migrations.md#migrations-back-compat`](docs/process/migrations.md#migrations-back-compat) (#696): this PR contains **only** the migration + docs — no source, no tests, no CI/fixtures/build. The existing feature-test suite is the back-compat gate (it applies V60 against embedded Postgres while exercising image-(N-1) code paths).

`DEFAULT FALSE` makes the column additive: every existing `app_hosts` row stays distinctive, matching pre-#1895 behavior, so the next image is backward-compatible. The flag is stored and **ignored** until the consuming PRs adopt it.

The parser/seeder that adopts the column is the separate **S1b** PR (#1896).

## Migration cost

`app_hosts` is a small, bounded table (one row per app/host pair from the template catalog) — not an unbounded-growth table — so this `ADD COLUMN` (with a non-volatile constant default, metadata-only in PG 11+) is fast at prod scale.

Fixes #1895
Relates to #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)