### PR TITLE
feat(#1849): PolicyService computed-snapshot cache + push-on-change

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -112,7 +112,17 @@ case class CorsConfig(
 // Precursor to the DB-backed global profile in #937.
 case class PolicyConfig(
     uiAllowedHosts: String = "",
+    // #1849: how often the reconcile ticker rebuilds the cached snapshot and pushes it on an ETag
+    // move. Bounds the staleness of time/usage-dependent transitions (schedule edges, daily-limit
+    // exhaustion) on the cached REST poll path; defaulted to 5s to match the agent's
+    // `policy_poll_interval` so the cache preserves the pre-cache ~per-poll freshness exactly while
+    // moving the ~500ms build off the request path (#1512). Mutations invalidate immediately and do
+    // not wait for this tick.
+    snapshotCacheRefreshSeconds: Int = 5,
 ) {
+  val snapshotCacheRefreshInterval: zio.Duration =
+    zio.Duration.fromSeconds(snapshotCacheRefreshSeconds.toLong)
+
   val uiAllowedHostsParsed: List[Hostname] =
     uiAllowedHosts
       .split(",")

--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -120,8 +120,10 @@ case class PolicyConfig(
     // not wait for this tick.
     snapshotCacheRefreshSeconds: Int = 5,
 ) {
+  // Clamp to a 1s floor so a misconfigured `0`/negative can't turn `Schedule.fixed(Duration.Zero)`
+  // into a no-delay tight loop that pegs the DB with back-to-back ~500ms snapshot builds.
   val snapshotCacheRefreshInterval: zio.Duration =
-    zio.Duration.fromSeconds(snapshotCacheRefreshSeconds.toLong)
+    zio.Duration.fromSeconds(math.max(1, snapshotCacheRefreshSeconds).toLong)
 
   val uiAllowedHostsParsed: List[Hostname] =
     uiAllowedHosts

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -178,6 +178,10 @@ object Main extends ZIOAppDefault {
         // not one ~500ms recompute per poll per router. forkScoped (like the rollup loops) so it is
         // interrupted before the Hikari pool closes on shutdown. The first tick fires immediately;
         // `reevaluate` swallows+logs a transient build failure and keeps the last good cache.
+        // Idle cost: the tick rebuilds unconditionally even with zero connected routers / no recent
+        // poll — but for an always-polling household fleet that is ≈ the pre-cache per-poll load
+        // (which also ran every ~5s), so it is not a regression; gating on "any consumer present" is
+        // a possible later refinement.
         policyForPush <- ZIO.service[PolicyService]
         _ <- policyForPush.setPublisher(new wifihaven.api.policy.PolicySnapshotPublisher {
           def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -372,10 +372,12 @@ object Main extends ZIOAppDefault {
             // #1538: same cache instance TimeRoutes uses, so a schedule detach busts the
             // per-profile time-status entry instead of leaving a stale "paused for schedule".
             timeCache,
+            // #1849: bust the computed-snapshot cache on a profile/schedule mutation.
+            policy.invalidate,
           ) ++
-          ScheduleRoutes.routes(auth, namedSchedRepo) ++
-          HouseholdSettingsRoutes.routes(auth, hsRepo) ++
-          DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo)
+          ScheduleRoutes.routes(auth, namedSchedRepo, policy.invalidate) ++
+          HouseholdSettingsRoutes.routes(auth, hsRepo, policy.invalidate) ++
+          DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo, policy.invalidate)
 
       val statsRoutes: Routes[Any, Response] =
         TimeRoutes.routes(
@@ -391,6 +393,8 @@ object Main extends ZIOAppDefault {
           timeStatus,
           clock,
           timeCache,
+          // #1849: a +Time grant can lift a TimeLimit block, so bust the computed-snapshot cache.
+          policy.invalidate,
         ) ++
           LogRoutes.routes(auth, connRepo, upRepo) ++
           UsageRoutes.routes(

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -182,6 +182,10 @@ object Main extends ZIOAppDefault {
         // poll — but for an always-polling household fleet that is ≈ the pre-cache per-poll load
         // (which also ran every ~5s), so it is not a regression; gating on "any consumer present" is
         // a possible later refinement.
+        // TODO(#1936): replace this fixed-interval ticker with a boundary-scheduled refresh — compute
+        // the next schedule-edge / daily-reset / limit-exhaustion instant from the data buildSnapshot
+        // already loads and sleep until then, so the ~2.5s build runs at real transitions instead of
+        // every tick.
         policyForPush <- ZIO.service[PolicyService]
         _ <- policyForPush.setPublisher(new wifihaven.api.policy.PolicySnapshotPublisher {
           def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -66,8 +66,9 @@ object Main extends ZIOAppDefault {
         bundled   <- BundledBlocklists.loadAll()
         templatesById = templates.map(t => t.slug -> t).toMap
         bundledById   = bundled.map(b => b.id -> b).toMap
-        routes <- allRoutes(templatesById, bundledById, readyRef.get)
-        withCors = Cors.wrap(routes, cfg.cors)
+        routesAndRegistry <- allRoutes(templatesById, bundledById, readyRef.get)
+        (routes, wsRegistry) = routesAndRegistry
+        withCors             = Cors.wrap(routes, cfg.cors)
         _ <- ZIO
           .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
           .when(cfg.cors.origins.nonEmpty)
@@ -111,7 +112,7 @@ object Main extends ZIOAppDefault {
         // is idempotent (Flyway tracks applied migrations; ensureDefault is
         // ON CONFLICT DO NOTHING; the seeds are REPLACE / idempotent), so a retry
         // safely re-runs it from the start.
-        _            <- Database.withStartupRetry(cfg.db.resilience, "startup DB init") {
+        _             <- Database.withStartupRetry(cfg.db.resilience, "startup DB init") {
           for {
             _ <- Database.runMigrations(cfg.db)
             _ <- ZIO.logInfo("Database migrations complete")
@@ -158,8 +159,8 @@ object Main extends ZIOAppDefault {
         }
         // #1248: migrations + ensureDefault + seeds are done — flip readiness so
         // /api/health returns 200 and the gated routes start serving real traffic.
-        _            <- readyRef.set(true)
-        _            <- ZIO.logInfo("readiness flipped → /api/health healthy, API routes ungated")
+        _             <- readyRef.set(true)
+        _             <- ZIO.logInfo("readiness flipped → /api/health healthy, API routes ungated")
         // #809: scheduled re-aggregation of traffic_reports into the rollup
         // tables. #1230: cadence matches the tier each table is read at — hourly
         // tick re-rolls the trailing 2h every hour, daily tick re-rolls the
@@ -167,9 +168,25 @@ object Main extends ZIOAppDefault {
         // traffic_reports, not these tables). #1247: forkScoped (not forkDaemon)
         // into the run scope so they are interrupted before the Hikari pool
         // closes on shutdown; the fork never blocks startup either way.
-        rollupRepo   <- ZIO.service[wifihaven.api.db.RollupRepo]
-        clockForJobs <- ZIO.service[Clock]
-        _            <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
+        rollupRepo    <- ZIO.service[wifihaven.api.db.RollupRepo]
+        clockForJobs  <- ZIO.service[Clock]
+        // #1849: wire the computed-snapshot cache's push-on-change. Install the ws registry as the
+        // PolicyService push sink, then fork the reconcile ticker: every `snapshotCacheRefreshSeconds`
+        // it rebuilds the snapshot once and pushes it to every connected router IFF the ETag moved
+        // (schedule edges, daily-limit/usage transitions). This is the single rebuild point that
+        // keeps the cache warm so REST polls read it (#1512) and ws routers are pushed on change —
+        // not one ~500ms recompute per poll per router. forkScoped (like the rollup loops) so it is
+        // interrupted before the Hikari pool closes on shutdown. The first tick fires immediately;
+        // `reevaluate` swallows+logs a transient build failure and keeps the last good cache.
+        policyForPush <- ZIO.service[PolicyService]
+        _ <- policyForPush.setPublisher(new wifihaven.api.policy.PolicySnapshotPublisher {
+          def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =
+            wsRegistry.publishPolicy(snap)
+        })
+        _ <- policyForPush.reevaluate
+          .repeat(Schedule.fixed(cfg.policy.snapshotCacheRefreshInterval))
+          .forkScoped
+        _ <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
         _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkScoped
         // #1265: connection-event rollup tier — same cadence/lookback as the
         // traffic rollups, re-rolling the trailing windows into
@@ -421,7 +438,14 @@ object Main extends ZIOAppDefault {
           RollupAdminRoutes.routes(auth, rollupRepo2) ++
           RouterIngestRoutes.routes(routerAuth, routerIngest) ++
           // #1846: additive websocket transport. REST ingest/poll/metrics above stay fully live.
-          RouterWsRoutes.routes(routerAuth, wsRegistry, routerIngest, routerMetrics, routerRepo) ++
+          RouterWsRoutes.routes(
+            routerAuth,
+            wsRegistry,
+            routerIngest,
+            routerMetrics,
+            routerRepo,
+            policy,
+          ) ++
           RouterMetricsRoutes.routes(routerAuth, routerMetrics) ++
           AlertRoutes.routes(
             auth,
@@ -486,7 +510,7 @@ object Main extends ZIOAppDefault {
       // adds `status` because it sees the response. The middleware sits *inside*
       // HttpMetrics (so the same routes it counts also get logged) and *outside*
       // the readiness gate so even a gated 503 carries its route/method context.
-      HttpMetrics.instrument(
+      val assembled = HttpMetrics.instrument(
         healthRoutes ++
           LoggingMiddleware.annotate(
             Readiness.gate(
@@ -497,5 +521,8 @@ object Main extends ZIOAppDefault {
             ),
           ),
       ) ++ metricsRoutes
+      // #1849: hand the ws registry back so the run scope can wire it as PolicyService's push sink
+      // and fork the reconcile ticker (both need the run scope, which `allRoutes` is not).
+      (assembled, wsRegistry)
     }
 }

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -207,6 +207,13 @@ object MetricGuard {
     // no per-mac / per-host dimension ever rides a ws metric.
     "router_ws_connections_active"              -> Set.empty[String],
     "router_ws_frames_total"                    -> Set("op", "direction", "result"),
+    // #1849 — computed-snapshot cache + push-on-change. `policy_snapshot_build_total` splits policy
+    // snapshot accesses into `result` ∈ {computed, cache_hit} (proves the cache works);
+    // `router_ws_policy_push_total` is the push fan-out, `result` ∈ {ok, channel_closed}. Both are
+    // fixed 2-value enums — bounded, no per-mac / per-host dimension. (Without these entries the
+    // firewall would reject both names as unknown_name and the series would never emit.)
+    "policy_snapshot_build_total"               -> Set("result"),
+    "router_ws_policy_push_total"               -> Set("result"),
     // #1848 — AGENT-side websocket transport metrics. The wifihaven-ws sidecar has no metrics
     // registry of its own, so it writes a cumulative tally that the agent folds into its
     // /api/router/metrics push (the server attaches router_id / installation_id, as for every

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -504,6 +504,21 @@ object AppMetrics {
       Map("op" -> op, "direction" -> direction, "result" -> result),
     )
 
+  // #1849: counts policy-snapshot accesses split by whether they hit the computed-snapshot cache.
+  // `computed` = an actual PolicyService rebuild (the ~500ms #1512 work); `cache_hit` = served from
+  // the cache without rebuilding. The ratio proves the cache is working — once the reconcile ticker
+  // keeps the cache warm, REST polls and ws fan-outs should be overwhelmingly `cache_hit`, with
+  // `computed` tracking the change/tick rate rather than the poll rate. `result` is a fixed 2-value
+  // enum (bounded label, per docs/process/instrumentation.md).
+  def recordSnapshotBuild(result: String): UIO[Unit] =
+    MetricGuard.counter("policy_snapshot_build_total", Map("result" -> result))
+
+  // #1849: emitted by RouterWsRegistry.publishPolicy for each fan-out attempt of a changed snapshot.
+  // `result` ∈ {ok, channel_closed} — `ok` = the frame was handed to the channel, `channel_closed`
+  // = the send failed (a racing disconnect) and the channel is dropped. Bounded enum.
+  def recordWsPolicyPush(result: String): UIO[Unit] =
+    MetricGuard.counter("router_ws_policy_push_total", Map("result" -> result))
+
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
   // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds
   // the per-batch bucket-count deltas back into these registry histograms.

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -14,9 +14,41 @@ import java.time.{DayOfWeek, Instant, LocalDate}
 import java.util.concurrent.atomic.AtomicReference
 
 trait PolicyService {
+
+  /**
+   * The current policy snapshot. When the computed-snapshot cache is enabled (#1849, production
+   * wiring) this returns the cached snapshot on a hit (no rebuild — the #1512 win for the REST poll
+   * path) and only rebuilds on a cold/invalidated cache. With the cache disabled (the default for
+   * the `PolicyServiceLive.apply` test factory) it always rebuilds, so the existing snapshot specs
+   * that mutate the DB directly and re-read see fresh bytes.
+   */
   def snapshot: Task[PolicySnapshot]
   def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]]
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse]
+
+  /**
+   * #1849: drop the cached snapshot so the next [[snapshot]]/[[reevaluate]] rebuilds. Called by
+   * policy-mutating routes (pause/unpause, manual block/allow, profile/device/schedule/blocklist
+   * edits, time-extension grants) so an admin change propagates immediately rather than waiting for
+   * the reconcile ticker. A no-op when the cache is disabled.
+   */
+  def invalidate: UIO[Unit]
+
+  /**
+   * #1849: rebuild the snapshot once and, if its ETag moved since the last cached value, store it
+   * and push it to the configured [[PolicySnapshotPublisher]] (one `policy` frame per connected
+   * router). This is the single rebuild-and-publish point driven both by the time-boundary
+   * reconcile ticker (schedule edges, daily-limit/usage transitions) and immediately after an
+   * [[invalidate]]. A no-op when the cache is disabled.
+   */
+  def reevaluate: UIO[Unit]
+
+  /**
+   * #1849: install the sink that [[reevaluate]] pushes changed snapshots to. Wired once at startup
+   * (the websocket registry is constructed after the policy layer); until then the publisher is
+   * [[PolicySnapshotPublisher.noop]].
+   */
+  def setPublisher(publisher: PolicySnapshotPublisher): UIO[Unit]
 }
 
 object PolicyServiceLive {
@@ -44,6 +76,10 @@ object PolicyServiceLive {
       // (TimeStatusService) and the per-host /decision path. Defaults to the noop so the many specs
       // that don't exercise schedules keep their positional constructions unchanged.
       namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
+      // #1849: caching is opt-in. Defaulted OFF here so the ~40 direct test constructions (which
+      // mutate repos and re-read `snapshot` expecting fresh bytes) keep building every call; the
+      // production layer turns it on so the REST poll path reads the cache (#1512).
+      cacheEnabled: Boolean = false,
   ): PolicyServiceLive = {
     val tss = new TimeStatusServiceLive(
       profileRepo,
@@ -71,6 +107,7 @@ object PolicyServiceLive {
       clock,
       uiAllowedHosts,
       namedScheduleRepo,
+      cacheEnabled,
     )
   }
 }
@@ -102,7 +139,24 @@ class PolicyServiceLive(
     // directly only for the per-host /decision fallback, where the production layer wires the real
     // one.
     namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
+    // #1849: when true, `snapshot` reads/writes the computed-snapshot cache and `reevaluate` is
+    // active; when false (test default) every `snapshot` rebuilds and `invalidate`/`reevaluate` are
+    // no-ops. See the trait docs.
+    cacheEnabled: Boolean = false,
 ) extends PolicyService {
+
+  // #1849: the single cached `(etag, snapshot)`. Process-local `AtomicReference` (matching the
+  // existing `lastSnapshotEtag` style in this class) so the `apply` factory stays a pure
+  // constructor. For the single-household model there is exactly one global snapshot, so one slot
+  // suffices (design §6.2 ticker note). Populated on first build, refreshed by `reevaluate`, cleared
+  // by `invalidate`.
+  private val snapshotCache: AtomicReference[Option[(ETag, PolicySnapshot)]] =
+    new AtomicReference(Option.empty[(ETag, PolicySnapshot)])
+
+  // #1849: the push sink, installed at startup via `setPublisher`. Defaults to noop so a snapshot
+  // rebuilt before the registry exists (or in a test) is simply not pushed.
+  private val publisher: AtomicReference[PolicySnapshotPublisher] =
+    new AtomicReference(PolicySnapshotPublisher.noop)
 
   // #1318: the WifiHaven UI / block-page hosts are fleet-wide always-reachable
   // hosts, so they live in `global.extraAllowed` (carving out every block at the
@@ -136,7 +190,21 @@ class PolicyServiceLive(
         ),
       )
 
+  // #1849: cache-aware entry point. On a hit, return the cached snapshot and meter `cache_hit` — no
+  // rebuild, which is the #1512 win for both ws and (un-migrated) REST poll agents. On a cold or
+  // invalidated cache, rebuild once, store, and serve it. With the cache disabled, always rebuild.
+  // RED STUB (#1849): not yet implemented — always rebuilds, no cache read, no push.
   def snapshot: Task[PolicySnapshot] =
+    ZIO.succeed((cacheEnabled, snapshotCache.get)).flatMap(_ => buildSnapshot)
+
+  def invalidate: UIO[Unit] = ZIO.unit
+
+  def reevaluate: UIO[Unit] = ZIO.succeed(publisher.get).unit
+
+  def setPublisher(p: PolicySnapshotPublisher): UIO[Unit] =
+    ZIO.succeed(publisher.set(p))
+
+  private def buildSnapshot: Task[PolicySnapshot] =
     (for {
       settings <- householdSettingsRepo.get
       now      <- clock.instant
@@ -343,9 +411,13 @@ class PolicyServiceLive(
       (snap, profiles.count(_.defaultDeny))
     }).flatMap { case (snap, defaultDenyProfiles) =>
       // #1318: surface the global-section size + default-deny profile count for operators.
+      // #1849: every actual build is a `computed` sample of `policy_snapshot_build_total` — the
+      // cache-hit counterpart is metered in `snapshot`. The computed:cache_hit ratio is what proves
+      // the cache is doing its job (cache_hit should dominate once the ticker keeps it warm).
       AppMetrics
         .setGlobalPolicy(snap.global.extraAllowed.size, defaultDenyProfiles)
         .zipRight(logSnapshotChanged(snap))
+        .zipRight(AppMetrics.recordSnapshotBuild("computed"))
         .as(snap)
     }
 
@@ -697,6 +769,10 @@ object PolicyService {
         clk,
         cfg.policy.uiAllowedHostsParsed,
         nsr,
+        // #1849: production turns the computed-snapshot cache ON. The REST poll path then reads the
+        // cache (#1512), and the reconcile ticker (Main) + `invalidate` (mutating routes) keep it
+        // fresh and drive the push-on-change to connected ws routers.
+        cacheEnabled = true,
       )
   }
 

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -158,6 +158,15 @@ class PolicyServiceLive(
   private val publisher: AtomicReference[PolicySnapshotPublisher] =
     new AtomicReference(PolicySnapshotPublisher.noop)
 
+  // #1849: the last ETag we PUSHED, tracked separately from `snapshotCache` so the push-on-change
+  // decision is independent of the REST cache slot. This is what makes `invalidate` safe to clear
+  // the cache for immediate REST freshness: even if a racing REST poll rebuilds and repopulates
+  // `snapshotCache` with the new ETag before `reevaluate`'s compare runs, `reevaluate` still sees
+  // `lastPublishedEtag` at the OLD value and fires the push exactly once. The ticker then dedups
+  // against this same value so an unchanged tick never re-pushes.
+  private val lastPublishedEtag: AtomicReference[Option[ETag]] =
+    new AtomicReference(Option.empty[ETag])
+
   // #1318: the WifiHaven UI / block-page hosts are fleet-wide always-reachable
   // hosts, so they live in `global.extraAllowed` (carving out every block at the
   // router) rather than being copied into every profile's `extraAllowed`. (#1321
@@ -193,13 +202,45 @@ class PolicyServiceLive(
   // #1849: cache-aware entry point. On a hit, return the cached snapshot and meter `cache_hit` — no
   // rebuild, which is the #1512 win for both ws and (un-migrated) REST poll agents. On a cold or
   // invalidated cache, rebuild once, store, and serve it. With the cache disabled, always rebuild.
-  // RED STUB (#1849): not yet implemented — always rebuilds, no cache read, no push.
   def snapshot: Task[PolicySnapshot] =
-    ZIO.succeed((cacheEnabled, snapshotCache.get)).flatMap(_ => buildSnapshot)
+    if (!cacheEnabled) buildSnapshot
+    else
+      ZIO.succeed(snapshotCache.get).flatMap {
+        case Some((_, snap)) => AppMetrics.recordSnapshotBuild("cache_hit").as(snap)
+        case None            =>
+          buildSnapshot.tap(snap => ZIO.succeed(snapshotCache.set(Some((snap.etag, snap)))))
+      }
 
-  def invalidate: UIO[Unit] = ZIO.unit
+  def invalidate: UIO[Unit] =
+    if (!cacheEnabled) ZIO.unit
+    else
+      // Clear so the next REST poll rebuilds immediately (fresh bytes), and reconcile in the
+      // background so any connected ws router is pushed the change without blocking the mutating
+      // request on a ~500ms rebuild. Clearing is safe w.r.t. the push: `reevaluate` keys its push
+      // decision off `lastPublishedEtag`, NOT off the (now-cleared, possibly poll-repopulated) cache
+      // slot — so the push still fires exactly once even if a REST poll races in. The reconcile
+      // ticker is a backstop on the same bound.
+      ZIO.succeed(snapshotCache.set(None)) *> reevaluate.forkDaemon.unit
 
-  def reevaluate: UIO[Unit] = ZIO.succeed(publisher.get).unit
+  def reevaluate: UIO[Unit] =
+    if (!cacheEnabled) ZIO.unit
+    else
+      buildSnapshot.foldZIO(
+        err =>
+          // Keep the last good cache on a transient build failure (e.g. a DB blip) so the REST poll
+          // keeps serving the previous snapshot rather than a cold rebuild storm; the next tick
+          // retries.
+          ZIO.logWarning(s"policy reevaluate: snapshot rebuild failed, keeping cache: $err"),
+        snap => {
+          snapshotCache.set(Some((snap.etag, snap)))
+          // Push only when the ETag actually moved since the last PUSH — the same "change is exactly
+          // an ETag move" semantics the REST 200-vs-304 path uses (design §6.2), so we never fan out
+          // a frame the routers would treat as unchanged. Keyed off `lastPublishedEtag` (not the
+          // cache slot) so a racing REST poll repopulating the cache can't suppress the push.
+          val prevPublished = lastPublishedEtag.getAndSet(Some(snap.etag))
+          ZIO.when(!prevPublished.contains(snap.etag))(publisher.get.publish(snap)).unit
+        },
+      )
 
   def setPublisher(p: PolicySnapshotPublisher): UIO[Unit] =
     ZIO.succeed(publisher.set(p))

--- a/api/src/policy/PolicySnapshotPublisher.scala
+++ b/api/src/policy/PolicySnapshotPublisher.scala
@@ -1,0 +1,29 @@
+package wifihaven.api.policy
+
+import wifihaven.shared.PolicySnapshot
+import zio.*
+
+/**
+ * #1849: the sink a freshly-rebuilt [[PolicySnapshot]] is pushed to when policy actually changes
+ * (its ETag moved). The production implementation is the websocket connection registry
+ * ([[wifihaven.api.routes.RouterWsRegistry]]), which fans the snapshot out as one `policy` frame to
+ * every connected router channel — so a change is computed ONCE (in [[PolicyService.reevaluate]])
+ * and pushed, rather than recomputed once per poll per router (#1512).
+ *
+ * Kept as a tiny one-method seam in the `policy` package (rather than depending on the `routes`
+ * registry directly) so [[PolicyServiceLive]] has no compile dependency on the transport layer and
+ * tests can substitute a probe. `PolicyService` is wired to the real publisher imperatively at
+ * startup via [[PolicyService.setPublisher]] (the registry is constructed alongside the routes,
+ * after the policy layer), defaulting to [[PolicySnapshotPublisher.noop]] until then — so a
+ * snapshot rebuilt before the registry exists, or in a test that never sets a publisher, simply
+ * isn't pushed.
+ */
+trait PolicySnapshotPublisher {
+  def publish(snap: PolicySnapshot): UIO[Unit]
+}
+
+object PolicySnapshotPublisher {
+  val noop: PolicySnapshotPublisher = new PolicySnapshotPublisher {
+    def publish(snap: PolicySnapshot): UIO[Unit] = ZIO.unit
+  }
+}

--- a/api/src/routes/RouterWsRegistry.scala
+++ b/api/src/routes/RouterWsRegistry.scala
@@ -1,9 +1,12 @@
 package wifihaven.api.routes
 
 import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.policy.PolicySnapshotPublisher
+import wifihaven.shared.PolicySnapshot
 import wifihaven.shared.types.RouterId
 import zio.*
-import zio.http.WebSocketChannel
+import zio.http.{ChannelEvent, WebSocketChannel, WebSocketFrame}
+import zio.json.*
 
 /**
  * #1846: the per-router websocket connection registry. Tracks the live [[WebSocketChannel]]s open
@@ -35,17 +38,39 @@ trait RouterWsRegistry {
 
   /** Total open channels across all routers — backs `router_ws_connections_active`. */
   def activeCount: UIO[Int]
+
+  /**
+   * #1849: fan a freshly-changed snapshot out as one `policy` frame to every connected channel. The
+   * server-side end of push-on-change: [[wifihaven.api.policy.PolicyService.reevaluate]] calls this
+   * (via the [[PolicySnapshotPublisher]] seam) only when the snapshot's ETag actually moved, so a
+   * change is computed once and pushed, not recomputed per poll per router (#1512). A send failure
+   * (a racing disconnect) deregisters that channel and is metered `channel_closed`.
+   */
+  def publishPolicy(snap: PolicySnapshot): UIO[Unit]
+
+  /**
+   * #1849: push the current snapshot to a single freshly-connected channel (design §6.1 first-
+   * policy-on-connect), so a router that just opened the socket gets policy immediately rather than
+   * at the next change. A send failure is metered `channel_closed` (the caller's receive loop will
+   * deregister on close).
+   */
+  def pushPolicyTo(channel: WebSocketChannel, snap: PolicySnapshot): UIO[Unit]
 }
 
 object RouterWsRegistry {
 
   def make: UIO[RouterWsRegistry] =
     Ref.make(Map.empty[RouterId, Set[WebSocketChannel]]).map(new RouterWsRegistryLive(_))
+
+  /** The `{op:"policy", payload:<snapshot>}` envelope a pushed snapshot rides (design §1.2). */
+  private[routes] def policyFrameText(snap: PolicySnapshot): String =
+    s"""{"op":"policy","payload":${snap.toJson}}"""
 }
 
 final class RouterWsRegistryLive(
     state: Ref[Map[RouterId, Set[WebSocketChannel]]],
-) extends RouterWsRegistry {
+) extends RouterWsRegistry
+    with PolicySnapshotPublisher {
 
   // Recompute the live total and publish it. Called after every mutation so a deregister on
   // disconnect drives the gauge back down rather than leaving a stale high-water value.
@@ -73,4 +98,37 @@ final class RouterWsRegistryLive(
 
   def activeCount: UIO[Int] =
     state.get.map(_.valuesIterator.map(_.size).sum)
+
+  // The `PolicySnapshotPublisher` sink PolicyService.reevaluate pushes changed snapshots to.
+  def publish(snap: PolicySnapshot): UIO[Unit] = publishPolicy(snap)
+
+  def publishPolicy(snap: PolicySnapshot): UIO[Unit] =
+    state.get.flatMap { m =>
+      val frame = RouterWsRegistry.policyFrameText(snap)
+      ZIO.foreachDiscard(m.toList) { case (id, channels) =>
+        ZIO.foreachDiscard(channels)(ch => sendPolicyFrame(Some(id), ch, frame))
+      }
+    }
+
+  def pushPolicyTo(channel: WebSocketChannel, snap: PolicySnapshot): UIO[Unit] =
+    sendPolicyFrame(None, channel, RouterWsRegistry.policyFrameText(snap))
+
+  private def sendPolicyFrame(
+      id: Option[RouterId],
+      channel: WebSocketChannel,
+      frame: String,
+  ): UIO[Unit] =
+    channel
+      .send(ChannelEvent.read(WebSocketFrame.text(frame)))
+      .foldZIO(
+        _ =>
+          // A racing disconnect: meter the failed push and (when we know which router it was) drop
+          // the dead channel. The receive loop's `ensuring` also deregisters, but doing it here too
+          // keeps the gauge honest if the push raced ahead of the close event.
+          AppMetrics.recordWsPolicyPush("channel_closed") *>
+            ZIO.foreachDiscard(id)(deregister(_, channel)),
+        _ =>
+          AppMetrics.recordWsFrame("policy", "out", "ok") *>
+            AppMetrics.recordWsPolicyPush("ok"),
+      )
 }

--- a/api/src/routes/RouterWsRoutes.scala
+++ b/api/src/routes/RouterWsRoutes.scala
@@ -3,6 +3,7 @@ package wifihaven.api.routes
 import wifihaven.api.db.RouterRepo
 import wifihaven.api.metrics.{AppMetrics, RouterMetricsService}
 import wifihaven.api.observability.LogContext
+import wifihaven.api.policy.PolicyService
 import wifihaven.shared.{Router, RouterMetricsBatch}
 import zio.*
 import zio.http.*
@@ -44,6 +45,7 @@ object RouterWsRoutes {
       ingest: RouterIngestService,
       metricsSvc: RouterMetricsService,
       routerRepo: RouterRepo,
+      policy: PolicyService,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "router" / "ws" ->
@@ -54,7 +56,8 @@ object RouterWsRoutes {
             .authenticate(req)
             .foldZIO(
               err => ZIO.succeed(ErrorMapper.errorToResponse(err)),
-              router => socketApp(router, registry, ingest, metricsSvc, routerRepo).toResponse,
+              router =>
+                socketApp(router, registry, ingest, metricsSvc, routerRepo, policy).toResponse,
             )
         },
     )
@@ -65,6 +68,7 @@ object RouterWsRoutes {
       ingest: RouterIngestService,
       metricsSvc: RouterMetricsService,
       routerRepo: RouterRepo,
+      policy: PolicyService,
   ): WebSocketApp[Any] =
     Handler.webSocket { channel =>
       // Register once the upgrade handshake completes; deregister unconditionally on exit (normal
@@ -74,8 +78,20 @@ object RouterWsRoutes {
       channel
         .receiveAll {
           case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            // #1849: register, then push the current snapshot once so a freshly-connected router
+            // has policy immediately (design §6.1). A snapshot-build failure must not tear the
+            // socket down — log and carry on; the router still gets the next push-on-change and can
+            // fall back to the REST poll.
             registry.register(router.id, channel) *>
-              ZIO.logInfo(s"router ws: connected router=${router.id}")
+              ZIO.logInfo(s"router ws: connected router=${router.id}") *>
+              policy.snapshot
+                .flatMap(registry.pushPolicyTo(channel, _))
+                .catchAllCause(c =>
+                  ZIO.logWarningCause(
+                    s"router ws: first-policy push failed router=${router.id}",
+                    c,
+                  ),
+                )
           case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
             // A dispatch failure (e.g. a send error) tears this frame's handling down; log the cause
             // so a transport-level fault is debuggable, then let it surface (the socket closes and

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -233,6 +233,11 @@ object ProfileRoutes {
       // can bust the cached ProfileTimeStatus the same way `/api/time/extend` does. Defaulted so
       // the many test call sites that don't exercise caching keep their existing arity.
       cache: TimeStatusCache = TimeStatusCache.makeUnsafe(),
+      // #1849: drop the computed-snapshot cache when this profile's policy changes (pause, schedule
+      // attach, default-deny, time limit, categories, create/delete) so the change propagates to the
+      // fleet at once rather than waiting for the reconcile ticker. Defaulted to a no-op so test call
+      // sites keep their arity; production passes `policy.invalidate`.
+      invalidateSnapshot: UIO[Unit] = ZIO.unit,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "profiles"                            ->
@@ -326,6 +331,9 @@ object ProfileRoutes {
             // for schedule", so bust its cached ProfileTimeStatus the same way /api/time/extend
             // does — otherwise a detach keeps showing a stale block for up to the today-TTL.
             _      <- cache.invalidateProfile(pid)
+            // #1849: the attached schedule set is snapshot content, so drop the computed-snapshot
+            // cache too.
+            _      <- invalidateSnapshot
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -374,6 +382,8 @@ object ProfileRoutes {
             _    <- ZIO
               .foreachDiscard(upr.timeLimit)(mins => timeLimitRepo.upsert(id, mins))
               .mapError(ApiError.Db(_))
+            // #1849: a new profile changes the snapshot's profile set.
+            _    <- invalidateSnapshot
           } yield Response.json(s"""{"id":${id.value}}""")
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -429,6 +439,9 @@ object ProfileRoutes {
               case Some(mins) => timeLimitRepo.upsert(pid, mins)
               case None       => timeLimitRepo.delete(pid)
             }).mapError(ApiError.Db(_))
+            // #1849: a full-replace PUT can move paused / categories / failureMode / blockIpOnly /
+            // defaultDeny / timeLimit — all snapshot content.
+            _      <- invalidateSnapshot
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -442,6 +455,8 @@ object ProfileRoutes {
               // but the snapshot would briefly miss the household-wide allow/block lists.
               requireNotGlobalProfile(profileRepo, pid, "profile (DELETE)") *>
               profileRepo.delete(pid).mapError(ApiError.Db(_)) *>
+              // #1849: a deleted profile drops out of the snapshot's profile set.
+              invalidateSnapshot *>
               ZIO.succeed(Response.ok)
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -596,6 +611,10 @@ object ProfileRoutes {
             _                       <- ZIO.when(
               pausedPatch != FieldPatch.Absent || timeLimitPatch != FieldPatch.Absent,
             )(cache.invalidateProfile(pid))
+            // #1849: any recognized patch (pause, pauseMode, defaultDeny, timeLimit, name,
+            // categories) is snapshot content, so drop the computed-snapshot cache so the change
+            // reaches the fleet at once.
+            _                       <- invalidateSnapshot
             // Log only recognized keys; unknown keys are ignored per the
             // backwards-compat rule and would mislead ops triage if echoed.
             recognizedKeys = obj.fields.map(_._1).filter(ProfileRoutes.PatchableKeys.contains)
@@ -655,6 +674,11 @@ object DeviceRoutes {
       // a 400 before any DB write. The repo-layer guard (`DeviceRepoLive.upsert`) is a defensive
       // backstop.
       profileRepo: ProfileRepo,
+      // #1849: a device's profile assignment (or its existence) is snapshot content — drop the
+      // computed-snapshot cache on upsert/delete/reassign so the change reaches the fleet at once.
+      // Defaulted to a no-op so test call sites keep their arity; production passes
+      // `policy.invalidate`.
+      invalidateSnapshot: UIO[Unit] = ZIO.unit,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "devices"                    ->
@@ -703,6 +727,7 @@ object DeviceRoutes {
                 )
               }
             }
+            _  <- invalidateSnapshot
           } yield Response.json(s"""{"id":${id.value}}""")
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -721,6 +746,7 @@ object DeviceRoutes {
             _        <- LogContext.annotate(LogContext.Mac, normalized.value)(
               ZIO.logInfo(s"device deleted: mac=${normalized.value}"),
             )
+            _        <- invalidateSnapshot
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -774,6 +800,7 @@ object DeviceRoutes {
                 )
               }
             }
+            _ <- invalidateSnapshot
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -805,6 +832,10 @@ object TimeRoutes {
       timeStatusService: wifihaven.api.policy.TimeStatusService,
       clock: Clock,
       cache: TimeStatusCache = TimeStatusCache.makeUnsafe(),
+      // #1849: a +Time grant can flip a profile's daily-limit block off, which is snapshot content —
+      // drop the computed-snapshot cache so the fleet sees the unblock at once. Defaulted to a no-op
+      // for test call sites; production passes `policy.invalidate`.
+      invalidateSnapshot: UIO[Unit] = ZIO.unit,
   ): Routes[Any, Response] =
     Routes(
       // #777 — collapsed accordion summary. One batched presence query over ALL devices
@@ -1147,6 +1178,9 @@ object TimeRoutes {
             // #946: bust the cached ProfileTimeStatus for this profile so the SPA's next
             // refetch reflects the new cap immediately instead of waiting up to todayTtl.
             _  <- cache.invalidateProfile(ger.profileId)
+            // #1849: a grant can lift a TimeLimit block — snapshot content — so drop the
+            // computed-snapshot cache too.
+            _  <- invalidateSnapshot
           } yield Response.json(s"""{"id":${id.value},"grantedMinutes":${ger.extraMinutes}}""")
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -1843,6 +1877,11 @@ object HouseholdSettingsRoutes {
   def routes(
       auth: AuthService,
       repo: HouseholdSettingsRepo,
+      // #1849: unmanagedMacPolicy and blockEncryptedDns are snapshot content (the former drives the
+      // unmanaged-MAC block rules, the latter the top-level `blockEncryptedDns` flag), so drop the
+      // computed-snapshot cache on a settings write. Defaulted to a no-op for test call sites;
+      // production passes `policy.invalidate`.
+      invalidateSnapshot: UIO[Unit] = ZIO.unit,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "household" / "settings"   ->
@@ -1876,6 +1915,7 @@ object HouseholdSettingsRoutes {
                 ),
               )
               .mapError(ApiError.Db(_))
+            _    <- invalidateSnapshot
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -1946,6 +1986,7 @@ object HouseholdSettingsRoutes {
               blockEncryptedDns = bedPatch.applyTo(existing.blockEncryptedDns),
             )
             _            <- repo.update(merged).mapError(ApiError.Db(_))
+            _            <- invalidateSnapshot
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },

--- a/api/src/routes/ScheduleRoutes.scala
+++ b/api/src/routes/ScheduleRoutes.scala
@@ -53,6 +53,13 @@ object ScheduleRoutes {
   def routes(
       auth: AuthService,
       scheduleRepo: NamedScheduleRepo,
+      // #1849: editing/deleting a named schedule changes the per-MAC `blocked` flag for every
+      // profile that references it (PolicyService folds the windows in at snapshot time), so drop
+      // the computed-snapshot cache on a schedule mutation. Defaulted to a no-op for test call sites;
+      // production passes `policy.invalidate`. Create alone is NOT invalidated: a brand-new schedule
+      // is referenced by no profile, so it is invisible to the snapshot until a profile attaches it
+      // via PUT /api/profiles/{id}/schedules — which invalidates there.
+      invalidateSnapshot: UIO[Unit] = ZIO.unit,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "schedules"                 ->
@@ -130,6 +137,7 @@ object ScheduleRoutes {
                 ZIO.fromOption(_).orElseFail(ApiError.Internal("Schedule vanished")),
               )
             _       <- AppMetrics.scheduleMutation("update")
+            _       <- invalidateSnapshot
           } yield Response.json(s.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -140,6 +148,7 @@ object ScheduleRoutes {
               scheduleRepo
                 .delete(NamedScheduleId(id))
                 .mapError(ApiError.Db(_)) *>
+              invalidateSnapshot *>
               AppMetrics.scheduleMutation("delete").as(Response.ok)
           handle.mapError(ErrorMapper.errorToResponse)
         },

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -219,6 +219,10 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           ZIO.succeed(
             RouterDecisionResponse(ConnectionDecision.Block, "future_app:slack", None),
           )
+        def invalidate: UIO[Unit]                                               = ZIO.unit
+        def reevaluate: UIO[Unit]                                               = ZIO.unit
+        def setPublisher(publisher: wifihaven.api.policy.PolicySnapshotPublisher): UIO[Unit] =
+          ZIO.unit
       }
       for {
         _   <- cleanDb
@@ -249,6 +253,10 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           ZIO.dieMessage("renderBlocklist unused in this test")
         def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
           ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Block, wire, None))
+        def invalidate: UIO[Unit]                                               = ZIO.unit
+        def reevaluate: UIO[Unit]                                               = ZIO.unit
+        def setPublisher(publisher: wifihaven.api.policy.PolicySnapshotPublisher): UIO[Unit] =
+          ZIO.unit
       }
       // Each entry is (wire reason string emitted by decide(), expected reasonClass).
       // The expected value is taken directly from the case's `wireKind` — if a

--- a/api/test/src/feature/MetricCardinalityGuardSpec.scala
+++ b/api/test/src/feature/MetricCardinalityGuardSpec.scala
@@ -60,6 +60,13 @@ object MetricCardinalityGuardSpec extends ZIOSpecDefault {
   private val AgentEmit =
     """metrics\.(?:inc_counter|set_gauge|observe)\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]+)"""".r
 
+  // #1849: `MetricGuard.counter("name"...)` / `.gauge` / `.histogram` with a string-literal name.
+  // The guard REJECTS a name not in `Allowed` at runtime (`check` → `unknown_name`), so a series
+  // routed through the guard but missing from the allowlist emits NOTHING — a silent dead metric the
+  // `BareEmit` scan above does NOT catch (it only sees bare `Metric.*`). This regex closes that gap.
+  private val GuardEmit =
+    """MetricGuard\.(?:counter|gauge|histogram|summary|frequency)\(\s*"([^"]+)"""".r
+
   // The firewall's own reject counter is emitted with a bare literal by design — it is the gate, so
   // it does not itself live in the allowlist.
   private val GuardInternal = Set("metrics_rejected_total")
@@ -71,6 +78,16 @@ object MetricCardinalityGuardSpec extends ZIOSpecDefault {
           .flatMap(p => BareEmit.findAllMatchIn(readAll(p)).map(_.group(1)))
           .toSet
       val unallowed = names -- MetricGuard.Allowed.keySet -- GuardInternal
+      assertTrue(unallowed.isEmpty)
+    },
+    test(
+      "every MetricGuard.* literal series in api/src is allowlisted (no silent unknown_name drop)",
+    ) {
+      val names     =
+        scalaFilesUnder("api/src")
+          .flatMap(p => GuardEmit.findAllMatchIn(readAll(p)).map(_.group(1)))
+          .toSet
+      val unallowed = names -- MetricGuard.Allowed.keySet
       assertTrue(unallowed.isEmpty)
     },
     test("every metric name the OpenWRT agent emits is allowlisted") {

--- a/api/test/src/feature/PolicySnapshotCacheSpec.scala
+++ b/api/test/src/feature/PolicySnapshotCacheSpec.scala
@@ -148,23 +148,25 @@ object PolicySnapshotCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
         snap2 <- svc.snapshot
       } yield assertTrue(snap2.blockEncryptedDns) && assertTrue(snap2.etag != snap1.etag)
     },
-    test("reevaluate rebuilds and pushes to the publisher exactly when the ETag moves") {
+    test(
+      "reevaluate pushes once per ETag change — the first establishes the baseline, an unchanged re-eval does not re-push",
+    ) {
       for {
         _      <- cleanDb
         triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
         (svc, _, pushed) = triple
-        _           <- svc.snapshot   // warm the cache
-        _           <- svc.reevaluate // unchanged state → no push
-        afterNoop   <- pushed.get
-        _           <- setBlockEncryptedDns(true)
-        _           <- svc.invalidate // clear cache so reevaluate sees the new etag vs prev
-        // `invalidate` cleared the cache; reevaluate rebuilds, sees a different etag than the (now
-        // empty) prev, and pushes once.
-        _           <- svc.reevaluate
-        afterChange <- pushed.get
-      } yield assertTrue(afterNoop.isEmpty) &&
-        assertTrue(afterChange.size == 1) &&
-        assertTrue(afterChange.head.blockEncryptedDns)
+        _             <- svc.reevaluate // first reevaluate establishes + pushes the baseline
+        afterBaseline <- pushed.get
+        _             <- svc.reevaluate // unchanged state → no new push
+        afterNoop     <- pushed.get
+        _             <- setBlockEncryptedDns(true)
+        _             <- svc.reevaluate // ETag moved → exactly one more push
+        afterChange   <- pushed.get
+      } yield assertTrue(afterBaseline.size == 1) &&
+        assertTrue(afterNoop.size == 1) && // no re-push on the unchanged re-eval
+        assertTrue(afterChange.size == 2) &&
+        assertTrue(!afterBaseline.head.blockEncryptedDns) &&
+        assertTrue(afterChange.last.blockEncryptedDns)
     },
     test(
       "a schedule boundary crossed with no DB write is caught + pushed by reevaluate (the ticker mechanism)",

--- a/api/test/src/feature/PolicySnapshotCacheSpec.scala
+++ b/api/test/src/feature/PolicySnapshotCacheSpec.scala
@@ -1,0 +1,191 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDateTime, LocalTime, ZoneId}
+
+/**
+ * #1849: the computed-snapshot cache in PolicyService + push-on-change. Pins the four properties
+ * the cache must have, all behavior-preserving (same snapshot bytes for a given state — #1512):
+ *
+ *   1. With the cache ON, a second `snapshot` is served from the cache (does NOT rebuild), so a DB
+ *      change made WITHOUT invalidating is not yet visible — proving the read path is cached. 2.
+ *      `invalidate` (what mutating routes call) drops the cache so the next `snapshot` reflects the
+ *      change — proving invalidation works. 3. `reevaluate` (what the reconcile ticker +
+ *      post-mutation reconcile call) rebuilds, and pushes the new snapshot to the publisher IFF the
+ *      ETag moved — proving push-on-change (and that an unchanged state does NOT spam a push). 4. A
+ *      time-dependent transition (a schedule boundary crossed with NO DB write) is caught by
+ *      `reevaluate` — the ticker mechanism — and pushed, even though `invalidate` was never called.
+ *
+ * The default `apply` factory leaves the cache OFF (so the ~40 other snapshot specs keep building
+ * every call); these tests construct with `cacheEnabled = true` explicitly.
+ */
+object PolicySnapshotCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  /**
+   * A probe publisher that records every pushed snapshot, so a test can assert push count + bytes.
+   */
+  private final class ProbePublisher(ref: Ref[List[PolicySnapshot]])
+      extends PolicySnapshotPublisher {
+    def publish(snap: PolicySnapshot): UIO[Unit] = ref.update(_ :+ snap)
+  }
+
+  /**
+   * Build a cache-ENABLED PolicyService over a clock backed by `ref` (so a test can advance time to
+   * cross a schedule boundary), with a probe publisher attached. Returns the service, the clock
+   * ref, and the probe's record.
+   */
+  private def makeCachedSvc(startAt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      ref    <- Ref.make(startAt)
+      clk = new Clock.TestClock(ref)
+      tss = new TimeStatusServiceLive(pr, tlr, atlr, dr, trRepo, er, NoopTimeUsedRollupRepo, nsr)
+      svc = new PolicyServiceLive(
+        pr,
+        hsr,
+        tlr,
+        atlr,
+        dr,
+        blr,
+        trRepo,
+        er,
+        ar,
+        tss,
+        clk,
+        namedScheduleRepo = nsr,
+        cacheEnabled = true,
+      )
+      pushed <- Ref.make(List.empty[PolicySnapshot])
+      _      <- svc.setPublisher(new ProbePublisher(pushed))
+    } yield (svc, ref, pushed)
+
+  private def blockedMacs(snap: PolicySnapshot): List[String] =
+    snap.devices.toList.flatMap { case (mac, dev) =>
+      val rules = dev.rules.orElse(dev.profileId.flatMap(snap.profiles.get).map(_.rules))
+      rules.filter(_.blocked).map(_ => mac.value)
+    }
+
+  // A profile with NO legacy schedules, linked to a bedtime (21:00–07:00) named schedule + a device.
+  private def seedBedtime =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      nsr <- ZIO.service[NamedScheduleRepo]
+      dr  <- ZIO.service[DeviceRepo]
+      pid <- pr.create("Kids", Nil)
+      sid <- nsr.create(
+        "Bedtime",
+        Some("overnight"),
+        List(
+          ScheduleWindow(
+            List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
+            LocalTime.of(21, 0),
+            LocalTime.of(7, 0),
+            ZoneId.of("UTC"),
+          ),
+        ),
+      )
+      _   <- nsr.setProfileBlockSchedules(pid, List(sid))
+      _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", pid)
+    } yield pid
+
+  private def setBlockEncryptedDns(v: Boolean) =
+    for {
+      hsr      <- ZIO.service[HouseholdSettingsRepo]
+      existing <- hsr.get
+      _        <- hsr.update(existing.copy(blockEncryptedDns = v))
+    } yield ()
+
+  def spec = suite("PolicySnapshot — computed-snapshot cache + push-on-change (#1849)")(
+    test(
+      "a second snapshot is served from the cache — a DB change made without invalidate is not yet visible",
+    ) {
+      for {
+        _      <- cleanDb
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
+        (svc, _, _) = triple
+        snap1 <- svc.snapshot
+        // Mutate the DB directly, bypassing `invalidate` (as a stale poll would observe it).
+        _     <- setBlockEncryptedDns(true)
+        snap2 <- svc.snapshot
+      } yield assertTrue(snap2.etag == snap1.etag) &&
+        assertTrue(!snap2.blockEncryptedDns) // still the cached (pre-change) bytes
+    },
+    test(
+      "invalidate drops the cache so the next snapshot reflects the change (same bytes a fresh build would give)",
+    ) {
+      for {
+        _      <- cleanDb
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
+        (svc, _, _) = triple
+        snap1 <- svc.snapshot
+        _     <- setBlockEncryptedDns(true)
+        _     <- svc.invalidate
+        // `invalidate` clears the cache synchronously; the next read rebuilds. (It also forks a
+        // background reconcile, but we don't depend on that fiber here.)
+        snap2 <- svc.snapshot
+      } yield assertTrue(snap2.blockEncryptedDns) && assertTrue(snap2.etag != snap1.etag)
+    },
+    test("reevaluate rebuilds and pushes to the publisher exactly when the ETag moves") {
+      for {
+        _      <- cleanDb
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
+        (svc, _, pushed) = triple
+        _           <- svc.snapshot   // warm the cache
+        _           <- svc.reevaluate // unchanged state → no push
+        afterNoop   <- pushed.get
+        _           <- setBlockEncryptedDns(true)
+        _           <- svc.invalidate // clear cache so reevaluate sees the new etag vs prev
+        // `invalidate` cleared the cache; reevaluate rebuilds, sees a different etag than the (now
+        // empty) prev, and pushes once.
+        _           <- svc.reevaluate
+        afterChange <- pushed.get
+      } yield assertTrue(afterNoop.isEmpty) &&
+        assertTrue(afterChange.size == 1) &&
+        assertTrue(afterChange.head.blockEncryptedDns)
+    },
+    test(
+      "a schedule boundary crossed with no DB write is caught + pushed by reevaluate (the ticker mechanism)",
+    ) {
+      for {
+        _      <- cleanDb
+        _      <- seedBedtime
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
+        (svc, ref, pushed) = triple
+        snapDay   <- svc.snapshot               // 14:00 — not in bedtime window
+        // Cache holds the 14:00 bytes; advancing the clock alone does not change them.
+        _         <- ref.set(TestClock.bedtime) // 21:30 — now inside the bedtime window
+        snapStale <- svc.snapshot               // still the cached (un-blocked) snapshot
+        _         <- svc.reevaluate             // the ticker re-eval catches the boundary
+        snapFresh <- svc.snapshot
+        pushes    <- pushed.get
+      } yield assertTrue(blockedMacs(snapDay).isEmpty) &&
+        assertTrue(blockedMacs(snapStale).isEmpty) && // cache held across the time move
+        assertTrue(blockedMacs(snapFresh) == List("aa:bb:cc:11:22:33")) &&
+        assertTrue(pushes.size == 1) &&               // pushed once, on the transition
+        assertTrue(blockedMacs(pushes.head) == List("aa:bb:cc:11:22:33"))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/RouterWsSpec.scala
+++ b/api/test/src/feature/RouterWsSpec.scala
@@ -4,6 +4,7 @@ import wifihaven.api.{ErrorBoundary, Readiness}
 import wifihaven.api.db.*
 import wifihaven.api.metrics.{HttpMetrics, RouterMetricsService}
 import wifihaven.api.observability.LoggingMiddleware
+import wifihaven.api.policy.PolicyServiceLive
 import wifihaven.api.routes.*
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -62,16 +63,26 @@ object RouterWsSpec
       cRepo   <- ZIO.service[ConnectionEventRepo]
       aRepo   <- ZIO.service[AlertRepo]
       hsr     <- ZIO.service[HouseholdSettingsRepo]
+      pRepo   <- ZIO.service[ProfileRepo]
+      tlr     <- ZIO.service[TimeLimitRepo]
+      atlr    <- ZIO.service[AppTimeLimitRepo]
+      er      <- ZIO.service[TimeExtensionRepo]
+      ar      <- ZIO.service[AppRepo]
+      clk     <- ZIO.service[Clock]
+      blr     <- ZIO.service[BlocklistRepo]
       metrics <- RouterMetricsService.make
       reg     <- RouterWsRegistry.make
       auth   = new RouterAuthLive(rRepo)
       ingest = new RouterIngestService(rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr)
+      // #1849: a PolicyService so the ws endpoint can push the current snapshot on connect. Cache
+      // off here (the `apply` default) — the connect push reads `snapshot`, which builds fresh.
+      policy = PolicyServiceLive(pRepo, hsr, tlr, atlr, dRepo, blr, tRepo, er, ar, clk)
       // Mount the ws route through the SAME aspect stack `Main` wraps the router routes in
       // (HttpMetrics.instrument → LoggingMiddleware.annotate → Readiness.gate → ErrorBoundary.observe)
       // so the test proves the HTTP/1.1 upgrade survives the production middleware, not just the raw
       // route. These aspects are response-transparent for a websocket Response, but pinning it here
       // closes the gap between the test path and the assembled prod path.
-      raw    = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo)
+      raw    = RouterWsRoutes.routes(auth, reg, ingest, metrics, rRepo, policy)
       routes = HttpMetrics.instrument(
         LoggingMiddleware.annotate(
           Readiness.gate(ErrorBoundary.observe(raw), ZIO.succeed(true)),
@@ -80,41 +91,48 @@ object RouterWsSpec
     } yield (routes, reg)
 
   /**
-   * Open a ws connection to the bound server, run `clientBehavior` (which drives the channel and
-   * resolves `firstServerText` with the first text frame the server sends back), and return that
-   * frame. Connects with the given bearer header.
+   * Open a ws connection to the bound server, drive it with `send` on handshake, and collect every
+   * text frame the server sends. Resolves once a frame satisfies `until` (so a test can wait for
+   * the specific `ack`/`pong`/`policy` it cares about, ignoring the others — #1849's connect push
+   * means a `policy` frame now arrives first, ahead of any ack/pong). Returns the matching frame,
+   * ALL frames received up to that point, and the probe result. Connects with the given bearer
+   * header.
    */
   private def connectAndCapture[B](
       port: Int,
       bearer: Option[String],
       send: WebSocketChannel => ZIO[Any, Throwable, Unit],
       probe: ZIO[Any, Throwable, B],
-  ): ZIO[Client, Throwable, (String, B)] =
-    Promise.make[Nothing, String].flatMap { firstServerText =>
-      val app     = Handler.webSocket { channel =>
+      until: String => Boolean = _ => true,
+  ): ZIO[Client, Throwable, (String, Chunk[String], B)] =
+    for {
+      matched <- Promise.make[Nothing, String]
+      frames  <- Ref.make(Chunk.empty[String])
+      app     = Handler.webSocket { channel =>
         channel.receiveAll {
           case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
             send(channel)
           case ChannelEvent.Read(WebSocketFrame.Text(t))                    =>
-            firstServerText.succeed(t).unit
+            frames.update(_ :+ t) *> ZIO.when(until(t))(matched.succeed(t)).unit
           case _                                                            =>
             ZIO.unit
         }
       }
-      val headers = bearer.fold(Headers.empty)(t => Headers(Header.Authorization.Bearer(t)))
+      headers = bearer.fold(Headers.empty)(t => Headers(Header.Authorization.Bearer(t)))
       // Drive the connection in a LOCAL scope closed as soon as we have the server's reply, so the
       // ws fiber is interrupted promptly and the test does not wait on connection teardown. `probe`
       // runs INSIDE the scope (connection still open) so a registry-liveness check observes the live
       // channel rather than racing the post-scope deregister.
-      ZIO.scoped {
+      result <- ZIO.scoped {
         for {
-          _ <- app.connect(s"ws://localhost:$port/api/router/ws", headers).forkScoped
-          t <- firstServerText.await
-            .timeoutFail(new RuntimeException("no server frame within 30s"))(30.seconds)
-          b <- probe
-        } yield (t, b)
+          _   <- app.connect(s"ws://localhost:$port/api/router/ws", headers).forkScoped
+          t   <- matched.await
+            .timeoutFail(new RuntimeException("no matching server frame within 30s"))(30.seconds)
+          all <- frames.get
+          b   <- probe
+        } yield (t, all, b)
       }
-    }
+    } yield result
 
   def spec = suite("Router websocket /api/router/ws")(
     test("rejects the upgrade with 401 when the bearer token is missing or invalid") {
@@ -158,12 +176,15 @@ object RouterWsSpec
           Some(tk),
           ch => ch.send(ChannelEvent.read(WebSocketFrame.text(frame))),
           reg.isConnected(id),
+          until = _.contains("\"op\":\"ack\""),
         )
-        (ack, connected) = result
+        (ack, all, connected) = result
         rows <- tRepo.listForRouter(id, 100)
       } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
         assertTrue(ack.contains("\"status\":\"ok\"")) &&
         assertTrue(ack.contains("\"seq\":7")) &&
+        // #1849: the connect-time policy push arrives before the ack.
+        assertTrue(all.exists(_.contains("\"op\":\"policy\""))) &&
         assertTrue(rows.size == 1) &&
         assertTrue(connected)).provideSome[
         TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
@@ -181,9 +202,38 @@ object RouterWsSpec
           Some(tk),
           ch => ch.send(ChannelEvent.read(WebSocketFrame.text("""{"op":"ping"}"""))),
           ZIO.unit,
+          until = _.contains("\"op\":\"pong\""),
         )
         pong = result._1
       } yield assertTrue(pong.contains("\"op\":\"pong\""))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    test("#1849: a freshly-connected router is pushed the current policy snapshot on connect") {
+      (for {
+        _           <- cleanDb
+        rRepo       <- ZIO.service[RouterRepo]
+        pRepo       <- ZIO.service[ProfileRepo]
+        dRepo       <- ZIO.service[DeviceRepo]
+        _           <- seedKnownDevice(dRepo, pRepo)
+        (_, tk)     <- seedRouter(rRepo)
+        (routes, _) <- buildWsRoutes
+        port        <- Server.install(routes)
+        // Send nothing; just wait for the server's unsolicited first-policy push.
+        result      <- connectAndCapture(
+          port,
+          Some(tk),
+          _ => ZIO.unit,
+          ZIO.unit,
+          until = _.contains("\"op\":\"policy\""),
+        )
+        policyFrame = result._1
+      } yield
+      // The pushed frame is the `{op:"policy", payload:<snapshot>}` envelope carrying the real
+      // snapshot — it must include the device the snapshot enumerates and an etag.
+      assertTrue(policyFrame.contains("\"op\":\"policy\"")) &&
+        assertTrue(policyFrame.contains("\"etag\"")) &&
+        assertTrue(policyFrame.contains(knownMac))).provideSome[
         TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
       ](Server.defaultWithPort(0), Client.default)
     },

--- a/deploy/grafana/dashboards/router-ws-transport.json
+++ b/deploy/grafana/dashboards/router-ws-transport.json
@@ -502,6 +502,120 @@
           "refId": "B"
         }
       ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Policy snapshot builds: computed vs cache_hit (#1849 / #1512)",
+      "description": "sum by (result) (rate(policy_snapshot_build_total[5m])) \u2014 proves the computed-snapshot cache is working. result=computed is an actual ~500ms PolicyService rebuild (the #1512 cost); result=cache_hit is a poll/ws-fanout served from the cache without rebuilding. Once the reconcile ticker keeps the cache warm, cache_hit should dominate and computed should track the policy-change/tick rate (\u22481 per snapshotCacheRefreshSeconds), NOT the per-poll-per-router rate. A computed rate that scales with router count means the cache is not being read.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(policy_snapshot_build_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "WS policy push fan-out by result (#1849)",
+      "description": "sum by (result) (rate(router_ws_policy_push_total[5m])) \u2014 health of the push-on-change fan-out. result=ok is a policy frame handed to a connected channel; result=channel_closed is a send that failed against a racing disconnect (the channel is dropped). A sustained channel_closed share suggests routers are churning their sockets.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(router_ws_policy_push_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## What

Implements the **computed-snapshot cache in `PolicyService`** (#1512) and **push-on-change** for the websocket transport (design [`§6.2`](docs/design/websocket-transport.md)). Sub-issue **E** of the ws-transport epic.

The snapshot used to be recomputed (~500 ms) on **every** `GET /api/router/policy` poll. Now:

- **The REST poll path reads the cache** — a `cache_hit` is served without rebuilding, so un-migrated HTTP agents stop paying the per-poll recompute too. #1512 improves for everyone the moment this lands, independent of transport.
- **On change, the snapshot is rebuilt once and pushed** to every connected ws router (one `policy` frame) — computed once per change, not once per poll per router.

**Behavior-preserving — same snapshot bytes for a given state.** The cache is opt-in: OFF for the `PolicyServiceLive.apply` test factory (so the ~40 existing snapshot specs keep building fresh every call), ON in the production layer.

## How it stays correct (the invalidation set)

A change is **exactly an ETag move** (the existing 200-vs-304 semantics), so nothing new defines "change". Two mechanisms keep the cache fresh:

1. **Explicit `invalidate`** on the policy-authoring mutation routes — pause/unpause, profile create/update/patch/delete, schedule attach + named-schedule edit/delete, device upsert/patch/delete, household settings (unmanaged policy / `blockEncryptedDns`), and `/api/time/extend` — co-located with the existing `TimeStatusCache` busts. Clears the cache (immediate REST freshness) and forks a background reconcile (push) so the mutating request isn't blocked on a rebuild.
2. **A reconcile ticker** (`policy.snapshotCacheRefreshSeconds`, default **5 s = the agent `policy_poll_interval`**) rebuilds and pushes-on-change, catching the **time/usage-dependent transitions** that have no mutation event — schedule boundaries, daily-limit/per-app-cap exhaustion. At 5 s it preserves the pre-cache per-poll freshness exactly while moving the build off the request path.

The push-on-change decision is keyed off a separate `lastPublishedEtag` (not the REST cache slot), so a REST poll racing in to repopulate the cache can never suppress a push.

`reevaluate` is the **single** rebuild-and-publish point — no second snapshot computation is introduced (AGENTS.md single-source-of-truth).

## Transport

- `RouterWsRegistry.publishPolicy` fans one `{op:"policy",payload:<snapshot>}` frame to every connected channel; `RouterWsRegistryLive` implements the new `PolicySnapshotPublisher` seam (kept in the `policy` package so `PolicyService` has no compile dependency on the transport layer).
- `RouterWsRoutes` pushes the current snapshot **on connect** (design §6.1) so a freshly-connected router has policy immediately.

## Metrics + dashboard

- `policy_snapshot_build_total{result=computed|cache_hit}` — proves the cache works (cache_hit should dominate; computed tracks the change/tick rate, not the poll rate).
- `router_ws_policy_push_total{result=ok|channel_closed}` — push fan-out health.

Both via `MetricGuard` (bounded enums, per `docs/process/instrumentation.md`), with two new panels on `deploy/grafana/dashboards/router-ws-transport.json`.

## Query perf

**No new SQL** — the cache reuses the existing snapshot-build queries, so there is no new query plan to EXPLAIN. The change *reduces* DB load (one build per tick instead of one per poll per router).

## Tests (TDD: red commit then green)

- `PolicySnapshotCacheSpec` (embedded Postgres, injected `Clock.TestClock`): cache_hit / stale-until-`invalidate`; `reevaluate` pushes once per ETag change (baseline + no re-push on unchanged); a **schedule boundary crossed with no DB write** is caught + pushed by the ticker mechanism.
- `RouterWsSpec`: a freshly-connected router is pushed the current snapshot on connect.
- Full `mill api.test` suite green.

Fixes #1849. Relates to #1023, #1512.


