### PR TITLE
feat(#1833): drop Recent Queries firehose + rename queries→connection events on /dashboard

### DIFF
--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -93,9 +93,9 @@ const mockAlerts = () => api.alerts.list as unknown as ReturnType<typeof vi.fn>
 beforeEach(() => {
   vi.resetAllMocks()
   mockStats().mockResolvedValue(stats)
-  // #1338: the "Most recently blocked" panel and the "Recent Queries" table
-  // both hit api.logs.query; split the canned response by the blocked filter so
-  // each surface renders its own (distinct) fixture.
+  // #1338: the "Most recently blocked" panel hits api.logs.query with
+  // blocked=true; serve the blocked fixture for it. The unfiltered (allow) branch
+  // is retained only as a guard — #1833 dropped the firehose that consumed it.
   mockQuery().mockImplementation((params?: { blocked?: boolean }) =>
     Promise.resolve(
       params?.blocked
@@ -108,7 +108,7 @@ beforeEach(() => {
 })
 
 describe('DashboardPage', () => {
-  it('renders stat cards, top-blocked, per-device, and recent queries', async () => {
+  it('renders stat cards, top-blocked, and per-device with connection-events copy', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
     expect(await screen.findByText('1234')).toBeInTheDocument()
     expect(screen.getByText('56')).toBeInTheDocument()
@@ -117,24 +117,31 @@ describe('DashboardPage', () => {
     expect(screen.getByText('evil.com')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
     expect(screen.getAllByText("Kid's iPad").length).toBeGreaterThan(0)
-    expect(screen.getByText('500 queries')).toBeInTheDocument()
+    expect(screen.getByText('500 events')).toBeInTheDocument()
     expect(screen.getByText('20 blocked')).toBeInTheDocument()
-    expect(screen.getByText('example.com')).toBeInTheDocument()
-
-    expect(api.logs.query).toHaveBeenCalledWith({ limit: 30 })
   })
 
-  it('shows empty state when no blocked queries', async () => {
+  it('drops the unfiltered Recent Queries firehose (#823): no inline log table or query() call', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    await screen.findByText('1234')
+    // The un-aggregated allow row used only by the dropped firehose must not render.
+    expect(screen.queryByText('example.com')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Recent Queries/)).not.toBeInTheDocument()
+    // One fewer network call on load: the page fetches only stats, never the firehose query.
+    expect(api.logs.stats).toHaveBeenCalledTimes(1)
+    expect(mockQuery()).not.toHaveBeenCalledWith({ limit: 30 })
+  })
+
+  it('uses "connection events" terminology, never "queries" (#299)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    await screen.findByText('1234')
+    expect(document.body.textContent).not.toMatch(/queries/i)
+  })
+
+  it('shows empty state when no blocked connection events', async () => {
     mockStats().mockResolvedValue({ ...stats, topBlocked: [] })
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    expect(await screen.findByText(/No blocked queries yet/)).toBeInTheDocument()
-  })
-
-  it('recent activity Time column renders in viewer local time (not UTC slice)', async () => {
-    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    await screen.findByText('example.com')
-    const expected = new Date(recent.ts).toLocaleTimeString()
-    expect(screen.getByText(expected)).toBeInTheDocument()
+    expect(await screen.findByText(/No blocked connection events yet/)).toBeInTheDocument()
   })
 
   it('renders Now section above stat cards', async () => {
@@ -143,7 +150,7 @@ describe('DashboardPage', () => {
     await screen.findByText('1234')
     await waitFor(() => expect(screen.getByTestId('now-profile-1')).toBeInTheDocument())
     const nowHeading = screen.getByText('Now')
-    const statsCard  = screen.getByText('Queries today')
+    const statsCard  = screen.getByText('Events today')
     const comparison = nowHeading.compareDocumentPosition(statsCard)
     expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -15,12 +15,11 @@ import { blockReasonText } from '@/types/blockReason'
 
 export function DashboardPage() {
   const [stats,  setStats]  = useState<DashboardStats | null>(null)
-  const [logs,   setLogs]   = useState<QueryLog[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    Promise.all([api.logs.stats(), api.logs.query({ limit: 30 })])
-      .then(([s, l]) => { setStats(s); setLogs(l.rows) })
+    api.logs.stats()
+      .then(setStats)
       .finally(() => setLoading(false))
   }, [])
 
@@ -41,9 +40,9 @@ export function DashboardPage() {
       {stats && (
         <>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Queries today"  value={stats.totalToday}   accent="emerald" />
+            <StatCard label="Events today"   value={stats.totalToday}   accent="emerald" />
             <StatCard label="Blocked today"  value={stats.blockedToday} accent="red" />
-            <StatCard label="Queries (1h)"   value={stats.totalHour}    accent="emerald" />
+            <StatCard label="Events (1h)"    value={stats.totalHour}    accent="emerald" />
             <StatCard label="Blocked (1h)"   value={stats.blockedHour}  accent="yellow" />
           </div>
 
@@ -53,7 +52,7 @@ export function DashboardPage() {
                 Top Blocked (24h)
               </h2>
               {stats.topBlocked.length === 0
-                ? <EmptyState variant="inline" title="No blocked queries yet" />
+                ? <EmptyState variant="inline" title="No blocked connection events yet" />
                 : stats.topBlocked.map(d => (
                     <div key={`${d.host.type}:${d.host.value}`} className="flex justify-between items-center py-2 border-b border-brand-border last:border-0">
                       <span className="font-mono text-sm text-brand-text truncate"><HostCell host={d.host} /></span>
@@ -74,7 +73,7 @@ export function DashboardPage() {
                     <p className="text-xs text-brand-text-muted font-mono">{d.mac}</p>
                   </div>
                   <div className="text-right shrink-0">
-                    <p className="text-sm text-brand-text">{d.total} queries</p>
+                    <p className="text-sm text-brand-text">{d.total} events</p>
                     <p className="text-xs text-red-700">{d.blocked} blocked</p>
                   </div>
                 </div>
@@ -83,15 +82,6 @@ export function DashboardPage() {
           </div>
         </>
       )}
-
-      <section className="bg-white rounded-2xl border border-brand-border overflow-hidden">
-        <div className="px-5 py-4 border-b border-brand-border">
-          <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">Recent Queries</h2>
-        </div>
-        <div className="overflow-x-auto">
-          <LogTable logs={logs} />
-        </div>
-      </section>
     </div>
   )
 }
@@ -280,35 +270,6 @@ function StatCard({ label, value, accent }: { label: string; value: number; acce
   )
 }
 
-function LogTable({ logs }: { logs: QueryLog[] }) {
-  return (
-    <table className="w-full text-xs font-mono">
-      <thead>
-        <tr className="text-brand-text-muted border-b border-brand-border">
-          <th className="text-left px-4 py-2">Time</th>
-          <th className="text-left px-4 py-2">Device</th>
-          <th className="text-left px-4 py-2">Domain</th>
-          <th className="text-left px-4 py-2">Status</th>
-          <th className="text-left px-4 py-2 hidden md:table-cell">Reason</th>
-        </tr>
-      </thead>
-      <tbody>
-        {logs.map(l => (
-          <tr key={l.id} className="border-b border-brand-border/50 hover:bg-brand-alt/30">
-            <td className="px-4 py-2 text-brand-text-muted">{new Date(l.ts).toLocaleTimeString()}</td>
-            <td className="px-4 py-2 text-amber-700">{l.deviceName ?? l.mac ?? '?'}</td>
-            <td className="px-4 py-2 text-brand-text max-w-[200px] truncate"><HostCell host={l.host} /></td>
-            <td className={`px-4 py-2 ${l.blocked ? 'text-red-700' : 'text-brand-accent-dark'}`}>
-              {l.blocked ? '✗ blocked' : '✓ ok'}
-            </td>
-            <td className="px-4 py-2 text-brand-text-muted hidden md:table-cell">{blockReasonText(l.reason)}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
-}
-
 function PageLoader() {
   return (
     <div className="flex items-center justify-center h-64">
@@ -317,4 +278,4 @@ function PageLoader() {
   )
 }
 
-export { LogTable, PageLoader, formatRelativeTime }
+export { PageLoader, formatRelativeTime }


### PR DESCRIPTION
Fixes #1833. Relates to #1148.

Dashboard redesign **chunk 1 of 5** (umbrella #1148, design `docs/design/dashboard-redesign.md` §7). Closes the terminology (#299) and firehose-drop (#823) inputs. Pure frontend, lowest-risk chunk, independent of #1834–#1837.

## What changed
- **Drop the unfiltered "Recent Queries" firehose** (#823): removed the `<section>` rendering `LogTable`, the `api.logs.query({ limit: 30 })` load-time call, and the `logs` state. `DashboardPage` now fetches only `api.logs.stats()` — **one fewer network call on load**. The unused `LogTable` component + export are removed (no other page imported it).
- **Rename "queries" → "connection events" / "events"** (#299): KPI tiles (`Events today` / `Events (1h)`), the per-device "N events" count, and the "No blocked connection events yet" empty state. Aligns the dashboard with the existing `/usage/events` "Connection Events" term.
- **Kept `RecentlyBlockedSection` (#1338) untouched** — it is the *filtered*, blocked-only trailing-hour recency feed, not the firehose #823 targets, and it already links **View all → /usage/events** (the design's link-out target is preserved here).

## Acceptance (per #1833)
- ✅ `/dashboard` no longer renders the unfiltered log table; one fewer network call on load.
- ✅ "Most Recently Blocked" feed unaffected.
- ✅ No dashboard copy reads "queries"; `/usage` and `/logs` pages untouched.
- ✅ `DashboardPage` tests updated; no broken `LogTable` imports.

## Tests
TDD: tests updated first. New assertions: the firehose table/`query({limit:30})` call is gone, no "queries" copy remains in the rendered dashboard, and `stats()` is the sole load fetch. Full web suite green (406 passed), `type-check` + `lint` clean (node 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)