### PR TITLE
feat(#1897): exclude shared hosts from per-app engaged-minutes stitch

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1023,8 +1023,22 @@ class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
   // made the exempt+no-limit carve unreachable.
   // #1679: `apa.allowed_during_schedule_block` carried straight through so the
   // `ProfileAppDispositions` fold can suppress the extraAllowed carve during Schedule blocks.
+  // #1897: `ah.shared` is carried through as the 10th column so `ProfileAppDispositions` can
+  // partition each app's host-set into distinctive (`shared = false`) vs shared hosts. The
+  // engaged-minutes stitch reads the distinctive subset only.
   private type R =
-    (ProfileId, String, Option[Int], String, Boolean, AppId, AppPolicyAssignmentId, String, Boolean)
+    (
+        ProfileId,
+        String,
+        Option[Int],
+        String,
+        Boolean,
+        AppId,
+        AppPolicyAssignmentId,
+        String,
+        Boolean,
+        Boolean,
+    )
   private def toS(r: R) =
     AppTimeLimit(
       AppTimeLimitId(0L),
@@ -1037,13 +1051,14 @@ class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
       AppMode.parse(r._8).getOrElse(AppMode.TimeLimited),
       r._7,
       r._9,
+      r._10,
     )
 
   def listForProfile(pid: ProfileId) =
     DbMetrics.timed("appTimeLimit.listForProfile")(
       sql"""SELECT apa.profile_id, ah.host, apa.daily_minutes, a.slug,
                    apa.exempt_from_daily, a.id, apa.id, apa.mode::text,
-                   apa.allowed_during_schedule_block
+                   apa.allowed_during_schedule_block, ah.shared
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id
@@ -1058,7 +1073,7 @@ class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
   def listAll =
     sql"""SELECT apa.profile_id, ah.host, apa.daily_minutes, a.slug,
                  apa.exempt_from_daily, a.id, apa.id, apa.mode::text,
-                 apa.allowed_during_schedule_block
+                 apa.allowed_during_schedule_block, ah.shared
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id

--- a/api/src/policy/ProfileAppDispositions.scala
+++ b/api/src/policy/ProfileAppDispositions.scala
@@ -62,6 +62,20 @@ final case class ProfileAppDispositions(
     capGroups.map(d => d.label -> d.hosts)
 
   /**
+   * #1897 (shared-hosts S2): the (label → DISTINCTIVE hosts) pairs for the per-app engaged-minutes
+   * stitch. Same shape and order as [[capGroupLabelHosts]] but with each app's `shared` hosts
+   * dropped. This is THE single definition of "an app's distinctive host-set for presence" — both
+   * engaged-minutes consumers ([[wifihaven.api.policy.TimeStatusService.appDayStates]] /
+   * [[wifihaven.api.policy.TimeStatusService.appSecondsByAppWithDropCount]]) and S3's shared-host
+   * co-presence overlap test read through it, so the distinctive-span computation lives in exactly
+   * one place (AGENTS.md §single-source-of-truth). A shared host overlapping a distinctive span is
+   * already counted inside that span, so excluding it from the stitch changes the minutes by zero
+   * while guaranteeing a shared host can never inflate, extend, or create an app's engaged time.
+   */
+  def capGroupLabelDistinctiveHosts: List[(String, List[String])] =
+    capGroups.map(d => d.label -> d.distinctiveHosts)
+
+  /**
    * Snapshot enforcement: collapse every assignment into the per-MAC `(extraAllowed, extraBlocked)`
    * BlockRules buckets the router applies, folding each assignment's per-app schedule windows over
    * its base mode (design §4.1):
@@ -138,6 +152,12 @@ final case class AppDisposition(
     dailyMinutes: Option[Int],
     label: String,
     hosts: List[String],
+    // #1897 (shared-hosts S2): the subset of `hosts` whose `app_hosts.shared` flag is false — the
+    // app's DISTINCTIVE hosts. Enforcement / exempt / attribution projections keep reading `hosts`
+    // (all of them); only the per-app engaged-minutes stitch reads this subset, so a shared backend
+    // never inflates or extends an app's time. An app with no shared hosts has
+    // `distinctiveHosts == hosts`.
+    distinctiveHosts: List[String],
     // #1679: when false, suppress this app's extraAllowed carve-out during Schedule-reason blocks.
     allowedDuringScheduleBlock: Boolean = true,
 )
@@ -175,6 +195,9 @@ object ProfileAppDispositions {
           dailyMinutes = first.dailyMinutes,
           label = first.label,
           hosts = rows.map(_.domainPattern).distinct,
+          // #1897: distinctive = the host rows whose `shared` flag is false. `shared` is per-(app,
+          // host) (one repo row per host), so it is read off each row, not off `first`.
+          distinctiveHosts = rows.filterNot(_.shared).map(_.domainPattern).distinct,
           allowedDuringScheduleBlock = first.allowedDuringScheduleBlock,
         )
       }

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -442,16 +442,17 @@ object TimeStatusService {
       continuationSeconds: Int,
   ): List[AppDayState] = {
     // #1564: feed Presence the cap-group label as its String key so the underlying span/union math
-    // is unchanged, then re-key the result by appId via the (label -> appId) map groupAppLimits
-    // emits directly. One canonical conversion, no slug parsing.
+    // is unchanged, then re-key the result by appId via the (label -> appId) map the same fold
+    // emits. One canonical conversion, no slug parsing.
     // #1897: the stitch reads each app's DISTINCTIVE host-set only (`capGroupLabelDistinctiveHosts`)
     // — a shared host overlapping a distinctive span is already counted there, so excluding it is a
-    // no-op that also guarantees it can never inflate or extend the app's engaged minutes.
-    val groups       = groupAppLimits(appLimits)
-    val labelToAppId = groups.map(g => g._2 -> g._1).toMap
+    // no-op that also guarantees it can never inflate or extend the app's engaged minutes. Both the
+    // label→appId map and the distinctive host-set come off ONE `ProfileAppDispositions.from` fold.
+    val dispositions = ProfileAppDispositions.from(appLimits)
+    val labelToAppId = dispositions.capGroups.map(d => d.label -> d.appId).toMap
     val perLabel     = Presence.patternGroupMinutesForProfile(
       presence,
-      ProfileAppDispositions.from(appLimits).capGroupLabelDistinctiveHosts,
+      dispositions.capGroupLabelDistinctiveHosts,
       overlap,
       filter,
       continuationSeconds,
@@ -588,12 +589,13 @@ object TimeStatusService {
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): (Map[AppId, Long], Int) = {
-    // #1897: distinctive host-set only — see `appDayStates` / `capGroupLabelDistinctiveHosts`.
-    val groups                 = groupAppLimits(appLimits)
-    val labelToAppId           = groups.map(g => g._2 -> g._1).toMap
+    // #1897: distinctive host-set only — see `appDayStates` / `capGroupLabelDistinctiveHosts`. Both
+    // the label→appId map and the distinctive host-set come off ONE `ProfileAppDispositions.from`.
+    val dispositions           = ProfileAppDispositions.from(appLimits)
+    val labelToAppId           = dispositions.capGroups.map(d => d.label -> d.appId).toMap
     val (secsByLabel, dropped) = Presence.appSecondsForProfileWithDropCount(
       presence,
-      ProfileAppDispositions.from(appLimits).capGroupLabelDistinctiveHosts,
+      dispositions.capGroupLabelDistinctiveHosts,
       profile.crossDeviceOverlapMode,
       settings.heartbeatFilter,
       settings.presenceContinuationSeconds,

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -444,11 +444,14 @@ object TimeStatusService {
     // #1564: feed Presence the cap-group label as its String key so the underlying span/union math
     // is unchanged, then re-key the result by appId via the (label -> appId) map groupAppLimits
     // emits directly. One canonical conversion, no slug parsing.
+    // #1897: the stitch reads each app's DISTINCTIVE host-set only (`capGroupLabelDistinctiveHosts`)
+    // — a shared host overlapping a distinctive span is already counted there, so excluding it is a
+    // no-op that also guarantees it can never inflate or extend the app's engaged minutes.
     val groups       = groupAppLimits(appLimits)
     val labelToAppId = groups.map(g => g._2 -> g._1).toMap
     val perLabel     = Presence.patternGroupMinutesForProfile(
       presence,
-      groups.map(g => g._2 -> g._5),
+      ProfileAppDispositions.from(appLimits).capGroupLabelDistinctiveHosts,
       overlap,
       filter,
       continuationSeconds,
@@ -585,11 +588,12 @@ object TimeStatusService {
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): (Map[AppId, Long], Int) = {
+    // #1897: distinctive host-set only — see `appDayStates` / `capGroupLabelDistinctiveHosts`.
     val groups                 = groupAppLimits(appLimits)
     val labelToAppId           = groups.map(g => g._2 -> g._1).toMap
     val (secsByLabel, dropped) = Presence.appSecondsForProfileWithDropCount(
       presence,
-      groups.map(g => g._2 -> g._5),
+      ProfileAppDispositions.from(appLimits).capGroupLabelDistinctiveHosts,
       profile.crossDeviceOverlapMode,
       settings.heartbeatFilter,
       settings.presenceContinuationSeconds,
@@ -598,6 +602,40 @@ object TimeStatusService {
       labelToAppId.get(label).map(_ -> secs)
     }.toMap
     (byAppId, dropped)
+  }
+
+  /**
+   * #1897 (shared-hosts S2): per-app DISTINCTIVE-host engaged spans, keyed by `apps.id` — the
+   * gap-bridged union of each app's `shared = false` hosts, the exact spans the per-app cap
+   * ([[appSecondsByApp]]) sums. Built on the SAME stitch primitive
+   * ([[Presence.appSpansForProfile]]) over the SAME distinctive host-set
+   * ([[ProfileAppDispositions.capGroupLabelDistinctiveHosts]]).
+   *
+   * This is the reusable seam S3's shared-host co-presence allocation consumes: a shared-host
+   * presence row attributes to app A iff it overlaps one of A's distinctive spans. S3 MUST read
+   * these spans rather than re-deriving the distinctive partition, so the distinctive-span
+   * computation lives in exactly one place (AGENTS.md §single-source-of-truth). Spans are combined
+   * across the profile's devices per `profile.crossDeviceOverlapMode`, matching the cap aggregate.
+   */
+  def distinctiveSpansByApp(
+      profile: Profile,
+      appLimits: List[AppTimeLimit],
+      presence: List[PresenceRow],
+      settings: HouseholdSettings,
+  ): Map[AppId, List[Presence.Span]] = {
+    val dispositions = ProfileAppDispositions.from(appLimits)
+    val labelToAppId = dispositions.capGroups.map(d => d.label -> d.appId).toMap
+    Presence
+      .appSpansForProfile(
+        presence,
+        dispositions.capGroupLabelDistinctiveHosts,
+        profile.crossDeviceOverlapMode,
+        settings.heartbeatFilter,
+        settings.presenceContinuationSeconds,
+      )
+      .iterator
+      .flatMap { case (label, spans) => labelToAppId.get(label).map(_ -> spans) }
+      .toMap
   }
 
   /**

--- a/api/test/src/feature/AppRepoSpec.scala
+++ b/api/test/src/feature/AppRepoSpec.scala
@@ -115,6 +115,27 @@ object AppRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Tr
         entries.toSet == Set(AppHostEntry(youtube, false), AppHostEntry(gvideo, true)),
       )
     },
+    test("#1897 AppTimeLimitRepo.listForProfile round-trips the per-host shared flag") {
+      for {
+        _      <- cleanDb
+        appR   <- ZIO.service[AppRepo]
+        atlR   <- ZIO.service[AppTimeLimitRepo]
+        pRepo  <- ZIO.service[ProfileRepo]
+        pid    <- pRepo.create("Kids", Nil)
+        id     <- appR.create("Feeling Great", "feeling-great", None, None)
+        // distinctive feelinggreat.com + shared elevenlabs.io (a multi-tenant TTS backend).
+        _      <- appR.setHostEntries(
+          id,
+          List(
+            AppHostEntry(Hostname.unsafe("feelinggreat.com"), shared = false),
+            AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+          ),
+        )
+        _      <- appR.upsertAssignment(id, pid, AppMode.TimeLimited, Some(30), false)
+        limits <- atlR.listForProfile(pid)
+        bySh = limits.map(l => l.domainPattern -> l.shared).toMap
+      } yield assertTrue(bySh == Map("feelinggreat.com" -> false, "elevenlabs.io" -> true))
+    },
     test("upsertAssignment inserts and overwrites on same (app, profile)") {
       for {
         _     <- cleanDb

--- a/api/test/src/unit/PerAppScheduleSpec.scala
+++ b/api/test/src/unit/PerAppScheduleSpec.scala
@@ -69,6 +69,7 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
       dailyMinutes = a.dailyMinutes,
       label = s"app:${a.appId.value}",
       hosts = hostsByApp.getOrElse(a.appId, Nil).map(_.value),
+      distinctiveHosts = hostsByApp.getOrElse(a.appId, Nil).map(_.value),
     )
     val (allowed, blocked) =
       ProfileAppDispositions(List(d)).enforcement(Map(a.id -> rules), capExhausted, now)
@@ -103,6 +104,7 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
       dailyMinutes = None,
       label = s"app:$appId",
       hosts = hosts,
+      distinctiveHosts = hosts,
     )
 
   def spec = suite("per-app schedules (#1379)")(

--- a/api/test/src/unit/SharedHostEngagedMinutesSpec.scala
+++ b/api/test/src/unit/SharedHostEngagedMinutesSpec.scala
@@ -101,5 +101,15 @@ object SharedHostEngagedMinutesSpec extends ZIOSpecDefault {
       val presence = List(row(0, "elevenlabs.io"), row(1, "elevenlabs.io"))
       assertTrue(engagedSeconds(presence) == 0L)
     },
+    test("distinctiveSpansByApp (the S3 seam) exposes distinctive-only spans") {
+      // The reusable per-app distinctive-span primitive S3 reads for the co-presence overlap
+      // test: feelinggreat.com [0, 600); elevenlabs.io at bucket 2 must NOT extend the span.
+      val presence =
+        List(row(0, "feelinggreat.com"), row(1, "feelinggreat.com"), row(2, "elevenlabs.io"))
+      val spans    =
+        TimeStatusService.distinctiveSpansByApp(profile, appLimits, presence, settings)
+      val totalSec = spans.getOrElse(appId, Nil).map(s => s.endEpoch - s.startEpoch).sum
+      assertTrue(totalSec == 600L)
+    },
   )
 }

--- a/api/test/src/unit/SharedHostEngagedMinutesSpec.scala
+++ b/api/test/src/unit/SharedHostEngagedMinutesSpec.scala
@@ -1,0 +1,105 @@
+package wifihaven.api.unit
+
+import wifihaven.api.policy.TimeStatusService
+import wifihaven.api.presence.PresenceRow
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate, LocalTime, ZoneId}
+
+/**
+ * #1897 (shared-hosts S2): the per-app engaged-minutes stitch
+ * ([[TimeStatusService.appSecondsByApp]]) must consume each app's DISTINCTIVE (`shared = false`)
+ * host-set only. A shared host that overlaps a distinctive span is already counted in that span
+ * (no-op); excluding it from the stitch guarantees a shared host can never inflate, extend, or
+ * single-handedly create an app's engaged time.
+ *
+ * Pure spec — `appSecondsByApp` is a pure projection over `(profile, appLimits, presence,
+ * settings)`, so no DB / Clock is needed to pin the rule. The DB round-trip of the
+ * `app_hosts.shared` flag through `listForProfile` is pinned separately in the feature suite.
+ */
+object SharedHostEngagedMinutesSpec extends ZIOSpecDefault {
+
+  private val mac      = MacAddress.unsafe("aa:bb:cc:dd:ee:01")
+  private val base     = Instant.parse("2026-06-23T00:00:00Z")
+  private val baseDate = LocalDate.parse("2026-06-23")
+
+  // bucket i → a 300 s presence row [i*300, i*300+300) on `mac` for `host`.
+  private def row(bucket: Int, host: String): PresenceRow =
+    PresenceRow(
+      mac,
+      baseDate,
+      base.plusSeconds(bucket * 300L),
+      HostId.Fqdn(Hostname.unsafe(host)),
+      activeSeconds = 300,
+      bytes = 1_000_000L, // ≥ AppSessionAnchorBytes so the session anchors (#1666)
+      periodSeconds = 300,
+    )
+
+  private val appId        = AppId(7L)
+  private val assignmentId = AppPolicyAssignmentId(11L)
+  private val pid          = ProfileId(3L)
+
+  // One (assignment × host) row, mirroring what AppTimeLimitRepo.listForProfile emits.
+  private def limit(host: String, shared: Boolean): AppTimeLimit =
+    AppTimeLimit(
+      id = AppTimeLimitId(0L),
+      profileId = pid,
+      domainPattern = host,
+      dailyMinutes = Some(60),
+      label = "app:feeling-great",
+      exemptFromDaily = false,
+      appId = appId,
+      mode = AppMode.TimeLimited,
+      assignmentId = assignmentId,
+      allowedDuringScheduleBlock = true,
+      shared = shared,
+    )
+
+  // Feeling Great: distinctive `feelinggreat.com`, shared `elevenlabs.io`.
+  private val appLimits = List(
+    limit("feelinggreat.com", shared = false),
+    limit("elevenlabs.io", shared = true),
+  )
+
+  private val profile  = Profile(pid, "Kid", Nil, paused = false)
+  private val settings = HouseholdSettings(
+    dailyResetTime = LocalTime.MIDNIGHT,
+    dailyResetTz = ZoneId.of("UTC"),
+    heartbeatFilter = HeartbeatFilter.Off,
+  )
+
+  private def engagedSeconds(presence: List[PresenceRow]): Long =
+    TimeStatusService.appSecondsByApp(profile, appLimits, presence, settings).getOrElse(appId, 0L)
+
+  def spec = suite("SharedHostEngagedMinutesSpec (#1897)")(
+    test("shared host inside a distinctive span adds 0 minutes (no-op)") {
+      // feelinggreat.com active buckets 0,1,2 → one engaged span [0, 900) = 900 s.
+      // elevenlabs.io fires at bucket 1, strictly inside that span. Excluding it
+      // from the stitch is a no-op: the wall-clock is already counted. == 900 s.
+      val presence = List(
+        row(0, "feelinggreat.com"),
+        row(1, "feelinggreat.com"),
+        row(2, "feelinggreat.com"),
+        row(1, "elevenlabs.io"),
+      )
+      assertTrue(engagedSeconds(presence) == 900L)
+    },
+    test("shared host adjacent to a distinctive span never extends it") {
+      // feelinggreat.com buckets 0,1 → span [0, 600). elevenlabs.io at bucket 2 is
+      // adjacent (gap 0), so with the shared host IN the stitch it would bridge and
+      // extend the app to [0, 900) = 900 s. Distinctive-only stitch keeps it at 600 s.
+      val presence =
+        List(row(0, "feelinggreat.com"), row(1, "feelinggreat.com"), row(2, "elevenlabs.io"))
+      assertTrue(engagedSeconds(presence) == 600L)
+    },
+    test("shared host with no distinctive activity is not credited to the app") {
+      // Only elevenlabs.io traffic, no feelinggreat.com. With the shared host in the
+      // stitch the app would show 600 s; distinctive-only credits zero — the app is
+      // absent from the engaged-seconds map.
+      val presence = List(row(0, "elevenlabs.io"), row(1, "elevenlabs.io"))
+      assertTrue(engagedSeconds(presence) == 0L)
+    },
+  )
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -294,6 +294,14 @@ case class AppTimeLimit(
     // during a Schedule-reason whole-MAC block. Only applies to Schedule; Paused/TimeLimit/Manual
     // are not affected. Default true preserves current behavior (extraAllowed beats every block).
     allowedDuringScheduleBlock: Boolean = true,
+    // #1897 (shared-hosts S2): this (app, host) row's `app_hosts.shared` flag. `true` marks a SHARED
+    // backend (a multi-tenant vendor API / CDN listed on several apps); `false` (default) is a
+    // DISTINCTIVE host that uniquely identifies the app's use. Carried per-(assignment × host) from
+    // `AppTimeLimitRepo.listForProfile` so `ProfileAppDispositions` can partition each app's host-set
+    // into distinctive vs shared. Shared hosts are excluded from the per-app engaged-minutes stitch
+    // (already counted inside any overlapping distinctive span — see docs/design/shared-host-
+    // allocation.md). Default false keeps every legacy hand-built construction distinctive.
+    shared: Boolean = false,
 ) derives JsonCodec
 
 // #761: app concept. An App is a household-scoped named bundle of host


### PR DESCRIPTION
## What & why

shared-hosts **S2** (parent #1888, design `docs/design/shared-host-allocation.md`; follows S1b #1896 which added the `shared_hosts:` template field + `app_hosts.shared` flag).

Makes the per-app **engaged-minutes** stitch (the per-app cap + daily-cap-exemption surface) consume each app's **DISTINCTIVE (`shared = false`) hosts only**.

### The no-op / exclusion reasoning
A shared host is a multi-tenant backend (e.g. `elevenlabs.io`, `launchdarkly.com`) listed on several apps. Per the design, a shared host is credited to an app only while that app's distinctive hosts are demonstrably active. On the engaged-minutes surface that collapses to a clean statement:

- A shared-host presence row that **overlaps** a distinctive span is **already counted** inside that span → feeding it into the stitch changes the number by **zero** (no-op).
- So we simply **exclude** shared hosts from the stitch. This guarantees a shared host can **never inflate, extend, or single-handedly create** an app's engaged time.

### Single-source-of-truth (reuses the #715 primitive)
No second time-accounting implementation. The distinctive partition is defined **once** in `ProfileAppDispositions` (`capGroupLabelDistinctiveHosts`), and the engaged-minutes consumers (`appDayStates` / `appSecondsByApp`) feed it to the existing #715 stitch primitive `Presence.appSpansForProfile`. `distinctiveSpansByApp` exposes those same per-app distinctive spans as the **reusable seam S3** consumes for its co-presence overlap test — S3 must not re-derive them.

## Changes
- `AppTimeLimit.shared` + `AppTimeLimitRepo.listForProfile`/`listAll` now select `ah.shared` (plumbing point per the issue).
- `ProfileAppDispositions`/`AppDisposition`: `distinctiveHosts` partition + `capGroupLabelDistinctiveHosts`.
- `TimeStatusService.appDayStates` / `appSecondsByAppWithDropCount`: stitch reads distinctive hosts only.
- `TimeStatusService.distinctiveSpansByApp`: reusable S3 seam.

## Tests (TDD, red → green)
- `SharedHostEngagedMinutesSpec` (pure): shared host **inside** a distinctive span → **0 added** minutes; shared host **adjacent** → never extends; shared host with **no distinctive activity** → **not credited**; `distinctiveSpansByApp` exposes distinctive-only spans.
- `AppRepoSpec`: `listForProfile` round-trips the per-`(app,host)` `shared` flag on embedded Postgres.
- Full `api.test` green.

## Scope
Engaged-minutes exclusion only. Per-host reporting allocation is **S3 (#1898)**; enforcement guardrails are **S4 (#1899)** — not pulled in here. No wire change.

Fixes #1897. Relates to #1888, #1896.