### PR TITLE
feat(#1922): app-catalog pass — Math Playground + Dance Mat Typing apps; emolingo.games blocklist

### DIFF
--- a/.claude/skills/app-catalog-pass/SKILL.md
+++ b/.claude/skills/app-catalog-pass/SKILL.md
@@ -65,12 +65,14 @@ jq '.items[] | select(.apex=="<apex>")' /tmp/apex_*.json
 rm -f /tmp/wh_token.txt   # don't leave creds on disk
 ```
 
-> **CAVEAT — the sample is IPv4-biased.** IPv6 host attribution has been broken
-> on prod (v6 recorded as bare literals / dropped — #1796, fixes #1807/#1802).
-> Do **not** conclude "no traffic" from a quiet apex; many sites (lego.com et al)
-> serve heavily over v6. **Cross-check every candidate with web research**, not
-> byte counts alone. Re-confirm whether this caveat still holds at run time
-> (check #1796/#1807/#1802 state) and update this note.
+> **CAVEAT — RESOLVED as of 2026-06-23 (#1922 run).** IPv6 host attribution
+> *was* broken on prod (v6 recorded as bare literals / dropped — #1796), making
+> the sample IPv4-biased. #1796 is now **closed** and its fixes **#1807** (NDP-
+> neighbor v6 events) and **#1802** (v6 in per-device usage) are **merged**, so
+> the sample now includes v6 traffic. **Still cross-check every candidate with
+> web research**, not byte counts alone. Re-confirm this state at run time
+> (`gh issue view 1796/1807/1802`) — if a new attribution gap appears, restore
+> the IPv4-biased warning here.
 
 ## Step 1 — Gap-check against existing apps
 
@@ -170,6 +172,23 @@ above is now wrong, fix the step too — don't just log around it.
 
 ## Learnings log (newest first)
 
+- **2026-06-23 (#1922)** — #1796 IPv6-attribution gap is FIXED (#1807/#1802
+  merged); sample is no longer IPv4-biased. Step 0 caveat updated. A site #1815
+  skipped as "below bar / IPv4-biased" (mathplayground.com, 181 kB → now 894 kB
+  visible) became a legit app this pass — re-evaluate prior-skipped educational
+  apexes now that v6 lands.
+- **2026-06-23 (#1922)** — Watch for "game"-NAMED ad-tech: `games-to-run123.com`
+  (`trk2-assets.`), `geektalesgames.com` (`tracker.`), `grandgamestech.com`
+  (`api.` RTB) are tracker/RTB endpoints, NOT game sites — skip. Classify by the
+  subdomain shape (trk/tracker/sync/prebid/rtb/exchange = ad-tech), not the
+  apex's name.
+- **2026-06-23 (#1922)** — A vendor-API backend hit ONLY at its `api.` host with
+  no branded web app the kid navigates to (e.g. `api.elevenlabs.io` at ~50 MB) is
+  shared-API collateral — skip, don't template. Bytes alone don't make an app.
+- **2026-06-23 (#1922)** — "Unblocked games" framing extends past proxy stacks to
+  single-game hosts: `emolingo.games` (Rainbow Obby) markets "works in restrictive
+  school networks" and serves rotating numbered subdomains (`rainbowobbyN.`) — the
+  evasion pattern. → `games.yml` apex block (suffix-matches all N), NOT an app.
 - **2026-06-21 (#1815)** — Host entries can be subdomains; enforcement AND
   attribution both suffix-match the entry's own subtree (`HostMatch.matchesApex`),
   so you can scope an app to a sub-experience (LEGO Builder → `*.i.lego.com` +

--- a/api/resources/app_templates/_index.yml
+++ b/api/resources/app_templates/_index.yml
@@ -40,3 +40,6 @@ slugs:
   # #1889: Feeling Great CBT app (distinctive host only; shared
   # elevenlabs/launchdarkly deferred to #1888)
   - feeling-great
+  # #1922: traffic-driven catalog pass (see evidence/classification-1922.md)
+  - math-playground
+  - dance-mat-typing

--- a/api/resources/app_templates/dance-mat-typing.yml
+++ b/api/resources/app_templates/dance-mat-typing.yml
@@ -1,0 +1,9 @@
+slug: dance-mat-typing
+name: Dance Mat Typing
+# Emoji fallback: ⌨️
+icon: "https://icons.duckduckgo.com/ip3/dancemattypingguide.com.ico"
+icon_type: url
+# Kid touch-typing tutor hosting the BBC Dance Mat Typing course (#1922).
+# Apex covers the observed www.dancemattypingguide.com subdomain.
+hosts:
+  - dancemattypingguide.com

--- a/api/resources/app_templates/evidence/classification-1922.md
+++ b/api/resources/app_templates/evidence/classification-1922.md
@@ -1,0 +1,42 @@
+# #1922 — traffic-driven app-catalog pass (kid devices, last 30 days)
+
+Source: read-only prod cloud API (`https://api.wifihaven.net`),
+`GET /api/devices/:mac/recent-apexes?windowDays=30&limit=500` for the four kid
+devices, aggregated by apex bytes:
+
+- Octavius iPad `a6:05:9a:63:83:af` (profile 7)
+- Prima iPad `04:72:ef:d6:e4:5a` (profile 6)
+- Quintus iPad `26:74:fc:f9:4e:9e` (profile 5)
+- Kid Mac `ca:ef:a1:72:6a:a3` (profile 1)
+
+> **CAVEAT NOW LIFTED.** Prior passes warned the sample was IPv4-biased because
+> IPv6 host attribution was broken on prod (#1796). As of this run #1796 is
+> **closed** and its fixes **#1807** (record v6 events via NDP neighbor) and
+> **#1802** (account v6 traffic in per-device usage) are **merged**. The byte
+> sample is no longer IPv4-biased. Candidates were still web-cross-checked.
+
+## Top uncovered apexes (in "Other"), and disposition
+
+| apex | kid bytes / hits | disposition |
+| ---- | ---------------- | ----------- |
+| `mathplayground.com` | 894 kB / 6 (subs `www.`, `tools.`) | **NEW app `math-playground`** — COPPA-compliant K-6 educational math-games site, school-used. (#1815 skipped this as "below bar / IPv4-biased" at 181 kB; now visible post-#1796 fix and above bar.) |
+| `dancemattypingguide.com` | 1.3 MB / 13 (sub `www.`) | **NEW app `dance-mat-typing`** — kid touch-typing tutor hosting the BBC Dance Mat Typing course. Genuine educational, kid-used. |
+| `emolingo.games` | 758 kB / 8 (subs `rainbowobby4/12.`) | **`blocklists/games.yml` only** — "Rainbow Obby" browser-game host marketed as *unblocked / works in restrictive school networks*; rotating numbered subdomains are the unblocked-games evasion pattern. A block target, not a time-budget app (operator rule, #1815). Apex suffix-matches all `rainbowobbyN.*`. |
+| `lego.com` (596 MB), `kastatic.org`/`khanacademy.org` (674 MB), `mathacademy.com` (123 MB), `tinkercad.com`, `duolingo.com`, `gimkitconnect.com` (15 MB), `thingiverse.com`, `crazygames.com`, `poki.io`, `giphy.com`, `eaglercraft.*`, `mocpilot.com` | large | already covered by existing apps |
+| `duckmath.org` (65 MB), `now.gg`, `holyunblocker.org` | large | already in `games.yml` (#1815) |
+| `apple.com`/`icloud-content.com`/`cdn-apple.com`/`apple-dns.net`/`aaplimg.com`, `google.com`/`gstatic.com`/`googleapis.com`/`gvt2.com`, `fastly.net`/`akadns.net`/`cloudfront.net`/`ctfassets.net` | very large | infra / Apple+Google service & CDN pools — not templatable (shared) |
+| `flashtalking.com`, `innovid.com`, `adsrvr.org`, `pubmatic.com`, `casalemedia.com`, `cootlogix.com`, `yellowblue.io`, `ingage.tech`, `media.net`, `sharethrough.com`, `3lift.com`, `adnxs.com`, … | large | ad / RTB networks — noise, skip |
+| `games-to-run123.com`, `geektalesgames.com`, `grandgamestech.com` | small | "game"-named **ad-tech trackers** (`trk2-assets.`, `tracker.`, `api.` RTB endpoints), NOT game sites — skip |
+| `elevenlabs.io` (`api.` only, ~50 MB), `adobe.com`/`adobe.io`, `autodesk.com`, `launchdarkly.com`, `unity3d.com`, `stripe.com`, `sentry.io` | medium-large | shared vendor API backends / corporate infra (no branded kid-facing web app) — skip per `_README.yml` shared-pool guidance |
+
+## Host-set coverage check
+
+- `math-playground` → `mathplayground.com`. `HostMatch.matchesApex` suffix-matches
+  `www.mathplayground.com` and `tools.mathplayground.com` (the observed subs).
+  Tight; no shared-CDN collateral pinned.
+- `dance-mat-typing` → `dancemattypingguide.com`. Covers observed
+  `www.dancemattypingguide.com`. Single dedicated domain, no collateral.
+- `emolingo.games` (games.yml) → apex covers `rainbowobby4.emolingo.games`,
+  `rainbowobby12.emolingo.games`, and any future numbered subdomain.
+
+Both apps are educational (not games), so neither is also added to `games.yml`.

--- a/api/resources/app_templates/math-playground.yml
+++ b/api/resources/app_templates/math-playground.yml
@@ -1,0 +1,9 @@
+slug: math-playground
+name: Math Playground
+# Emoji fallback: 🧮
+icon: "https://icons.duckduckgo.com/ip3/mathplayground.com.ico"
+icon_type: url
+# COPPA-compliant K-6 educational math-games site (#1922). Apex covers the
+# observed www.mathplayground.com + tools.mathplayground.com subdomains.
+hosts:
+  - mathplayground.com

--- a/api/resources/blocklists/games.yml
+++ b/api/resources/blocklists/games.yml
@@ -90,3 +90,9 @@ hosts:
   - garena.com
   - tencentgames.com
   - epicgames.dev
+  # #1922: "Rainbow Obby" browser-game host marketed as unblocked / works in
+  # restrictive school networks; observed on a kid iPad via rotating numbered
+  # subdomains (rainbowobby4/12.emolingo.games) — the unblocked-games evasion
+  # pattern. Block target only, NOT an app template (no daily budget for a
+  # filter-positioned game host). Apex covers all rainbowobbyN.* subdomains.
+  - emolingo.games

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -123,6 +123,9 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           "lego",
           // #1889: Feeling Great CBT app
           "feeling-great",
+          // #1922: traffic-driven catalog pass
+          "math-playground",
+          "dance-mat-typing",
         )
         val slugs    = templates.map(_.slug.value).toSet
         assertTrue(slugs == expected) &&


### PR DESCRIPTION
Weekly traffic-driven app-catalog pass (`app-catalog-pass` skill). Window = last 30 days, kid devices (Octavius / Prima / Quintus iPads + Kid Mac), read-only prod traffic via `recent-apexes`.

## New app templates
- **`math-playground`** → `mathplayground.com` — COPPA-compliant K-6 educational math-games site (school-used; web-confirmed). Apex suffix-matches the observed `www.`/`tools.` subs. #1815 had skipped this as "below bar / IPv4-biased" (181 kB); it's now **894 kB** and visible because the #1796 IPv6-attribution gap is fixed (#1807/#1802 merged).
- **`dance-mat-typing`** → `dancemattypingguide.com` — kid touch-typing tutor hosting the BBC Dance Mat Typing course (web-confirmed educational). Single dedicated domain, no shared-CDN collateral.

Both are educational (not games), so neither is added to `games.yml`.

## Blocklist
- **`games.yml` += `emolingo.games`** — "Rainbow Obby" browser-game host marketed as *unblocked / works in restrictive school networks*; observed via rotating numbered subdomains (`rainbowobby4/12.emolingo.games`) — the unblocked-games evasion pattern. Block target only, **not** an app (operator rule, #1815). Apex suffix-matches all `rainbowobbyN.*`.

## Skipped (noted in evidence doc)
Apple/Google/CDN infra pools; ad/RTB networks; "game"-named ad-tech that are actually trackers (`games-to-run123.com`, `geektalesgames.com`, `grandgamestech.com`); and `api.`-only vendor backends with no branded kid web app (`api.elevenlabs.io`).

## Skill self-update (Step 6)
- Marks the #1796 IPv4-bias caveat **resolved** in Step 0 (#1807/#1802 merged).
- Logs this run's learnings (re-evaluate prior-skipped educational apexes now that v6 lands; classify by subdomain shape not apex name; `api.`-only = collateral; unblocked-games framing extends to single-game hosts).

## Validation
- `mill api.test.testOnly AppTemplatesSpec` — 29 passed (pinned slug set updated; both new apps seed + round-trip).
- `mill api.test.testOnly BundledBlocklistsSpec` — 19 passed.
- `mill scalafmt checkFormatAll` — clean.

Evidence: `api/resources/app_templates/evidence/classification-1922.md`.

Relates to #1922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)