### PR TITLE
Fixes #1912, fixes #1913: blockEncryptedDns household setting + snapshot field + UI toggle

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -925,13 +925,21 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
       sql"""SELECT daily_reset_time, daily_reset_tz,
                  heartbeat_filter_enabled, heartbeat_bytes_threshold,
                  unmanaged_mac_policy::text,
-                 presence_continuation_seconds
+                 presence_continuation_seconds,
+                 block_encrypted_dns
             FROM household_settings WHERE id=1"""
-        .query[(LocalTime, ZoneId, Boolean, Int, String, Int)]
+        .query[(LocalTime, ZoneId, Boolean, Int, String, Int, Boolean)]
         .unique
-        .map { case (t, z, hbEnabled, hbBytes, ummJson, presenceCont) =>
+        .map { case (t, z, hbEnabled, hbBytes, ummJson, presenceCont, blockEncDns) =>
           val umm = ummJson.fromJson[UnmanagedMacPolicy].getOrElse(UnmanagedMacPolicy.Default)
-          HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, Nil), umm, presenceCont)
+          HouseholdSettings(
+            t,
+            z,
+            HeartbeatFilter(hbEnabled, hbBytes, Nil),
+            umm,
+            presenceCont,
+            blockEncDns,
+          )
         }
         .transact(xa),
     )
@@ -950,7 +958,12 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
     // from V24 so existing rows keep their seed value until the follow-up migration drops it
     // entirely; nothing in the API reads it anymore (see `Presence.isHeartbeat` →
     // `InfraHosts.isBackground`).
-    val upd           =
+    val upd =
+      // #1912: `block_encrypted_dns` does NOT gate the active-minute definition,
+      // so it doesn't strictly need the rollup invalidation below — but the
+      // invalidation is already wholesale (these fields share one aggregation
+      // path) and an admin toggling it is rare, so refilling the cache from
+      // first principles is harmless and keeps the update path single.
       sql"""UPDATE household_settings
               SET daily_reset_time=${s.dailyResetTime},
                   daily_reset_tz=${s.dailyResetTz},
@@ -958,6 +971,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
                   heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
                   unmanaged_mac_policy=${ummJson}::jsonb,
                   presence_continuation_seconds=${s.presenceContinuationSeconds},
+                  block_encrypted_dns=${s.blockEncryptedDns},
                   updated_at=NOW()
             WHERE id=1""".update.run
     val invalidate    = sql"DELETE FROM time_used_daily".update.run

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -320,7 +320,14 @@ class PolicyServiceLive(
       val pBlocklists: Map[BlocklistId, Blocklist] =
         pBlocklistsAll.view.filterKeys(referencedBlocklistIds).toMap
 
-      val core = SnapshotCore(globalRules, devicePolicies, profilePolicies, pBlocklists)
+      val core =
+        SnapshotCore(
+          globalRules,
+          devicePolicies,
+          profilePolicies,
+          pBlocklists,
+          settings.blockEncryptedDns,
+        )
       val etag = PolicyService.computeEtag(core)
       val snap = PolicySnapshot(
         etag = etag,
@@ -329,6 +336,9 @@ class PolicyServiceLive(
         devices = devicePolicies,
         profiles = profilePolicies,
         blocklists = pBlocklists,
+        // #1912 / #1909: network-wide bypass-disable flag, straight from the
+        // household setting. Curated host/IP lists are baked in the agent.
+        blockEncryptedDns = settings.blockEncryptedDns,
       )
       (snap, profiles.count(_.defaultDeny))
     }).flatMap { case (snap, defaultDenyProfiles) =>
@@ -647,6 +657,7 @@ private case class SnapshotCore(
     devices: Map[MacAddress, DevicePolicy],
     profiles: Map[ProfileId, ProfilePolicy],
     blocklists: Map[BlocklistId, Blocklist],
+    blockEncryptedDns: Boolean,
 )
 
 object PolicyService {
@@ -742,6 +753,9 @@ object PolicyService {
     core.blocklists.toList
       .sortBy(_._1.value)
       .foreach((k, v) => parts += s"bl:${k.value}=${v.version.value}")
+    // #1912: the network-wide bypass-disable flag is logical snapshot content,
+    // so toggling it must move the ETag and re-poll the fleet.
+    parts += s"bed:${core.blockEncryptedDns}"
     ETag.unsafe("\"sha256:" + sha256Hex(parts.mkString("\n")) + "\"")
   }
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1872,6 +1872,7 @@ object HouseholdSettingsRoutes {
                   upd.heartbeatFilter,
                   upd.unmanagedMacPolicy,
                   upd.presenceContinuationSeconds,
+                  upd.blockEncryptedDns,
                 ),
               )
               .mapError(ApiError.Db(_))
@@ -1896,6 +1897,17 @@ object HouseholdSettingsRoutes {
             tzPatch   <- ZIO
               .fromEither(FieldPatch.from[ZoneId](obj, "dailyResetTz"))
               .mapError(ApiError.BadRequest(_))
+            // #1912: top-level boolean, standard PATCH semantics — absent
+            // preserves, present sets, null clears (rejected; a boolean toggle
+            // is never nullable).
+            bedPatch  <- ZIO
+              .fromEither(FieldPatch.from[Boolean](obj, "blockEncryptedDns"))
+              .mapError(ApiError.BadRequest(_))
+            _         <- bedPatch match {
+              case FieldPatch.Cleared =>
+                ZIO.fail(ApiError.BadRequest("blockEncryptedDns cannot be cleared"))
+              case _                  => ZIO.unit
+            }
             _         <- timePatch match {
               case FieldPatch.Cleared =>
                 ZIO.fail(ApiError.BadRequest("dailyResetTime cannot be cleared"))
@@ -1931,6 +1943,7 @@ object HouseholdSettingsRoutes {
               heartbeatFilter = mergedFilter,
               unmanagedMacPolicy = mergedUmm,
               presenceContinuationSeconds = existing.presenceContinuationSeconds,
+              blockEncryptedDns = bedPatch.applyTo(existing.blockEncryptedDns),
             )
             _            <- repo.update(merged).mapError(ApiError.Db(_))
           } yield Response.ok

--- a/api/test/src/feature/HouseholdPatchApiSpec.scala
+++ b/api/test/src/feature/HouseholdPatchApiSpec.scala
@@ -65,6 +65,14 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         .addHeader(Header.ContentType(MediaType.application.json)),
     )
 
+  private def put(routes: Routes[Any, Response], token: String, body: String) =
+    routes.runZIO(
+      Request
+        .put(url("/api/household/settings"), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
   def spec = suite("PATCH /api/household/settings (#998)")(
     test("single top-level field patch") {
       for {
@@ -215,6 +223,71 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         (routes, tk) <- routesAndToken
         resp         <- patch(routes, tk, """{"unmanagedMacPolicy":null}""")
       } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("#1912 blockEncryptedDns defaults to false") {
+      for {
+        _     <- cleanDb
+        repo  <- ZIO.service[HouseholdSettingsRepo]
+        _     <- repo.ensureDefault(ZoneId.of("UTC"))
+        after <- repo.get
+      } yield assertTrue(!after.blockEncryptedDns)
+    },
+    test("#1912 PATCH {blockEncryptedDns:true} round-trips and preserves other fields") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"blockEncryptedDns":true}""")
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.blockEncryptedDns) &&
+        // a single-field PATCH leaves everything else untouched.
+        assertTrue(after.dailyResetTime == Seed.dailyResetTime) &&
+        assertTrue(after.unmanagedMacPolicy == Seed.unmanagedMacPolicy)
+    },
+    test("#1912 PATCH {blockEncryptedDns:false} clears the flag") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        _            <- patch(routes, tk, """{"blockEncryptedDns":true}""")
+        resp         <- patch(routes, tk, """{"blockEncryptedDns":false}""")
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(!after.blockEncryptedDns)
+    },
+    test("#1912 PATCH that omits blockEncryptedDns preserves the stored value") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        _            <- patch(routes, tk, """{"blockEncryptedDns":true}""")
+        _            <- patch(routes, tk, """{"dailyResetTime":"04:00:00"}""")
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(after.blockEncryptedDns) &&
+        assertTrue(after.dailyResetTime == LocalTime.of(4, 0))
+    },
+    test("#1912 PUT carries blockEncryptedDns through the full-replace path") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        body =
+          """{"dailyResetTime":"00:00:00","dailyResetTz":"America/Los_Angeles","heartbeatFilter":{"enabled":false,"bytesThreshold":1024,"heartbeatHostPatterns":[]},"unmanagedMacPolicy":{"policy":"allow","blockPage":true},"blockEncryptedDns":true}"""
+        resp  <- put(routes, tk, body)
+        repo  <- ZIO.service[HouseholdSettingsRepo]
+        after <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(after.blockEncryptedDns)
+    },
+    test("#1912 PUT that omits blockEncryptedDns decodes to the default (false)") {
+      // Older SPA builds PUT without the field; tolerate it (additive default).
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        body =
+          """{"dailyResetTime":"00:00:00","dailyResetTz":"America/Los_Angeles","heartbeatFilter":{"enabled":false,"bytesThreshold":1024,"heartbeatHostPatterns":[]},"unmanagedMacPolicy":{"policy":"allow","blockPage":true}}"""
+        resp  <- put(routes, tk, body)
+        repo  <- ZIO.service[HouseholdSettingsRepo]
+        after <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(!after.blockEncryptedDns)
     },
     test("403 when non-admin (adult) tries to PATCH") {
       for {

--- a/api/test/src/feature/PolicySnapshotBlockEncryptedDnsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockEncryptedDnsSpec.scala
@@ -1,0 +1,85 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.json.*
+import zio.test.*
+
+/**
+ * #1912 / #1909: the network-wide "block encrypted DNS & relays" toggle lives on `household_settings`
+ * and surfaces on the wire as the additive top-level `PolicySnapshot.blockEncryptedDns` boolean. The
+ * router agent (#1911) bakes the curated relay/DoH host + resolver-IP lists itself; the snapshot only
+ * carries the boolean. This spec pins that the snapshot reflects the household setting and that
+ * toggling it moves the ETag (so the fleet re-polls).
+ */
+object PolicySnapshotBlockEncryptedDnsSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makeSvc =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      clock  <- ZIO.service[Clock]
+    } yield PolicyServiceLive(pr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock)
+
+  private def setBlockEncryptedDns(v: Boolean) =
+    for {
+      hsr      <- ZIO.service[HouseholdSettingsRepo]
+      existing <- hsr.get
+      _        <- hsr.update(existing.copy(blockEncryptedDns = v))
+    } yield ()
+
+  def spec = suite("PolicySnapshot — blockEncryptedDns (#1912)")(
+    test("default household setting → snapshot.blockEncryptedDns is false") {
+      for {
+        _    <- cleanDb
+        svc  <- makeSvc
+        snap <- svc.snapshot
+      } yield assertTrue(!snap.blockEncryptedDns)
+    },
+    test("household setting true → snapshot.blockEncryptedDns is true") {
+      for {
+        _    <- cleanDb
+        _    <- setBlockEncryptedDns(true)
+        svc  <- makeSvc
+        snap <- svc.snapshot
+      } yield assertTrue(snap.blockEncryptedDns)
+    },
+    test("blockEncryptedDns serializes on the wire (the lua agent reads it as a plain bool)") {
+      for {
+        _    <- cleanDb
+        _    <- setBlockEncryptedDns(true)
+        svc  <- makeSvc
+        snap <- svc.snapshot
+        json = snap.toJson
+      } yield assertTrue(json.contains("\"blockEncryptedDns\":true"))
+    },
+    test("ETag flips when the household toggle changes") {
+      for {
+        _     <- cleanDb
+        svc   <- makeSvc
+        snap1 <- svc.snapshot
+        _     <- setBlockEncryptedDns(true)
+        snap2 <- svc.snapshot
+      } yield assertTrue(snap1.etag != snap2.etag) && assertTrue(!snap1.blockEncryptedDns) &&
+        assertTrue(snap2.blockEncryptedDns)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/PolicySnapshotBlockEncryptedDnsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockEncryptedDnsSpec.scala
@@ -11,11 +11,12 @@ import zio.json.*
 import zio.test.*
 
 /**
- * #1912 / #1909: the network-wide "block encrypted DNS & relays" toggle lives on `household_settings`
- * and surfaces on the wire as the additive top-level `PolicySnapshot.blockEncryptedDns` boolean. The
- * router agent (#1911) bakes the curated relay/DoH host + resolver-IP lists itself; the snapshot only
- * carries the boolean. This spec pins that the snapshot reflects the household setting and that
- * toggling it moves the ETag (so the fleet re-polls).
+ * #1912 / #1909: the network-wide "block encrypted DNS & relays" toggle lives on
+ * `household_settings` and surfaces on the wire as the additive top-level
+ * `PolicySnapshot.blockEncryptedDns` boolean. The router agent (#1911) bakes the curated relay/DoH
+ * host + resolver-IP lists itself; the snapshot only carries the boolean. This spec pins that the
+ * snapshot reflects the household setting and that toggling it moves the ETag (so the fleet
+ * re-polls).
  */
 object PolicySnapshotBlockEncryptedDnsSpec
     extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {

--- a/contract/api-to-router/policy_snapshot.json
+++ b/contract/api-to-router/policy_snapshot.json
@@ -77,5 +77,6 @@
       "version" : "2026.05.01",
       "url" : "https://example.org/lists/adult.txt"
     }
-  }
+  },
+  "blockEncryptedDns" : false
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,20 @@ case class PolicySnapshot(
     devices: Map[MacAddress, DevicePolicy],
     profiles: Map[ProfileId, ProfilePolicy],   // wire-dedup only; not consulted at enforcement
     blocklists: Map[BlocklistId, Blocklist],
+    blockEncryptedDns: Boolean,                // #1912/#1909: network-wide "block encrypted
+                                               //   DNS & relays" toggle, resolved from
+                                               //   household_settings.block_encrypted_dns.
+                                               //   When true the agent (#1911) forces devices
+                                               //   onto the LAN resolver: NXDOMAIN for the
+                                               //   curated relay/DoH hostnames (iCloud Private
+                                               //   Relay, public DoH) + nftables drops for
+                                               //   hardcoded resolver IPs and DoT/853. Carries
+                                               //   ONLY the boolean — the curated host/IP
+                                               //   lists are baked in the agent, never shipped
+                                               //   on the wire. Deliberate, narrow exception to
+                                               //   Architectural Truth #1 ("DNS always
+                                               //   resolves") — bypass-disablement signaling is
+                                               //   itself enforcement-enabling. Default false.
 )
 
 case class DevicePolicy(

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -1242,5 +1242,61 @@ print('ok' if isinstance(r.get('topHosts'), list) and isinstance(r.get('buckets'
 [ "$SER932" = "ok" ] || fail "#932: /api/usage/series shape unexpected: $SER932"
 pass "#932: /api/usage/series returns topHosts + buckets arrays"
 
+# ── #1912: network-wide blockEncryptedDns reflected on the wire ───────────
+#
+# The household "block encrypted DNS & relays" toggle surfaces on the snapshot
+# as the additive top-level boolean `blockEncryptedDns` (sibling of global /
+# devices / profiles / blocklists). The router agent (#1911) bakes the curated
+# relay/DoH host + resolver-IP lists itself; the API only ships the boolean.
+# Assert: default is false, flipping the household setting flips the wire flag,
+# and we reset it so the run is idempotent against persistent staging.
+step "#1912: blockEncryptedDns reflects the household setting"
+
+read_bed() {  # → "true"/"false" from a fresh /api/router/policy read
+  curl -fsS "${RAUTH[@]}" "$BASE/api/router/policy" >"$TMP/snap_bed.json"
+  _py "
+import json
+snap = json.load(open('$TMP/snap_bed.json'))
+print('true' if snap.get('blockEncryptedDns') is True else ('false' if snap.get('blockEncryptedDns') is False else 'MISSING'))
+"
+}
+
+# Default (household setting untouched this run) must be a present, false bool —
+# never absent (the field is non-optional on the wire).
+BED0="$(read_bed)"
+[ "$BED0" = "false" ] || fail "#1912: expected default blockEncryptedDns=false, got: $BED0"
+pass "#1912: default blockEncryptedDns=false"
+
+curl -fsS -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
+  -H 'content-type: application/json' \
+  -d '{"blockEncryptedDns":true}' >/dev/null
+pass "#1912: household setting → blockEncryptedDns=true"
+
+# Poll (staging Render rollover may briefly serve a stale instance — same
+# pattern as the TimeLimit step above).
+BED1=""
+deadline=$(( $(date +%s) + 15 ))
+while (( $(date +%s) < deadline )); do
+  BED1="$(read_bed)"
+  [ "$BED1" = "true" ] && break
+  sleep 1
+done
+[ "$BED1" = "true" ] || fail "#1912: expected blockEncryptedDns=true after toggle, got: $BED1"
+pass "#1912: snapshot blockEncryptedDns=true after enabling"
+
+# Reset to false so persistent staging is left as we found it.
+curl -fsS -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
+  -H 'content-type: application/json' \
+  -d '{"blockEncryptedDns":false}' >/dev/null
+BED2=""
+deadline=$(( $(date +%s) + 15 ))
+while (( $(date +%s) < deadline )); do
+  BED2="$(read_bed)"
+  [ "$BED2" = "false" ] && break
+  sleep 1
+done
+[ "$BED2" = "false" ] || fail "#1912: expected blockEncryptedDns=false after reset, got: $BED2"
+pass "#1912: snapshot blockEncryptedDns=false after disabling"
+
 echo
 echo "All router e2e checks passed."

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -685,6 +685,15 @@ case class HouseholdSettings(
     // presence is the [first, last]-activity span. Default 120 (migration V52);
     // the rollup raises it to the 2×R collapse guard at compute time.
     presenceContinuationSeconds: Int = HouseholdSettings.DefaultPresenceContinuationSeconds,
+    // #1912 / #1909: network-wide "block encrypted DNS & relays" toggle. When
+    // true, PolicyService emits the additive top-level `PolicySnapshot.blockEncryptedDns`
+    // and the agent (#1911) forces devices onto the LAN resolver — NXDOMAIN for
+    // the curated relay/DoH hostnames (iCloud Private Relay, public DoH) plus
+    // nftables drops for hardcoded resolver IPs and DoT/853. Household-level
+    // (NOT per-profile): the clean disable signal is NXDOMAIN, which stock
+    // dnsmasq answers network-wide only. Default false (migration V61). The
+    // curated host/IP lists are baked in the agent, never shipped on the wire.
+    blockEncryptedDns: Boolean = false,
 ) derives JsonCodec
 
 object HouseholdSettings {
@@ -697,6 +706,10 @@ case class UpdateHouseholdSettingsRequest(
     heartbeatFilter: HeartbeatFilter,
     unmanagedMacPolicy: UnmanagedMacPolicy = UnmanagedMacPolicy.Default,
     presenceContinuationSeconds: Int = HouseholdSettings.DefaultPresenceContinuationSeconds,
+    // #1912: additive — an older SPA build that PUTs without this field decodes
+    // to the default (false), so a full-replace PUT never silently clears it for
+    // a peer that doesn't know about it yet.
+    blockEncryptedDns: Boolean = false,
 ) derives JsonCodec
 
 /**
@@ -1616,6 +1629,16 @@ case class PolicySnapshot(
     devices: Map[MacAddress, DevicePolicy],
     profiles: Map[ProfileId, ProfilePolicy],
     blocklists: Map[BlocklistId, Blocklist],
+    // #1912 / #1909: network-wide "block encrypted DNS & relays" flag, resolved
+    // from `household_settings.block_encrypted_dns`. Additive top-level boolean,
+    // defaults false (so an older snapshot JSON predating it decodes to off, and
+    // an un-updated agent ignoring it is also off). It carries ONLY the boolean:
+    // the curated relay/DoH host + resolver-IP lists are baked in the agent
+    // (#1911), not shipped here — the router enforces NXDOMAIN/nftables drops
+    // off its own lists when this is true. This is the snapshot's one deliberate,
+    // narrowly-scoped exception to "DNS always resolves" (Architectural Truth #1),
+    // and it is bypass-disablement signaling, which is itself enforcement-enabling.
+    blockEncryptedDns: Boolean = false,
 ) derives JsonCodec
 
 // ── Block reasons (snapshot + router-emitted) ─────────────────────────────

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
     dailyResetTz: 'America/Los_Angeles',
     heartbeatFilter: { ...DEFAULT_HF },
     unmanagedMacPolicy: { ...DEFAULT_UMM },
+    blockEncryptedDns: false,
   }
   ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
     async () => ({
@@ -193,5 +194,39 @@ describe('AdminPage — unmanaged-MAC policy autosave (#1002)', () => {
     const card = await screen.findByTestId('unmanaged-mac-policy-card')
     const blockPage = within(card).getByTestId('unmanaged-mac-policy-block-page') as HTMLInputElement
     expect(blockPage.disabled).toBe(true)
+  })
+})
+
+describe('AdminPage — block-encrypted-DNS toggle (#1913)', () => {
+  it('renders the toggle reflecting the stored setting (off by default)', async () => {
+    render(<AdminPage />)
+    const toggle = await screen.findByTestId('block-encrypted-dns-enabled') as HTMLInputElement
+    expect(toggle.checked).toBe(false)
+  })
+
+  it('toggling on fires PATCH {blockEncryptedDns:true}', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('block-encrypted-dns-enabled')
+
+    await user.click(screen.getByTestId('block-encrypted-dns-enabled'))
+
+    await waitFor(() =>
+      expect(api.household.patch).toHaveBeenCalledWith({ blockEncryptedDns: true }),
+    )
+  })
+
+  it('reflects a stored true after the round-trip (persists via the API client)', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    const toggle = await screen.findByTestId('block-encrypted-dns-enabled') as HTMLInputElement
+
+    await user.click(toggle)
+
+    // The card re-reads the server-of-record after autosave; the persisted
+    // value must come back checked.
+    await waitFor(() =>
+      expect((screen.getByTestId('block-encrypted-dns-enabled') as HTMLInputElement).checked).toBe(true),
+    )
   })
 })

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -34,6 +34,7 @@ export function AdminPage() {
 
       {hs && <DailyResetCard value={hs} reload={reload} />}
       {hs && <HeartbeatFilterCard value={hs} reload={reload} />}
+      {hs && <BlockEncryptedDnsCard value={hs} reload={reload} />}
       {hs && <UnmanagedMacPolicyCard value={hs} reload={reload} />}
     </div>
   )
@@ -125,6 +126,63 @@ function UnmanagedMacPolicyCard({
           className="h-4 w-4"
         />
         Show block page (HTTP/80 DNATs to the "device not enrolled" page)
+      </label>
+    </div>
+  )
+}
+
+// #1913 / #1909 — network-wide "block encrypted DNS & relays" toggle. Forces
+// every device onto the LAN resolver (turns off iCloud Private Relay + public
+// DoH/DoT, drops hardcoded resolver IPs) so WifiHaven's filtering and
+// hostname attribution actually see the traffic. Household-wide, not
+// per-profile (the clean disable signal — NXDOMAIN — is network-wide only).
+function BlockEncryptedDnsCard({
+  value, reload,
+}: {
+  value: HouseholdSettings
+  reload: () => Promise<void>
+}) {
+  const [enabled, setEnabled] = useState(value.blockEncryptedDns)
+  useEffect(() => { setEnabled(value.blockEncryptedDns) }, [value.blockEncryptedDns])
+
+  const save = useDebouncedSave(
+    enabled,
+    async (next) => {
+      await api.household.patch({ blockEncryptedDns: next })
+      await reload()
+    },
+  )
+
+  return (
+    <div
+      data-testid="block-encrypted-dns-card"
+      className="bg-white rounded-2xl border border-brand-border p-5 space-y-3"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-bold text-brand-ink">Block encrypted DNS &amp; relays</h2>
+        <SaveStatusBadge
+          testId="block-encrypted-dns-save-status"
+          status={save.status}
+          error={save.error}
+          onRetry={save.retry}
+        />
+      </div>
+
+      <p className="text-xs text-brand-text">
+        Forces every device onto this network's local DNS resolver so WifiHaven can filter
+        traffic and attribute it to the right site. Turns off iCloud Private Relay and public
+        encrypted DNS (DoH/DoT) — without this, a device can tunnel around all filtering and
+        time limits. Applies to the whole household, not a single profile.
+      </p>
+      <label className="flex items-center gap-2 text-sm text-brand-ink">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={e => setEnabled(e.target.checked)}
+          data-testid="block-encrypted-dns-enabled"
+          className="h-4 w-4"
+        />
+        Block encrypted DNS &amp; relays
       </label>
     </div>
   )

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -102,6 +102,12 @@ export interface HouseholdSettings {
   dailyResetTz: string    // IANA timezone
   heartbeatFilter: HeartbeatFilter
   unmanagedMacPolicy: UnmanagedMacPolicy
+  // #1912 / #1909 — network-wide "block encrypted DNS & relays" toggle. When on,
+  // the API ships `blockEncryptedDns:true` on the policy snapshot and the router
+  // forces devices onto the LAN resolver (NXDOMAIN for iCloud Private Relay +
+  // public DoH/DoT hostnames, connection-layer drops for hardcoded resolver IPs)
+  // so filtering and hostname attribution work. Household-wide, not per-profile.
+  blockEncryptedDns: boolean
 }
 
 export interface TimeLimit {


### PR DESCRIPTION
Producer + UI for the network-wide **"block encrypted DNS & relays"** toggle (feature #1909, epic #1903 — DNS-Bypass & Attribution). Closes #1912 (API) and #1913 (web).

> **Stacked on the schema-only migration PR #1916** (`base: claude/1912-migration-block-encrypted-dns`). This PR's diff is code+tests only; the V61 column lives in the base. Once #1916 merges to `main`, GitHub auto-retargets this PR to `main`.

## What this delivers
A single household-level toggle. When on, the API emits one **additive top-level boolean** `blockEncryptedDns` on the policy snapshot. The router agent (PR #1911) bakes the curated relay/DoH host + resolver-IP lists itself and enforces (NXDOMAIN for iCloud Private Relay + public DoH hostnames, nftables drops for hardcoded resolver IPs and DoT/853). **Only the boolean crosses the wire** — no curated lists, no per-profile tier.

Network-wide, **not** per-profile: the clean disable signal (NXDOMAIN) is network-wide only in stock dnsmasq, and a per-profile connection-layer drop of the relay ingress is the path Apple warns against (client hangs — the #1891 symptom). Rationale in #1909.

## Shared wire contract (matches the agent PR #1911)
`PolicySnapshot.blockEncryptedDns: Boolean = false` — top-level sibling of `global`/`devices`/`profiles`/`blocklists`. Additive, defaults false (old snapshot JSON decodes to off; un-updated agent ignores it → off). Folded into the ETag so toggling re-polls the fleet.

## Changes
**API**
- `HouseholdSettings` + `UpdateHouseholdSettingsRequest` gain `blockEncryptedDns` (default false); `HouseholdSettingsRepoLive` reads/writes the V61 column.
- PUT passes it through; PATCH treats it as a standard tri-state top-level boolean (absent preserves, present sets, null → 400).
- `PolicyService.snapshot` emits `settings.blockEncryptedDns`; `SnapshotCore`/`computeEtag` include it.

**Web**
- "Block encrypted DNS & relays" autosave toggle on the Admin household-settings page (`web/src/pages/AdminPage.tsx`), wired through `api.household.patch`. Copy explains it forces devices onto the LAN resolver (off iCloud Private Relay + public DoH/DoT) so filtering and hostname attribution work.

**Docs / contract**
- `docs/architecture.md` documents the field + its narrow, deliberate exception to Architectural Truth #1.
- Regenerated `contract/api-to-router/policy_snapshot.json` golden (additive field; the lua contract spec reads specific keys and tolerates the new one).

## Tests (TDD — red commit then green)
- `PolicySnapshotBlockEncryptedDnsSpec` — snapshot reflects the household setting (true→true, default→false), serializes on the wire, ETag flips on toggle.
- `HouseholdPatchApiSpec` — PATCH/PUT read-write round-trip + preserve-on-omit + default-false.
- `AdminPage.test.tsx` — toggle renders, reflects the setting, persists via the API client.
- **Gate 1 e2e** (`scripts/e2e-router.sh`): the real API serves `blockEncryptedDns:false` by default and `true` after the household toggle on `/api/router/policy`, then resets (idempotent against staging). Added to the existing Gate-1 harness — no new docker-compose job.

Local runs green: `mill shared.test`, the affected `api.test` specs, contract golden, web `vitest`/`type-check`/`lint`. The Gate-1 e2e runs in CI (Docker unavailable locally this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)