### PR TITLE
Fixes #1911: enforce network-wide blockEncryptedDns (NXDOMAIN relay/DoH hosts + nft drop resolver IPs & DoT/853)

### DIFF
--- a/deploy/grafana/dashboards/enforcement.json
+++ b/deploy/grafana/dashboards/enforcement.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "WifiHaven enforcement plane (#1280): the nftables forward-drop activity on the gateway router — the ACTUAL block plane (DNS always resolves; blocking is connection-layer, never a DNS sinkhole). Every panel targets the single emitted series enforcement_drops_total{reason} (#1325): the agent reads the per-rule nft `counter` packets in the wifihaven_block chain (nft_drops.lua), classifies each by its wh_drop:<mac>:<reason> comment into a bounded reason enum — whole_mac / host_block / category_block / ip_only — and folds the per-tick growth into its 60s metrics push (metrics.fold_external). RouterMetricsService re-exports it on /metrics with the server-attached router_id (+ installation_id); Alloy adds env at scrape time. The counter is dropped PACKETS, so rate() is packets/sec. Slices only by the bounded reason / router_id labels per the §4 cardinality firewall — never per-mac / per-host / per-ip / per-blocklist-id. See docs/architecture.md (enforcement model) and docs/design/metrics-observability.md §5.1.",
+  "description": "WifiHaven enforcement plane (#1280): the nftables forward-drop activity on the gateway router — the ACTUAL block plane (DNS always resolves; blocking is connection-layer, never a DNS sinkhole). Every panel targets the single emitted series enforcement_drops_total{reason} (#1325): the agent reads the per-rule nft `counter` packets in the wifihaven_block chain (nft_drops.lua), classifies each by its wh_drop:<mac>:<reason> comment into a bounded reason enum — whole_mac / host_block / category_block / ip_only / encrypted_dns — and folds the per-tick growth into its 60s metrics push (metrics.fold_external). RouterMetricsService re-exports it on /metrics with the server-attached router_id (+ installation_id); Alloy adds env at scrape time. The counter is dropped PACKETS, so rate() is packets/sec. Slices only by the bounded reason / router_id labels per the §4 cardinality firewall — never per-mac / per-host / per-ip / per-blocklist-id. See docs/architecture.md (enforcement model) and docs/design/metrics-observability.md §5.1.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -95,7 +95,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Drop share by reason (5m rate)",
-      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — proportion of forward-drops attributable to each bounded reason. whole_mac = a whole-MAC @blocked_macs drop (paused / schedule / time-limit / manual, the resolved MacBlockReason); host_block = per-(MAC, host) eb_ drop; category_block = per-(MAC, blocklistId) bl_ drop; ip_only = blockIpOnly unresolved-destination drop. A category_block share collapsing to zero while categories are assigned is the #1334 silent-no-op signature.",
+      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — proportion of forward-drops attributable to each bounded reason. whole_mac = a whole-MAC @blocked_macs drop (paused / schedule / time-limit / manual, the resolved MacBlockReason); host_block = per-(MAC, host) eb_ drop; category_block = per-(MAC, blocklistId) bl_ drop; ip_only = blockIpOnly unresolved-destination drop; encrypted_dns = network-wide blockEncryptedDns curated resolver-IP + DoT/853 drop (#1911). A category_block share collapsing to zero while categories are assigned is the #1334 silent-no-op signature.",
       "type": "piechart",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
       "id": 3,
@@ -125,7 +125,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Forward-drop rate by reason (fleet)",
-      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — stacked packets/sec dropped at the forward chain, broken down by the four bounded drop reasons. This is the core enforcement view: how much traffic is really being blocked and why. reason ∈ {whole_mac, host_block, category_block, ip_only}.",
+      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — stacked packets/sec dropped at the forward chain, broken down by the bounded drop reasons. This is the core enforcement view: how much traffic is really being blocked and why. reason ∈ {whole_mac, host_block, category_block, ip_only, encrypted_dns}.",
       "type": "timeseries",
       "gridPos": { "h": 9, "w": 24, "x": 0, "y": 8 },
       "id": 4,

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -319,7 +319,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Enforcement forward-drops by reason",
-      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — packets dropped at the nftables forward chain (the actual enforcement plane), reason ∈ {whole_mac, host_block, category_block, ip_only}. Sourced from the per-rule nft counters the agent folds on each tick (#1325). This is how much traffic is really being blocked and why — the prerequisite signal for the enforcement dashboard (#1280).",
+      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — packets dropped at the nftables forward chain (the actual enforcement plane), reason ∈ {whole_mac, host_block, category_block, ip_only, encrypted_dns}. Sourced from the per-rule nft counters the agent folds on each tick (#1325). This is how much traffic is really being blocked and why — the prerequisite signal for the enforcement dashboard (#1280).",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
       "id": 10,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,49 @@ The `blockIpOnly` flag (see §0.2) is what closes the DoH / hard-coded-IP
 hole: forwarded traffic to an IP we did not resolve for this MAC is
 dropped.
 
+#### Truth #1 — the `blockEncryptedDns` exception (bypass-disable signalling)
+
+There is exactly **one** deliberate, narrowly-scoped place where the agent
+returns a **negative DNS answer**, and it is *not* content blocking — it is
+**bypass-disable signalling**. The network-wide `blockEncryptedDns` toggle
+([#1909](https://github.com/wifihaven/wifihaven/issues/1909) /
+[#1911](https://github.com/wifihaven/wifihaven/issues/1911), epic
+[#1903](https://github.com/wifihaven/wifihaven/issues/1903)) exists because a
+device running iCloud Private Relay / DoH / DoT tunnels its traffic around the
+LAN resolver and defeats **both** hostname attribution **and** connection-layer
+enforcement (the [#1891](https://github.com/wifihaven/wifihaven/issues/1891)
+root cause). When the household enables the toggle, the agent enforces, for
+every managed MAC:
+
+1. **A negative DNS answer (NXDOMAIN) for a curated list of relay / DoH
+   *hostnames*** (`mask.icloud.com`, `mask-h2.icloud.com`, `cloudflare-dns.com`,
+   `dns.google`, …) via dnsmasq `local=/<host>/`. For iCloud Private Relay this
+   is **Apple's documented clean signal**: a negative answer for the relay
+   ingress makes iOS *disable* Private Relay and fall back to direct, filterable
+   connections — **without** the client-side hang that a silent connection-layer
+   *drop* of the relay ingress causes (that hang is the #1891 symptom, and the
+   path Apple explicitly warns against). A positive `0.0.0.0` sinkhole does
+   **not** disable Private Relay; the answer must be negative. The DoH-by-name
+   hosts are denied a positive answer so a browser's built-in DoH falls back to
+   Do53 through us. The parent apex (e.g. `icloud.com`) keeps resolving — only
+   the curated relay/DoH names are answered negatively.
+2. **A connection-layer drop** (nftables forward-drop, the normal enforcement
+   plane) for a curated set of public-resolver **IPs** (`1.1.1.1`, `8.8.8.8`,
+   … + v6) reached by hardcoded IP, and for **DoT (TCP/853) to any IP**.
+
+Why this does not violate Truth #1 in spirit: the negative DNS answer here does
+not *block content* — it tells the client to **stop tunnelling** so our real,
+connection-layer enforcement can see the traffic at all. It is gated behind the
+household toggle, scoped to a small curated list baked into the agent
+(`openwrt/files/usr/lib/lua/wifihaven/encrypted_dns.lua` — not shipped on the
+wire), and is the *only* sanctioned DNS-layer negative answer. Do **not**
+generalize it into content blocking. The wire stays a single additive top-level
+boolean, `blockEncryptedDns` (default `false`); the agent ignores it when absent
+(old-agent / no-flag intermediate states are all no-ops). Curated-list drops are
+a hard network-wide block: they carry **no** `extraAllowed` / `@global_allow`
+carve-out (an allow entry must not re-open an encrypted-DNS escape) and are
+**not** DNAT'd to the block page (a DoH/DoT flow is not a browser navigation).
+
 ### 0.2 The router agent is a dumb applier
 
 The API server's `PolicyService` evaluates every policy concept — schedules,

--- a/openwrt/files/usr/lib/lua/wifihaven/encrypted_dns.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/encrypted_dns.lua
@@ -1,0 +1,80 @@
+-- encrypted_dns.lua — curated relay / DoH / DoT lists for the network-wide
+-- `blockEncryptedDns` toggle (#1909 / #1911; epic #1903).
+--
+-- The wire carries a SINGLE top-level boolean (`snapshot.blockEncryptedDns`);
+-- the lists below are deliberately NOT shipped on the wire. They are small,
+-- stable, and apply identically to every router, so baking them into the agent
+-- keeps the snapshot to one flag (the "snapshot is a minimal functional shape"
+-- rule — a new policy concept rides an existing/parsimonious wire shape, never a
+-- new data channel). When the lists need to grow, edit this module and ship a
+-- new agent build; no API/wire change is required.
+--
+-- Two enforcement halves (see render.lua):
+--   1. HOSTS              — answered NEGATIVELY by dnsmasq (`local=/<host>/` →
+--                           NXDOMAIN). This is Apple's documented *clean* signal
+--                           to disable iCloud Private Relay: a negative answer
+--                           for mask.icloud.com / mask-h2.icloud.com makes iOS
+--                           fall back to direct, filterable connections WITHOUT
+--                           the client-side hang that a silent connection-layer
+--                           drop of the relay ingress causes (the #1891 symptom).
+--                           A positive 0.0.0.0 sinkhole does NOT disable it —
+--                           the answer must be negative.
+--   2. RESOLVER_IPS_*/    — dropped at the nftables forward chain (no DNS query
+--      DOT_PORT             to negative-answer here: the device reached a public
+--                           resolver by hardcoded IP or DoT on a fixed port,
+--                           bypassing our resolver entirely).
+--
+-- NOTE — deliberate Truth-#1 exception. Architectural Truth #1 is "DNS is never
+-- the enforcement plane; DNS always resolves." The HOSTS half breaks that, on
+-- purpose and narrowly: a negative DNS answer here is *bypass-disable
+-- signalling* (it tells the client to stop tunnelling so our real,
+-- connection-layer enforcement can see the traffic), not content blocking. It
+-- is scoped to this curated relay/DoH list and gated behind the household
+-- toggle. See docs/architecture.md ("Truth #1 — the blockEncryptedDns
+-- exception").
+
+local M = {}
+
+-- Relay ingress + DoH-by-name hostnames. `local=/<host>/` scopes to the host
+-- and everything under it (e.g. *.mask.icloud.com), never the parent apex
+-- (icloud.com keeps resolving). Keep these as bare DNS names — no scheme, no
+-- `#`, no `/` — render.dnsmasq wraps each as `local=/<host>/`.
+M.HOSTS = {
+  -- Apple iCloud Private Relay ingress (the #1891 root cause).
+  "mask.icloud.com",
+  "mask-h2.icloud.com",
+  -- Public DoH endpoints addressable by name.
+  "cloudflare-dns.com",
+  "dns.google",
+  "dns.quad9.net",
+  "dns.nextdns.io",
+  "dns.adguard-dns.com",
+  "doh.opendns.com",
+}
+
+-- Curated public-resolver v4 IPs. Dropped at the forward chain for every
+-- managed MAC so a device pinning DoH/Do53 to a literal IP can't bypass the
+-- LAN resolver. Cloudflare / Google / Quad9 anycast.
+M.RESOLVER_IPS_V4 = {
+  "1.1.1.1",         -- Cloudflare
+  "1.0.0.1",         -- Cloudflare
+  "8.8.8.8",         -- Google
+  "8.8.4.4",         -- Google
+  "9.9.9.9",         -- Quad9
+  "149.112.112.112", -- Quad9 secondary
+}
+
+-- Curated public-resolver v6 IPs (siblings of the v4 set above).
+M.RESOLVER_IPS_V6 = {
+  "2606:4700:4700::1111", -- Cloudflare
+  "2606:4700:4700::1001", -- Cloudflare
+  "2001:4860:4860::8888", -- Google
+  "2001:4860:4860::8844", -- Google
+  "2620:fe::fe",          -- Quad9
+}
+
+-- DoT (DNS-over-TLS) fixed port. Dropped to ANY IP (a DoT resolver can live on
+-- any address, so this is port-based, not IP-based).
+M.DOT_PORT = 853
+
+return M

--- a/openwrt/files/usr/lib/lua/wifihaven/nft_drops.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/nft_drops.lua
@@ -15,10 +15,12 @@
 -- — and a category drop carries `category:<blocklistId>`). classify_reason
 -- folds those into the four bounded buckets the §4 cardinality firewall allows:
 --
---   host        → host_block       (per-(MAC, host) eb_ drop, #515)
---   ip_only     → ip_only          (blockIpOnly un-resolved-daddr drop, #353)
---   category:*  → category_block   (per-(MAC, blocklistId) bl_ drop, #352)
---   <anything   → whole_mac        (whole-MAC @blocked_macs drop carrying a
+--   host          → host_block     (per-(MAC, host) eb_ drop, #515)
+--   ip_only       → ip_only        (blockIpOnly un-resolved-daddr drop, #353)
+--   category:*    → category_block (per-(MAC, blocklistId) bl_ drop, #352)
+--   encrypted_dns* → encrypted_dns (network-wide blockEncryptedDns curated
+--                                   resolver-IP + DoT/853 drop, #1911)
+--   <anything     → whole_mac      (whole-MAC @blocked_macs drop carrying a
 --    else>                          MacBlockReason — Paused/Schedule/…/blocked)
 --
 -- There is deliberately NO per-mac / per-host / per-ip / per-blocklist-id
@@ -60,6 +62,11 @@ function M.classify_reason(comment_reason)
     return "ip_only"
   elseif comment_reason:match("^category:") then
     return "category_block"
+  elseif comment_reason:match("^encrypted_dns") then
+    -- #1911: the network-wide blockEncryptedDns drops (curated resolver IPs →
+    -- `encrypted_dns`; DoT/853 → `encrypted_dns_dot`) fold into ONE bounded
+    -- bucket. The dst IP / port is never a label (§4 cardinality firewall).
+    return "encrypted_dns"
   else
     -- Whole-MAC drops carry a MacBlockReason (or "blocked"); fold them — and
     -- any unrecognised future string — into the single whole_mac bucket so the

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -77,6 +77,27 @@
 
 local M = {}
 
+-- Lazy require of the curated encrypted-DNS lists (#1909/#1911) — compatible
+-- with both the on-device path (wifihaven.encrypted_dns) and the busted test
+-- path (encrypted_dns). Cached after first use.
+local _edns_module
+local function edns()
+  if not _edns_module then
+    local ok, m = pcall(require, "wifihaven.encrypted_dns")
+    _edns_module = ok and m or require("encrypted_dns")
+  end
+  return _edns_module
+end
+
+-- #1909/#1911: the network-wide "block encrypted DNS & relays" toggle. A single
+-- top-level boolean on the snapshot; absent/false renders byte-identically to a
+-- snapshot that never carried it (default off, additive — old agents ignore it,
+-- a new agent reading an absent flag treats it as false).
+local function block_encrypted_dns(snapshot)
+  return (snapshot and snapshot.blockEncryptedDns) and true or false
+end
+M.block_encrypted_dns = block_encrypted_dns
+
 -- Directory where per-blocklist dnsmasq conf shards live (#1782). A SUBDIR of
 -- the dnsmasq confdir (/tmp/dnsmasq.d, itself tmpfs = RAM on OpenWRT), NOT bare
 -- /tmp — #1812. OpenWRT runs dnsmasq inside a procd ujail that bind-mounts ONLY
@@ -605,6 +626,27 @@ function M.dnsmasq(snapshot, opts)
     emit("")
   end
 
+  -- #1909/#1911: blockEncryptedDns — negative DNS answer for the curated
+  -- relay/DoH hostnames. `local=/<host>/` makes dnsmasq authoritative for the
+  -- name with no records, so it answers NXDOMAIN (verified live on dnsmasq 2.91
+  -- / OpenWRT — a clean negative answer, NOT a 0.0.0.0 sinkhole). This is the
+  -- documented Truth-#1 exception: a negative answer for mask.icloud.com /
+  -- mask-h2.icloud.com is Apple's clean signal to DISABLE iCloud Private Relay
+  -- (the device then makes direct, filterable connections without the hang a
+  -- silent connection-layer drop causes); the DoH-by-name hosts are denied a
+  -- positive answer so a browser's built-in DoH falls back to Do53 through us.
+  -- Scoped to bypass-disable signalling and gated on the household toggle; the
+  -- parent apex (e.g. icloud.com) keeps resolving. See docs/architecture.md.
+  if block_encrypted_dns(snapshot) then
+    emit("# blockEncryptedDns (#1909/#1911): NEGATIVE DNS answer (NXDOMAIN) for")
+    emit("# curated relay/DoH hostnames — Apple's clean Private-Relay disable")
+    emit("# signal; deliberate, scoped Truth-#1 exception (docs/architecture.md).")
+    for _, host in ipairs(edns().HOSTS) do
+      emit("local=/" .. host .. "/")
+    end
+    emit("")
+  end
+
   return table.concat(out, "\n")
 end
 
@@ -755,6 +797,16 @@ function M.nft(snapshot, opts)
   for mac, _ in sorted_devices(snapshot.devices) do
     if not allowall_macs[mac] then managed_macs[#managed_macs + 1] = mac end
   end
+
+  -- #1909/#1911: network-wide blockEncryptedDns. When on, every managed MAC gets
+  -- a forward-chain drop on the curated public-resolver IPs (v4/v6) and on DoT
+  -- (TCP/853, any IP) — the connection-layer half of the toggle (the DNS half is
+  -- the NXDOMAIN directives in render.dnsmasq). Network-wide, NOT per-profile,
+  -- and NOT carved out by extraAllowed/@global_allow: this is a hard bypass
+  -- block, so an allow entry must not re-open an encrypted-DNS escape. Suppressed
+  -- only for allow-all-failover MACs (they reach this point absent from
+  -- managed_macs), mirroring every other drop's failover behaviour.
+  local block_edns = block_encrypted_dns(snapshot)
 
   -- ga_suffix(family) → the fleet-wide @global_allow carve-out clause appended
   -- to EVERY hostname/MAC drop and DNAT (per-MAC or global). Returns "" when
@@ -920,6 +972,29 @@ function M.nft(snapshot, opts)
     ind2("type ipv6_addr")
     ind2("flags dynamic,timeout")
     ind2("timeout 1h")
+    ind("}")
+    emit("")
+  end
+
+  -- #1909/#1911: blockEncryptedDns curated public-resolver IP sets. Unlike
+  -- eb_/bl_/global sets these are NOT dynamic/DNS-populated — they are a fixed,
+  -- agent-baked constant (encrypted_dns.lua), so they carry static `elements`
+  -- and no timeout. Declared only when the toggle is on, so a snapshot without
+  -- the flag renders byte-identically to pre-#1911.
+  if block_edns then
+    local e = edns()
+    ind("set encrypted_dns_resolvers {")
+    ind2("type ipv4_addr")
+    if #e.RESOLVER_IPS_V4 > 0 then
+      ind2("elements = { " .. table.concat(e.RESOLVER_IPS_V4, ", ") .. " }")
+    end
+    ind("}")
+    emit("")
+    ind("set encrypted_dns_resolvers6 {")
+    ind2("type ipv6_addr")
+    if #e.RESOLVER_IPS_V6 > 0 then
+      ind2("elements = { " .. table.concat(e.RESOLVER_IPS_V6, ", ") .. " }")
+    end
     ind("}")
     emit("")
   end
@@ -1291,6 +1366,28 @@ function M.nft(snapshot, opts)
       for _, mac in ipairs(managed_macs) do
         emit_drop(string.format("ether saddr %s", mac), mac, g_block_reason)
       end
+    end
+  end
+  -- #1909/#1911: blockEncryptedDns drops. For each managed MAC, drop forwarded
+  -- traffic to the curated public-resolver IPs (v4/v6) and to DoT (TCP/853, any
+  -- IP). No ea/ga carve-out suffix: a hard bypass block must not be re-openable
+  -- by an allow entry. Per-MAC (not one fleet-wide rule) so each drop carries an
+  -- attributable `wh_drop:<mac>:encrypted_dns[_dot]` comment for nflog/metrics
+  -- (folds to the bounded `encrypted_dns` reason — nft_drops.classify_reason).
+  -- Deliberately NOT DNAT'd to the block page (see the DNAT chain): a DoH/DoT
+  -- flow is not a browser navigation, so a block page is meaningless there.
+  if block_edns then
+    for _, mac in ipairs(managed_macs) do
+      emit_drop(string.format("ether saddr %s ip daddr @encrypted_dns_resolvers", mac),
+                mac, "encrypted_dns")
+    end
+    for _, mac in ipairs(managed_macs) do
+      emit_drop(string.format("ether saddr %s ip6 daddr @encrypted_dns_resolvers6", mac),
+                mac, "encrypted_dns")
+    end
+    for _, mac in ipairs(managed_macs) do
+      emit_drop(string.format("ether saddr %s tcp dport %d", mac, edns().DOT_PORT),
+                mac, "encrypted_dns_dot")
     end
   end
   ind("}")

--- a/openwrt/test/encrypted_dns_spec.lua
+++ b/openwrt/test/encrypted_dns_spec.lua
@@ -1,0 +1,65 @@
+-- encrypted_dns_spec.lua — curated relay/DoH/DoT lists baked into the agent for
+-- the network-wide blockEncryptedDns toggle (#1909 / #1911).
+--
+-- These lists are intentionally NOT shipped on the wire (the snapshot carries a
+-- single `blockEncryptedDns` bool); they live in-agent so the wire stays a
+-- single flag. This spec pins the curated contents the issue enumerates so a
+-- careless edit can't silently drop a bypass channel.
+
+local edns = require("encrypted_dns")
+
+describe("encrypted_dns curated lists", function()
+  it("includes the Apple iCloud Private Relay ingress hostnames", function()
+    local set = {}
+    for _, h in ipairs(edns.HOSTS) do set[h] = true end
+    assert.is_true(set["mask.icloud.com"])
+    assert.is_true(set["mask-h2.icloud.com"])
+  end)
+
+  it("includes the public DoH-by-name hostnames the issue enumerates", function()
+    local set = {}
+    for _, h in ipairs(edns.HOSTS) do set[h] = true end
+    for _, h in ipairs({
+      "cloudflare-dns.com", "dns.google", "dns.quad9.net",
+      "dns.nextdns.io", "dns.adguard-dns.com", "doh.opendns.com",
+    }) do
+      assert.is_true(set[h], "expected curated DoH host " .. h)
+    end
+  end)
+
+  it("includes the curated public-resolver v4 IPs", function()
+    local set = {}
+    for _, ip in ipairs(edns.RESOLVER_IPS_V4) do set[ip] = true end
+    for _, ip in ipairs({
+      "1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4", "9.9.9.9", "149.112.112.112",
+    }) do
+      assert.is_true(set[ip], "expected curated v4 resolver IP " .. ip)
+    end
+  end)
+
+  it("includes the curated public-resolver v6 IPs", function()
+    local set = {}
+    for _, ip in ipairs(edns.RESOLVER_IPS_V6) do set[ip] = true end
+    for _, ip in ipairs({
+      "2606:4700:4700::1111", "2606:4700:4700::1001",
+      "2001:4860:4860::8888", "2001:4860:4860::8844", "2620:fe::fe",
+    }) do
+      assert.is_true(set[ip], "expected curated v6 resolver IP " .. ip)
+    end
+  end)
+
+  it("exposes the DoT port (853)", function()
+    assert.equal(853, edns.DOT_PORT)
+  end)
+
+  it("hostnames are bare apex/host names — never an address=/host/# sinkhole token", function()
+    -- Truth-1 guard: the curated entries are HOSTNAMES the dnsmasq layer answers
+    -- with a NEGATIVE record (local=/host/), never a 0.0.0.0 sinkhole. A list
+    -- entry that accidentally carried a `#`/`/` would mean someone reached for a
+    -- sinkhole; keep them clean DNS names.
+    for _, h in ipairs(edns.HOSTS) do
+      assert.is_nil(h:find("#", 1, true))
+      assert.is_nil(h:find("/", 1, true))
+    end
+  end)
+end)

--- a/openwrt/test/nft_drops_spec.lua
+++ b/openwrt/test/nft_drops_spec.lua
@@ -36,6 +36,18 @@ describe("nft_drops.classify_reason", function()
     assert.equal("whole_mac", nft_drops.classify_reason("SomeFutureReason"))
     assert.equal("whole_mac", nft_drops.classify_reason(nil))
   end)
+
+  -- #1911: the network-wide blockEncryptedDns drops (curated resolver IPs +
+  -- DoT/853) carry `encrypted_dns` / `encrypted_dns_dot` reasons. Both fold
+  -- into ONE bounded `encrypted_dns` bucket (the metric label space stays
+  -- bounded; the dst IP / port never becomes a label).
+  it("folds the resolver-IP drop into the encrypted_dns bucket", function()
+    assert.equal("encrypted_dns", nft_drops.classify_reason("encrypted_dns"))
+  end)
+
+  it("folds the DoT/853 drop into the same encrypted_dns bucket", function()
+    assert.equal("encrypted_dns", nft_drops.classify_reason("encrypted_dns_dot"))
+  end)
 end)
 
 -- A representative `nft -j list chain inet wifihaven wifihaven_block` body: four

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -2993,4 +2993,45 @@ describe("render.nft — blockEncryptedDns", function()
     assert.equal(render.nft(snap_edns(nil)), render.nft(snap_edns(false)))
     assert.equal(render.dnsmasq(snap_edns(nil)), render.dnsmasq(snap_edns(false)))
   end)
+
+  -- The deliberate "hard block, NO extraAllowed / @global_allow carve-out"
+  -- invariant (a documented deviation from "extraAllowed beats every block
+  -- path", mirroring blockIpOnly). A future refactor that mechanically threads
+  -- the ea_/ga carve-out suffix onto every drop would silently re-open the
+  -- bypass with the rest of the suite still green — so pin the ABSENCE of any
+  -- `!= @ea_…` / `!= @global_allow` clause on the encrypted_dns drops even when
+  -- the device's profile AND the global section both carry extraAllowed.
+  it("emits encrypted_dns drops with NO ea_/@global_allow carve-out suffix", function()
+    local s = snap_global()
+    s.blockEncryptedDns = true
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    s.profiles["3"].rules.extraAllowed = { "khanacademy.org" }
+    s.global.extraAllowed = { "connectivitycheck.gstatic.com" }
+    local nft = render.nft(s)
+    local mac = "aa:bb:cc:11:22:33"
+    -- The exact predicate runs straight from the set/port reference into the
+    -- `limit …` log rule and the `counter drop` rule with nothing in between —
+    -- any inserted `ip daddr != @ea_…` / `!= @global_allow` clause would break
+    -- these literal substrings.
+    assert.truthy(nft:find(
+      "ether saddr " .. mac .. " ip daddr @encrypted_dns_resolvers limit rate", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr " .. mac .. " ip daddr @encrypted_dns_resolvers counter drop", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr " .. mac .. " ip6 daddr @encrypted_dns_resolvers6 counter drop", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr " .. mac .. " tcp dport 853 counter drop", 1, true))
+    -- And, defensively, no carve-out token appears anywhere on an encrypted_dns
+    -- line (the global-allow carve-out IS present elsewhere — the @blocked_macs
+    -- path — so we can't just assert it's globally absent; check per drop line).
+    for line in (nft .. "\n"):gmatch("([^\n]*)\n") do
+      if line:find("encrypted_dns", 1, true) then
+        assert.is_nil(line:find("@ea_", 1, true),
+          "encrypted_dns drop must not carry a per-MAC ea_ carve-out: " .. line)
+        assert.is_nil(line:find("@global_allow", 1, true),
+          "encrypted_dns drop must not carry a @global_allow carve-out: " .. line)
+      end
+    end
+  end)
 end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -2901,3 +2901,96 @@ describe("render.nft #1174 schedule-block + ui-host allow", function()
     assert.is_nil(nft:find("!= @global_allow", 1, true))
   end)
 end)
+
+-- ── blockEncryptedDns — network-wide encrypted-DNS / relay bypass disable ────
+-- #1909 / #1911. A single top-level `blockEncryptedDns` bool. When true the
+-- agent (a) returns a NEGATIVE DNS answer (NXDOMAIN via `local=/host/`) for the
+-- curated relay/DoH hostnames — the deliberate, narrow exception to
+-- Architectural Truth #1, scoped to bypass-disable signalling — and (b) drops,
+-- for every managed MAC, forwarded traffic to the curated public-resolver IPs
+-- and to DoT (TCP/853). Flag absent/false → byte-identical no-op.
+
+local edns = require("encrypted_dns")
+
+local function snap_edns(flag)
+  local s = snap_one()
+  -- Strip the extraBlocked/blocklist noise from snap_one so the flag's output
+  -- is the only thing under test; keep a single assigned device (a managed MAC).
+  s.profiles["3"].rules.extraBlocked = {}
+  s.profiles["3"].rules.blocklistIds = {}
+  if flag ~= nil then s.blockEncryptedDns = flag end
+  return s
+end
+
+describe("render.dnsmasq — blockEncryptedDns", function()
+  it("emits a NEGATIVE-answer local=/host/ for every curated relay/DoH host when on", function()
+    local conf = render.dnsmasq(snap_edns(true))
+    for _, h in ipairs(edns.HOSTS) do
+      assert.truthy(conf:find("local=/" .. h .. "/", 1, true),
+        "expected local=/" .. h .. "/ for curated host " .. h)
+    end
+  end)
+
+  it("never sinkholes the curated hosts (Truth 1: no address=/host/# / 0.0.0.0)", function()
+    local conf = render.dnsmasq(snap_edns(true))
+    for _, h in ipairs(edns.HOSTS) do
+      assert.is_nil(conf:find("address=/" .. h .. "/#", 1, true))
+      assert.is_nil(conf:find("address=/" .. h .. "/0.0.0.0", 1, true))
+    end
+  end)
+
+  it("emits NO local= directives when the flag is false", function()
+    local conf = render.dnsmasq(snap_edns(false))
+    assert.is_nil(conf:find("local=/mask.icloud.com/", 1, true))
+    assert.is_nil(conf:find("local=/dns.google/", 1, true))
+  end)
+
+  it("emits NO local= directives when the flag is absent (default off)", function()
+    local conf = render.dnsmasq(snap_edns(nil))
+    assert.is_nil(conf:find("local=/", 1, true))
+  end)
+end)
+
+describe("render.nft — blockEncryptedDns", function()
+  it("declares the curated resolver-IP sets with the curated v4/v6 elements when on", function()
+    local nft = render.nft(snap_edns(true))
+    assert.truthy(nft:find("set encrypted_dns_resolvers {", 1, true))
+    assert.truthy(nft:find("set encrypted_dns_resolvers6 {", 1, true))
+    for _, ip in ipairs(edns.RESOLVER_IPS_V4) do
+      assert.truthy(nft:find(ip, 1, true), "expected v4 resolver IP " .. ip)
+    end
+    for _, ip in ipairs(edns.RESOLVER_IPS_V6) do
+      assert.truthy(nft:find(ip, 1, true), "expected v6 resolver IP " .. ip)
+    end
+  end)
+
+  it("drops the curated resolver IPs (v4 + v6) per managed MAC when on", function()
+    local nft = render.nft(snap_edns(true))
+    local mac = "aa:bb:cc:11:22:33"
+    assert.truthy(nft:find(
+      "ether saddr " .. mac .. " ip daddr @encrypted_dns_resolvers", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr " .. mac .. " ip6 daddr @encrypted_dns_resolvers6", 1, true))
+    -- carries an attributable wh_drop reason so nflog/metrics can bucket it
+    assert.truthy(nft:find("wh_drop:" .. mac .. ":encrypted_dns", 1, true))
+  end)
+
+  it("drops DoT (TCP/853) to any IP per managed MAC when on", function()
+    local nft = render.nft(snap_edns(true))
+    local mac = "aa:bb:cc:11:22:33"
+    assert.truthy(nft:find("ether saddr " .. mac .. " tcp dport 853", 1, true))
+    assert.truthy(nft:find("wh_drop:" .. mac .. ":encrypted_dns_dot", 1, true))
+  end)
+
+  it("is a no-op (no sets, no drops, no port rule) when the flag is false", function()
+    local nft = render.nft(snap_edns(false))
+    assert.is_nil(nft:find("encrypted_dns_resolvers", 1, true))
+    assert.is_nil(nft:find("tcp dport 853", 1, true))
+    assert.is_nil(nft:find("encrypted_dns", 1, true))
+  end)
+
+  it("renders byte-identically with the flag absent vs explicitly false", function()
+    assert.equal(render.nft(snap_edns(nil)), render.nft(snap_edns(false)))
+    assert.equal(render.dnsmasq(snap_edns(nil)), render.dnsmasq(snap_edns(false)))
+  end)
+end)

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -24,6 +24,7 @@ markers =
     v6_attribution: #1677 — v6 destinations attribute to FQDN (CD-tier follow-up to #1673 / #1668)
     v6_usage_attribution: #1804 — v6 per-device usage round-trip surfaces by FQDN with non-zero bytes (e2e gate for #1796 / #1802)
     global_policy: suite H (#1460) — @global_allow / @global_block fleet-wide enforcement (gate for #1321)
+    encrypted_dns: suite J (#1911) — network-wide blockEncryptedDns: NXDOMAIN for relay/DoH hosts + nft drop of resolver IPs & DoT/853
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -410,3 +410,53 @@ def wait_event_with_host_attribution(
             f"{branded_host!r}"
         ),
     )
+
+
+# ── #1909/#1911 blockEncryptedDns (network-wide encrypted-DNS bypass disable) ─
+#
+# Two halves on the router: (1) dnsmasq answers the curated relay/DoH hostnames
+# NEGATIVELY (NXDOMAIN via `local=/host/`) — observable directly through `dig`;
+# (2) the nftables forward chain drops the curated public-resolver IPs (a static,
+# agent-baked `encrypted_dns_resolvers` set) and DoT (TCP/853). Unlike the
+# eb_/bl_/global sets, the resolver-IP set is NOT DNS-populated — it carries
+# constant `elements`, so it's present with members as soon as the agent applies
+# the snapshot.
+
+ENCRYPTED_DNS_RESOLVERS_SET = "encrypted_dns_resolvers"
+
+
+def wait_encrypted_dns_resolvers_populated(*, timeout_s: float = 180) -> list[str]:
+    """Wait until the static curated v4 resolver-IP drop set has its elements.
+
+    Membership is the router-state proof that the agent applied the
+    blockEncryptedDns connection-layer half — the set is agent-baked (static
+    elements), so a populated set means the rendered ruleset with the flag on is
+    live.
+    """
+    return _wait_set_populated(ENCRYPTED_DNS_RESOLVERS_SET, timeout_s=timeout_s)
+
+
+def dot_drop_rule_present() -> bool:
+    """True iff the forward chain carries the DoT (TCP/853) drop rule (#1911)."""
+    res = router_ssh(
+        "nft list table inet wifihaven 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    return "tcp dport 853" in (res.stdout or "")
+
+
+def wait_dot_drop_rule_present(*, timeout_s: float = 180) -> None:
+    wait_until(
+        lambda: True if dot_drop_rule_present() else None,
+        timeout_s=timeout_s, interval_s=3,
+        description="forward-chain DoT (tcp dport 853) drop rule present",
+    )
+
+
+def resolver_ip_drop_rule_present() -> bool:
+    """True iff the forward chain carries the curated resolver-IP drop rule."""
+    res = router_ssh(
+        "nft list table inet wifihaven 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    return "@encrypted_dns_resolvers" in (res.stdout or "")

--- a/scripts/e2e/scenarios_fake/snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/snapshot_builder.py
@@ -66,6 +66,11 @@ class SnapshotBuilder:
         # layer omit the key entirely and render byte-identically to pre-#1319
         # (render.lua treats an absent `global` as BlockRules.allowAll).
         self._global: dict[str, Any] | None = None
+        # The network-wide `blockEncryptedDns` toggle (#1909/#1911). None until
+        # `set_block_encrypted_dns()` is called, so snapshots that don't exercise
+        # it omit the top-level key entirely and render byte-identically to
+        # pre-#1911 (the agent treats an absent flag as false).
+        self._block_encrypted_dns: bool | None = None
 
     def add_profile(
         self,
@@ -168,6 +173,19 @@ class SnapshotBuilder:
         )
         return self
 
+    def set_block_encrypted_dns(self, value: bool = True) -> "SnapshotBuilder":
+        """Set the top-level `blockEncryptedDns` toggle (#1909/#1911).
+
+        When True the agent enforces, network-wide: a NEGATIVE DNS answer
+        (NXDOMAIN) for the curated relay/DoH hostnames (mask.icloud.com,
+        dns.google, …) plus an nftables forward-drop for the curated
+        public-resolver IPs and for DoT (TCP/853). The curated lists are baked
+        into the agent (openwrt/.../encrypted_dns.lua), NOT shipped on the wire —
+        the snapshot carries only this single boolean.
+        """
+        self._block_encrypted_dns = value
+        return self
+
     def add_blocklist(
         self,
         *,
@@ -205,6 +223,11 @@ class SnapshotBuilder:
         # scenarios (and test_snapshot_builder) that don't touch it.
         if self._global is not None:
             snap["global"] = dict(self._global)
+        # Emit `blockEncryptedDns` only when explicitly set, so unrelated
+        # scenarios keep the default top-level key set and exercise the
+        # absent-flag no-op path.
+        if self._block_encrypted_dns is not None:
+            snap["blockEncryptedDns"] = self._block_encrypted_dns
         return snap
 
 

--- a/scripts/e2e/scenarios_fake/test_encrypted_dns.py
+++ b/scripts/e2e/scenarios_fake/test_encrypted_dns.py
@@ -1,0 +1,151 @@
+"""Suite J — network-wide blockEncryptedDns enforcement on a real OpenWRT agent
+(#1909 / #1911; epic #1903).
+
+VM-level end-to-end proof that a deployed agent enforces the snapshot's
+top-level `blockEncryptedDns` toggle. The busted unit coverage
+(`openwrt/test/render_spec.lua`, `encrypted_dns_spec.lua`, `nft_drops_spec.lua`)
+proves the *render*; this proves the *enforced behaviour against live traffic +
+real router state*.
+
+Two halves under test:
+
+  1. **DNS half (NEGATIVE answer, observable via `dig`).** With the flag on, the
+     curated relay/DoH hostnames (`mask.icloud.com`, `dns.google`, …) resolve to
+     a NEGATIVE answer (NXDOMAIN via dnsmasq `local=/host/`) — Apple's clean
+     iCloud-Private-Relay disable signal — while a normal host (`example.com`)
+     keeps resolving through the LAN resolver. This is the *one* sanctioned
+     Truth-#1 exception: a negative answer here is bypass-disable signalling,
+     not a content sinkhole (no `0.0.0.0`).
+
+  2. **Connection-layer half (nftables forward-drop, router-state proof).** With
+     the flag on, the forward chain drops the curated public-resolver IPs (the
+     static, agent-baked `encrypted_dns_resolvers` set) and DoT (TCP/853). We
+     assert the set is populated and the drop rules are live — the deterministic
+     router-state observable the rest of this suite uses for enforcement (a raw
+     "curl 1.1.1.1 times out" probe can't distinguish a drop from a no-route).
+
+Reachability/blocking here is a CONNECTION-LAYER property; a successful DNS
+lookup proves nothing (DNS always resolves; the resolved IP is what nftables
+drops). See `docs/architecture.md` §0.1 and the AGENTS.md anti-pattern callout.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    dig_ipv4_answers,
+    resolver_ip_drop_rule_present,
+    wait_dot_drop_rule_present,
+    wait_encrypted_dns_resolvers_populated,
+)
+from .snapshot_builder import SnapshotBuilder
+from lib.vm import router_nft_set
+from lib.wait import wait_until
+
+pytestmark = pytest.mark.encrypted_dns
+
+PID = 800
+
+# A curated relay/DoH host that must get a NEGATIVE answer when the flag is on.
+RELAY_HOST = "mask.icloud.com"
+DOH_HOST = "dns.google"
+# A normal host that must keep resolving through the LAN resolver regardless.
+CONTROL_HOST = "example.com"
+# A curated public-resolver IP that must be in the drop set when the flag is on.
+RESOLVER_IP = "1.1.1.1"
+
+
+def _wait_dig_negative(client, host: str, *, timeout_s: float = 120) -> None:
+    """Block until `dig <host>` returns NO IPv4 answer (NXDOMAIN/NODATA).
+
+    `dig +short` prints nothing for a negative answer, so an empty A-answer list
+    is the observable. Polled because the agent applies the dnsmasq `local=`
+    directive asynchronously after the snapshot is served.
+    """
+    wait_until(
+        lambda: True if not dig_ipv4_answers(client, host) else None,
+        timeout_s=timeout_s, interval_s=3,
+        description=f"dig {host} to return a NEGATIVE answer (no A record)",
+    )
+
+
+@pytest.mark.smoke
+def test_block_encrypted_dns_negative_answer_and_drops(router, client, fake_api):
+    """J1: flag on → curated relay/DoH hosts get a NEGATIVE DNS answer, a normal
+    host still resolves, and the curated resolver-IP + DoT/853 forward-drops are
+    live on the router."""
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PID, name="e2e-edns")
+        .add_device(mac=client.mac, name="e2e-edns-dev", profile_id=PID)
+        .set_block_encrypted_dns(True)
+        .build(etag='"sha256:block-encrypted-dns-on-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Connection-layer half applied: the static curated v4 resolver-IP set is
+    # populated (proves the flag-on ruleset is live) and the drop rules exist.
+    members = wait_encrypted_dns_resolvers_populated(timeout_s=180)
+    assert any(RESOLVER_IP in m for m in members), (
+        f"expected curated resolver IP {RESOLVER_IP} in @encrypted_dns_resolvers; "
+        f"got {members!r}"
+    )
+    wait_dot_drop_rule_present(timeout_s=60)
+    assert resolver_ip_drop_rule_present(), (
+        "expected a forward-chain drop rule on @encrypted_dns_resolvers"
+    )
+
+    # DNS half: the curated relay/DoH hosts get a NEGATIVE answer (NXDOMAIN),
+    # NOT a 0.0.0.0 sinkhole — Apple's clean Private-Relay disable signal.
+    _wait_dig_negative(client, RELAY_HOST, timeout_s=120)
+    _wait_dig_negative(client, DOH_HOST, timeout_s=60)
+    assert RELAY_HOST not in dig_ipv4_answers(client, RELAY_HOST)
+    # No sinkhole: a negative answer means zero A records, so 0.0.0.0 must never
+    # appear (a positive 0.0.0.0 would NOT disable Private Relay).
+    assert "0.0.0.0" not in dig_ipv4_answers(client, RELAY_HOST)
+
+    # The LAN resolver still works for everything else — the toggle is scoped to
+    # the curated list, it does not break normal DNS.
+    control = wait_until(
+        lambda: dig_ipv4_answers(client, CONTROL_HOST) or None,
+        timeout_s=60, interval_s=3,
+        description=f"normal DNS for {CONTROL_HOST} still resolves via the LAN resolver",
+    )
+    assert control, f"expected {CONTROL_HOST} to resolve through the LAN resolver"
+
+
+def test_block_encrypted_dns_off_is_a_noop(router, client, fake_api):
+    """J2 (control): flag absent → NO encrypted_dns set/rules, and the curated
+    relay/DoH hosts resolve normally through the LAN resolver. Proves J1's
+    behaviour is driven by the flag, not by the host list alone."""
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PID, name="e2e-edns-off")
+        .add_device(mac=client.mac, name="e2e-edns-off-dev", profile_id=PID)
+        # NOTE: set_block_encrypted_dns NOT called → top-level key omitted.
+        .build(etag='"sha256:block-encrypted-dns-off-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # The static resolver-IP set must be ABSENT (router_nft_set → [] for an
+    # absent set; the set is never empty-but-present, so [] ⇒ no flag).
+    def _set_gone():
+        return True if not router_nft_set("encrypted_dns_resolvers") else None
+
+    wait_until(
+        _set_gone, timeout_s=180, interval_s=3,
+        description="encrypted_dns_resolvers set absent when the flag is off",
+    )
+    assert not resolver_ip_drop_rule_present(), (
+        "no resolver-IP drop rule should exist when blockEncryptedDns is off"
+    )
+
+    # And the curated relay host resolves normally (a real answer, NOT NXDOMAIN).
+    answers = wait_until(
+        lambda: dig_ipv4_answers(client, CONTROL_HOST) or None,
+        timeout_s=60, interval_s=3,
+        description=f"{CONTROL_HOST} resolves normally with the flag off",
+    )
+    assert answers

--- a/scripts/e2e/scenarios_fake/test_snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/test_snapshot_builder.py
@@ -203,6 +203,36 @@ def test_set_global_matches_golden_global_keys():
     assert set(built) == set(g)
 
 
+# ── blockEncryptedDns toggle (#1909/#1911) ────────────────────────────────────
+
+
+def test_block_encrypted_dns_omitted_unless_set():
+    """Without set_block_encrypted_dns(), the snapshot carries no
+    `blockEncryptedDns` key — keeping the default top-level shape and rendering
+    byte-identically to pre-#1911 (the agent treats an absent flag as false)."""
+    snap = SnapshotBuilder().build(etag='"sha256:no-edns"')
+    assert "blockEncryptedDns" not in snap
+
+
+def test_set_block_encrypted_dns_emits_top_level_bool():
+    """set_block_encrypted_dns() adds a top-level boolean sibling of
+    devices/profiles/blocklists/global — the single additive wire field the
+    agent reads."""
+    snap = (
+        SnapshotBuilder()
+        .set_block_encrypted_dns(True)
+        .build(etag='"sha256:edns-on"')
+    )
+    assert snap["blockEncryptedDns"] is True
+
+    off = (
+        SnapshotBuilder()
+        .set_block_encrypted_dns(False)
+        .build(etag='"sha256:edns-off"')
+    )
+    assert off["blockEncryptedDns"] is False
+
+
 def test_set_global_lockdown_allows_optional_reason():
     """Unlike add_profile(blocked=True), set_global(blocked=True) does NOT
     require a block_reason — a global lockdown's reason is cosmetic."""


### PR DESCRIPTION
## What

Agent half of the household **"block encrypted DNS & relays"** toggle (#1909, epic #1903). Closes #1911.

The policy snapshot gains a single **additive top-level boolean `blockEncryptedDns`** (sibling of `global`/`devices`/`profiles`/`blocklists`, default `false`). This PR reads the flag and enforces; the API producer side is #1912 — they land in any order (additive field, agent ignores absent → off, every intermediate state is a no-op).

When `blockEncryptedDns == true`, the router enforces **network-wide (all managed MACs):**

1. **Negative DNS answer (NXDOMAIN), not a sinkhole**, for curated relay/DoH **hostnames** (`mask.icloud.com`, `mask-h2.icloud.com`, `cloudflare-dns.com`, `dns.google`, `dns.quad9.net`, `dns.nextdns.io`, `dns.adguard-dns.com`, `doh.opendns.com`) via dnsmasq `local=/<host>/`. For iCloud Private Relay this is Apple's **clean disable signal** — iOS falls back to direct, filterable connections **without** the client-side hang a silent connection-layer drop causes (the #1891 root cause). Verified on dnsmasq 2.91 that `local=/host/` returns a negative answer, **not** a `0.0.0.0` sinkhole.
2. **nftables forward-drop** for curated public-resolver **IPs** (`1.1.1.1`/`1.0.0.1`/`8.8.8.8`/`8.8.4.4`/`9.9.9.9`/`149.112.112.112` + v6) and for **DoT (TCP/853) to any IP**.

Curated lists are **baked into the agent** (`encrypted_dns.lua`), not shipped on the wire — the snapshot stays a single bool. Flag absent/false renders **byte-identically** to today.

## Architectural Truth #1 exception (documented)

This is the **one sanctioned** place the agent returns a negative DNS answer. It is **bypass-disable signalling**, not content blocking: the negative answer tells the client to stop tunnelling so the real connection-layer enforcement can see the traffic. Scoped to the curated list, gated on the household toggle. Documented in `docs/architecture.md` §0.1 ("Truth #1 — the `blockEncryptedDns` exception"). The curated-IP drops carry **no** `extraAllowed`/`@global_allow` carve-out (an allow entry must not re-open a bypass) and are **not** DNAT'd to the block page.

## Changes

- **`openwrt/.../encrypted_dns.lua`** (new) — curated relay/DoH host + resolver-IP (v4/v6) + DoT-port lists, baked in.
- **`render.lua`** — `local=/host/` directives (dnsmasq half); static `encrypted_dns_resolvers`/`_resolvers6` sets + per-managed-MAC drops on the resolver sets and `tcp dport 853` (nft half). Both gated on the flag; no-op when off.
- **`nft_drops.lua`** — fold `encrypted_dns*` drops into a bounded `encrypted_dns` metric reason bucket (`enforcement_drops_total{reason}`); dashboard reason enums updated in `enforcement.json` + `router-fleet.json` (panels already `sum by (reason)`).
- **Gate 2 e2e** (`scripts/e2e/scenarios_fake/test_encrypted_dns.py`, auto-discovered) — flag-on: `dig` returns a negative answer for relay/DoH hosts while normal DNS still resolves, and the curated resolver-IP set + DoT/853 + resolver-IP drop rules are live; flag-off no-op control. `SnapshotBuilder.set_block_encrypted_dns()` + unit tests.

## Tests

- TDD: failing busted specs committed first (red), then green. Full lua suite: **882 passing**.
- Builder + snapshot unit tests pass.
- **Validated on a real Lua 5.1 router** (openwrt.lan): render runs clean, `nft -c -f` syntax OK, runtime `nft -f` load OK with v4/v6 resolver sets populated and the live DoT/853 drop rule, dnsmasq `--test` OK, and `local=/host/` → NXDOMAIN confirmed with a throwaway dnsmasq. Test router restored afterward.

