### PR TITLE
feat(#1847): ws capability handshake (hello/ready + snapshotVersion negotiation)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -202,11 +202,19 @@ object MetricGuard {
     // #1846 — websocket router transport (server side). `router_ws_connections_active` is the live
     // count of open channels (a household-scoped gauge, refreshed on every register/deregister so it
     // ages out cleanly on disconnect). `router_ws_frames_total` counts every frame demuxed/sent:
-    // `op` ∈ {hello, usage, events, metrics, ping, pong, ack, unknown} (the fixed envelope
+    // `op` ∈ {hello, ready, usage, events, metrics, ping, pong, ack, unknown} (the fixed envelope
     // vocabulary), `direction` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. All bounded enums —
     // no per-mac / per-host dimension ever rides a ws metric.
     "router_ws_connections_active"              -> Set.empty[String],
     "router_ws_frames_total"                    -> Set("op", "direction", "result"),
+    // #1847 — capability-handshake outcomes for the ws transport. `result` ∈
+    // {ok, auth_fail, hello_timeout, version_exceeded} (a fixed enum, design §2 /
+    // §7): `ok` once `hello`→`ready` negotiates a snapshotVersion, `auth_fail`
+    // when the upgrade is rejected at the token check, `hello_timeout` when no
+    // `hello` arrives within the window (close 4002), `version_exceeded` when the
+    // agent's max-known snapshotVersion is below the server's floor (close 4003).
+    // Bounded enum — no per-router dimension rides this series.
+    "router_ws_handshake_total"                 -> Set("result"),
     // #1718 — native OpenWRT OS-level metrics the agent collects from /proc/* and `iw dev`
     // and pushes through the existing #1205 batch transport. Gives operators the LuCI-style
     // view of router health (load / cpu / mem / bandwidth / conntrack / wifi clients) in
@@ -489,6 +497,12 @@ object AppMetrics {
       "router_ws_frames_total",
       Map("op" -> op, "direction" -> direction, "result" -> result),
     )
+
+  // Emitted from RouterWsRoutes for every capability-handshake outcome (#1847).
+  // `result` ∈ {ok, auth_fail, hello_timeout, version_exceeded} — a fixed enum,
+  // never a per-router dimension (the §4 cardinality firewall).
+  def recordWsHandshake(result: String): UIO[Unit] =
+    MetricGuard.counter("router_ws_handshake_total", Map("result" -> result))
 
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
   // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds

--- a/api/src/routes/RouterWsRoutes.scala
+++ b/api/src/routes/RouterWsRoutes.scala
@@ -11,13 +11,14 @@ import zio.json.*
 import zio.json.ast.Json
 
 /**
- * #1846: the persistent-websocket router transport, `GET /api/router/ws`. This is sub-issue A of
- * the websocket-transport epic
- * ([`docs/design/websocket-transport.md`](../../../docs/design/websocket-transport.md)) — the
- * SERVER endpoint + `{op, payload}` envelope demux + per-router connection registry. It is purely
- * additive: the REST ingest/poll/metrics endpoints stay fully live (design §3), and a router may
- * use either transport. Capability negotiation (`hello`/`ready`, #1847), the agent ws client
- * (#1848), and policy push-on-change (#1849) build on this and are explicitly out of scope here.
+ * #1846 + #1847: the persistent-websocket router transport, `GET /api/router/ws`. Sub-issue A
+ * (#1846) is the SERVER endpoint + `{op, payload}` envelope demux + per-router connection registry;
+ * sub-issue B (#1847) adds the `hello`→`ready` capability handshake + `snapshotVersion` negotiation
+ * layered on top
+ * ([`docs/design/websocket-transport.md`](../../../docs/design/websocket-transport.md) §2, see
+ * [[handleHello]]). It is purely additive: the REST ingest/poll/metrics endpoints stay fully live
+ * (design §3), and a router may use either transport. The agent ws client (#1848) and policy
+ * push-on-change / first-policy-on-connect (#1849) build on this and are out of scope here.
  *
  * Auth (design §4.1): the upgrade request carries the existing per-router bearer token; we call the
  * SAME [[RouterAuth.authenticate]] the REST routes use, BEFORE completing the upgrade. A
@@ -31,12 +32,34 @@ import zio.json.ast.Json
  * unrecognized `op` is ignored + metered (`unknown_op`), the forward-compat rule that lets a future
  * op ship without a flag day.
  *
- * Out of scope for #1846, with a clear seam: the `hello` op is logged + metered but NOT negotiated
- * here — the `hello`→`ready` capability handshake and the first-policy-on-connect push land in
- * #1847 / #1849. The agent does not yet open this socket (the Lua client is #1848); the endpoint is
+ * Handshake (design §2, #1847): the agent sends `hello` (its capability set + max-known
+ * `snapshotVersion`) and the server replies `ready` (its capability set + the negotiated
+ * `snapshotVersion = min(agent.maxKnown, server.maxKnown)`). Refusal paths: no `hello` within
+ * `helloTimeout` → close `4002 hello-required`; a `hello` below the server's version floor → close
+ * `4003 version-exceeded`. Still out of scope here: the first-policy-on-connect push and
+ * push-on-change (#1849), and the agent ws client (the Lua client is #1848). The endpoint is
  * exercisable by a test ws client today.
  */
 object RouterWsRoutes {
+
+  // #1847 capability-handshake constants (design §2). The server's max-known and minimum-understood
+  // `PolicySnapshot` shape versions: both 1 today (the only shape that has ever shipped). The
+  // negotiated version is `min(agent.maxKnown, ServerSnapshotVersion)`; if that drops below
+  // `ServerMinSnapshotVersion` there is no shape both ends speak and we refuse (close 4003). These
+  // bump only on a breaking snapshot-shape change (sub-issue F / #376) — not in this issue.
+  private val ServerSnapshotVersion    = 1
+  private val ServerMinSnapshotVersion = 1
+
+  // Server-advertised capability set echoed in `ready`. v1 names only the features the server
+  // actually implements today: the transport itself and the per-data-frame `ack`s (#1846). The set
+  // is the EXTENSION POINT (design §2.2) — `policy-push` (#1849), diffs, compression are added here
+  // when those features land, never inferred. Agents intersect it on their side; the server emits
+  // its own full set.
+  private val ServerCapabilities: List[String] = List("ws-transport-v1", "ack-frames")
+
+  // Default time the server waits after upgrade for the agent's `hello` before closing 4002 (§2.2).
+  // Overridable on `routes` so tests can drive the timeout path without a real 5 s sleep.
+  val DefaultHelloTimeout: Duration = 5.seconds
 
   def routes(
       auth: RouterAuth,
@@ -44,6 +67,7 @@ object RouterWsRoutes {
       ingest: RouterIngestService,
       metricsSvc: RouterMetricsService,
       routerRepo: RouterRepo,
+      helloTimeout: Duration = DefaultHelloTimeout,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "router" / "ws" ->
@@ -53,8 +77,18 @@ object RouterWsRoutes {
           auth
             .authenticate(req)
             .foldZIO(
-              err => ZIO.succeed(ErrorMapper.errorToResponse(err)),
-              router => socketApp(router, registry, ingest, metricsSvc, routerRepo).toResponse,
+              // A rejected upgrade is the `auth_fail` handshake outcome (#1847, §7): meter it, then
+              // return the SAME 401 the REST routes produce.
+              err => AppMetrics.recordWsHandshake("auth_fail").as(ErrorMapper.errorToResponse(err)),
+              router =>
+                socketApp(
+                  router,
+                  registry,
+                  ingest,
+                  metricsSvc,
+                  routerRepo,
+                  helloTimeout,
+                ).toResponse,
             )
         },
     )
@@ -65,48 +99,68 @@ object RouterWsRoutes {
       ingest: RouterIngestService,
       metricsSvc: RouterMetricsService,
       routerRepo: RouterRepo,
+      helloTimeout: Duration,
   ): WebSocketApp[Any] =
     Handler.webSocket { channel =>
-      // Register once the upgrade handshake completes; deregister unconditionally on exit (normal
-      // close, error, or interruption) so the registry + active-connections gauge never leak a dead
-      // channel. deregister is idempotent, so the explicit Unregistered handler below is harmless
-      // belt-and-suspenders.
-      channel
-        .receiveAll {
-          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
-            registry.register(router.id, channel) *>
-              ZIO.logInfo(s"router ws: connected router=${router.id}")
-          case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
-            // A dispatch failure (e.g. a send error) tears this frame's handling down; log the cause
-            // so a transport-level fault is debuggable, then let it surface (the socket closes and
-            // the agent reconnects per the design's reconnect-is-the-throttle rule).
-            dispatch(router, channel, text, ingest, metricsSvc, routerRepo)
-              .tapErrorCause(c =>
-                ZIO.logErrorCause(s"router ws: dispatch failed router=${router.id}", c),
-              )
-          case ChannelEvent.Unregistered                                    =>
-            registry.deregister(router.id, channel)
-          case _                                                            =>
-            ZIO.unit
+      // Per-connection handshake state: flipped true once a `hello` is received (design §2.2), so
+      // the hello-timeout watcher can stand down. Re-deliveries of `hello` on the same connection
+      // are harmless idempotent re-acks.
+      Ref.make(false).flatMap { helloDone =>
+        // Hello-timeout watcher: if no `hello` arrives within HelloTimeout, close 4002 hello-required
+        // and meter the outcome (§2.2). Forked daemon so it runs alongside the receive loop;
+        // interrupted in `ensuring` on connection close so it can never leak past the socket.
+        val startWatcher =
+          (ZIO.sleep(helloTimeout) *> ZIO
+            .unlessZIO(helloDone.get) {
+              AppMetrics.recordWsHandshake("hello_timeout") *>
+                ZIO.logWarning(
+                  s"router ws: no hello within $helloTimeout router=${router.id}, closing 4002",
+                ) *>
+                closeWith(channel, 4002, "hello-required")
+            }
+            .unit).forkDaemon
+
+        startWatcher.flatMap { watcher =>
+          channel
+            .receiveAll {
+              case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+                registry.register(router.id, channel) *>
+                  ZIO.logInfo(s"router ws: connected router=${router.id}")
+              case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
+                // A dispatch failure (e.g. a send error) tears this frame's handling down; log the
+                // cause so a transport-level fault is debuggable, then let it surface (the socket
+                // closes and the agent reconnects per the design's reconnect-is-the-throttle rule).
+                dispatch(router, channel, text, helloDone, ingest, metricsSvc, routerRepo)
+                  .tapErrorCause(c =>
+                    ZIO.logErrorCause(s"router ws: dispatch failed router=${router.id}", c),
+                  )
+              case ChannelEvent.Unregistered                                    =>
+                registry.deregister(router.id, channel)
+              case _                                                            =>
+                ZIO.unit
+            }
+            .ensuring(
+              watcher.interrupt *>
+                registry.deregister(router.id, channel) *>
+                ZIO.logInfo(s"router ws: disconnected router=${router.id}"),
+            )
         }
-        .ensuring(
-          registry.deregister(router.id, channel) *>
-            ZIO.logInfo(s"router ws: disconnected router=${router.id}"),
-        )
+      }
     }
 
   /**
    * Demux one inbound text frame. A frame that does not parse as the envelope, or carries an
    * unrecognized `op`, is metered + logged and otherwise ignored (forward-compat, design §1.3).
    * Data ops (`usage`/`events`/`metrics`) run through the shared ingest services and reply with an
-   * `ack` frame (`ok`/`reject`). `ping` is answered with `pong`. `hello` is the #1847 handshake
-   * seam — it is logged + metered but not yet negotiated. Every recognized frame touches
+   * `ack` frame (`ok`/`reject`). `ping` is answered with `pong`. `hello` runs the #1847 capability
+   * handshake ([[handleHello]]) — reply `ready` or refuse. Every recognized frame touches
    * `routers.last_seen_at` for uniform liveness with the REST path (design §3.1/§5.5).
    */
   private def dispatch(
       router: Router,
       channel: WebSocketChannel,
       text: String,
+      helloDone: Ref[Boolean],
       ingest: RouterIngestService,
       metricsSvc: RouterMetricsService,
       routerRepo: RouterRepo,
@@ -137,14 +191,7 @@ object RouterWsRoutes {
             case "pong"    =>
               touch(routerRepo, router) *> AppMetrics.recordWsFrame("pong", "in", "ok")
             case "hello"   =>
-              // #1847 seam: the capability handshake (hello→ready + snapshotVersion negotiation) is
-              // NOT implemented here. Acknowledge receipt in the logs/metrics so the frame is
-              // observable, but do not negotiate or reply `ready` yet.
-              touch(routerRepo, router) *>
-                AppMetrics.recordWsFrame("hello", "in", "ok") *>
-                ZIO.logInfo(
-                  s"router ws: hello from router=${router.id} (handshake deferred to #1847)",
-                )
+              handleHello(router, channel, frame, helloDone, routerRepo)
             case other     =>
               // Forward-compat: ignore + meter an unrecognized op (design §1.3) so a future op
               // (e.g. policy_diff) can ship without a flag day. The arbitrary op string is collapsed
@@ -156,6 +203,76 @@ object RouterWsRoutes {
           }
         }
     }
+
+  /**
+   * #1847 capability handshake (design §2.2). The agent's `hello` advertises its capability set,
+   * its max-known `snapshotVersion`, and (observability only) its agent version. The server replies
+   * `ready` with ITS capability set and the negotiated `snapshotVersion = min(agent.maxKnown,
+   * ServerSnapshotVersion)` — so a future agent that knows a higher version is handed today's v1
+   * shape, and the next breaking shape change is a version bump rather than a flag day (the durable
+   * #376 slice). If the negotiated version falls below the server's floor (an agent that doesn't
+   * even understand v1 — `snapshotVersion < 1`, or a malformed/absent payload that decodes to
+   * version 0) there is no common shape: we close `4003 version-exceeded` so the agent falls back
+   * to its last-good cached snapshot (`docs/resilience.md §1`). Either outcome marks `helloDone` so
+   * the hello-timeout watcher (§2.2) stands down — a `hello` DID arrive.
+   *
+   * The capability sets are string sets, intersected on each side to gate optional behavior; v1 has
+   * no behavior gated on it yet (it is purely the extension point), so we only log the negotiated
+   * intersection for observability. Unknown fields in the payload are ignored (forward-compat) —
+   * the `WsHello` decoder simply doesn't bind them.
+   */
+  private def handleHello(
+      router: Router,
+      channel: WebSocketChannel,
+      frame: WsFrame,
+      helloDone: Ref[Boolean],
+      routerRepo: RouterRepo,
+  ): ZIO[Any, Throwable, Unit] = {
+    // A `hello` whose payload is absent or undecodable (missing the required `snapshotVersion`)
+    // decodes to version 0, which is below the floor → the version-exceeded path closes it cleanly
+    // rather than the server guessing a shape.
+    val hello        = frame.payload.flatMap(_.toString.fromJson[WsHello].toOption)
+    val agentVersion = hello.map(_.snapshotVersion).getOrElse(0)
+    val agentCaps    = hello.map(_.agentCapabilities.toSet).getOrElse(Set.empty[String])
+    val negotiated   = math.min(agentVersion, ServerSnapshotVersion)
+
+    helloDone.set(true) *>
+      touch(routerRepo, router) *>
+      AppMetrics.recordWsFrame("hello", "in", "ok") *> {
+        if negotiated < ServerMinSnapshotVersion then
+          AppMetrics.recordWsHandshake("version_exceeded") *>
+            ZIO.logWarning(
+              s"router ws: hello router=${router.id} snapshotVersion=$agentVersion below floor " +
+                s"$ServerMinSnapshotVersion, closing 4003",
+            ) *>
+            closeWith(channel, 4003, "version-exceeded")
+        else
+          send(
+            channel,
+            WsFrame(
+              "ready",
+              Some(WsReady(ServerCapabilities, negotiated).toJsonAST.getOrElse(Json.Obj())),
+            ),
+          ) *>
+            AppMetrics.recordWsFrame("ready", "out", "ok") *>
+            AppMetrics.recordWsHandshake("ok") *>
+            ZIO.logInfo(
+              s"router ws: ready router=${router.id} snapshotVersion=$negotiated " +
+                s"caps=${agentCaps.intersect(ServerCapabilities.toSet)}",
+            )
+      }
+  }
+
+  /**
+   * Send a Close frame with an application close code (§2.2: 4002 hello-required, 4003
+   * version-exceeded).
+   */
+  private def closeWith(
+      channel: WebSocketChannel,
+      code: Int,
+      reason: String,
+  ): ZIO[Any, Throwable, Unit] =
+    channel.send(ChannelEvent.read(WebSocketFrame.close(code, Some(reason))))
 
   /**
    * Run a data-frame payload through `ingestF` (one of the shared ingest services) and reply with
@@ -251,5 +368,24 @@ object RouterWsRoutes {
    * The `ack` frame payload (design §1.3): which data frame, its seq, ok/reject, optional reason.
    */
   private case class WsAck(op: String, seq: Option[Int], status: String, reason: Option[String])
+      derives JsonCodec
+
+  /**
+   * The `hello` frame payload (design §2.2), agent→server. `snapshotVersion` is the agent's
+   * max-known `PolicySnapshot` shape version (required). `agentCapabilities` defaults to empty and
+   * `agentVersion` is optional (observability only) so a terse/older `hello` still decodes. Unknown
+   * fields are ignored (forward-compat — zio-json drops extras).
+   */
+  private case class WsHello(
+      snapshotVersion: Int,
+      agentCapabilities: List[String] = Nil,
+      agentVersion: Option[String] = None,
+  ) derives JsonCodec
+
+  /**
+   * The `ready` frame payload (design §2.2), server→agent. Carries the server's own capability set
+   * and the negotiated `snapshotVersion = min(agent.maxKnown, ServerSnapshotVersion)`.
+   */
+  private case class WsReady(serverCapabilities: List[String], snapshotVersion: Int)
       derives JsonCodec
 }

--- a/api/test/src/feature/RouterWsSpec.scala
+++ b/api/test/src/feature/RouterWsSpec.scala
@@ -19,11 +19,14 @@ import zio.test.*
 import java.time.{Instant, LocalDateTime}
 
 /**
- * #1846: server-side websocket transport. Exercises the real `/api/router/ws` endpoint end to end —
- * a real [[Server]] on an ephemeral port and a real ws [[Client]] — to prove upgrade-time auth, the
- * `{op, payload}` demux dispatching into the shared ingest service, the per-router connection
- * registry, and the heartbeat (`ping`→`pong`). The REST ingest path stays covered by
- * [[RouterIngestSpec]], which is the back-compat gate for the transport-agnostic ingest extraction.
+ * #1846 + #1847: server-side websocket transport. Exercises the real `/api/router/ws` endpoint end
+ * to end — a real [[Server]] on an ephemeral port and a real ws [[Client]] — to prove upgrade-time
+ * auth, the `{op, payload}` demux dispatching into the shared ingest service, the per-router
+ * connection registry, the heartbeat (`ping`→`pong`), and the #1847 capability handshake:
+ * `hello`→`ready` with `snapshotVersion` negotiation (`min` rule), the future-agent back-compat
+ * down-negotiation, the below-floor refusal (close 4003), and the hello-timeout refusal (close
+ * 4002). The REST ingest path stays covered by [[RouterIngestSpec]], which is the back-compat gate
+ * for the transport-agnostic ingest extraction.
  */
 object RouterWsSpec
     extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
@@ -53,7 +56,9 @@ object RouterWsSpec
       _   <- dRepo.upsert(MacAddress.unsafe(knownMac), "kid-ipad", Some(pid), "192.168.1.10")
     } yield ()
 
-  private def buildWsRoutes =
+  private def buildWsRoutes(
+      helloTimeout: Duration = RouterWsRoutes.DefaultHelloTimeout,
+  ) =
     for {
       rRepo   <- ZIO.service[RouterRepo]
       tRepo   <- ZIO.service[TrafficReportRepo]
@@ -71,7 +76,7 @@ object RouterWsSpec
       // so the test proves the HTTP/1.1 upgrade survives the production middleware, not just the raw
       // route. These aspects are response-transparent for a websocket Response, but pinning it here
       // closes the gap between the test path and the assembled prod path.
-      raw    = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo)
+      raw    = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo, helloTimeout)
       routes = HttpMetrics.instrument(
         LoggingMiddleware.annotate(
           Readiness.gate(ErrorBoundary.observe(raw), ZIO.succeed(true)),
@@ -116,11 +121,46 @@ object RouterWsSpec
       }
     }
 
+  /**
+   * Open a ws connection, run `send` on handshake-complete, and resolve with the close code the
+   * server sends (the #1847 handshake-refusal paths: 4002 hello-required, 4003 version-exceeded).
+   */
+  private def connectAndCaptureClose(
+      port: Int,
+      bearer: Option[String],
+      send: WebSocketChannel => ZIO[Any, Throwable, Unit],
+  ): ZIO[Client, Throwable, Int] =
+    Promise.make[Nothing, Int].flatMap { closeCode =>
+      // Forward close frames to userland (Netty's default `handleCloseFrames=true` would otherwise
+      // swallow the server's Close and complete the handshake silently) so we can assert the exact
+      // application close code (4002 hello-required / 4003 version-exceeded).
+      val app     = Handler
+        .webSocket { channel =>
+          channel.receiveAll {
+            case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+              send(channel)
+            case ChannelEvent.Read(WebSocketFrame.Close(code, _))             =>
+              closeCode.succeed(code).unit
+            case _                                                            =>
+              ZIO.unit
+          }
+        }
+        .withConfig(WebSocketConfig.default.forwardCloseFrames(true))
+      val headers = bearer.fold(Headers.empty)(t => Headers(Header.Authorization.Bearer(t)))
+      ZIO.scoped {
+        for {
+          _ <- app.connect(s"ws://localhost:$port/api/router/ws", headers).forkScoped
+          c <- closeCode.await
+            .timeoutFail(new RuntimeException("no close frame within 30s"))(30.seconds)
+        } yield c
+      }
+    }
+
   def spec = suite("Router websocket /api/router/ws")(
     test("rejects the upgrade with 401 when the bearer token is missing or invalid") {
       for {
         _           <- cleanDb
-        (routes, _) <- buildWsRoutes
+        (routes, _) <- buildWsRoutes()
         noToken     <- routes.runZIO(
           Request.get(URL.decode("/api/router/ws").toOption.get),
         )
@@ -141,7 +181,7 @@ object RouterWsSpec
         tRepo         <- ZIO.service[TrafficReportRepo]
         _             <- seedKnownDevice(dRepo, pRepo)
         (id, tk)      <- seedRouter(rRepo)
-        (routes, reg) <- buildWsRoutes
+        (routes, reg) <- buildWsRoutes()
         port          <- Server.install(routes)
         rec       = UsageRecord(
           MacAddress.unsafe(knownMac),
@@ -174,7 +214,7 @@ object RouterWsSpec
         _           <- cleanDb
         rRepo       <- ZIO.service[RouterRepo]
         (id, tk)    <- seedRouter(rRepo)
-        (routes, _) <- buildWsRoutes
+        (routes, _) <- buildWsRoutes()
         port        <- Server.install(routes)
         result      <- connectAndCapture(
           port,
@@ -184,6 +224,88 @@ object RouterWsSpec
         )
         pong = result._1
       } yield assertTrue(pong.contains("\"op\":\"pong\""))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    // #1847 — capability handshake. A v1 `hello` negotiates `snapshotVersion: 1` and gets the
+    // server's capability set back in `ready`.
+    test("a hello at snapshotVersion 1 is answered with ready (negotiated v1 + server caps)") {
+      (for {
+        _           <- cleanDb
+        rRepo       <- ZIO.service[RouterRepo]
+        (_, tk)     <- seedRouter(rRepo)
+        (routes, _) <- buildWsRoutes()
+        port        <- Server.install(routes)
+        hello =
+          """{"op":"hello","payload":{"agentCapabilities":["ws-transport-v1"],"snapshotVersion":1,"agentVersion":"0.3.1"}}"""
+        result <- connectAndCapture(
+          port,
+          Some(tk),
+          ch => ch.send(ChannelEvent.read(WebSocketFrame.text(hello))),
+          ZIO.unit,
+        )
+        ready = result._1
+      } yield assertTrue(ready.contains("\"op\":\"ready\"")) &&
+        assertTrue(ready.contains("\"snapshotVersion\":1")) &&
+        assertTrue(ready.contains("ws-transport-v1")) &&
+        assertTrue(ready.contains("ack-frames"))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    // #1847 / #376 back-compat: a FUTURE agent that knows a higher snapshotVersion polling a v1
+    // server is handed today's v1 shape (negotiated = min(agent.max, server.max)) — no flag day.
+    test("a hello at a future snapshotVersion negotiates down to the server's v1") {
+      (for {
+        _           <- cleanDb
+        rRepo       <- ZIO.service[RouterRepo]
+        (_, tk)     <- seedRouter(rRepo)
+        (routes, _) <- buildWsRoutes()
+        port        <- Server.install(routes)
+        hello =
+          """{"op":"hello","payload":{"agentCapabilities":["ws-transport-v1","policy-diff"],"snapshotVersion":5,"agentVersion":"9.9.9"}}"""
+        result <- connectAndCapture(
+          port,
+          Some(tk),
+          ch => ch.send(ChannelEvent.read(WebSocketFrame.text(hello))),
+          ZIO.unit,
+        )
+        ready = result._1
+      } yield assertTrue(ready.contains("\"op\":\"ready\"")) &&
+        assertTrue(ready.contains("\"snapshotVersion\":1"))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    // #1847 / §2.3 version ceiling: an agent that doesn't even understand v1 (snapshotVersion 0)
+    // has no shape in common with the server → close 4003 version-exceeded, no `ready`.
+    test("a hello below the server's version floor is refused with close 4003") {
+      (for {
+        _           <- cleanDb
+        rRepo       <- ZIO.service[RouterRepo]
+        (_, tk)     <- seedRouter(rRepo)
+        (routes, _) <- buildWsRoutes()
+        port        <- Server.install(routes)
+        hello =
+          """{"op":"hello","payload":{"agentCapabilities":[],"snapshotVersion":0,"agentVersion":"0.0.1"}}"""
+        code <- connectAndCaptureClose(
+          port,
+          Some(tk),
+          ch => ch.send(ChannelEvent.read(WebSocketFrame.text(hello))),
+        )
+      } yield assertTrue(code == 4003)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    // #1847 / §2.2 hello-timeout: a connection that never sends `hello` is closed 4002 after the
+    // window (driven short here so the test does not wait the real 5 s).
+    test("a connection that never sends hello is closed 4002 after the timeout") {
+      (for {
+        _           <- cleanDb
+        rRepo       <- ZIO.service[RouterRepo]
+        (_, tk)     <- seedRouter(rRepo)
+        (routes, _) <- buildWsRoutes(200.millis)
+        port        <- Server.install(routes)
+        code        <- connectAndCaptureClose(port, Some(tk), _ => ZIO.unit)
+      } yield assertTrue(code == 4002)).provideSome[
         TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
       ](Server.defaultWithPort(0), Client.default)
     },

--- a/deploy/grafana/dashboards/router-ws-transport.json
+++ b/deploy/grafana/dashboards/router-ws-transport.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven websocket router transport (#1846, epic #1023): server-side health for the persistent /api/router/ws endpoint. Panels target only the series the API actually emits today \u2014 router_ws_connections_active (RouterWsRegistry) and router_ws_frames_total{op,direction,result} (RouterWsRoutes demux). The REST transport stays the fallback; until the agent ws client (#1848) ships these read 0/flat. Push-on-change health (router_ws_policy_push_total) lands with #1849. Labels are bounded enums only per the \u00a74 cardinality firewall. datasource/env are templated for per-environment view.",
+  "description": "WifiHaven websocket router transport (#1846/#1847, epic #1023): server-side health for the persistent /api/router/ws endpoint. Panels target only the series the API actually emits today \u2014 router_ws_connections_active (RouterWsRegistry), router_ws_frames_total{op,direction,result} (RouterWsRoutes demux), and router_ws_handshake_total{result} (the #1847 capability handshake). The REST transport stays the fallback; until the agent ws client (#1848) ships these read 0/flat. Push-on-change health (router_ws_policy_push_total) lands with #1849. Labels are bounded enums only per the \u00a74 cardinality firewall. datasource/env are templated for per-environment view.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -253,6 +253,63 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Capability handshake outcomes (#1847)",
+      "description": "sum by (result) (rate(router_ws_handshake_total[5m])) — the hello→ready capability-handshake outcomes (design §2). result ∈ {ok, auth_fail, hello_timeout, version_exceeded}: ok once a snapshotVersion is negotiated; auth_fail when the upgrade is rejected at the token check; hello_timeout when no hello arrives within the window (close 4002); version_exceeded when the agent's max-known snapshotVersion is below the server's floor (close 4003). A non-zero hello_timeout / version_exceeded share is the signal that agents and server disagree on the protocol or shape version during a rollover.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(router_ws_handshake_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",
@@ -319,6 +376,6 @@
   "timezone": "",
   "title": "WifiHaven \u2014 Router WS transport",
   "uid": "wifihaven-router-ws-transport",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -798,6 +798,41 @@ Query params: `mac`, `host`, `reason`. Renders a page showing why the request
 was blocked and offering a "request extension" button gated on parent login.
 This is the URL the router's local block page redirects to.
 
+### 6.8 Wire evolution policy — the ws capability handshake (#376 / #1847)
+
+The persistent websocket transport (`GET /api/router/ws`,
+[`docs/design/websocket-transport.md`](design/websocket-transport.md)) carries a
+**capability handshake** that lands the durable, minimal slice of
+[#376](https://github.com/wifihaven/wifihaven/issues/376) — the wire-evolution
+policy this contract previously lacked. The full rules (with the `hello`/`ready`
+JSON) live in [`docs/process/wire-contract.md`](process/wire-contract.md#evolution-policy-376--1847);
+the architecturally-load-bearing points:
+
+- **`hello` → `ready`.** Right after the ws upgrade the agent sends `hello`
+  (`agentCapabilities`, its max-known `snapshotVersion`, `agentVersion`) and the
+  server replies `ready` (`serverCapabilities`, the negotiated `snapshotVersion`).
+  These three fields exist **only inside these new frames on the new endpoint** —
+  the §6.2 `PolicySnapshot` JSON and every REST body are byte-identical, so no
+  deployed agent parses anything new (the change is additive).
+- **`snapshotVersion = min(agent.maxKnown, server.maxKnown)`**, starting at **1**
+  (today's snapshot shape, §6.2), bumped only on a breaking shape change. A newer
+  agent polling an older server is handed the older shape; the next breaking
+  change is a version bump, not a flag day.
+- **Capability sets are string sets**, intersected to gate optional behavior, and
+  are the **extension point** for future features (diffs, compression,
+  per-field snapshot gating) — those are announced here, never inferred. v1
+  gates no behavior on them yet.
+- **Forward-compat is now explicit:** a receiver ignores (and meters) an unknown
+  `op` (envelope) and unknown payload fields, so new ops/fields ship additively.
+- **Refusal paths:** no `hello` within the window → server closes `4002
+  hello-required` (agent falls back to HTTP polling); a `hello` below the
+  server's version floor → `4003 version-exceeded`. The REST poll (§6.2) stays
+  fully live as the fallback throughout.
+
+Deferred to the #376 follow-up that *uses* this handshake: per-field snapshot
+capability gating and the `snapshotVersion ≥ 2` shape-translation machinery —
+unneeded while the payload is frozen.
+
 ## 7. OpenWRT agent design
 
 This section describes the OpenWRT-specific rendering layer. It is implementation

--- a/docs/process/wire-contract.md
+++ b/docs/process/wire-contract.md
@@ -29,8 +29,74 @@ the policy snapshot, the usage/event ingest payloads):
 Non-additive / breaking wire changes are gated on **wire versioning and
 capability negotiation** ([#376](https://github.com/wifihaven/wifihaven/issues/376)):
 that mechanism is what will eventually let the two sides agree on a shape
-before using it. Until #376 lands, treat breaking wire changes as off the
+before using it. The durable, minimal slice of that mechanism shipped with the
+websocket transport handshake (#1847) — see the Evolution policy below. Until a
+breaking change actually needs the `snapshotVersion ≥ 2` translation machinery
+(filed as the deferred #376 follow-up), treat breaking wire changes as off the
 table.
+
+## Evolution policy (#376 / #1847)
+
+The websocket transport ([`docs/design/websocket-transport.md`](../design/websocket-transport.md) §2)
+adds a capability handshake on the `GET /api/router/ws` connection. This is the
+durable half of #376 — the rules below are now part of the wire contract.
+
+**The handshake.** Immediately after the ws upgrade, the agent sends a `hello`
+frame and the server replies `ready`:
+
+```jsonc
+// agent → server
+{ "op": "hello", "payload": {
+    "agentCapabilities": ["ws-transport-v1"],   // string set; the extension point
+    "snapshotVersion": 1,                        // agent's max-known PolicySnapshot shape
+    "agentVersion": "0.3.1"                       // observability only
+} }
+// server → agent
+{ "op": "ready", "payload": {
+    "serverCapabilities": ["ws-transport-v1", "ack-frames"],  // the server's own set
+    "snapshotVersion": 1                                       // = min(agent.maxKnown, server.maxKnown)
+} }
+```
+
+The rules a conforming peer MUST follow:
+
+- **Ignore-unknown — envelope.** A receiver MUST ignore (and meter) a frame
+  whose `op` it does not recognize. New ops are additive; this is what lets a
+  future op (e.g. `policy_diff`) ship without a flag day.
+- **Ignore-unknown — payload.** Both sides MUST ignore unknown JSON fields in a
+  payload. New payload fields are additive. (Already the case — zio-json's
+  derived decoders drop extras and the Lua `jsonc` decoder ignores them.)
+- **`min`-version rule.** The negotiated `snapshotVersion` is
+  `min(agent.maxKnown, server.maxKnown)`. The server emits snapshots at that
+  version. So a newer agent that knows a higher version polling an older server
+  is handed the older shape, and the next breaking shape change is a version
+  bump rather than a flag day. `snapshotVersion` starts at **1** (today's shape)
+  and bumps **only** on a breaking snapshot-shape change.
+- **Version-ceiling refusal.** An agent MUST refuse a snapshot whose negotiated
+  `snapshotVersion` exceeds its max-known (it falls back to its last-good cached
+  snapshot per [`docs/resilience.md`](../resilience.md) §1). The `min` rule means
+  this cannot happen in normal operation, but it is stated so a server bug can't
+  silently push a newer shape to an older agent. Symmetrically, the **server**
+  refuses a `hello` whose advertised `snapshotVersion` is below its floor (no
+  shape both ends understand) by closing the socket with code `4003
+  version-exceeded`.
+- **Handshake-required.** If the agent never sends `hello`, the server closes
+  the socket with code `4002 hello-required` after a timeout and the agent falls
+  back to HTTP polling.
+
+**Why this is additive and safe.** `snapshotVersion`, `serverCapabilities`, and
+`agentCapabilities` live **only** inside the new `hello`/`ready` frames on the
+new ws endpoint. They do not touch the existing `PolicySnapshot` JSON or any REST
+body, so no already-deployed agent parses anything new — the REST poll path is
+byte-identical. The machinery sits dormant until the first real shape change
+needs it.
+
+**Scope of #1847 (this slice).** Only "can this pair speak the ws transport, and
+at what snapshot version?" is negotiated. **Per-field** capability gating of the
+snapshot (e.g. `"unmanaged-mac-policy"`, `"https-block-page"`) and the
+`snapshotVersion ≥ 2` shape-translation machinery are deferred to the #376
+follow-up that *uses* this handshake — they are not needed while the payload is
+frozen.
 
 Surfaces that are **not** part of the cross-process wire contract — UCI keys
 written and read by the same agent build, CLI flags, and DB schema (guarded


### PR DESCRIPTION
Fixes #1847. Relates to #1023, #376.

Sub-issue **B** of the websocket-transport epic ([`docs/design/websocket-transport.md`](https://github.com/wifihaven/wifihaven/blob/main/docs/design/websocket-transport.md) §2), building on the #1846 server endpoint. Adds the `hello`→`ready` capability handshake to `GET /api/router/ws` — the durable, minimal slice of #376 that lets mismatched API/agent versions coexist during rollouts and fall back to HTTP polling when ws/capabilities aren't supported.

## What this ships

- **Handshake** (`RouterWsRoutes.handleHello`): agent sends `hello` (`agentCapabilities`, `snapshotVersion`, `agentVersion`) → server replies `ready` (`serverCapabilities`, negotiated `snapshotVersion = min(agent.maxKnown, ServerSnapshotVersion)`). Capability sets are string sets — the **extension point** for future features (diffs, compression, per-field gating); v1 gates no behavior on them yet. Server advertises only what it actually implements today: `ws-transport-v1`, `ack-frames`.
- **`snapshotVersion`** starts at **1** (today's `PolicySnapshot` shape), introduced **only inside the new `hello`/`ready` frames** — the REST poll/snapshot JSON is byte-identical, so no deployed agent parses anything new (additive, §2.4).
- **Refusal paths:** no `hello` within `helloTimeout` (default 5 s, forked watcher interrupted on disconnect) → close **4002** `hello-required`; a `hello` below the server's version floor → close **4003** `version-exceeded`. The agent falls back to its last-good cached snapshot / HTTP polling.
- **REST fallback stays fully live** — purely additive on the new endpoint.

## Metrics + dashboard

- `router_ws_handshake_total{result=ok|auth_fail|hello_timeout|version_exceeded}` (bounded enum, cardinality-firewall safe) via `AppMetrics.recordWsHandshake`.
- A consuming "Capability handshake outcomes" panel added to the Router WS transport Grafana dashboard (version bumped 1→2).

## Docs (the #376 "Evolution policy" ask)

Written into both [`docs/process/wire-contract.md`](https://github.com/wifihaven/wifihaven/blob/claude/fix-1847/docs/process/wire-contract.md) and [`docs/architecture.md`](https://github.com/wifihaven/wifihaven/blob/claude/fix-1847/docs/architecture.md) §6.8: ignore-unknown `op` (envelope) + ignore-unknown fields (payload), the `min`-version rule, the version-ceiling refusal.

## Scope

Per the issue: only the handshake + version/capability negotiation. Per-field snapshot capability gating and `snapshotVersion ≥ 2` translation machinery are deferred to the #376 follow-up (sub-issue F) that *uses* this handshake. The agent ws client is #1848; policy push-on-change / first-policy-on-connect is #1849.

## Tests

`RouterWsSpec` (real `Server` + ws `Client`): `hello`@v1 → `ready` (negotiated v1 + server caps); future agent (v5) negotiates **down** to v1 (back-compat); below-floor (v0/malformed) → close **4003**; never-sends-`hello` → close **4002** (driven with a short timeout). Full `api` test suite green; `scalafmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)