### PR TITLE
fix(#1842): drop cloudflare_ruleset.redirects (token scope + low value)

### DIFF
--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -23,21 +23,20 @@ Custom domain layout:
 | `app.wifihaven.net`            | Cloudflare Pages: `wifihaven` (canonical app host, #1832) |
 | `app-staging.wifihaven.net`    | Cloudflare Pages: `wifihaven-staging` (canonical staging app host) |
 | `wifihaven.net` (apex)         | Cloudflare Pages: `wifihaven-www` (marketing site, #1842) |
-| `www.wifihaven.net`            | Cloudflare Pages: `wifihaven-www` → **301-redirects to `app.wifihaven.net`** (#1842) |
-| `staging.wifihaven.net`        | **301-redirects to `app-staging.wifihaven.net`** (#1842) |
+| `www.wifihaven.net`            | Cloudflare Pages: `wifihaven-www` (marketing site, #1842) |
+| `staging.wifihaven.net`        | Cloudflare Pages: `wifihaven-staging` (staging SPA) |
 | `api.wifihaven.net`            | Render: `wifihaven-api-prod`      |
 | `api-staging.wifihaven.net`    | Render: `wifihaven-api-staging`   |
 
 `app.wifihaven.net` / `app-staging.wifihaven.net` are additional custom domains
 on the *same* Pages projects — the SPA bundle is identical, only the fronting
-host is canonical now. Post-#1842 the apex + `www` front the **marketing site**
-(`wifihaven-www`, source under `web-marketing/`), not the SPA. A zone-level
-dynamic-redirect ruleset (`cloudflare_ruleset.redirects` in
-`infra/cloudflare/main.tf`) sends `www`/`staging` → the app host (301,
-query-preserving) so old SPA bookmarks keep working. There is no apex
-`/blocked` router-compat shim — existing routers were already re-pointed to
-`app.wifihaven.net` for their block page (#1842), so the apex just serves
-marketing for every path. The API host (`api.wifihaven.net`) is unchanged.
+host is canonical now. Post-#1842 the apex + `www` both front the **marketing
+site** (`wifihaven-www`, source under `web-marketing/`), not the SPA. There is
+no zone-level redirect ruleset (a `www`/`staging` → app ruleset shipped briefly
+but was dropped — it needed a Cloudflare token scope the deploy token lacks, and
+the redirects are low-value) and no apex `/blocked` shim (existing routers were
+re-pointed to `app.wifihaven.net` for their block page, #1842). The API host
+(`api.wifihaven.net`) is unchanged.
 
 ---
 
@@ -133,18 +132,17 @@ terraform apply
 This creates three Pages projects (`wifihaven`, `wifihaven-staging`, and
 `wifihaven-www` for the marketing site — all Direct Upload, CI pushes via
 Wrangler), the Pages custom domains (`app`, `app-staging`, apex, `www`,
-`staging`), the redirect ruleset, and the two API CNAMEs.
+`staging`), and the two API CNAMEs.
 
 Cloudflare auto-issues edge certs (DNS-01 challenge — no path
 interception). Cert status flips to **Active** in the dash within a
 minute or two.
 
-Apex + `www` behavior (post-#1842): the apex fronts the marketing site
-(`wifihaven-www`); `www` and `staging` 301-redirect to the app host via the
-`cloudflare_ruleset.redirects` ruleset (query-preserving). There is no apex
-`/blocked` router-compat shim — existing routers were re-pointed to
-`app.wifihaven.net` for their block page. All redirects are declarative in the
-Terraform module — no manual Page Rules.
+Apex + `www` behavior (post-#1842): the apex and `www` both front the marketing
+site (`wifihaven-www`); `staging` keeps serving the staging SPA. There is no
+zone-level redirect ruleset (dropped — needed a token scope the deploy token
+lacks; low-value) and no apex `/blocked` router-compat shim (existing routers
+were re-pointed to `app.wifihaven.net` for their block page).
 
 > The §1 table above lists the two API CNAME records for reference; both
 > are managed by Terraform now and should NOT be added manually in the
@@ -189,17 +187,15 @@ Verify:
 curl -sS https://api.wifihaven.net/api/health
 curl -sS -o /dev/null -w "%{http_code}\n" https://app.wifihaven.net/   # 200, SPA
 curl -sS -o /dev/null -w "%{http_code}\n" https://wifihaven.net/        # 200, marketing site (#1842)
+curl -sS -o /dev/null -w "%{http_code}\n" https://www.wifihaven.net/    # 200, marketing site (#1842)
 
-# www → app redirect (301), query-preserving
-curl -sS -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://www.wifihaven.net/
-
-# Staging API + app host
+# Staging API + hosts
 curl -sS https://api-staging.wifihaven.net/api/health
-curl -sS -o /dev/null -w "%{http_code}\n" https://app-staging.wifihaven.net/
-curl -sS -o /dev/null -w "%{http_code} -> %{redirect_url}\n" https://staging.wifihaven.net/  # 301 -> app-staging
+curl -sS -o /dev/null -w "%{http_code}\n" https://app-staging.wifihaven.net/  # 200, staging SPA
+curl -sS -o /dev/null -w "%{http_code}\n" https://staging.wifihaven.net/      # 200, staging SPA
 ```
 
-The two `/api/health` calls should report `"db":"ok"`; every SPA-host curl
+The two `/api/health` calls should report `"db":"ok"`; every host curl
 should print `200`. Inspect the prod SPA HTML (`view-source` on
 `https://app.wifihaven.net/`) and search for `api.wifihaven.net` to confirm
 the right `VITE_API_BASE_URL` got baked in.

--- a/docs/design/app-host-rename.md
+++ b/docs/design/app-host-rename.md
@@ -224,6 +224,15 @@ Net: **the SPA bundle needs no code change** to live at `app.wifihaven.net`.
 
 ### 2.4 Redirects (old host → app, and the block-page compatibility shim)
 
+> **Outcome (2026-06): neither redirect shipped.** The `/blocked` router-compat
+> shim was dropped because existing routers were re-pointed to
+> `app.wifihaven.net` directly (so no router DNATs its block page at the apex),
+> and the `www → app` / `staging → app-staging` redirects were dropped because a
+> Cloudflare dynamic-redirect ruleset needs a token scope the deploy token
+> doesn't carry and the redirects are low-value. Apex and `www` simply serve the
+> marketing site; `staging` keeps serving the staging SPA. The plan below is
+> retained as the original design record.
+
 Two distinct redirect needs, with different lifetimes:
 
 1. **`www.wifihaven.net` → `app.wifihaven.net` (human bookmarks):** once apex/www

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -5,11 +5,9 @@ Declarative config for everything Cloudflare-side (#613):
 - Pages projects `wifihaven` (SPA prod), `wifihaven-staging` (SPA staging), and
   `wifihaven-www` (marketing site, #1842) — all Direct Upload.
 - Pages custom domains: `app` + apex + `www` (apex/www front `wifihaven-www`),
-  `app-staging` + `staging`.
-- A zone-level dynamic-redirect ruleset (`cloudflare_ruleset.redirects`, #1842):
-  `www`/`staging` → app 301 redirects (query-preserving), so old SPA bookmarks
-  keep working after the marketing split. There is intentionally **no** apex
-  `/blocked` router-compat shim — dropped 2026-06, see `main.tf`.
+  `app-staging` + `staging`. There is **no** zone-level redirect ruleset — apex
+  and www both serve the marketing site, staging keeps serving the staging SPA,
+  and there is no apex `/blocked` shim (dropped 2026-06, see `main.tf`).
 - DNS-only CNAMEs: `api.wifihaven.net`, `api-staging.wifihaven.net` → Render.
 - SPF TXT record + the `e2e-brand` / `e2e-mid` / `e2e-edge` test-fixture
   CNAME chain (#1351).
@@ -121,7 +119,7 @@ before merging anything that would trigger the pipeline.**
    `terraform state list` should show at least these resources (the original
    #1357 migration snapshot; the live set has since grown — the `app` /
    `app-staging` domains + `spa_app*` records (#1832), the `e2e_edge` AAAA
-   (#1677), and the `marketing` project + `redirects` ruleset (#1842)):
+   (#1677), and the `marketing` project (#1842)):
 
    ```
    cloudflare_pages_project.prod

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -5,7 +5,6 @@
 #     wifihaven (SPA), wifihaven-staging (SPA), wifihaven-www (marketing).
 #   - Five Pages custom domains (apex, www, staging, app, app-staging). apex/www
 #     front the marketing project; app/app-staging front the SPA (#1842).
-#   - A zone-level dynamic-redirect ruleset: www/staging → app redirects (#1842).
 #   - Two DNS-only CNAMEs pointing api / api-staging at Render.
 #
 # Does NOT manage:
@@ -84,10 +83,9 @@ resource "cloudflare_pages_project" "marketing" {
 # ACME path-interception class of bug (#609).
 
 # Apex + www now front the MARKETING project (#1842). The SPA moved to its own
-# host (app.wifihaven.net, below); the apex serves the static landing page and
-# www 301-redirects to the app (redirect ruleset below). Repointing project_name
-# replaces the domain attachment — a brief gap on the apex's Pages backing, which
-# is acceptable for the marketing landing page.
+# host (app.wifihaven.net, below); apex and www both serve the static landing
+# page. Repointing project_name replaces the domain attachment — a brief gap on
+# the apex's Pages backing, which is acceptable for the marketing landing page.
 resource "cloudflare_pages_domain" "apex" {
   account_id   = var.account_id
   project_name = cloudflare_pages_project.marketing.name # "wifihaven-www"
@@ -189,61 +187,14 @@ resource "cloudflare_record" "spa_app_staging" {
   comment = "Cloudflare Pages wifihaven-staging — app host (#1832)"
 }
 
-# ── Redirects — marketing split (#1842) ─────────────────────────────────────
-#
-# A single zone-level dynamic-redirect ruleset for the marketing split: the
-# old SPA hosts (www, staging) 301 to the canonical app host so existing
-# human bookmarks keep working. Rules run at the edge BEFORE Cloudflare Pages
-# serves content, and preserve the query string.
-#
-# NOTE: there is intentionally NO apex `/blocked` router-compat shim — it was
-# dropped (2026-06) because there are no pre-rename routers still pointing their
-# block_page_url at the apex; new cloud installs default to app.wifihaven.net
-# (openwrt/install.sh) and any older router is re-pointed directly. The apex
-# therefore just serves the marketing site for all paths.
-resource "cloudflare_ruleset" "redirects" {
-  zone_id     = var.zone_id
-  name        = "wifihaven redirects"
-  description = "Marketing split: www/staging → app (#1842 / #1832)"
-  kind        = "zone"
-  phase       = "http_request_dynamic_redirect"
-
-  # 1. Old SPA bookmarks on www → app (301, query-preserving).
-  rules {
-    ref         = "www_to_app"
-    description = "www.wifihaven.net/* → app.wifihaven.net/:splat (#1842)"
-    expression  = "(http.host eq \"www.wifihaven.net\")"
-    action      = "redirect"
-    enabled     = true
-    action_parameters {
-      from_value {
-        status_code = 301
-        target_url {
-          expression = "concat(\"https://app.wifihaven.net\", http.request.uri.path)"
-        }
-        preserve_query_string = true
-      }
-    }
-  }
-
-  # 2. Staging mirror: staging → app-staging (301, query-preserving).
-  rules {
-    ref         = "staging_to_app_staging"
-    description = "staging.wifihaven.net/* → app-staging.wifihaven.net/:splat (#1842)"
-    expression  = "(http.host eq \"staging.wifihaven.net\")"
-    action      = "redirect"
-    enabled     = true
-    action_parameters {
-      from_value {
-        status_code = 301
-        target_url {
-          expression = "concat(\"https://app-staging.wifihaven.net\", http.request.uri.path)"
-        }
-        preserve_query_string = true
-      }
-    }
-  }
-}
+# NOTE: there is no zone-level redirect ruleset. The marketing split (#1842)
+# briefly shipped a `cloudflare_ruleset.redirects` with www→app / staging→
+# app-staging redirects, but it was dropped (2026-06): creating a dynamic-
+# redirect ruleset needs a Cloudflare token scope (Zone → Dynamic Redirect →
+# Edit) that the deploy token doesn't carry, and the redirects are low-value —
+# apex and www both simply front the marketing site, and staging keeps serving
+# the staging SPA. (The apex `/blocked` router-compat shim was likewise dropped:
+# existing routers were re-pointed to app.wifihaven.net; see openwrt/install.sh.)
 
 resource "cloudflare_record" "api_prod" {
   zone_id = var.zone_id

--- a/web-marketing/README.md
+++ b/web-marketing/README.md
@@ -22,23 +22,22 @@ CI-driven: a push to `main` touching `web-marketing/**` triggers
 which runs `wrangler pages deploy` against the `wifihaven-www` project. There is
 no build — the contents of `site/` are uploaded as-is.
 
-The Pages **project**, its **custom domains** (apex + www), the apex/www DNS
-CNAMEs, and the redirect rules are all declared in
+The Pages **project**, its **custom domains** (apex + www), and the apex/www DNS
+CNAMEs are declared in
 [`infra/cloudflare/main.tf`](../infra/cloudflare/main.tf) and applied by
 `master-cloudflare.yml`. On the very first rollout, that Terraform apply must
 land before this deploy job runs (the project must exist); subsequent deploys
 are independent.
 
-## Redirects — NOT here
+## No redirects
 
-The `www → app` and `staging → app-staging` redirects are a zone-level
-**dynamic-redirect ruleset in Terraform** (`cloudflare_ruleset.redirects` in
-`infra/cloudflare/main.tf`), not a Pages `_redirects` file — they are
-**host-level**, which a path-based Pages `_redirects` file can't express.
-Keeping them in one Terraform ruleset is the single source of truth.
+There is no zone-level redirect ruleset. Apex and `www` both simply front this
+marketing site, and `staging` keeps serving the staging SPA. (A `www → app` /
+`staging → app-staging` ruleset shipped briefly but was dropped 2026-06 — it
+needed a Cloudflare token scope the deploy token doesn't carry, and the
+redirects are low-value; see `infra/cloudflare/main.tf`.)
 
-There is intentionally **no** apex `/blocked` router-compat shim: existing
-routers were already re-pointed to `app.wifihaven.net` for their block page (per
-#1842), and new cloud installs default to it (`openwrt/install.sh`), so no
-router DNATs its block page at the apex. The apex therefore just serves this
-marketing site for every path.
+There is also no apex `/blocked` router-compat shim: existing routers were
+re-pointed to `app.wifihaven.net` for their block page (per #1842), and new
+cloud installs default to it (`openwrt/install.sh`), so no router DNATs its
+block page at the apex.

--- a/web-marketing/wrangler.toml
+++ b/web-marketing/wrangler.toml
@@ -5,11 +5,9 @@
 # `wrangler pages deploy` from .github/workflows/master-marketing.yml.
 #
 # The project (`wifihaven-www`) and its custom domains / DNS are declared in
-# infra/cloudflare/main.tf and created by the master-cloudflare apply. The
-# www/staging → app redirects live in that same Terraform (a zone-level
-# dynamic-redirect ruleset), NOT in a Pages `_redirects` file, because they are
-# host-level. There is no apex `/blocked` shim (existing routers were re-pointed
-# to app.wifihaven.net; see main.tf), so the apex just serves this site.
+# infra/cloudflare/main.tf and created by the master-cloudflare apply. There are
+# no redirect rules and no apex `/blocked` shim — apex and www both just serve
+# this site (see main.tf for why the redirects were dropped).
 
 name = "wifihaven-www"
 pages_build_output_dir = "./site"


### PR DESCRIPTION
Relates to #1832. Follow-up to the merged #1902.

## What happened
On merge of #1902, **`master-cloudflare` (TF apply) failed** creating `cloudflare_ruleset.redirects`:

```
Error: error creating ruleset wifihaven redirects
Authentication error (10000)
```

Creating a Cloudflare **dynamic-redirect ruleset** requires a token scope (Zone → Dynamic Redirect → Edit) that the Pages+DNS deploy token doesn't carry. The DNS/Pages parts of the apply succeeded first — so the `wifihaven-www` project was created and apex/www were repointed to it — but the ruleset step then failed and aborted the apply. Separately, `master-marketing` raced ahead of the project creation and failed with `Project not found`.

Net effect: apex/www briefly **522'd** (pointing at an empty Pages project) until I re-ran the marketing deploy. **Live state is now healthy** — `wifihaven.net`, `www.wifihaven.net`, and `app.wifihaven.net` all return 200.

## The fix
The `www → app` / `staging → app-staging` redirects are **low-value**: apex and www both serving the marketing site is fine (the site has an "Open the app" CTA), and staging keeps serving the staging SPA. Rather than widen the Cloudflare token, **drop the ruleset**. `master-cloudflare` then applies cleanly with the existing token (the ruleset isn't in TF state — the create failed — so removing it from config is a no-op there; the rest of the apply already succeeded).

- Remove `cloudflare_ruleset.redirects` from `infra/cloudflare/main.tf`; reword the header + apex-domain comments.
- Docs: `infra/cloudflare/README.md`, `web-marketing/README.md` + `wrangler.toml`, `docs/deploy-cloud.md` (topology table → www/staging no longer redirect, apply note, verify curls), and an outcome note on the `app-host-rename.md` RFC.

This also follows the earlier removal of the `/blocked` shim (existing routers were re-pointed to `app.wifihaven.net`), so the zone now has **no** redirect ruleset at all.

## Validation
- `terraform fmt -check` + `terraform validate` clean.
- Live: apex/www/app all 200 (after the marketing redeploy that restored the apex).
- After merge, `master-cloudflare` should report a clean apply (no ruleset to create).

🤖 Generated with [Claude Code](https://claude.com/claude-code)