### PR TITLE
feat(#1896): shared_hosts template field + parser + seeder + validation

### DIFF
--- a/api/resources/app_templates/_README.yml
+++ b/api/resources/app_templates/_README.yml
@@ -81,6 +81,43 @@
 # When in doubt: block the dedicated-bytes host, leave the shared edge alone,
 # and file against #1663 rather than editing blind.
 #
+# ──────────────────────────────────────────────────────────────────────────
+# SHARED HOSTS FOR ATTRIBUTION — `shared_hosts:` (#1888 / #1896)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# The collateral rule above is about NOT BLOCKING a host whose IPs you don't
+# own. `shared_hosts:` is its ATTRIBUTION sibling — the same multi-tenant
+# vendor backends are also dangerous to CREDIT, because a host listed on many
+# apps would otherwise mis-attribute its time to whichever app won the
+# minBy(appId) tiebreak. The two rules reinforce each other: a host that's
+# shared for attribution is exactly the kind of host that's dangerous to block.
+#
+#   hosts:         DISTINCTIVE — traffic here, on its own, is strong evidence
+#                  THIS app is in use (`app.feelinggreat.com`, `youtube.com`).
+#                  Keep their current unconditional attribution.
+#   shared_hosts:  SHARED — multi-tenant vendor APIs/backends several unrelated
+#                  apps legitimately depend on (`elevenlabs.io`, `launchdarkly.com`,
+#                  generic auth/CDN edges). Traffic here, in isolation, tells you
+#                  nothing about which app is running.
+#
+# `shared_hosts:` is OPTIONAL and defaults to empty — every existing template is
+# unchanged. It is enforced by the directory-wide validation test (S1b, #1896):
+#
+#   1. Every app MUST have at least one distinctive host (`hosts:` non-empty).
+#      An all-shared template could never be "demonstrably in use" and would
+#      receive zero attribution forever — almost certainly an authoring error.
+#   2. GLOBAL CONSISTENCY: a host marked `shared` on ANY template must be
+#      `shared` on EVERY template that lists it. Listing it under plain `hosts:`
+#      somewhere else re-introduces the unconditional mis-credit the flag exists
+#      to prevent. (The flag is stored per-(app, host), but distinctiveness is an
+#      emergent property of a host across the whole catalog.)
+#
+# A shared host is credited to an app ONLY while that app's distinctive hosts
+# have a live session on the same device (the co-presence rule). NOTE: as of
+# S1b the flag is STORED AND IGNORED — attribution behavior is unchanged until
+# S2-S5 land. See `docs/design/shared-host-allocation.md` (#1888) for the full
+# allocation rule.
+#
 # File names beginning with `_` are reserved for documentation (this file) and
 # the manifest (`_index.yml`) and are ignored by the template loader.
 
@@ -88,6 +125,9 @@ slug: example
 name: Example App
 icon: "🧩"
 icon_type: emoji
-hosts:
+hosts:                  # distinctive — uniquely identify this app's use
   - example.com
   - cdn.example.com
+# shared_hosts:         # optional — multi-tenant backends; credited only while a
+#   - elevenlabs.io     #   distinctive host above is active (#1888). Stored but
+#   - launchdarkly.com  #   ignored until S2-S5.

--- a/api/src/AppTemplates.scala
+++ b/api/src/AppTemplates.scala
@@ -1,6 +1,7 @@
 package wifihaven.api
 
 import wifihaven.api.db.AppRepo
+import wifihaven.shared.AppHostEntry
 import wifihaven.shared.IconType
 import wifihaven.shared.types.*
 import org.yaml.snakeyaml.LoaderOptions
@@ -49,6 +50,11 @@ final case class AppTemplate(
     icon: Option[String],
     iconType: IconType,
     hosts: List[Hostname],
+    // #1896: optional, parallel to `hosts`. `hosts` are DISTINCTIVE (uniquely identify this app);
+    // `sharedHosts` are multi-tenant vendor backends listed on many apps. Defaults to empty, so every
+    // existing template is unchanged. The flag is stored but ignored until S2-S5 — see
+    // `docs/design/shared-host-allocation.md`.
+    sharedHosts: List[Hostname] = Nil,
 )
 
 object AppTemplates {
@@ -105,27 +111,27 @@ object AppTemplates {
       Option(root.get(key)).toRight(s"missing required field '$key'").flatMap(f)
 
     for {
-      slugRaw  <- req("slug") {
+      slugRaw     <- req("slug") {
         case s: String => Right(s)
         case other     => Left(s"slug must be a string, got $other")
       }
-      slug     <- AppTemplateId.parse(slugRaw)
-      name     <- req("name") {
+      slug        <- AppTemplateId.parse(slugRaw)
+      name        <- req("name") {
         case s: String if s.trim.nonEmpty => Right(s.trim)
         case _                            => Left("name must be a non-empty string")
       }
-      icon     <- Option(root.get("icon")) match {
+      icon        <- Option(root.get("icon")) match {
         case None            => Right(None)
         case Some(s: String) => Right(Some(s).filter(_.trim.nonEmpty))
         case Some(other)     => Left(s"icon must be a string if present, got $other")
       }
-      iconType <- Option(root.get("icon_type")) match {
+      iconType    <- Option(root.get("icon_type")) match {
         case None            => Right(IconType.Emoji)
         case Some(s: String) =>
           IconType.parse(s.trim).toRight(s"unknown icon_type '$s' (expected emoji|url|png_base64)")
         case Some(other)     => Left(s"icon_type must be a string if present, got $other")
       }
-      hosts    <- Option(root.get("hosts")) match {
+      hosts       <- Option(root.get("hosts")) match {
         case Some(xs: java.util.List[?]) =>
           val strs = xs.asScala.toList.map(_.toString)
           if strs.isEmpty then Left("hosts must contain at least one entry")
@@ -139,13 +145,70 @@ object AppTemplates {
               .map(_.reverse.distinct)
         case _                           => Left("hosts must be a non-empty list of strings")
       }
-      _        <- Either.cond(
+      sharedHosts <- Option(root.get("shared_hosts")) match {
+        case None                        => Right(Nil)
+        case Some(xs: java.util.List[?]) =>
+          xs.asScala.toList
+            .map(_.toString)
+            .foldLeft[Either[String, List[Hostname]]](Right(Nil)) { (acc, raw) =>
+              acc.flatMap(prev =>
+                Hostname
+                  .parse(raw.trim)
+                  .left
+                  .map(e => s"invalid shared host '$raw': $e")
+                  .map(_ :: prev),
+              )
+            }
+            .map(_.reverse.distinct)
+        case Some(other)                 =>
+          Left(s"shared_hosts must be a list of strings if present, got $other")
+      }
+      _           <- {
+        val overlap = hosts.toSet.intersect(sharedHosts.toSet)
+        Either.cond(
+          overlap.isEmpty,
+          (),
+          s"host(s) ${overlap.map(_.value).mkString(",")} listed in both hosts and shared_hosts",
+        )
+      }
+      _           <- Either.cond(
         source.endsWith(s"/${slug.value}.yml"),
         (), {
           s"slug '${slug.value}' does not match file name $source"
         },
       )
-    } yield AppTemplate(slug, name, icon, iconType, hosts)
+    } yield AppTemplate(slug, name, icon, iconType, hosts, sharedHosts)
+  }
+
+  /**
+   * #1896: directory-wide invariants for the shared-host attribution catalog. Returns a
+   * human-readable violation per breach (empty == valid); used by the validation test:
+   *   1. every app has ≥1 distinctive host (`hosts` non-empty) — an all-shared app could never be
+   *      "demonstrably in use" and would receive zero attribution forever; 2. a host marked
+   *      `shared` on any template must be `shared` on every template that lists it. Listing it
+   *      under plain `hosts` elsewhere would re-introduce the unconditional mis-credit the shared
+   *      flag exists to prevent. Distinctiveness is thus globally consistent across the catalog
+   *      even though the flag is stored per-`(app, host)`.
+   */
+  def sharedHostViolations(templates: List[AppTemplate]): List[String] = {
+    val emptyDistinctive  = templates.collect {
+      case t if t.hosts.isEmpty =>
+        s"template '${t.slug.value}' has no distinctive hosts — an all-shared template is rejected"
+    }
+    val distinctiveOwners = templates.flatMap(t => t.hosts.map(_ -> t.slug.value))
+    val sharedOwners      = templates.flatMap(t => t.sharedHosts.map(_ -> t.slug.value))
+    val distinctiveByHost = distinctiveOwners.groupMap(_._1)(_._2)
+    val sharedByHost      = sharedOwners.groupMap(_._1)(_._2)
+    val conflicts         = distinctiveByHost.keySet
+      .intersect(sharedByHost.keySet)
+      .toList
+      .sortBy(_.value)
+      .map { h =>
+        s"host '${h.value}' is distinctive on [${distinctiveByHost(h).sorted.mkString(",")}] but " +
+          s"shared on [${sharedByHost(h).sorted.mkString(",")}] — a shared host must be shared on " +
+          "every template that lists it"
+      }
+    emptyDistinctive ++ conflicts
   }
 
   private def withResource[A](resource: String)(f: InputStream => A): Task[A] =
@@ -201,40 +264,51 @@ object AppTemplates {
     final case class Augmented(added: List[Hostname]) extends SeedOutcome
   }
 
+  /**
+   * The template's full host-set as repo entries: distinctive `hosts` (shared=false) followed by
+   * `sharedHosts` (shared=true). #1896 — `parseTemplate` guarantees the two lists are disjoint.
+   */
+  private def templateEntries(t: AppTemplate): List[AppHostEntry] =
+    t.hosts.map(AppHostEntry(_, shared = false)) ++ t.sharedHosts.map(
+      AppHostEntry(_, shared = true),
+    )
+
   private def seedOne(repo: AppRepo, t: AppTemplate): Task[(String, SeedOutcome)] =
     repo
       .findByTemplateId(t.slug)
       .flatMap {
         case Some(existing) =>
-          repo.getHosts(existing.id).flatMap { hosts =>
-            if hosts.isEmpty then
-              repo.setHosts(existing.id, t.hosts) *>
+          repo.getHostEntries(existing.id).flatMap { existingEntries =>
+            if existingEntries.isEmpty then
+              repo.setHostEntries(existing.id, templateEntries(t)) *>
                 ZIO.logInfo(
                   s"app_templates: slug=${t.slug.value} exists with empty hosts — repopulated (${t.hosts.size} hosts)",
                 ) *>
                 ZIO.succeed((t.slug.value, SeedOutcome.Repopulated))
             else {
-              val existingSet = hosts.toSet
-              val missing     = t.hosts.filterNot(existingSet.contains)
+              val existingHosts = existingEntries.map(_.host).toSet
+              // Additively merge only NEW hosts; existing rows keep their stored shared flag and
+              // operator-added hosts are never removed (#1087). New rows carry the template flag.
+              val missing       = templateEntries(t).filterNot(e => existingHosts.contains(e.host))
               if missing.isEmpty then
                 ZIO.logDebug(
-                  s"app_templates: slug=${t.slug.value} exists (id=${existing.id.value}, hosts=${hosts.size}) — preserved",
+                  s"app_templates: slug=${t.slug.value} exists (id=${existing.id.value}, hosts=${existingEntries.size}) — preserved",
                 ) *>
                   ZIO.succeed((t.slug.value, SeedOutcome.Preserved))
               else
-                repo.setHosts(existing.id, (hosts ++ missing).distinct) *>
+                repo.setHostEntries(existing.id, existingEntries ++ missing) *>
                   ZIO.logInfo(
                     s"app_templates: slug=${t.slug.value} augmented (added ${missing.size} hosts: " +
-                      s"${missing.map(_.value).mkString(",")})",
+                      s"${missing.map(_.host.value).mkString(",")})",
                   ) *>
-                  ZIO.succeed((t.slug.value, SeedOutcome.Augmented(missing)))
+                  ZIO.succeed((t.slug.value, SeedOutcome.Augmented(missing.map(_.host))))
             }
           }
         case None           =>
           for {
             freeSlug <- findFreeSlug(repo, t.slug.value)
             id       <- repo.create(t.name, freeSlug, Some(t.slug), t.icon, t.iconType)
-            _        <- repo.setHosts(id, t.hosts)
+            _        <- repo.setHostEntries(id, templateEntries(t))
             _        <- ZIO.logInfo(
               s"app_templates: created slug=${t.slug.value} (id=${id.value}, hosts=${t.hosts.size})",
             )

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -3028,9 +3028,11 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
     // Order matters only for `app_used_daily`: we INSERT-then-aggregate (so engaged_seconds sum)
     // before the cascade DELETE on `apps` would have wiped the `from` rows. Everything else is
     // safely commutative within the transaction.
+    // #1896: carry the `shared` flag through the union so a merged-in shared host isn't silently
+    // downgraded to distinctive. `to` wins on conflict, so its own flag is preserved either way.
     val unionHosts =
-      sql"""INSERT INTO app_hosts (app_id, host)
-            SELECT $to, host FROM app_hosts WHERE app_id = $from
+      sql"""INSERT INTO app_hosts (app_id, host, shared)
+            SELECT $to, host, shared FROM app_hosts WHERE app_id = $from
             ON CONFLICT DO NOTHING""".update.run
 
     val reattachAssignments =

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2884,6 +2884,17 @@ trait AppRepo {
   def getHosts(appId: AppId): Task[List[Hostname]]
 
   /**
+   * #1896: replace the full host-set carrying each host's `shared` flag (`false` == distinctive).
+   * Same replace semantics as [[setHosts]] (which is the all-distinctive special case). The flag is
+   * stored per-`(app_id, host)` and ignored until S2-S5 — see
+   * `docs/design/shared-host-allocation.md`.
+   */
+  def setHostEntries(appId: AppId, entries: List[AppHostEntry]): Task[Unit]
+
+  /** #1896: the host-set with each host's `shared` flag, ordered by host. */
+  def getHostEntries(appId: AppId): Task[List[AppHostEntry]]
+
+  /**
    * Current `app_hosts_version` — a global counter bumped by every host-set mutation ([[setHosts]],
    * [[delete]]). The rollup writer stamps rolled rows with the value it read here; a read path
    * compares it against the value stamped on rollup rows to decide whether the pre-attributed
@@ -3087,11 +3098,16 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       bumpHostsVersion).transact(xa).unit
   }
 
-  def setHosts(appId: AppId, hosts: List[Hostname]) = {
+  // setHosts is the all-distinctive special case of setHostEntries (#1896): every host shared=false.
+  def setHosts(appId: AppId, hosts: List[Hostname]) =
+    setHostEntries(appId, hosts.map(AppHostEntry(_, shared = false)))
+
+  def setHostEntries(appId: AppId, entries: List[AppHostEntry]) = {
     val del = sql"DELETE FROM app_hosts WHERE app_id=$appId".update.run
-    val ins = hosts.distinct.map(h =>
-      sql"INSERT INTO app_hosts(app_id,host) VALUES($appId,$h) ON CONFLICT DO NOTHING".update.run,
-    )
+    val ins = entries.distinctBy(_.host).map { e =>
+      sql"""INSERT INTO app_hosts(app_id,host,shared) VALUES($appId,${e.host},${e.shared})
+            ON CONFLICT DO NOTHING""".update.run
+    }
     (del *> ins.foldLeft(FC.unit)(_ *> _.void) *> bumpHostsVersion).transact(xa).unit
   }
 
@@ -3099,6 +3115,15 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
     DbMetrics.timed("app.getHosts")(
       sql"SELECT host FROM app_hosts WHERE app_id=$appId ORDER BY host"
         .query[Hostname]
+        .to[List]
+        .transact(xa),
+    )
+
+  def getHostEntries(appId: AppId) =
+    DbMetrics.timed("app.getHostEntries")(
+      sql"SELECT host, shared FROM app_hosts WHERE app_id=$appId ORDER BY host"
+        .query[(Hostname, Boolean)]
+        .map { case (h, s) => AppHostEntry(h, s) }
         .to[List]
         .transact(xa),
     )

--- a/api/test/src/feature/AppRepoSpec.scala
+++ b/api/test/src/feature/AppRepoSpec.scala
@@ -101,6 +101,20 @@ object AppRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Tr
         entries.toSet == Set(AppHostEntry(youtube, false), AppHostEntry(ytimg, true)),
       ) && assertTrue(plain.nonEmpty && plain.forall(!_.shared))
     },
+    test("#1896 mergeAppInto carries the shared flag onto the surviving app") {
+      for {
+        _       <- cleanDb
+        repo    <- ZIO.service[AppRepo]
+        to      <- repo.create("Keep", "keep", None, None)
+        from    <- repo.create("Gone", "gone", None, None)
+        _       <- repo.setHostEntries(to, List(AppHostEntry(youtube, shared = false)))
+        _       <- repo.setHostEntries(from, List(AppHostEntry(gvideo, shared = true)))
+        _       <- repo.mergeAppInto(from = from, to = to)
+        entries <- repo.getHostEntries(to)
+      } yield assertTrue(
+        entries.toSet == Set(AppHostEntry(youtube, false), AppHostEntry(gvideo, true)),
+      )
+    },
     test("upsertAssignment inserts and overwrites on same (app, profile)") {
       for {
         _     <- cleanDb

--- a/api/test/src/feature/AppRepoSpec.scala
+++ b/api/test/src/feature/AppRepoSpec.scala
@@ -84,6 +84,23 @@ object AppRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Tr
       } yield assertTrue(a.toSet == Set(youtube, ytimg)) &&
         assertTrue(b.toSet == Set(youtube, gvideo))
     },
+    test("#1896 setHostEntries persists the shared flag; setHosts defaults shared=false") {
+      for {
+        _       <- cleanDb
+        repo    <- ZIO.service[AppRepo]
+        id      <- repo.create("YouTube", "youtube", None, None)
+        _       <- repo.setHostEntries(
+          id,
+          List(AppHostEntry(youtube, shared = false), AppHostEntry(ytimg, shared = true)),
+        )
+        entries <- repo.getHostEntries(id)
+        // setHosts is the plain (all-distinctive) overload — every row defaults shared=false.
+        _       <- repo.setHosts(id, List(youtube, gvideo))
+        plain   <- repo.getHostEntries(id)
+      } yield assertTrue(
+        entries.toSet == Set(AppHostEntry(youtube, false), AppHostEntry(ytimg, true)),
+      ) && assertTrue(plain.nonEmpty && plain.forall(!_.shared))
+    },
     test("upsertAssignment inserts and overwrites on same (app, profile)") {
       for {
         _     <- cleanDb

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -15,6 +15,8 @@ import zio.http.*
 import zio.json.*
 import zio.test.*
 
+import scala.jdk.CollectionConverters.*
+
 /**
  * #768: tests for the starter library YAML templates, the idempotent startup seeder, and the
  * reset-to-template endpoint.
@@ -35,6 +37,30 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
   private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def url(p: String) = URL.decode(p).toOption.get
+
+  /** Build a raw YAML-shaped root map for exercising [[AppTemplates.parseTemplate]] directly. */
+  private def rootMap(
+      slug: String,
+      hosts: List[String],
+      sharedHosts: Option[List[String]],
+  ): java.util.Map[String, AnyRef] = {
+    val m = new java.util.HashMap[String, AnyRef]()
+    m.put("slug", slug)
+    m.put("name", slug)
+    m.put("hosts", hosts.asJava)
+    sharedHosts.foreach(s => m.put("shared_hosts", s.asJava))
+    m
+  }
+
+  private def tmpl(slug: String, hosts: List[String], sharedHosts: List[String]): AppTemplate =
+    AppTemplate(
+      AppTemplateId.unsafe(slug),
+      slug,
+      None,
+      IconType.Emoji,
+      hosts.map(Hostname.unsafe),
+      sharedHosts.map(Hostname.unsafe),
+    )
 
   private def adminToken =
     for {
@@ -130,6 +156,63 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         assertTrue(templates.forall(_.name.nonEmpty)) &&
         assertTrue(templates.map(_.slug).distinct.size == templates.size)
       }
+    },
+    test("#1896 shared_hosts defaults to empty and parses parallel to hosts") {
+      val base       = AppTemplates.parseTemplate(
+        rootMap("youtube", List("youtube.com"), None),
+        "/app_templates/youtube.yml",
+      )
+      val withShared = AppTemplates.parseTemplate(
+        rootMap("youtube", List("youtube.com"), Some(List("elevenlabs.io", "launchdarkly.com"))),
+        "/app_templates/youtube.yml",
+      )
+      assertTrue(base.map(_.sharedHosts) == Right(Nil)) &&
+      assertTrue(
+        withShared.map(_.sharedHosts) ==
+          Right(List(Hostname.unsafe("elevenlabs.io"), Hostname.unsafe("launchdarkly.com"))),
+      )
+    },
+    test("#1896 parseTemplate rejects a host listed in both hosts and shared_hosts") {
+      val r = AppTemplates.parseTemplate(
+        rootMap("youtube", List("youtube.com"), Some(List("youtube.com"))),
+        "/app_templates/youtube.yml",
+      )
+      assertTrue(r.isLeft)
+    },
+    test("#1896 catalog satisfies the shared-host invariants") {
+      for {
+        templates <- AppTemplates.loadAll()
+      } yield assertTrue(AppTemplates.sharedHostViolations(templates).isEmpty)
+    },
+    test("#1896 sharedHostViolations flags an all-shared template (no distinctive host)") {
+      assertTrue(
+        AppTemplates.sharedHostViolations(List(tmpl("x", Nil, List("elevenlabs.io")))).nonEmpty,
+      )
+    },
+    test("#1896 sharedHostViolations flags a host distinctive on one app but shared on another") {
+      val a = tmpl("a", List("elevenlabs.io"), Nil)
+      val b = tmpl("b", List("b.com"), List("elevenlabs.io"))
+      assertTrue(AppTemplates.sharedHostViolations(List(a, b)).nonEmpty)
+    },
+    test("#1896 sharedHostViolations passes a globally consistent catalog") {
+      val a = tmpl("a", List("a.com"), List("elevenlabs.io"))
+      val b = tmpl("b", List("b.com"), List("elevenlabs.io"))
+      assertTrue(AppTemplates.sharedHostViolations(List(a, b)).isEmpty)
+    },
+    test("#1896 seeder persists the shared flag per host") {
+      for {
+        _       <- cleanDb
+        appRepo <- ZIO.service[AppRepo]
+        t = tmpl("youtube", List("youtube.com"), List("elevenlabs.io"))
+        _       <- AppTemplates.seed(appRepo, List(t))
+        app     <- appRepo.findByTemplateId(t.slug)
+        entries <- appRepo.getHostEntries(app.get.id)
+      } yield assertTrue(
+        entries.toSet == Set(
+          AppHostEntry(Hostname.unsafe("youtube.com"), false),
+          AppHostEntry(Hostname.unsafe("elevenlabs.io"), true),
+        ),
+      )
     },
     test("every starter template has icon_type=url with a non-empty URL (#1041)") {
       for {

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -361,6 +361,14 @@ case class App(
 
 case class AppHost(appId: AppId, host: Hostname) derives JsonCodec
 
+/**
+ * #1896: an app's host paired with its `shared` flag (`false` == distinctive). Distinctive hosts
+ * keep the unconditional `minBy(appId)` attribution; shared hosts (multi-tenant vendor backends)
+ * are stored now and attributed only under the co-presence rule once S2-S5 land. See
+ * `docs/design/shared-host-allocation.md`.
+ */
+case class AppHostEntry(host: Hostname, shared: Boolean) derives JsonCodec
+
 case class AppPolicyAssignment(
     id: AppPolicyAssignmentId,
     appId: AppId,


### PR DESCRIPTION
## What

Adds the `shared_hosts:` app-template field, persists a `shared` flag per `(app_id, host)`, and enforces directory-wide catalog invariants. **No attribution behavior change yet** — the flag is stored and ignored until S2-S5 (the S1a migration [#1895](https://github.com/wifihaven/wifihaven/issues/1895), V60, already added `app_hosts.shared`).

This is sub-issue **S1b** of the shared-host allocation design ([`docs/design/shared-host-allocation.md`](docs/design/shared-host-allocation.md), parent [#1888](https://github.com/wifihaven/wifihaven/issues/1888)).

## Why

Some hosts are multi-tenant vendor backends (`elevenlabs.io`, `launchdarkly.com`) that many unrelated apps legitimately depend on. Listed under plain `hosts:`, their traffic mis-attributes to whichever app wins the `minBy(appId)` tiebreak. The `shared_hosts:` field marks these so a later slice can credit them only under the co-presence rule (a distinctive host of the same app is live on the same device). This PR lays the storage + authoring foundation only.

## Changes

- **`AppTemplate.sharedHosts: List[Hostname]`** (default `Nil`) — parser reads an optional `shared_hosts:` list parallel to `hosts:`; existing templates parse unchanged (backward compatible). Rejects a host listed in both `hosts:` and `shared_hosts:` within one template.
- **`AppHostEntry(host, shared)`** + **`AppRepo.setHostEntries` / `getHostEntries`** carry the flag. `setHosts` becomes the all-distinctive special case (`shared = false`), so every existing caller is unchanged. The seeder writes distinctive + shared entries and preserves stored flags on additive merge (#1087 semantics intact).
- **`AppTemplates.sharedHostViolations`** — directory-wide validation used by the test: (1) every app has ≥1 distinctive host (reject all-shared templates); (2) global consistency — a host `shared` on any template must be `shared` on every template that lists it.
- **`_README.yml`** documents `shared_hosts:` tied to the existing shared-pool collateral section (block-collateral and attribution rules reinforce each other).

## Tests (TDD — red commit first)

- `AppRepoSpec`: `setHostEntries`/`getHostEntries` round-trip the flag; `setHosts` defaults `shared = false`.
- `AppTemplatesSpec`: `shared_hosts` defaults empty + parses; rejects in-both-lists; real catalog satisfies invariants; `sharedHostViolations` flags all-shared and distinctive-vs-shared conflicts and passes a consistent catalog; seeder persists the flag per host.

No template data changed — no template uses `shared_hosts:` yet (would mis-attribute until S2 teaches attribution about the flag).

Fixes #1896. Relates to #1888. Blocks S2, S3, S4, S5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)