### PR TITLE
fix(#1915): per-flow wh_drop LOG limiter — distinct blocked flows synthesize events again

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1080,12 +1080,14 @@ function M.nft(snapshot, opts)
   end
 
   -- #1122/#1126: each drop is rendered as a pair of rules sharing one predicate
-  -- (see #1826 / `emit_drop` below):
-  --   `<predicate> limit rate 2/second burst 10 packets log prefix "wh_drop:<mac>:<reason> "`
+  -- (see #1826/#1915 / `emit_drop` below):
+  --   `<predicate> update @wh_drop_log4 { ether saddr . ip daddr limit rate 1/minute burst 5 packets } log prefix "wh_drop:<mac>:<reason> "`
   --   `<predicate> counter drop comment "wh_drop:<mac>:<reason>"`
   -- (pre-#1826 this was a single `… log prefix … counter drop` rule; the LOG is
-  -- now on its own rate-limited rule so a retry storm can't flood the kernel
-  -- ring buffer, while the drop stays unconditional).
+  -- now on its own rule so a retry storm can't flood the kernel ring buffer,
+  -- while the drop stays unconditional. #1915 made the LOG gate a per-flow
+  -- (per-(mac,dst)) limiter set instead of a flat per-rule rate — see the
+  -- emit_drop comment below for why.)
   -- The `log prefix` form writes to the kernel ring buffer (the LOG backend),
   -- so the wifihaven-nflog-tail sidecar can read the dropped-packet records
   -- straight off `logread -f` on stock OpenWRT — no NFLOG netlink consumer

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1129,27 +1129,68 @@ function M.nft(snapshot, opts)
   -- shared `logread` ring buffer when several MACs retry-storm at once — the
   -- aggregate (10/s × N drop rules) evicted wifihaven-agent and dnsmasq lines
   -- from the ring buffer, leaving the router undiagnosable during an incident.
-  -- Throttle the LOG harder: 2/second with a burst of 10 still captures the
-  -- distinct flows the agent's nflog tail needs to label blocked-flow events
-  -- (the labels are deduped per (mac, reason, dst), so a retry storm to one
-  -- endpoint needs only a single sample), but cuts the steady-state ring-buffer
-  -- footprint ~5×. The burst absorbs the initial flurry of distinct hosts; the
-  -- low sustained rate keeps the ring buffer usable for everything else. The
-  -- `counter drop` rule is unchanged, so enforcement and drop counts are exact.
-  local DROP_LOG_LIMIT = "limit rate 2/second burst 10 packets"
-  local function log_suffix(mac, reason)
-    return string.format(" %s log prefix \"wh_drop:%s:%s \"",
-                         DROP_LOG_LIMIT, mac, reason)
+  -- That was first throttled harder (a flat 2/second per-rule limit), but —
+  --
+  -- #1915: a flat per-RULE `limit rate` is a single token bucket SHARED across
+  -- every flow that hits the rule. It conflates two needs the wh_drop LOG
+  -- serves: flood control (suppress retry STORMS) and event synthesis (the
+  -- agent's nflog tail needs ≥1 line per DISTINCT (mac,reason,dst) to emit a
+  -- blocked/paused connection_event). Once a storm drains the shared bucket,
+  -- the NEXT distinct flow's first packet is rate-limited away before the tail
+  -- reads it — so events silently stop synthesizing (Gate 2
+  -- test_paused_mac_https_traffic_surfaces_as_nflog_event hung; the regression
+  -- that took Master Router CD red ~2026-06-22 and blocked every router
+  -- publish, #1865 included).
+  --
+  -- Fix: gate the LOG with a PER-ELEMENT (per-flow) limiter instead — a
+  -- dynamic set keyed on (ether saddr . ip[6] daddr) with an embedded
+  -- `limit rate`. Each distinct (mac,dst) flow gets its OWN token bucket, so
+  -- the first packet of every distinct flow always logs (fresh bucket) and
+  -- synthesis is never starved; a storm to the SAME (mac,dst) drains only that
+  -- element's bucket and is suppressed, so the ring buffer stays usable. The
+  -- embedded limit is a match: when the bucket is empty the `update` expression
+  -- is false and the rule stops BEFORE the log (no verdict), falling through to
+  -- the unconditional `counter drop` on the next rule — enforcement and drop
+  -- counts are unchanged, exactly as the two-rule #1826 split guarantees. The
+  -- small burst headroom (5) is collapsed back to one event by the agent's own
+  -- per-(mac,reason,dst) dedup (nflog.new_dedup, 60s window). The two sets
+  -- (wh_drop_log4/6) are declared just above `chain wifihaven_block`.
+  --
+  -- Per-flow rate keyed on (mac,dst): 1/minute lines up with the agent's 60s
+  -- dedup window; burst 5 absorbs a couple of initial retransmits per flow
+  -- without flooding. Distinct flows are never throttled against each other.
+  local DROP_LOG_RATE = "limit rate 1/minute burst 5 packets"
+  -- LOG suffix for a family-constrained predicate ("ip" → v4 set, else v6).
+  local function log_suffix(family, mac, reason)
+    local set, key
+    if family == "ip6" then
+      set, key = "wh_drop_log6", "ether saddr . ip6 daddr"
+    else
+      set, key = "wh_drop_log4", "ether saddr . ip daddr"
+    end
+    return string.format(
+      " update @%s { %s %s } log prefix \"wh_drop:%s:%s \"",
+      set, key, DROP_LOG_RATE, mac, reason)
   end
   local function drop_suffix(mac, reason)
     return string.format(" counter drop comment \"wh_drop:%s:%s\"",
                          mac, reason)
   end
-  -- Emit the rate-limited log rule then the unconditional drop rule for one
-  -- predicate. `predicate` is everything up to (but excluding) the log/drop
-  -- suffix; both rules share it verbatim so they match the same packets.
-  local function emit_drop(predicate, mac, reason)
-    ind2(predicate .. log_suffix(mac, reason))
+  -- Emit the per-flow rate-limited log rule(s) then the unconditional drop
+  -- rule for one predicate. `family` is "ip", "ip6", or "any". "any" (the
+  -- family-agnostic whole-MAC drop, which has no daddr predicate) emits both a
+  -- v4 and a v6 log rule guarded by `meta nfproto` so each can read its
+  -- family's daddr into the (mac,dst) key, then one shared family-agnostic
+  -- drop. `predicate` is everything up to (but excluding) the log/drop suffix;
+  -- the log and drop rules share it verbatim so they match the same packets.
+  local function emit_drop(predicate, mac, reason, family)
+    family = family or "any"
+    if family == "any" then
+      ind2(predicate .. " meta nfproto ipv4" .. log_suffix("ip", mac, reason))
+      ind2(predicate .. " meta nfproto ipv6" .. log_suffix("ip6", mac, reason))
+    else
+      ind2(predicate .. log_suffix(family, mac, reason))
+    end
     ind2(predicate .. drop_suffix(mac, reason))
   end
   local blocked_reason_by_mac = {}
@@ -1159,6 +1200,25 @@ function M.nft(snapshot, opts)
       blocked_reason_by_mac[mac] = r.blockReason or "blocked"
     end
   end
+
+  -- #1915: per-flow wh_drop LOG limiter sets (see emit_drop above). Keyed on
+  -- (mac, dst) so each distinct blocked flow gets its own token bucket and logs
+  -- on first-seen (synthesis is never starved), while a retry storm to one flow
+  -- drains only that element's bucket. The short timeout bounds set memory and
+  -- keeps the limiter state alive across a storm (each `update` refreshes it); a
+  -- flow that resumes after the timeout logs fresh — a new visibility window.
+  ind("set wh_drop_log4 {")
+  ind2("type ether_addr . ipv4_addr")
+  ind2("flags dynamic,timeout")
+  ind2("timeout 2m")
+  ind("}")
+  emit("")
+  ind("set wh_drop_log6 {")
+  ind2("type ether_addr . ipv6_addr")
+  ind2("flags dynamic,timeout")
+  ind2("timeout 2m")
+  ind("}")
+  emit("")
 
   ind("chain wifihaven_block {")
   ind2("type filter hook forward priority 0; policy accept;")
@@ -1200,9 +1260,9 @@ function M.nft(snapshot, opts)
   for _, mac in ipairs(blocked_ea_macs) do
     local reason = blocked_reason_by_mac[mac] or "blocked"
     emit_drop(string.format("ether saddr %s%s%s", mac, ea_suffix(mac, "ip"),
-                            ga_suffix("ip")), mac, reason)
+                            ga_suffix("ip")), mac, reason, "ip")
     emit_drop(string.format("ether saddr %s%s%s", mac, ea_suffix(mac, "ip6"),
-                            ga_suffix("ip6")), mac, reason)
+                            ga_suffix("ip6")), mac, reason, "ip6")
   end
   -- v4 drops first, then v6 (#392). One ipset directive populates both sets
   -- at DNS time; here we gate on whichever family the destination matched.
@@ -1224,22 +1284,22 @@ function M.nft(snapshot, opts)
   for _, p in ipairs(eb_pairs) do
     emit_drop(string.format("ether saddr %s ip daddr @%s%s%s",
                             p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip"),
-                            ga_suffix("ip")), p.mac, "host:" .. p.host)
+                            ga_suffix("ip")), p.mac, "host:" .. p.host, "ip")
   end
   for _, p in ipairs(eb_pairs) do
     emit_drop(string.format("ether saddr %s ip6 daddr @%s%s%s",
                             p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6"),
-                            ga_suffix("ip6")), p.mac, "host:" .. p.host)
+                            ga_suffix("ip6")), p.mac, "host:" .. p.host, "ip6")
   end
   for _, p in ipairs(bl_pairs) do
     emit_drop(string.format("ether saddr %s ip daddr @%s%s%s",
                             p.mac, bl_set_name(p.id), ea_suffix(p.mac, "ip"),
-                            ga_suffix("ip")), p.mac, "category:" .. tostring(p.id))
+                            ga_suffix("ip")), p.mac, "category:" .. tostring(p.id), "ip")
   end
   for _, p in ipairs(bl_pairs) do
     emit_drop(string.format("ether saddr %s ip6 daddr @%s%s%s",
                             p.mac, bl6_set_name(p.id), ea_suffix(p.mac, "ip6"),
-                            ga_suffix("ip6")), p.mac, "category:" .. tostring(p.id))
+                            ga_suffix("ip6")), p.mac, "category:" .. tostring(p.id), "ip6")
   end
   -- #353: blockIpOnly drop. Predicate `ip daddr != @resolved_<mac>` matches
   -- any v4 destination the device did not DNS-resolve via our resolver in
@@ -1247,11 +1307,11 @@ function M.nft(snapshot, opts)
   -- entries past the set timeout.
   for _, mac in ipairs(bio_macs) do
     emit_drop(string.format("ether saddr %s ip daddr != @%s",
-                            mac, resolved_set_name(mac)), mac, "ip_only")
+                            mac, resolved_set_name(mac)), mac, "ip_only", "ip")
   end
   for _, mac in ipairs(bio_macs) do
     emit_drop(string.format("ether saddr %s ip6 daddr != @%s",
-                            mac, resolved6_set_name(mac)), mac, "ip_only")
+                            mac, resolved6_set_name(mac)), mac, "ip_only", "ip6")
   end
   -- #1319: global block (hosts ∪ categories) → drop for every managed MAC on
   -- @global_block, carved out ONLY by @global_allow (a per-MAC extraAllowed
@@ -1261,12 +1321,12 @@ function M.nft(snapshot, opts)
     for _, mac in ipairs(managed_macs) do
       emit_drop(string.format("ether saddr %s ip daddr @%s%s",
                               mac, GLOBAL_BLOCK4, ga_suffix("ip")),
-                mac, "global_block")
+                mac, "global_block", "ip")
     end
     for _, mac in ipairs(managed_macs) do
       emit_drop(string.format("ether saddr %s ip6 daddr @%s%s",
                               mac, GLOBAL_BLOCK6, ga_suffix("ip6")),
-                mac, "global_block")
+                mac, "global_block", "ip6")
     end
   end
   -- #1319: global lockdown (global.blocked) → whole-network kill switch. Drop
@@ -1280,11 +1340,11 @@ function M.nft(snapshot, opts)
       -- Per-family so each can carry its family-specific @global_allow carve-out.
       for _, mac in ipairs(managed_macs) do
         emit_drop(string.format("ether saddr %s%s", mac, ga_suffix("ip")),
-                  mac, g_block_reason)
+                  mac, g_block_reason, "ip")
       end
       for _, mac in ipairs(managed_macs) do
         emit_drop(string.format("ether saddr %s%s", mac, ga_suffix("ip6")),
-                  mac, g_block_reason)
+                  mac, g_block_reason, "ip6")
       end
     else
       -- No global allow → one family-agnostic unconditional drop per MAC.

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1049,6 +1049,113 @@ describe("render.nft rate-limits wh_drop logging (#1826)", function()
   end)
 end)
 
+-- ── wh_drop LOG must log DISTINCT flows, not flat-throttle (#1915) ─────────
+--
+-- Regression from #1864: the flat per-rule `limit rate 2/second burst 10`
+-- token bucket is shared across ALL flows that hit one drop rule. Once a retry
+-- storm drains the bucket, the NEXT distinct (mac,dst) flow's first packet is
+-- rate-limited away before the agent's nflog tail (logread -f) ever sees it —
+-- so blocked/paused connection_events stop synthesizing (Gate 2
+-- test_paused_mac_https_traffic_surfaces_as_nflog_event +
+-- test_ea_direct_requery_allowed_under_blocked_mac time out).
+--
+-- The fix replaces the flat per-rule limit with a PER-ELEMENT (per-flow)
+-- limiter: a dynamic set keyed on (ether saddr . ip[6] daddr) with an embedded
+-- `limit rate`, so each distinct flow gets its OWN token bucket. The first
+-- packet of every distinct (mac,dst) always logs (fresh bucket) → synthesis is
+-- never starved; a storm to the SAME flow drains only that element's bucket.
+-- Enforcement (`counter drop`) is unchanged — only the LOG gating moves from
+-- per-rule to per-flow.
+
+describe("render.nft logs distinct blocked flows, not a flat per-rule throttle (#1915)", function()
+
+  local function filter_chain_body(nft)
+    local start = nft:find("chain wifihaven_block {", 1, true)
+    if not start then return nil end
+    local open  = nft:find("{", start, true)
+    local close = nft:find("\n  }", open, true)
+    return nft:sub(open + 1, close - 1)
+  end
+
+  it("declares per-flow (mac,dst) LOG limiter sets for v4 and v6", function()
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find("set wh_drop_log4 {", 1, true),
+      "expected v4 per-flow log limiter set")
+    assert.truthy(nft:find("set wh_drop_log6 {", 1, true),
+      "expected v6 per-flow log limiter set")
+    -- Keyed on (mac, dst) with dynamic+timeout so each distinct flow is its
+    -- own rate-limited element.
+    assert.truthy(nft:find("type ether_addr . ipv4_addr", 1, true))
+    assert.truthy(nft:find("type ether_addr . ipv6_addr", 1, true))
+  end)
+
+  it("gates the LOG with a per-element limiter keyed on (mac,dst), NOT a flat per-rule limit", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked     = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    local nft  = render.nft(s)
+    local body = filter_chain_body(nft)
+    assert.truthy(body)
+    -- The flat shared-bucket form (#1864) must be gone: no wh_drop log line may
+    -- carry a bare `limit rate N/second` clause (that conflates flood control
+    -- with synthesis and starves distinct flows).
+    for line in body:gmatch("[^\n]+") do
+      if line:find("log prefix \"wh_drop:", 1, true) then
+        assert(not line:find("limit rate %d+/second"),
+          "wh_drop LOG still uses a flat per-rule per-second limit (starves distinct flows): " .. line)
+        -- It MUST instead update a per-flow limiter set with an embedded limit.
+        assert(line:find("update @wh_drop_log", 1, true)
+               and line:find("limit rate ", 1, true),
+          "wh_drop LOG not gated by a per-flow @wh_drop_log limiter: " .. line)
+      end
+    end
+  end)
+
+  it("whole-MAC (family-agnostic) drop logs both v4 and v6 distinct flows", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked     = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    -- The whole-MAC drop has no daddr predicate, so its LOG is split per family
+    -- to extract a (mac,dst) key; the single counter drop stays family-agnostic.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 meta nfproto ipv4 update @wh_drop_log4 { ether saddr . ip daddr limit rate 1/minute burst 5 packets } log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \"",
+      1, true), "expected v4 per-flow log rule for whole-MAC drop")
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 meta nfproto ipv6 update @wh_drop_log6 { ether saddr . ip6 daddr limit rate 1/minute burst 5 packets } log prefix \"wh_drop:aa:bb:cc:11:22:33:Paused \"",
+      1, true), "expected v6 per-flow log rule for whole-MAC drop")
+    -- Drop verdict unchanged and unconditional.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      1, true), "expected unconditional counter drop")
+  end)
+
+  it("per-host (eb_) drop logs its distinct flow via the v4 limiter set", function()
+    local nft  = render.nft(snap_one())
+    -- snap_one's extraBlocked tiktok.com → eb_ v4 drop. Its log rule updates the
+    -- per-flow set with the (mac,dst) key and an embedded limit, then logs.
+    assert.truthy(nft:find(
+      "ip daddr @eb_tiktok_com update @wh_drop_log4 { ether saddr . ip daddr limit rate 1/minute burst 5 packets } log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \"",
+      1, true), "expected per-flow v4 log rule for eb_ drop")
+  end)
+
+  it("the drop verdict is still never gated by the rate limit (no `limit … drop` on one line)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Schedule"
+    s.profiles["3"].rules.blockIpOnly  = true
+    s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    local body = filter_chain_body(render.nft(s))
+    for line in body:gmatch("[^\n]+") do
+      if line:find("limit rate ", 1, true) and line:find(" drop", 1, true) then
+        assert(false, "limit and drop on same rule (block leaks over budget): " .. line)
+      end
+    end
+  end)
+end)
+
 -- ── nft syntax validation (skipped if `nft` binary unavailable) ───────────
 
 describe("render.nft syntax validation", function()

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -877,7 +877,7 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     end
   end)
 
-  it("every drop rule carries `counter drop` + comment and is preceded by its rate-limited log rule (#1826)", function()
+  it("every drop rule carries `counter drop` + comment and is preceded by its per-flow log rule (#1826/#1915)", function()
     local s = snap_one()
     -- Force every kind of drop to appear.
     s.profiles["3"].rules.blocked      = true
@@ -889,13 +889,14 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     local nft  = render.nft(s)
     local body = filter_chain_body(nft)
     assert.truthy(body)
-    -- Post-#1826 each drop is two rules: a rate-limited log rule (the agent's
-    -- read channel) immediately followed by an unconditional `counter drop`
-    -- carrying the `wh_drop:` comment. We scan line-by-line: every `counter
-    -- drop` line must carry the comment, and the line directly above it must be
-    -- the matching rate-limited `log prefix "wh_drop:…"` rule with the same
-    -- predicate (so the log can never be unbounded and the drop is never gated
-    -- by the limit).
+    -- Post-#1826/#1915 each drop is a per-flow rate-limited log rule (the
+    -- agent's read channel) immediately followed by an unconditional `counter
+    -- drop` carrying the `wh_drop:` comment. We scan line-by-line: every
+    -- `counter drop` line must carry the comment, and the line directly above
+    -- it must be the matching per-flow `log prefix "wh_drop:…"` rule with the
+    -- same predicate (so the log can never be unbounded and the drop is never
+    -- gated by the limit). The per-flow limiter is keyed via `update
+    -- @wh_drop_log…` — never a flat per-rule `limit rate N/second` (#1915).
     local prev = nil
     for line in body:gmatch("[^\n]+") do
       if line:find("counter drop", 1, true) then
@@ -906,11 +907,14 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
                "drop rule gated by limit rate: " .. line)
         assert(not line:find("log prefix", 1, true),
                "drop rule still logs (flood risk): " .. line)
-        -- The matching log rule is the line directly above, same predicate.
+        -- The matching log rule is the line directly above, same predicate,
+        -- gated by the per-flow @wh_drop_log limiter (not a flat per-rule one).
         local predicate = line:gsub(" counter drop.*$", "")
         assert(prev and prev:find(predicate, 1, true)
-               and prev:find("limit rate 2/second burst 10 packets log prefix \"wh_drop:", 1, true),
-               "drop not preceded by its rate-limited log rule: " .. line)
+               and prev:find("update @wh_drop_log", 1, true)
+               and prev:find("log prefix \"wh_drop:", 1, true)
+               and not prev:find("limit rate %d+/second"),
+               "drop not preceded by its per-flow log rule: " .. line)
       end
       prev = line
     end
@@ -969,15 +973,18 @@ describe("render.nft rate-limits wh_drop logging (#1826)", function()
     return nft:sub(open + 1, close - 1)
   end
 
-  it("whole-MAC Schedule drop rate-limits the LOG on a separate rule", function()
+  it("whole-MAC Schedule drop rate-limits the LOG on a separate rule (per-flow, #1915)", function()
     local s = snap_one()
     s.profiles["3"].rules.blocked     = true
     s.profiles["3"].rules.blockReason = "Schedule"
     local nft = render.nft(s)
-    -- Rate-limited log rule for this MAC/reason (limit precedes log prefix).
+    -- Per-flow rate-limited log rule for this MAC/reason. The whole-MAC drop is
+    -- family-agnostic, so its LOG is split per family (v4/v6) to key on
+    -- (mac,dst); the limiter is embedded in the @wh_drop_log… set update, which
+    -- precedes the log prefix (#1915 replaced the flat per-rule 2/second form).
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 limit rate 2/second burst 10 packets log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \"",
-      1, true), "expected rate-limited wh_drop log rule")
+      "ether saddr aa:bb:cc:11:22:33 meta nfproto ipv4 update @wh_drop_log4 { ether saddr . ip daddr limit rate 1/minute burst 5 packets } log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \"",
+      1, true), "expected per-flow v4 wh_drop log rule")
     -- Unconditional drop rule (counter + comment), with NO limit/log.
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
@@ -1023,29 +1030,37 @@ describe("render.nft rate-limits wh_drop logging (#1826)", function()
     end
   end)
 
-  -- #1864: even rate-limited at 10/second, the aggregate across many
-  -- simultaneously-storming drop rules dominated the shared `logread` ring
-  -- buffer and evicted agent/dnsmasq lines, leaving the router undiagnosable.
-  -- The LOG is throttled harder (≤ 2/second sustained) to keep the ring buffer
-  -- usable; the drop verdict is unaffected (asserted above). Guard against a
-  -- regression that bumps the sustained rate back up.
-  it("throttles the wh_drop LOG to ≤ 2/second sustained (#1864)", function()
+  -- #1864 → #1915: a flat per-rule `limit rate N/second` was the original
+  -- ring-buffer-flood mitigation, but it is a single bucket SHARED across all
+  -- flows on the rule, so a storm starves the next distinct flow's first log
+  -- line and breaks event synthesis. Ring-buffer protection now comes from the
+  -- PER-FLOW limiter (each (mac,dst) its own bucket), so no wh_drop LOG line may
+  -- carry a flat per-second per-rule limit. Guard against a regression that
+  -- reintroduces the flat throttle.
+  it("never uses a flat per-rule per-second LOG throttle (#1864/#1915)", function()
     local s = snap_one()
-    s.profiles["3"].rules.blocked     = true
-    s.profiles["3"].rules.blockReason = "Schedule"
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Schedule"
+    s.profiles["3"].rules.blockIpOnly  = true
+    s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
     local nft  = render.nft(s)
     local body = filter_chain_body(nft)
     assert.truthy(body)
     local saw_log = false
     for line in body:gmatch("[^\n]+") do
-      local rate = line:match("limit rate (%d+)/second")
-      if rate and line:find("log prefix \"wh_drop:", 1, true) then
+      if line:find("log prefix \"wh_drop:", 1, true) then
         saw_log = true
-        assert(tonumber(rate) <= 2,
-               "wh_drop LOG rate too high (ring-buffer flood risk): " .. line)
+        assert(not line:find("limit rate %d+/second"),
+               "wh_drop LOG uses a flat per-rule per-second throttle (#1915 regression): " .. line)
+        -- Ring-buffer protection is the per-flow limiter set, embedded in the
+        -- packet-keyed `update @wh_drop_log…`.
+        assert(line:find("update @wh_drop_log", 1, true),
+               "wh_drop LOG not gated by the per-flow limiter set: " .. line)
       end
     end
-    assert.truthy(saw_log, "expected at least one rate-limited wh_drop log rule")
+    assert.truthy(saw_log, "expected at least one per-flow wh_drop log rule")
   end)
 end)
 
@@ -2811,7 +2826,7 @@ describe("render.nft global composition (#1319)", function()
 
   -- Every drop in wifihaven_block — including the new global drops — must
   -- carry the nflog attribution prefix (the #1122 invariant).
-  it("every global drop carries `counter drop` + comment, preceded by its rate-limited log rule (#1826)", function()
+  it("every global drop carries `counter drop` + comment, preceded by its per-flow log rule (#1826/#1915)", function()
     local s = snap_global()
     s.global.blocked      = true
     s.global.blockReason  = "DefaultDeny"
@@ -2822,9 +2837,11 @@ describe("render.nft global composition (#1319)", function()
     local block_start = nft:find("chain wifihaven_block {", 1, true)
     local next_chain  = nft:find("\n%s*chain ", block_start + 1)
     local body = nft:sub(block_start, (next_chain or #nft + 1) - 1)
-    -- Post-#1826: each drop is a `counter drop` + comment rule preceded by its
-    -- own rate-limited `log prefix` rule with the same predicate (see the
-    -- per-MAC equivalent above). The drop itself never logs or rate-limits.
+    -- Post-#1826/#1915: each drop is a `counter drop` + comment rule preceded by
+    -- its own per-flow `log prefix` rule with the same predicate (see the
+    -- per-MAC equivalent above). The drop itself never logs or rate-limits, and
+    -- the log is gated by the per-flow @wh_drop_log… limiter, not a flat
+    -- per-rule per-second throttle.
     local prev = nil
     for line in body:gmatch("[^\n]+") do
       if line:find("counter drop", 1, true) then
@@ -2836,8 +2853,10 @@ describe("render.nft global composition (#1319)", function()
                "drop rule still logs (flood risk): " .. line)
         local predicate = line:gsub(" counter drop.*$", "")
         assert(prev and prev:find(predicate, 1, true)
-               and prev:find("limit rate 2/second burst 10 packets log prefix \"wh_drop:", 1, true),
-               "drop not preceded by its rate-limited log rule: " .. line)
+               and prev:find("update @wh_drop_log", 1, true)
+               and prev:find("log prefix \"wh_drop:", 1, true)
+               and not prev:find("limit rate %d+/second"),
+               "drop not preceded by its per-flow log rule: " .. line)
       end
       prev = line
     end


### PR DESCRIPTION
Fixes #1915. Relates to #1864, #1865.

## Problem (critical path — Master Router CD red ~1 day, blocking ALL router publishes incl. #1865)

#1864/#1867 tightened the nftables `wh_drop` LOG to a flat per-rule `limit rate 2/second burst 10` to stop the kernel ring-buffer flood. But that same `wh_drop` kernel log is the SOURCE the agent's `wifihaven-nflog-tail` sidecar greps (`logread -f`) to synthesize **blocked/paused `connection_event`s** (`wifihaven-agent:840–855`, #1122/#1126).

A flat per-rule limit is a **single token bucket SHARED across every flow** that hits the drop rule. Once a retry storm drains the bucket, the **next DISTINCT `(mac,dst)` flow's first packet is rate-limited away before the agent's tail ever reads it** → events never synthesize. Gate 2 `test_paused_mac_https_traffic_surfaces_as_nflog_event` and `test_ea_direct_requery_allowed_under_blocked_mac` time out, deterministically, across runs.

The flat limit conflated two purposes of the LOG: **flood control** (suppress REPEATS) vs **event synthesis** (needs ≥1 line per distinct event).

## Fix — per-element (per-flow) limiter (issue's PREFERRED option)

Replace the flat per-rule limit with a dynamic set keyed on `(ether saddr . ip[6] daddr)` with an **embedded `limit rate 1/minute burst 5`**:

```
… update @wh_drop_log4 { ether saddr . ip daddr limit rate 1/minute burst 5 packets } log prefix "wh_drop:<mac>:<reason> "
… counter drop comment "wh_drop:<mac>:<reason>"
```

- **Each distinct flow gets its own token bucket** → a fresh `(mac,dst)` element starts with a full burst, so the **first packet of every distinct flow always logs** → synthesis is never starved.
- A storm to the **same** `(mac,dst)` drains only that element's bucket → suppressed → ring buffer stays usable (the #1864 goal, now achieved per-flow instead of by a blunt global throttle).
- The embedded limit is a **match**: over budget the `update` evaluates false and the rule stops **before** the log (no verdict), falling through to the unchanged unconditional `counter drop`. **Enforcement and drop counts are exact** — only the LOG gating moved from per-rule to per-flow.

### Why `(mac, dst)` is the right key — it removes only duplicates, never real events

`(mac, dst_ip)` is exactly the granularity at which a distinct event exists. In `nflog.lua`, the synthesized event's `hname = lookup(dst_ip)` and `reason` come from the matched rule — **both are functions of `dst_ip`**: hname is a reverse lookup of it, and a given `(mac,dst_ip)` always hits the same first-matching drop rule (the rules don't match on L4 port), so the reason is deterministic. The agent's own dedup key `(mac, dst_ip, hname)` therefore collapses to `(mac, dst_ip)` — the same granularity my limiter uses. So every distinct flow logs its first packet; only repeats the agent would dedup anyway (60s window) are suppressed before they flood the ring buffer.

Whole-MAC drops are family-agnostic (no daddr predicate), so their LOG is split into a `meta nfproto ipv4`/`ipv6` pair to extract a `(mac,dst)` key per family; the single `counter drop` stays family-agnostic.

Why not the ALT (revert nft limit, rely on agent dedup + spool): the agent dedup runs *after* the kernel has already written every packet's LOG line, so it can't protect the **kernel** ring buffer — reverting re-introduces the #1864/#1826 flood. The per-element limiter protects both.

## Validation

- New failing-first busted specs (`render_spec.lua`, committed red then green): per-flow `(mac,dst)` limiter sets exist; the LOG is gated by `update @wh_drop_log…` and **never** a flat `limit rate N/second`; whole-MAC drops log both v4+v6 distinct flows; the drop verdict is still never gated by the limit. Updated the #1826/#1864 specs that pinned the old flat format.
- `busted test/render_spec.lua` → **201 passing**; `nflog_spec` → 21 passing. (Other specs' local errors are missing C libs `luci.jsonc`/`cqueues` on the lua5.5 host — env, not this change; CI runs lua5.1 with deps.)
- **`nft -c -f` clean (exit 0) on a real OpenWRT v1.1.6 / kernel 6.12 router** for both the ea-carve and whole-MAC `meta nfproto` rulesets — confirms the embedded-limit-in-set and `meta nfproto` syntax are kernel-valid.
- Final reachability is Gate 2 on the self-hosted KVM runner (can't run locally) — relying on this PR's CI.

## `udhcpc: no lease` VM noise — ruled out

Transient client boot-time DHCP lag. The harness already absorbs it: `_wait_for_client_lan` (`scripts/e2e/lib/vm.py`) retries the eth0 lease + DNS probe for up to 60s and only `log.warning`s on miss (never fails the run). The deterministic, cross-run failure is the event-synthesis `TimeoutError`, not a connectivity/DHCP error. Primary fix is the throttle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)