### PR TITLE
feat(#1923): traffic-driven ads-blocklist additions

### DIFF
--- a/.claude/skills/ads-blocklist-pass/SKILL.md
+++ b/.claude/skills/ads-blocklist-pass/SKILL.md
@@ -125,6 +125,34 @@ that edit in the same PR.** If a step above is now wrong, fix the step too.
 
 ## Learnings log (newest first)
 
+- **2026-06-23** (#1923) — **Diff candidates against the StevenBlack
+  `ads-extended` feed before adding.** Fetch
+  `raw.githubusercontent.com/StevenBlack/hosts/master/hosts`, extract the
+  `0.0.0.0 <host>` second field into a set, and test each candidate apex for
+  exact + subdomain membership. This cleanly splits **genuine gaps** (feed
+  misses the apex entirely → highest value to hand-curate) from apexes the
+  extended feed already covers (lower value, only helps curated-only profiles).
+  Prioritize the gaps; add a small set of the highest-traffic covered apexes for
+  the curated baseline.
+- **2026-06-23** (#1923) — **A name that resembles a known ad co is NOT
+  identity — verify ownership.** `ttdns2.com` reads like TheTradeDesk
+  (`adsrvr.org`/`ttd*`) but is actually **TikTok** shared DNS infra
+  (CapCut/Pangle/app analytics) per netify — content collateral, skip. Web-fetch
+  netify/whois for any apex whose owner you're inferring from the name alone.
+- **2026-06-23** (#1923) — **New dual-use to skip:**
+  `app-analytics-services.com` (Google GA4) and its ATT-segmentation pair
+  `app-ads-services.com` — both Google-operated, same shared-product class as the
+  already-listed `app-measurement.com` (Firebase). Both showed high prod traffic;
+  skip anyway.
+- **2026-06-23** (#1923) — **High hit-count alone is not an ad signal — check
+  the category.** `demonii.com` had 9,240 hits but is a BitTorrent tracker
+  (`open.demonii.com`), not ad infra. Classify by what the apex *is*, not by how
+  often it's hit.
+- **2026-06-23** (#1923) — **One ad vendor fronts multiple apexes.** Verve Group
+  (MGI) served `vervegroupinc.net`, `verve.net`, and `personaly.bid` (its `.bid`
+  bidder endpoint) — list every observed apex, not just the obvious one. Same for
+  Vidazoo (`vidazoo.com` + `vidazoo.services`) and AppLovin
+  (`applovin.com` + `applvn.com` + `safedk.com`).
 - **2026-06-21** — Skill seeded from the `app-catalog-pass` method. Reuse the
   same `recent-apexes` pull; the difference is the classification target
   (ad/RTB/tracker infra) and that the bulk of coverage belongs in the

--- a/api/resources/blocklists/ads.yml
+++ b/api/resources/blocklists/ads.yml
@@ -102,3 +102,43 @@ hosts:
   - adjust.com
   - appsflyer.com
   - singular.net
+  # traffic-driven additions (#1923): observed but unblocked ad/RTB/tracker infra.
+  # Sourced from a 30-day prod recent-apexes sweep (25 devices). Cross-checked
+  # against the StevenBlack ads-extended feed: the first group are genuine gaps
+  # that even ads-extended misses entirely; the second are clearly-ad apexes the
+  # extended feed covers, added to the curated baseline for curated-only profiles.
+  # Dual-use SKIPPED: app-analytics-services.com / app-ads-services.com (Google
+  # GA4/Firebase), ttdns2.com (TikTok shared infra), demonii.com (BitTorrent
+  # tracker). See evidence/ads-classification-1923.md for per-apex hits + what-it-is.
+  # Mobile ad networks / DSP / SSP / RTB exchanges (gaps not in ads-extended)
+  - bidmachine.io
+  - bidease.com
+  - kayzen.io
+  - openwebmp.com
+  - krushmedia.com
+  - vervegroupinc.net
+  - verve.net
+  - personaly.bid
+  - appiersig.com
+  # Video / SDK ad infra (gaps not in ads-extended)
+  - vidazoo.com
+  - vidazoo.services
+  - safedk.com
+  # Attribution / session-replay trackers (gaps not in ads-extended)
+  - sng.link
+  - clarity.ms
+  # High-traffic ad apexes also in ads-extended (curated-baseline coverage)
+  - applvn.com
+  - adthrive.com
+  - jampp.com
+  - inner-active.mobi
+  - celtra.com
+  - pub.network
+  - adswizz.com
+  - contentsquare.net
+  - rayjump.com
+  - mtgglobals.com
+  - aarki.net
+  - mgid.com
+  - creativecdn.com
+  - demdex.net

--- a/api/resources/blocklists/evidence/ads-classification-1923.md
+++ b/api/resources/blocklists/evidence/ads-classification-1923.md
@@ -1,0 +1,90 @@
+# ads-blocklist pass — 2026-06-23 (#1923)
+
+Traffic-driven ads-blocklist pass via the `/ads-blocklist-pass` skill.
+
+## Method
+
+- Pulled `GET /api/devices/<mac>/recent-apexes?windowDays=30&limit=500` for all
+  25 prod devices (read-only, admin token). Aggregated bytes + hits per apex
+  across devices (1,702 distinct apexes).
+- Classified ad/RTB/SSP/DSP/tracker/attribution apexes not already in
+  `ads.yml`.
+- Cross-checked each candidate against the StevenBlack `ads-extended` feed
+  (`raw.githubusercontent.com/StevenBlack/hosts/master/hosts`, 82,622 distinct
+  hosts) to separate genuine gaps (feed misses the apex entirely) from apexes
+  the extended feed already covers.
+- Skipped dual-use / shared infra per the collateral rule; web-verified the
+  ambiguous high-traffic apexes.
+
+IPv4-bias caveat (#1796) applies — byte totals under-count IPv6-heavy flows.
+
+## Skipped (dual-use / wrong category)
+
+| Apex | bytes / hits | Why skipped |
+|------|-------------|-------------|
+| `app-analytics-services.com` | 36.2 MB / 552 | Google GA4 + Firebase SDK endpoint (verified). Same shared-product class as the already-skipped `app-measurement.com`. |
+| `app-ads-services.com` | 26.3 MB / 210 | Google-operated (ATT-segmentation pair of the analytics endpoint above). Google shared pool — conservative skip. |
+| `ttdns2.com` | 4.8 MB / 334 | TikTok shared DNS infra (CapCut/Pangle/app analytics), **not** TheTradeDesk as the name suggests (verified via netify). Content collateral. |
+| `demonii.com` | 1.7 MB / 9,240 | BitTorrent tracker (`open.demonii.com`), not ad infra — wrong category. |
+
+## Added — genuine gaps (NOT in the StevenBlack ads-extended feed)
+
+These ad apexes are absent from `ads-extended` (no apex, no/low subdomains), so
+hand-curating them is the only way they get blocked.
+
+| Apex | bytes / hits | What it is |
+|------|-------------|-----------|
+| `bidmachine.io` | 28.3 MB / 1,975 | Appodeal BidMachine in-app RTB exchange |
+| `bidease.com` | 4.7 MB / 299 | Bidease mobile programmatic DSP |
+| `kayzen.io` | 1.3 MB / 81 | Kayzen mobile-first programmatic DSP (verified) |
+| `openwebmp.com` | 1.2 MB / 308 | OpenWeb ad / monetization infra (verified, netify) |
+| `krushmedia.com` | 1.1 MB / 64 | KrushMedia ad exchange / SSP |
+| `vervegroupinc.net` | 2.2 MB / 601 | Verve Group (MGI) ad-tech (verified) |
+| `verve.net` | 1.2 MB / 39 | Verve Group ad infra |
+| `personaly.bid` | 15.7 MB / 87 | Verve Group programmatic bidder endpoint (`.bid`) |
+| `appiersig.com` | 0.9 MB / 138 | Appier AI ad-tech signal endpoint |
+| `vidazoo.com` | 1.4 MB / 39 | Vidazoo video ad monetization / yield |
+| `vidazoo.services` | 3.1 MB / 55 | Vidazoo video ad serving |
+| `safedk.com` | 5.3 MB / 328 | SafeDK (AppLovin) mobile ad SDK measurement |
+| `sng.link` | 1.2 MB / 158 | Singular attribution smart-links (pairs with `singular.net`, already listed) |
+| `clarity.ms` | 5.4 MB / 93 | Microsoft Clarity session-replay / analytics tracker (dedicated domain, same category as the already-listed hotjar/fullstory) |
+
+## Added — clearly-ad apexes also covered by ads-extended (curated baseline)
+
+High-traffic, unambiguous ad-tech. The extended feed already lists these, but
+they belong in the curated `ads.yml` so profiles on the curated-only list also
+block them.
+
+| Apex | bytes / hits | What it is |
+|------|-------------|-----------|
+| `applvn.com` | 17.1 MB / 43 | AppLovin tracking / ad domain (short form of `applovin.com`) |
+| `adthrive.com` | 9.6 MB / 94 | AdThrive / Raptive publisher display-ad management |
+| `jampp.com` | 11.7 MB / 277 | Jampp programmatic app-marketing DSP |
+| `inner-active.mobi` | 13.1 MB / 910 | InnerActive (Fyber / Digital Turbine) mobile ad exchange |
+| `celtra.com` | 7.1 MB / 86 | Celtra creative ad management |
+| `pub.network` | 5.3 MB / 763 | Freestar `pub.network` publisher ad framework |
+| `adswizz.com` | 2.8 MB / 129 | AdsWizz audio / podcast advertising |
+| `contentsquare.net` | 4.1 MB / 71 | ContentSquare experience-analytics tracker |
+| `rayjump.com` | 4.5 MB / 443 | Mintegral / Rayjump mobile ad network |
+| `mtgglobals.com` | 4.5 MB / 457 | Mobvista / Mintegral ad infra |
+| `aarki.net` | 3.3 MB / 232 | Aarki mobile DSP |
+| `mgid.com` | 1.6 MB / 95 | MGID native ad network |
+| `creativecdn.com` | 1.1 MB / 310 | RTB House creative CDN |
+| `demdex.net` | 1.0 MB / 207 | Adobe Audience Manager (Demdex) DMP / cross-site tracker |
+
+## Deferred to ads-extended (not hand-curated this pass)
+
+Other genuine ad-tech apexes seen in traffic that the StevenBlack feed already
+covers and that are lower-traffic / lower-priority for the curated baseline:
+`id5-sync.com`, `eu-1-id5-sync.com`, `parsely.com`, `statcounter.com`,
+`360yield.com`, `1rx.io`, `the-ozone-project.com`, `postrelease.com`,
+`dotomi.com`, `ipredictive.com`, `unrulymedia.com`, `mediavine.com`,
+`admanmedia.com`, `sharethis.com`, `intentiq.com`, `intergient.com`,
+`omnitagjs.com`, `zmaticoo.com`, `brid.tv`, `ad-score.com`,
+`bounceexchange.com`, `permutive.com`, `loopme.me`. Left to `ads-extended`
+per the skill's "reserve curated `ads.yml` for a handful of clearly-ad
+high-traffic apexes" guidance.
+
+Unverifiable obscure bidders left out for lack of confirmation:
+`coldbidder.com`, `smarterbidder.com` (suggestive names, no third-party
+confirmation, no collateral risk in omitting).

--- a/api/test/src/feature/BundledBlocklistsSpec.scala
+++ b/api/test/src/feature/BundledBlocklistsSpec.scala
@@ -140,6 +140,8 @@ object BundledBlocklistsSpec
         meta    <- blRepo.findMeta(BlocklistId.unsafe("ads"))
       } yield assertTrue(ads.nonEmpty) &&
         assertTrue(ads.contains(Hostname.unsafe("doubleclick.net"))) &&
+        // traffic-driven addition pinned for presence (#1923)
+        assertTrue(ads.contains(Hostname.unsafe("bidmachine.io"))) &&
         assertTrue(meta.isDefined) &&
         assertTrue(meta.exists(m => m.bundled && m.name == "Ads & Trackers"))
     },


### PR DESCRIPTION
## What

Weekly traffic-driven ads-blocklist pass (the `/ads-blocklist-pass` skill). Adds **28 ad/RTB/tracker apexes** to the curated `api/resources/blocklists/ads.yml`, sourced from a 30-day `recent-apexes` sweep across all 25 prod devices (read-only).

Each candidate was cross-checked against the StevenBlack `ads-extended` feed (82,622 hosts):

- **14 genuine gaps** the extended feed misses entirely — highest value, since hand-curation is the only way they get blocked: `bidmachine.io`, `bidease.com`, `kayzen.io`, `openwebmp.com`, `krushmedia.com`, `vervegroupinc.net`, `verve.net`, `personaly.bid`, `appiersig.com`, `vidazoo.com`, `vidazoo.services`, `safedk.com`, `sng.link`, `clarity.ms`.
- **14 high-traffic clearly-ad apexes** also in `ads-extended`, added to the curated baseline for curated-only profiles: `applvn.com`, `adthrive.com`, `jampp.com`, `inner-active.mobi`, `celtra.com`, `pub.network`, `adswizz.com`, `contentsquare.net`, `rayjump.com`, `mtgglobals.com`, `aarki.net`, `mgid.com`, `creativecdn.com`, `demdex.net`.

## Skipped after verification (dual-use / wrong category)

- `app-analytics-services.com`, `app-ads-services.com` — Google GA4/Firebase SDK endpoints (same class as the already-skipped `app-measurement.com`).
- `ttdns2.com` — TikTok shared DNS infra (CapCut/Pangle), **not** TheTradeDesk as the name suggests (verified via netify).
- `demonii.com` — BitTorrent tracker (9,240 hits but wrong category).

## Evidence

Per-apex hit table + classification + what-it-is in [`evidence/ads-classification-1923.md`](api/resources/blocklists/evidence/ads-classification-1923.md).

## Validation

- `mill api.test.testOnly 'wifihaven.api.feature.BundledBlocklistsSpec'` — 19/19 pass; pinned `bidmachine.io` for presence.
- `scalafmt` clean.
- No duplicate hosts in `ads.yml`.

Self-updated the `ads-blocklist-pass` skill Learnings log (StevenBlack diffing method, name-resemblance verification trap, new Google dual-use pair, hit-count-is-not-category, one-vendor-many-apexes).

Relates to #1923

🤖 Generated with [Claude Code](https://claude.com/claude-code)