### PR TITLE
docs(#1847): mark ws capability handshake (sub-issue B) won't-do

### DIFF
--- a/docs/design/websocket-transport.md
+++ b/docs/design/websocket-transport.md
@@ -9,11 +9,14 @@ negotiation, the gate this re-examines), [#1512](https://github.com/wifihaven/wi
 that triggered this).
 
 > **Scope of this doc.** This is the umbrella design for the EPIC. It does NOT
-> implement the transport. It (a) fixes the wire protocol, (b) specifies the
+> implement the transport. It (a) fixes the wire protocol, ~~(b) specifies the
 > *minimal* capability-negotiation needed to ship a non-additive transport
-> change safely (the part of #376 that actually blocks #1023), and (c) lays out
+> change safely (the part of #376 that actually blocks #1023),~~ and (c) lays out
 > a phased, independently-shippable, back-compat rollout. The implementation
-> sub-issues filed against this doc are listed in §9.
+> sub-issues filed against this doc are listed in §9. **(b) was dropped:** the ws
+> transport carries the REST payloads verbatim, so the existing additive +
+> ignore-unknown wire contract already covers it — no capability handshake (§2
+> status, #1847 closed won't-do 2026-06-23).
 
 ---
 
@@ -115,6 +118,11 @@ agent                                   API
 The connection is **long-lived**: opened once at agent boot, kept warm by
 heartbeats, re-established on drop (§5).
 
+> **Note (2026-06-23):** the `hello`/`ready` exchange shown above is **not built**
+> — the capability handshake was closed won't-do (§2 status, #1847). In the
+> implemented flow the connection upgrades, the server registers the channel, and
+> (under #1849) pushes the first `policy` frame directly — no handshake step.
+
 ### 1.2 Frame envelope
 
 Every frame is a single JSON **text** websocket message:
@@ -145,8 +153,8 @@ into multiple `usage` frames instead of one over-cap POST.
 
 | `op` | Dir | Payload | Maps to today's |
 | --- | --- | --- | --- |
-| `hello` | A→S | `{agentCapabilities:[…], snapshotVersion:int, agentVersion:str}` | (new — handshake, §2) |
-| `ready` | S→A | `{serverCapabilities:[…], snapshotVersion:int}` | (new — handshake, §2) |
+| ~~`hello`~~ | A→S | ~~`{agentCapabilities:[…], snapshotVersion:int, agentVersion:str}`~~ | **NOT BUILT** — handshake won't-do, see §2 status (#1847) |
+| ~~`ready`~~ | S→A | ~~`{serverCapabilities:[…], snapshotVersion:int}`~~ | **NOT BUILT** — handshake won't-do, see §2 status (#1847) |
 | `policy` | S→A | `PolicySnapshot` JSON | `GET /api/router/policy` 200 body |
 | `usage` | A→S | `UsageReport` JSON | `POST /api/router/usage` body |
 | `events` | A→S | `RouterEventsRequest` JSON | `POST /api/router/events` body |
@@ -185,6 +193,27 @@ change-detection key the server uses to decide *whether* to push (§6.2).
 ---
 
 ## 2. Capability negotiation (re-examining #376)
+
+> **Status (2026-06-23): NOT BUILDING THIS — sub-issue B
+> ([#1847](https://github.com/wifihaven/wifihaven/issues/1847)) closed won't-do.**
+> The premise below — that replacing the poll "forces the question" of capability
+> negotiation — was reconsidered and rejected. The ws transport **carries the REST
+> payloads verbatim** (`PolicySnapshot`, `UsageReport`, events, metrics — §1.2/§1.3
+> are explicit that no payload shapes change), so the **existing REST wire contract
+> (additive-only + ignore-unknown fields, `docs/process/wire-contract.md`) already
+> makes ws evolution safe, identically to REST.** A `hello`/`ready` handshake with
+> `snapshotVersion` negotiation gated **zero behavior** today: version negotiation /
+> a `4003`-style refusal only buys anything for a *non-additive* snapshot change,
+> which the wire contract forbids without a deprecation window **regardless of
+> transport** — so the handshake was pure insurance for a hypothetical future
+> breaking change. The one genuinely-needed forward-compat rule — **ignore + meter
+> an unknown `op`** (§1.3) — already shipped in #1846, and unknown payload fields
+> are already ignored by both decoders. If an actual breaking snapshot-shape change
+> ever needs the `snapshotVersion ≥ 2` translation machinery, that is the deferred
+> #376 follow-up (sub-issue **F**) — built then, against a concrete need. **Do not
+> build the `hello`/`ready`/`snapshotVersion` handshake.** The rest of this section
+> is retained as the rejected design's rationale; the `hello`/`ready` rows in §1.1
+> and §1.3 are likewise not implemented.
 
 [#376](https://github.com/wifihaven/wifihaven/issues/376) was deferred on the
 grounds that a single prod router can tandem-deploy. **This transport change
@@ -570,7 +599,7 @@ Grafana panel per the dashboard rule — sub-issue tasks include the panel):
 | `router_ws_connections_active` | gauge | — | currently-open channels |
 | `router_connected` | gauge | `router_id` (fleet-bounded) | 1/0 link-up per router (§5.5) — emitted only for currently-connected routers and **aged out on deregister** so the `router_id` series doesn't accumulate stale values (impl: sub-issue A) |
 | `router_ws_frames_total` | counter | `op`, `dir` (`in`/`out`), `result` (`ok`/`reject`/`unknown_op`) | frame throughput + the unknown-op forward-compat counter |
-| `router_ws_handshake_total` | counter | `result` (`ok`/`auth_fail`/`hello_timeout`/`version_exceeded`) | handshake outcomes |
+| ~~`router_ws_handshake_total`~~ | — | — | **NOT BUILT** — handshake won't-do (§2 status, #1847) |
 | `router_ws_policy_push_total` | counter | `result` (`ok`/`dropped_full`/`channel_closed`) | push fan-out health |
 | `router_transport` | counter/gauge | `transport` (`ws`/`http`) | rollout-progress dashboard (§3.2) |
 | `policy_snapshot_build_total` | counter | `result` (`computed`/`cache_hit`) | proves the #1512 cache is working |
@@ -614,18 +643,21 @@ agent (gated on the spike) → optimization → deprecation.
 
 Filed: D0 → [#1845](https://github.com/wifihaven/wifihaven/issues/1845),
 A → [#1846](https://github.com/wifihaven/wifihaven/issues/1846),
-B → [#1847](https://github.com/wifihaven/wifihaven/issues/1847),
+B → [#1847](https://github.com/wifihaven/wifihaven/issues/1847) **(closed
+won't-do 2026-06-23 — see §2 status)**,
 C → [#1848](https://github.com/wifihaven/wifihaven/issues/1848),
 E → [#1849](https://github.com/wifihaven/wifihaven/issues/1849),
 G → [#1850](https://github.com/wifihaven/wifihaven/issues/1850).
 F (deferred #376) is not filed yet — it is created when the first breaking
-snapshot-shape change needs the version machinery this design lands.
+snapshot-shape change needs the version machinery. (Originally this doc said F
+"uses B's handshake"; with B dropped, F would land both the version machinery
+and whatever minimal handshake it actually needs at that point.)
 
 | # | Sub-issue | Independently shippable? | Back-compat |
 | --- | --- | --- | --- |
 | **D0** | **Spike: Lua websocket library viability on OpenWRT** — pick/prove a library, long-soak a TLS ws on real/qemu hardware, confirm Render limits. Gate for C. | yes (spike, no prod code) | n/a |
 | **A** | **API `/api/router/ws` endpoint + envelope demux + connection registry** — `RouterWsRoutes`, extract transport-agnostic ingest service from `RouterIngestRoutes` (no behavior change), per-frame structured logging, server metrics (§7). REST untouched. | yes | additive — new route only |
-| **B** | **Capability handshake + `snapshotVersion` + Evolution-policy doc** — `hello`/`ready` frames, `min`-version rule, ignore-unknown rules written into `wire-contract.md` + `architecture.md` (the durable #376 slice, §2). | yes (builds on A) | additive — handshake only on new endpoint |
+| **B** | ~~**Capability handshake + `snapshotVersion` + Evolution-policy doc** — `hello`/`ready` frames, `min`-version rule, ignore-unknown rules.~~ **WON'T-DO ([#1847](https://github.com/wifihaven/wifihaven/issues/1847) closed 2026-06-23, see §2 status).** ws inherits the REST additive + ignore-unknown contract verbatim; the handshake gated zero behavior. Unknown-`op` forward-compat shipped in #1846. Version machinery deferred to F against a concrete need. | n/a (not built) | n/a |
 | **C** | **Agent websocket sidecar (`wifihaven-ws`)** — new procd instance, ws client over the proven library, drains existing tmpfs spools out / writes pushed `policy` in, HTTP-fallback wiring (§3.1), agent metrics. Gated on D0. | yes (behind UCI flag, default off until proven) | additive — main agent HTTP path unchanged |
 | **E** | **Push-on-change + computed-snapshot cache in `PolicyService`** (#1512) — cache + invalidation + time-boundary ticker; registry push on change; REST poll also reads the cache. | yes (improves REST path even with zero ws agents) | behavior-preserving (same snapshot bytes) |
 | **F** | **(deferred #376) per-field snapshot capability gating + `snapshotVersion ≥ 2` machinery** — only when the first breaking shape change needs it; *uses* B's handshake. | yes, later | additive |

--- a/docs/design/websocket-transport.md
+++ b/docs/design/websocket-transport.md
@@ -170,7 +170,8 @@ future `policy_diff` op (out of scope here, per #1023) ship without a flag day.
 
 The ETag stays the snapshot's identity, but the *transfer* inverts:
 
-- **On connect** (after `ready`), the server sends exactly one `policy` frame
+- **On connect** (right after the upgrade — there is no `ready` step; the
+  handshake is won't-do, §2 status), the server sends exactly one `policy` frame
   with the current snapshot. This replaces the agent's first `GET` poll. The
   agent applies it before sending any data frame (avoids a first-connect policy
   race — same guarantee #1023 calls out).
@@ -322,7 +323,7 @@ agent boot
   ├─ ws-transport enabled in UCI?  ── no ──▶  HTTP poll/POST path (today's code, untouched)
   │            │ yes
   ├─ open wss://…/api/router/ws
-  │     ├─ 101 + ready within connect_timeout?  ── no ──▶  log, mark ws-unhealthy, HTTP path
+  │     ├─ 101 + first policy frame within connect_timeout?  ── no ──▶  log, mark ws-unhealthy, HTTP path  (no `ready` — handshake won't-do, §2)
   │     │            │ yes
   │     └─ run ws sidecar; main agent's HTTP poll timer goes dormant
   │
@@ -371,10 +372,10 @@ Before any agent ws code is committed, sub-issue **D0** must answer:
   without leaking? (long-soak test on real hardware / qemu).
 - Does it cleanly surface "connection dropped" so the sidecar can reconnect?
 
-**If D0 fails** (no viable library), the epic stops at the server endpoint +
-handshake (A, B) — those are independently valuable (a future agent or an
-OPNsense agent can use them) — and the agent stays on HTTP. This is why A/B are
-sequenced first and sized to ship without C.
+**If D0 fails** (no viable library), the epic stops at the server endpoint (A;
+B the handshake is won't-do, §2) — independently valuable (a future agent or an
+OPNsense agent can use the endpoint) — and the agent stays on HTTP. This is why
+A is sequenced first and sized to ship without C.
 
 ---
 
@@ -428,8 +429,9 @@ surface.
 ### 5.1 Reconnect / backoff
 
 - The ws sidecar reconnects with **exponential backoff + jitter** (e.g. 1 s →
-  2 s → 4 s → … cap 60 s), reset on a successful `ready`. Reconnect *is* the
-  throttle — there is no per-frame retry (#1023).
+  2 s → 4 s → … cap 60 s), reset on a successful connect (the `101` upgrade; not
+  a `ready` — handshake won't-do, §2). Reconnect *is* the throttle — there is no
+  per-frame retry (#1023).
 - On every (re)connect the server pushes the current full snapshot, so the agent
   re-syncs policy unconditionally — a missed change during a disconnect window
   converges on reconnect, no diff bookkeeping needed.
@@ -523,7 +525,7 @@ Method.GET / "api" / "router" / "ws" ->
         Handler.webSocket { channel =>
           for {
             _ <- registry.register(router.id, channel)      // §6.2
-            _ <- handshake(channel, router)                 // hello→ready→first policy
+            _ <- pushCurrentSnapshot(channel, router)        // first policy on connect (#1849); no hello/ready handshake — §2 won't-do
             _ <- channel.receiveAll {
                    case Read(WebSocketFrame.Text(json)) => dispatch(router, json)  // demux on op
                    case Read(WebSocketFrame.Close(_,_)) => registry.deregister(router.id, channel)
@@ -660,11 +662,12 @@ and whatever minimal handshake it actually needs at that point.)
 | **B** | ~~**Capability handshake + `snapshotVersion` + Evolution-policy doc** — `hello`/`ready` frames, `min`-version rule, ignore-unknown rules.~~ **WON'T-DO ([#1847](https://github.com/wifihaven/wifihaven/issues/1847) closed 2026-06-23, see §2 status).** ws inherits the REST additive + ignore-unknown contract verbatim; the handshake gated zero behavior. Unknown-`op` forward-compat shipped in #1846. Version machinery deferred to F against a concrete need. | n/a (not built) | n/a |
 | **C** | **Agent websocket sidecar (`wifihaven-ws`)** — new procd instance, ws client over the proven library, drains existing tmpfs spools out / writes pushed `policy` in, HTTP-fallback wiring (§3.1), agent metrics. Gated on D0. | yes (behind UCI flag, default off until proven) | additive — main agent HTTP path unchanged |
 | **E** | **Push-on-change + computed-snapshot cache in `PolicyService`** (#1512) — cache + invalidation + time-boundary ticker; registry push on change; REST poll also reads the cache. | yes (improves REST path even with zero ws agents) | behavior-preserving (same snapshot bytes) |
-| **F** | **(deferred #376) per-field snapshot capability gating + `snapshotVersion ≥ 2` machinery** — only when the first breaking shape change needs it; *uses* B's handshake. | yes, later | additive |
+| **F** | **(deferred #376) per-field snapshot capability gating + `snapshotVersion ≥ 2` machinery** — only when the first breaking shape change needs it. (B is won't-do, so F lands both the version machinery **and** whatever minimal handshake it actually needs at that point — it no longer builds on a B handshake.) | yes, later | additive |
 | **G** | **Deprecate the REST poll** — after the operator confirms the ws path healthy across the fleet (the `router_transport` dashboard shows 100% ws), add a one-release deprecation log to the REST poll, then remove in a later release per the wire-contract deprecation window. | yes, last | the *only* non-additive step, gated on fleet rollover |
 
-**Critical path:** D0 → C (agent). **Parallel track:** A → B (server + handshake)
-and E (perf) can land while D0 runs, since they are valuable even if the agent
-never migrates. **G is last and operator-gated** — never armed automatically
+**Critical path:** D0 → C (agent). **Parallel track:** A (server endpoint; B the
+handshake is won't-do, §2) and E (perf) can land while D0 runs, since they are
+valuable even if the agent never migrates. **G is last and operator-gated** —
+never armed automatically
 (`docs/pr-review-checklist.md#monitor-to-merged` discipline: the cutover is the
 operator's call).


### PR DESCRIPTION
Follow-up to closing #1847 / PR #1908. The merged websocket-transport epic design (#1851) still described the `hello`/`ready` capability handshake + `snapshotVersion` negotiation (sub-issue **B**, #1847) as a thing to build. With #1847 closed won't-do, that's stale doc drift — this corrects it.

## Why B was dropped

The ws frames carry the REST payloads **verbatim** (`PolicySnapshot`, `UsageReport`, events, metrics — the design itself states no payload shapes change). So the existing wire contract (**additive-only + ignore-unknown fields**) already makes ws evolution safe, identically to REST. A `hello`/`ready` handshake with `snapshotVersion` negotiation gated **zero behavior** today — version negotiation / a `4003` refusal only buys anything for a *non-additive* snapshot change, which the contract forbids without a deprecation window **regardless of transport**. The one genuinely-needed forward-compat rule — unknown-`op` ignore+meter — already shipped in #1846.

## Changes (docs-only, surgical)

- **§2** Capability negotiation: prominent **NOT BUILDING THIS** status banner with the full rationale; the section body retained as the rejected design's record.
- **§0** scope blurb: struck the "(b) minimal capability-negotiation" goal.
- **§1.1** lifecycle diagram: note that `hello`/`ready` is not built; implemented flow upgrades → registers → (under #1849) pushes first `policy` directly.
- **§1.3** message table: `hello`/`ready` rows struck and marked NOT BUILT.
- **§7** metrics: `router_ws_handshake_total` struck (never shipped).
- **§9** sub-issue table row B + filing list: marked won't-do, pointing at §2 status; clarified F lands its own minimal handshake if/when a real breaking change needs it.

No code, no behavior change. #1846 stands as the complete ws server endpoint.

Relates to #1023, #376, #1851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)