### PR TITLE
fix(#1929): pin allow-path e2e probes to IPv4 — dual-stack leaf drifted to v6 redirect

### DIFF
--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -787,6 +787,40 @@ describe("render.nft #1865 block page is never dropped", function()
       "ether saddr @blocked_macs tcp dport 443 dnat ip to 127.0.0.1:8443", 1, true))
   end)
 
+  -- #1929: #1865 (block page never dropped / v6 redirect that now DELIVERS) and
+  -- #421 (extraAllowed carve under a whole-MAC block) must COEXIST: a blocked
+  -- MAC's allowed host must be carved out of the block-page DNAT/redirect in
+  -- BOTH families, while a fully-blocked dest still reaches the listener. If the
+  -- block-page DNAT/redirect ever stops carrying the ea_/ea6_ exception, an
+  -- allowed dest would be redirected to the block page — the prod
+  -- "allowed app blocked under schedule" family (#1344/#1891) and the exact
+  -- shape that took Master Router CD red on the v6 path post-#1868. Pin both
+  -- here so neither fix can silently un-fix the other.
+  it("#1929: blocked+extraAllowed dest is carved out of the block-page DNAT/redirect (v4 AND v6) while the never-drop guard stays", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Schedule"
+    s.profiles["3"].rules.extraAllowed = { "mathacademy.com" }
+    local nft = render.nft(s)
+    -- v4 block-page DNAT for the blocked MAC carries the ea_ carve, so an
+    -- allowed dest is NEVER DNAT'd to the local block page.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true),
+      "expected v4 block-page DNAT to carve out the ea_ allowed dest")
+    -- v6 block-page REDIRECT (the path #1868 made deliver) carries the ea6_
+    -- carve, so an allowed v6 dest is NEVER redirected to the block page.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != ::1 ip6 daddr != @ea6_aa_bb_cc_11_22_33_mathacademy_com tcp dport 80 redirect to :8081",
+      1, true),
+      "expected v6 block-page redirect to carve out the ea6_ allowed dest")
+    -- And the #1865 never-drop guard is still present so a FULLY-blocked dest
+    -- (no carve) still reaches the block-page listener rather than being dropped.
+    local body = filter_chain_body(nft)
+    assert.truthy(body and body:find("fib daddr type local counter accept", 1, true),
+      "expected the #1865 block-page never-drop guard to coexist with the ea carve")
+  end)
+
 end)
 
 -- ── nflog drop-rule shape (#1122) ─────────────────────────────────────────

--- a/scripts/e2e/lib/traffic.py
+++ b/scripts/e2e/lib/traffic.py
@@ -25,13 +25,25 @@ class HttpProbe:
     raw: Result
 
 
-def http_get(client: Client, url: str, *, timeout_s: int = 8) -> HttpProbe:
-    """Curl a URL from the client. Captures status code + first 256 bytes."""
+def http_get(
+    client: Client, url: str, *, timeout_s: int = 8, ipv4_only: bool = False
+) -> HttpProbe:
+    """Curl a URL from the client. Captures status code + first 256 bytes.
+
+    `ipv4_only=True` adds curl's `-4` so the request resolves and connects over
+    IPv4 only. Use this when the test set up and asserted an IPv4-family carve /
+    drop set (e.g. ea_/eb_/bl_) and must exercise THAT family end-to-end: a
+    dual-stack fixture host (one with both an A and an AAAA, e.g. the #1677
+    e2e-edge leaf) would otherwise let curl's happy-eyeballs prefer the v6
+    address and probe the v6 chain — a different set the test never populated
+    (see test_cname_direct_requery for the concrete #1929 trap).
+    """
+    family = "-4 " if ipv4_only else ""
     cmd = [
         "sh", "-c",
         # `-w` writes status code on its own line at the end of stdout. We pipe
         # the body through head to bound size. `--max-time` prevents hangs.
-        f"curl -s --max-time {timeout_s} -o - -w '\\nHTTPCODE:%{{http_code}}\\n' "
+        f"curl {family}-s --max-time {timeout_s} -o - -w '\\nHTTPCODE:%{{http_code}}\\n' "
         f"{shell_quote(url)} | head -c 4096",
     ]
     res = client_exec(client, cmd, timeout=timeout_s + 10, check=False)

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -89,6 +89,11 @@ def is_block_page_body(body: str | None) -> bool:
 
 
 def wait_block_page(client, *, host: str = "example.com", timeout_s: float = 90):
+    # No `ipv4_only` knob (cf. wait_http_succeeds): the block-path DNAT/redirect
+    # serves the block page in BOTH families (v4 DNAT → 127.0.0.1, v6 redirect →
+    # br-lan), so whichever address curl's happy-eyeballs picks for a dual-stack
+    # host still lands on the block page. Only the ALLOW path is family-sensitive
+    # — it must hit the same family whose ea_/ea6_ set the test populated (#1929).
     def probe():
         p = http_get(client, f"http://{host}/", timeout_s=8)
         if p.http_code == 200 and is_block_page_body(p.body):

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -100,10 +100,17 @@ def wait_block_page(client, *, host: str = "example.com", timeout_s: float = 90)
     )
 
 
-def wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float = 60):
-    """Probe HTTP success, disambiguating block-page (also 200) by body."""
+def wait_http_succeeds(
+    client, *, host: str = "example.com", timeout_s: float = 60, ipv4_only: bool = False
+):
+    """Probe HTTP success, disambiguating block-page (also 200) by body.
+
+    `ipv4_only=True` pins the probe to IPv4 (curl `-4`) so it exercises the same
+    address family the caller populated/asserted in the kernel sets — see
+    http_get for the dual-stack happy-eyeballs trap (#1929).
+    """
     def probe():
-        p = http_get(client, f"http://{host}/", timeout_s=8)
+        p = http_get(client, f"http://{host}/", timeout_s=8, ipv4_only=ipv4_only)
         if p.http_code is not None and 200 <= p.http_code < 400:
             if is_block_page_body(p.body):
                 return None

--- a/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
+++ b/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
@@ -114,6 +114,13 @@ pytestmark = pytest.mark.cname_direct_requery
 BRAND_HOST = "e2e-brand.wifihaven.net"  # branded/queried host in extraBlocked/extraAllowed
 MID_HOST = "e2e-mid.wifihaven.net"  # intermediate CNAME hop
 LEAF_HOST = "e2e-edge.wifihaven.net"  # final CNAME target; Apple devices re-query this directly
+# NOTE (#1929): LEAF_HOST is DUAL-STACK — it carries both an A (LEAF_IP below)
+# and an AAAA (2001:db8::10, RFC 3849, added in #1677 for the v6-attribution
+# scenario). The allow-path probes here are pinned to IPv4 (`ipv4_only=True`)
+# so they exercise the v4 ea_/eb_ sets these tests populate and assert; an
+# unpinned probe drifts to the v6 chain (whose ea6_ set is unpopulated at
+# connect time) and, post-#1868, lands on the now-delivering v6 block-page
+# redirect. See _xfail_if_leaf_unreachable for the full mechanism.
 # Leaf A record — RFC 5737 TEST-NET-1, reserved-for-documentation and GUARANTEED
 # never globally routed or reassigned (#1360). The previous value 93.184.216.34
 # (legacy IANA example.com) was decommissioned ~2025 and its HTTP/80 went dead,
@@ -196,8 +203,25 @@ def _xfail_if_leaf_unreachable(client) -> None:
     which needs only DNS resolution. A future harness-served origin (a fake-mode
     DNAT of the TEST-NET leaf to a local HTTP responder) would let these run for
     real again — tracked as the #1360 follow-up.
+
+    #1929: the probe is PINNED to IPv4 (`-4`). The leaf is dual-stack — an A
+    (192.0.2.10) AND an AAAA (2001:db8::10), the latter added in #1677 for the
+    v6-attribution scenario, AFTER this suite was authored against a v4-only
+    leaf (#1360). Without `-4`, curl's happy-eyeballs prefers the v6 address and
+    probes the v6 chain instead of the v4 ea_ set this test populated and
+    asserted. That is a real trap, not cosmetic: #1868 switched the v6
+    block-page path from a DNAT-to-::1 that never delivered to an nft `redirect`
+    that DOES deliver to the local uhttpd listener, so a v6 probe to the leaf —
+    whose ea6_ carve set is empty here (no AAAA is resolved through the router
+    before curl's own lookup, so dns-tail has not populated ea6_ at connect
+    time) — now lands on the block page and hard-fails the allow assertion
+    (Master Router CD red 2026-06-22 → 06-24). Pinning to v4 exercises the v4
+    ea_ carve the test actually proved, restoring the documented "unroutable v4
+    leaf ⇒ xfail" semantics. The carve itself is correct in both families
+    (render.lua emits `ip daddr != @ea_…` / `ip6 daddr != @ea6_…`; dns-tail
+    populates both) — this was test-harness drift, not a carve regression.
     """
-    probe = http_get(client, f"http://{LEAF_HOST}/", timeout_s=8)
+    probe = http_get(client, f"http://{LEAF_HOST}/", timeout_s=8, ipv4_only=True)
     if probe.http_code is None:
         pytest.xfail(
             f"leaf origin {LEAF_HOST} ({LEAF_IP}, RFC 5737 TEST-NET-1) is "
@@ -364,8 +388,12 @@ def test_ea_direct_requery_allowed_under_blocked_mac(router, client, fake_api):
     # answers) and must NOT come back as the block page. The unroutable
     # TEST-NET leaf can't answer, so this xfails rather than red-gating (#1360);
     # the carve-out itself is already proven by the ea_ membership above.
+    # #1929: pin the probe to IPv4 — the leaf is dual-stack (A + #1677 AAAA) and
+    # the v4 ea_ set is the one populated/asserted above; see
+    # _xfail_if_leaf_unreachable for why an unpinned (v6) probe hits the block
+    # page post-#1868.
     _xfail_if_leaf_unreachable(client)
-    probe = wait_http_succeeds(client, host=LEAF_HOST, timeout_s=120)
+    probe = wait_http_succeeds(client, host=LEAF_HOST, timeout_s=120, ipv4_only=True)
     assert probe.http_code is not None and 200 <= probe.http_code < 400, (
         f"expected allowed HTTP response (200-399) for {LEAF_HOST} under "
         f"blocked=True, got {probe.http_code!r} — ea_ carve-out may be missing"
@@ -416,8 +444,11 @@ def test_attribution_reports_branded_host_after_direct_requery(router, client, f
     # needs a real flow to the origin; the unroutable TEST-NET leaf can't
     # provide one, so xfail rather than red-gate when it's unreachable (#1360).
     # The branded-host alias recovery itself is unit-covered in dns_log_spec.
+    # #1929: pin to IPv4 for the same dual-stack reason as G2 — keep the probe
+    # on the A-record path the attribution fixture exercises (the v4 conntrack
+    # NEW event) rather than letting happy-eyeballs drift to the #1677 AAAA.
     _xfail_if_leaf_unreachable(client)
-    wait_http_succeeds(client, host=LEAF_HOST, timeout_s=60)
+    wait_http_succeeds(client, host=LEAF_HOST, timeout_s=60, ipv4_only=True)
 
     # Primary assertion: the event posted to /api/router/events carries the
     # branded host, not the CDN leaf target.


### PR DESCRIPTION
## Summary
Master Router CD has been **red since 2026-06-22 13:45Z** (last green `1665d720`, v0.3.13). After #1920 fixed the #1915 starvation cause, Gate 2 still failed **deterministically** on a second test, so nothing publishes:

```
FAILED scenarios_fake/test_cname_direct_requery.py::test_ea_direct_requery_allowed_under_blocked_mac
  - TimeoutError: timed out waiting for allowed HTTP response for e2e-edge.wifihaven.net
```

This blocks the #1865 `::1:8443` fix, #1864, #1848 ws sidecar, and #1921 from ever shipping past v0.3.13.

## Diagnosis — test-harness probe drift, **NOT** an ea_ carve regression
The leaf `e2e-edge.wifihaven.net` is **dual-stack**: `A 192.0.2.10` **and** `AAAA 2001:db8::10`. The AAAA was added in #1677 (v6-attribution scenario), *after* this suite was authored against a v4-only leaf in #1360.

1. Plain `curl` happy-eyeballs **prefers the v6 address**, so the allow-path probe connects over IPv6.
2. The test populates and asserts only the **v4 `ea_`** set. The **v6 `ea6_`** carve set is **empty at curl-connect time** — curl's own AAAA lookup is the first v6 resolution, so dns-tail hasn't populated `ea6_` yet.
3. #1868 (#1865) switched the v6 block-page path from `dnat ip6 to ::1` (never delivered) to nft `redirect` (**does** deliver to the local uhttpd listener). So the v6 redirect now serves the **block page** for the uncarved v6 leaf → the allow assertion fails. *Pre-#1868 the same miss merely timed out → the test xfailed (green).*

### Why this is NOT a carve regression (ruled out on a real router)
- **Behavioral proof:** on green (`1665d720`) G2 xfailed = leaf **unreachable/None**, NOT a block page. The v4 DNAT target `127.0.0.1:8081` *does* deliver, so a broken v4 carve would have block-paged on green and red-gated it. It didn't.
- **Code proof:** `render.lua` carves both families — `ip daddr != @ea_…` (DNAT) and `ip6 daddr != @ea6_…` (redirect); `dns_tail_sets.maybe_populate_ea` branches on `r.family` and populates `ea6_` for AAAA replies.
- **Real-router confirmation** (`openwrt.lan`, nft 1.1.6): the rendered G2 ruleset carves `ea_`/`ea6_` out of **both** the DNAT and the redirect; `nft -c -f -` accepts it; `net.ipv6.bindv6only=0` (so `[::]:8081` dual-binds v4). #1865's `::1:8443` fix and the `[::]` listener stay intact.

## Fix
- Pin the allow-path probes (G2 + G3) to **IPv4** (`curl -4`) via a new `ipv4_only` arg on `http_get` / `wait_http_succeeds` / `_xfail_if_leaf_unreachable`, so they exercise the **v4 `ea_` family the test actually proved** — restoring the documented "unroutable v4 leaf ⇒ xfail" semantics.
- **Did not** adopt "treat a block-page response as xfail": that would *neuter the regression guard* — a genuine v4 carve break would then silently xfail. The v4 pin keeps **block-page → hard-fail** for the v4 path.
- Added a **busted render pin** (`render_spec`) locking the `ea_`/`ea6_` carve in the block-page DNAT **and** redirect **together with** the #1865 `fib daddr type local` never-drop guard — so #1865 and the #421 carve cannot un-fix each other again (the #1344/#1891 "allowed app blocked under schedule" family).

## How #1865 stays fixed
No `render.lua` enforcement change. The v6 `redirect` + `[::]` listener (the #1865 `::1:8443` fix) are untouched; the new busted test asserts the never-drop guard still precedes every drop while the ea carve is present.

## Tests
- `busted` render_spec + dns_tail_sets: 216 passed (2 nft-binary pending on macOS).
- Rendered G2 ruleset validated with `nft -c -f -` on a real OpenWRT target.
- Gate 2 KVM e2e runs on the self-hosted plex runner — validated by watching Master Router CD on this PR.

Fixes #1929
Relates to #1865/#1868, #1677, #1891/#1344, #1360, #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)