### PR TITLE
feat(#1898): shared-host reporting allocation by co-presence + equal-split

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -3149,9 +3149,9 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
     sql"SELECT version FROM app_hosts_version".query[Long].unique.transact(xa)
 
   def listAllHostMappings =
-    sql"SELECT app_id, host FROM app_hosts"
-      .query[(AppId, Hostname)]
-      .map { case (id, h) => AppHost(id, h) }
+    sql"SELECT app_id, host, shared FROM app_hosts"
+      .query[(AppId, Hostname, Boolean)]
+      .map { case (id, h, shared) => AppHost(id, h, shared) }
       .to[List]
       .transact(xa)
 

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -76,6 +76,10 @@ object MetricGuard {
       // 2-value enum (`in` agent→server / `out` server→agent); bounded, so it
       // satisfies the §4 cardinality firewall.
       "direction",
+      // #1898 — shared-host reporting attribution outcome for
+      // `usage_shared_host_attribution_total`. A fixed 3-value enum (attributed /
+      // split / other); bounded, so it satisfies the §4 cardinality firewall.
+      "outcome",
     )
 
   /**
@@ -135,6 +139,10 @@ object MetricGuard {
     // too aggressive (real sessions vanishing), a flat zero while phantom
     // inflation returns means it is too lax.
     "presence_app_sessions_dropped_total"       -> Set.empty[String],
+    // #1898 — outcome of attributing a SHARED host's stitched span in usage-by-app
+    // by temporal co-presence with apps' distinctive sessions. `outcome` is a
+    // bounded 3-value enum (attributed / split / other); no per-mac/host/app label.
+    "usage_shared_host_attribution_total"       -> Set("outcome"),
     // #1885 — log events the loki4j appender shed because its bounded send queue
     // (sendQueueMaxBytes) was full while Loki was slow/unreachable. The appender
     // is async/drop-on-backpressure by construction (fail-open: the request path
@@ -443,6 +451,25 @@ object AppMetrics {
           "presence_app_sessions_dropped_total",
           Map.empty,
           count.toLong,
+        ),
+      )
+      .unit
+
+  // ── #1898: shared-host reporting attribution outcome ─────────────────────────
+  // Emitted from UsageRoutes.buildUsageByApp, counted per shared-host stitched span:
+  // `attributed` (one co-present qualifier), `split` (≥2 qualifiers, bytes split
+  // equally), `other` (no qualifier → "Other"/orphan bucket). Bounded `outcome`
+  // label (exactly three values) — no per-mac/host/app cardinality. A sustained
+  // rise in `other` means shared backends are firing with no app demonstrably in
+  // use; a rise in `split` means several apps' distinctive sessions co-occur.
+
+  def recordSharedHostAttribution(outcome: String, count: Long): UIO[Unit] =
+    ZIO
+      .when(count > 0L)(
+        MetricGuard.counter(
+          "usage_shared_host_attribution_total",
+          Map("outcome" -> outcome),
+          count,
         ),
       )
       .unit

--- a/api/src/policy/ProfileAppDispositions.scala
+++ b/api/src/policy/ProfileAppDispositions.scala
@@ -76,6 +76,26 @@ final case class ProfileAppDispositions(
     capGroups.map(d => d.label -> d.distinctiveHosts)
 
   /**
+   * #1898 (shared-hosts S3): the (label → DISTINCTIVE hosts) pairs for EVERY assigned app,
+   * mode-agnostic. Same per-(app, host) `shared = false` partition as
+   * [[capGroupLabelDistinctiveHosts]], but NOT restricted to `mode = TimeLimited`: the per-host
+   * reporting co-presence test attributes a shared host to an app whose distinctive session
+   * overlaps it regardless of the app's enforcement mode (an Allowed app like Feeling Great still
+   * earns its shared-backend bytes), whereas the per-app daily cap only ticks for TimeLimited apps.
+   * Attribution is a structural relationship, not an enforcement one — same reasoning as
+   * [[appHostPatterns]] / [[exemptPatterns]] being mode-agnostic. Stable order by label.
+   */
+  def appLabelDistinctiveHosts: List[(String, List[String])] =
+    perApp.map(d => d.label -> d.distinctiveHosts)
+
+  /**
+   * #1898: (label → appId) for EVERY assigned app — the mode-agnostic re-key partner of
+   * [[appLabelDistinctiveHosts]] used by `TimeStatusService.distinctiveSpansByApp`.
+   */
+  def appLabelToAppId: Map[String, AppId] =
+    perApp.map(d => d.label -> d.appId).toMap
+
+  /**
    * Snapshot enforcement: collapse every assignment into the per-MAC `(extraAllowed, extraBlocked)`
    * BlockRules buckets the router applies, folding each assignment's per-app schedule windows over
    * its base mode (design §4.1):

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -607,17 +607,20 @@ object TimeStatusService {
   }
 
   /**
-   * #1897 (shared-hosts S2): per-app DISTINCTIVE-host engaged spans, keyed by `apps.id` — the
-   * gap-bridged union of each app's `shared = false` hosts, the exact spans the per-app cap
-   * ([[appSecondsByApp]]) sums. Built on the SAME stitch primitive
-   * ([[Presence.appSpansForProfile]]) over the SAME distinctive host-set
-   * ([[ProfileAppDispositions.capGroupLabelDistinctiveHosts]]).
+   * #1897 (shared-hosts S2) / #1898 (S3): per-app DISTINCTIVE-host engaged spans, keyed by
+   * `apps.id` — the gap-bridged union of each app's `shared = false` hosts. Built on the SAME
+   * stitch primitive ([[Presence.appSpansForProfile]]) over the SAME distinctive host-set the
+   * per-app cap reads, so for a TimeLimited app these are exactly the spans [[appSecondsByApp]]
+   * sums. Unlike the cap, this is mode-agnostic
+   * ([[ProfileAppDispositions.appLabelDistinctiveHosts]], not the TimeLimited-only
+   * `capGroupLabelDistinctiveHosts`): an Allowed-mode app earns the co-presence attribution of its
+   * shared backends too — attribution is structural, not enforcement.
    *
    * This is the reusable seam S3's shared-host co-presence allocation consumes: a shared-host
    * presence row attributes to app A iff it overlaps one of A's distinctive spans. S3 MUST read
    * these spans rather than re-deriving the distinctive partition, so the distinctive-span
    * computation lives in exactly one place (AGENTS.md §single-source-of-truth). Spans are combined
-   * across the profile's devices per `profile.crossDeviceOverlapMode`, matching the cap aggregate.
+   * across the profile's devices per `profile.crossDeviceOverlapMode`.
    */
   def distinctiveSpansByApp(
       profile: Profile,
@@ -625,12 +628,16 @@ object TimeStatusService {
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Map[AppId, List[Presence.Span]] = {
+    // #1898: mode-agnostic — `appLabelDistinctiveHosts` / `appLabelToAppId` cover EVERY assigned app,
+    // not just the TimeLimited cap subset, so an Allowed-mode app's distinctive session still gates
+    // the co-presence allocation of its shared backends. The span math is the SAME stitch primitive
+    // ([[Presence.appSpansForProfile]]) over the SAME distinctive host-set the cap reads.
     val dispositions = ProfileAppDispositions.from(appLimits)
-    val labelToAppId = dispositions.capGroups.map(d => d.label -> d.appId).toMap
+    val labelToAppId = dispositions.appLabelToAppId
     Presence
       .appSpansForProfile(
         presence,
-        dispositions.capGroupLabelDistinctiveHosts,
+        dispositions.appLabelDistinctiveHosts,
         profile.crossDeviceOverlapMode,
         settings.heartbeatFilter,
         settings.presenceContinuationSeconds,

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -832,6 +832,112 @@ object Presence {
     }
   }
 
+  /**
+   * #1898 (shared-hosts S3): outcome tally for the shared-host reporting-attribution metric,
+   * counted per shared-host stitched span. Bounded — exactly three buckets, no per-mac/host/app
+   * cardinality: `attributed` (exactly one co-present qualifier), `split` (≥2 qualifiers, bytes
+   * split equally), `other` (no qualifier → surfaces in the "Other"/orphan bucket).
+   */
+  final case class SharedHostAttributionCounts(attributed: Long, split: Long, other: Long) {
+    def +(o: SharedHostAttributionCounts): SharedHostAttributionCounts =
+      SharedHostAttributionCounts(
+        attributed + o.attributed,
+        split + o.split,
+        other + o.other,
+      )
+  }
+  object SharedHostAttributionCounts                                                       {
+    val zero: SharedHostAttributionCounts = SharedHostAttributionCounts(0L, 0L, 0L)
+  }
+
+  /**
+   * Strict (positive-length) temporal intersection — `[start, end)` half-open, so spans that merely
+   * touch at an endpoint do NOT overlap. A shared row may refine WITHIN a distinctive session but
+   * never extend or create one (design §"Allocation rule").
+   */
+  private def spansOverlap(a: Span, b: Span): Boolean =
+    a.startEpoch.max(b.startEpoch) < a.endEpoch.min(b.endEpoch)
+
+  /**
+   * #1898 (shared-hosts S3): allocate ONE shared host's stitched session-seconds to app(s) by
+   * TEMPORAL CO-PRESENCE with each candidate app's DISTINCTIVE spans (the #1897
+   * [[wifihaven.api.policy.TimeStatusService.distinctiveSpansByApp]] seam), returning the
+   * proportional seconds keyed by `Some(appId)` for each qualifying app and `None` for the
+   * unattributed "Other" bucket, plus the per-span outcome tally for the metric.
+   *
+   * This is NOT the rejected #842/#715 Path 1 argmax-foreground heuristic: a shared span is
+   * credited to an app iff that app's OWN distinctive session overlaps it — a presence predicate,
+   * never a byte magnitude comparison — and when several apps qualify the seconds split EQUALLY
+   * among them (deterministic, symmetric, picks no winner). A span overlapping no candidate's
+   * distinctive span is credited to NONE (`None` key).
+   *
+   * The host's rows are stitched the SAME way [[proportionalHostSeconds]] stitches them (same
+   * [[spanOf]]/[[stitch]], the same [[effectiveGap]] over the full active set, and the same
+   * per-device → `overlap`-mode combination), so summing the returned allocation reproduces
+   * `proportionalHostSeconds(host)` exactly — equal split conserves seconds and the integer
+   * remainder rides the lowest-`appId` qualifier so nothing is lost.
+   *
+   * `rows` is the full profile presence batch (used to size the gap consistently with
+   * `proportionalHostSeconds`); only `sharedHost`'s rows are stitched. `candidateDistinctiveSpans`
+   * must already be restricted to the apps that LIST this host as shared.
+   */
+  def allocateSharedHostSeconds(
+      rows: List[PresenceRow],
+      sharedHost: HostId,
+      candidateDistinctiveSpans: Map[AppId, List[Span]],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): (Map[Option[AppId], Long], SharedHostAttributionCounts) = {
+    val active    = rows.filterNot(r => isHeartbeat(r, filter))
+    val gap       = effectiveGap(active, continuationSeconds)
+    val hostRows  = active.filter(_.host == sharedHost)
+    // Per device, stitch THIS host's sessions (one device can't be on the host twice at once), then
+    // combine across devices exactly as `proportionalHostSeconds` does: `Sum` keeps per-device spans
+    // separate; `Dedup` unions them so simultaneous cross-device use counts once.
+    val perDevice =
+      hostRows.groupBy(_.mac).valuesIterator.map(rs => stitch(rs.map(spanOf), gap)).toList
+    val hostSpans = overlap match {
+      case CrossDeviceOverlapMode.Sum   => perDevice.flatten
+      case CrossDeviceOverlapMode.Dedup => mergeSpans(perDevice.flatten)
+    }
+
+    val alloc  = scala.collection.mutable.Map.empty[Option[AppId], Long]
+    var counts = SharedHostAttributionCounts.zero
+    hostSpans.foreach { s =>
+      if (s.seconds > 0L) {
+        val qualifiers = candidateDistinctiveSpans.iterator
+          .collect {
+            case (appId, dSpans) if dSpans.exists(d => spansOverlap(d, s)) => appId
+          }
+          .toList
+          .sortBy(_.value)
+        qualifiers match {
+          case Nil       =>
+            alloc.updateWith(None)(p => Some(p.getOrElse(0L) + s.seconds))
+            counts = counts.copy(other = counts.other + 1L)
+          case oneOrMore =>
+            val n    = oneOrMore.size.toLong
+            val base = s.seconds / n
+            val rem  = s.seconds % n
+            // Equal split; the indivisible remainder rides the first (lowest-appId) qualifiers so the
+            // allocation sums to the span's seconds exactly (no winner-by-magnitude — purely by id).
+            oneOrMore.zipWithIndex.foreach { case (appId, i) =>
+              val share = base + (if (i.toLong < rem) 1L else 0L)
+              if (share > 0L) {
+                alloc.updateWith(Some(appId))(p => Some(p.getOrElse(0L) + share))
+                ()
+              }
+            }
+            counts =
+              if (n == 1L) counts.copy(attributed = counts.attributed + 1L)
+              else counts.copy(split = counts.split + 1L)
+        }
+      }
+    }
+    (alloc.toMap, counts)
+  }
+
   /** Convenience: floor-divided minute view of [[proportionalHostSeconds]]. */
   def proportionalHostMinutes(
       rows: List[PresenceRow],

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -3,6 +3,7 @@ package wifihaven.api.routes
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
 import wifihaven.api.db.{RollupRepo, RollupRow}
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.usage.{
   AppMembership,
   RawTrafficCursorKey,
@@ -169,8 +170,8 @@ object UsageRoutes {
               deviceRepo,
               trafficRepo,
               appRepo,
-              settings.heartbeatFilter,
-              settings.presenceContinuationSeconds,
+              appTimeLimitRepo,
+              settings,
             )
           } yield Response.json(resp.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
@@ -478,9 +479,11 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       appRepo: AppRepo,
-      filter: HeartbeatFilter,
-      continuationSeconds: Int,
-  ): IO[ApiError, ProfileUsageByApp] =
+      appTimeLimitRepo: AppTimeLimitRepo,
+      settings: HouseholdSettings,
+  ): IO[ApiError, ProfileUsageByApp] = {
+    val filter              = settings.heartbeatFilter
+    val continuationSeconds = settings.presenceContinuationSeconds
     for {
       profile <- profileRepo
         .findById(pid)
@@ -488,115 +491,217 @@ object UsageRoutes {
         .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
       allDevs <- deviceRepo.listAll.mapError(ApiError.Db(_))
       macs = allDevs.collect { case d if d.profileId.contains(pid) => d.mac }
-      presence <- (if (macs.isEmpty) ZIO.succeed(Nil)
+      presence  <- (if (macs.isEmpty) ZIO.succeed(Nil)
                    else trafficRepo.listPresenceRows(macs, from, to))
         .mapError(ApiError.Db(_))
-      appList  <- appRepo.listAll.mapError(ApiError.Db(_))
-      mappings <- appRepo.listAllHostMappings.mapError(ApiError.Db(_))
-    } yield {
-      val appById                            = appList.iterator.map(a => a.id -> a).toMap
-      // Deterministic host → owning-app: lowest appId wins when a host is in
-      // multiple apps. Avoids double-counting one bucket of activity into two
-      // apps for the per-profile screen-time view (matches #1061 acceptance).
-      //
-      // #1161: app_hosts rows are stored apex-form (`youtube.com`) but traffic
-      // rows carry FQDNs (`m.youtube.com`). Use suffix-aware lookup — same
-      // matcher as #1085's groupBy=app fix and PolicyService — so subdomain
-      // traffic attributes to the apex-form app entry instead of falling into
-      // the synthetic "Other" bucket.
-      val appOfHost: HostId => Option[AppId] = {
-        val byApex = mappings
-          .groupBy(_.host.value)
-          .view
-          .mapValues(ms => ms.iterator.map(_.appId).minBy(_.value))
-          .toMap
-        h => h.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, byApex))
+      appList   <- appRepo.listAll.mapError(ApiError.Db(_))
+      mappings  <- appRepo.listAllHostMappings.mapError(ApiError.Db(_))
+      // #1898: the per-(app, host) `shared` flag rides the per-profile assignment join so
+      // `distinctiveSpansByApp` can partition each app's host-set; classification of which traffic
+      // hosts are shared comes from the GLOBAL `mappings` above (a catalog-wide property).
+      appLimits <- appTimeLimitRepo.listForProfile(pid).mapError(ApiError.Db(_))
+      built          = computeUsageByApp(
+        pid,
+        from,
+        to,
+        profile,
+        presence,
+        appList,
+        mappings,
+        appLimits,
+        settings,
+        filter,
+        continuationSeconds,
+      )
+      (resp, counts) = built
+      // #1898: bounded-label outcome counter for shared-row attribution (attributed/split/other).
+      _ <- AppMetrics.recordSharedHostAttribution("attributed", counts.attributed)
+      _ <- AppMetrics.recordSharedHostAttribution("split", counts.split)
+      _ <- AppMetrics.recordSharedHostAttribution("other", counts.other)
+    } yield resp
+  }
+
+  // #1898: pure core of `buildUsageByApp`. Distinctive hosts keep the unconditional `minBy(appId)`
+  // mapping; SHARED hosts (multi-tenant backends listed on several apps) are routed through the
+  // co-presence allocation — their per-row proportional seconds attribute to the app(s) whose
+  // DISTINCTIVE session overlaps the row, split EQUALLY among co-present qualifiers, else "Other".
+  // This is NOT the rejected #842/#715 argmax-foreground heuristic: allocation is gated purely on an
+  // app's own distinctive presence, never on byte magnitude. Returns the response plus the per-span
+  // attribution tally for the metric.
+  private def computeUsageByApp(
+      pid: ProfileId,
+      from: LocalDate,
+      to: LocalDate,
+      profile: Profile,
+      presence: List[wifihaven.api.presence.PresenceRow],
+      appList: List[App],
+      mappings: List[AppHost],
+      appLimits: List[AppTimeLimit],
+      settings: HouseholdSettings,
+      filter: HeartbeatFilter,
+      continuationSeconds: Int,
+  ): (ProfileUsageByApp, wifihaven.api.presence.Presence.SharedHostAttributionCounts) = {
+    import wifihaven.api.presence.Presence
+    val appById = appList.iterator.map(a => a.id -> a).toMap
+    val overlap = profile.crossDeviceOverlapMode
+
+    // Distinctive host → owning-app: lowest appId wins when a host is in multiple apps (#1061),
+    // apex-aware so subdomain traffic attributes to the apex-form entry (#1161). #1898: SHARED rows
+    // are EXCLUDED from this map — a shared host is never distinctively credited to one app.
+    val distinctiveByApex = mappings
+      .filterNot(_.shared)
+      .groupBy(_.host.value)
+      .view
+      .mapValues(ms => ms.iterator.map(_.appId).minBy(_.value))
+      .toMap
+    // #1898: apps that LIST a host as shared (the co-presence candidates), apex-keyed. Global
+    // consistency (validation S1b) guarantees a host shared on any app is shared on every app
+    // listing it, so a host is never simultaneously distinctive and shared.
+    val sharedAppsByApex  = mappings
+      .filter(_.shared)
+      .groupBy(_.host.value)
+      .view
+      .mapValues(ms => ms.iterator.map(_.appId).toSet)
+      .toMap
+
+    def distinctiveAppOf(h: HostId): Option[AppId] =
+      h.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, distinctiveByApex))
+    def sharedAppsOf(h: HostId): Set[AppId]        =
+      h.asFqdn
+        .flatMap(fqdn => HostMatch.lookupApex(fqdn.value, sharedAppsByApex))
+        .getOrElse(Set.empty)
+
+    // #1898: the S2 single-source-of-truth seam — each app's DISTINCTIVE-host engaged spans. S3 reads
+    // these for the co-presence overlap test rather than re-deriving the distinctive partition.
+    val distinctiveSpans =
+      wifihaven.api.policy.TimeStatusService.distinctiveSpansByApp(
+        profile,
+        appLimits,
+        presence,
+        settings,
+      )
+
+    // #1465: per-host presence is the session-stitch span (heartbeat-filtered), combined across the
+    // profile's devices by its `crossDeviceOverlapMode`.
+    val propByHost    =
+      Presence.proportionalHostSeconds(presence, overlap, filter, continuationSeconds)
+    val seenByHost    = Presence.hostMinutes(presence, filter)
+    val propMinByHost =
+      Presence.proportionalHostMinutes(presence, overlap, filter, continuationSeconds)
+
+    // Per host, the proportional-seconds allocation across `Some(appId)` / `None` ("Other").
+    var counts = Presence.SharedHostAttributionCounts.zero
+    val allocByHost: Map[HostId, Map[Option[AppId], Long]] =
+      propByHost.map { case (h, secs) =>
+        val candidates = sharedAppsOf(h)
+        if (candidates.nonEmpty) {
+          val candidateSpans = distinctiveSpans.view.filterKeys(candidates.contains).toMap
+          val (alloc, c)     = Presence.allocateSharedHostSeconds(
+            presence,
+            h,
+            candidateSpans,
+            overlap,
+            filter,
+            continuationSeconds,
+          )
+          counts = counts + c
+          h -> alloc
+        } else h -> Map(distinctiveAppOf(h) -> secs)
       }
+    // The set of `Option[AppId]` keys each host's activity touches (for the non-additive
+    // presence-seconds surface). A shared host split across apps + "Other" touches all of them.
+    val touchedByHost: Map[HostId, Set[Option[AppId]]]     =
+      allocByHost.view.mapValues(_.keySet).toMap
 
-      val overlap       = profile.crossDeviceOverlapMode
-      // #1465: per-host presence is now the session-stitch span (heartbeat-filtered),
-      // combined across the profile's devices by its `crossDeviceOverlapMode`.
-      val propByHost    =
-        wifihaven.api.presence.Presence
-          .proportionalHostSeconds(presence, overlap, filter, continuationSeconds)
-      val seenByHost    = wifihaven.api.presence.Presence.hostMinutes(presence, filter)
-      val propMinByHost =
-        wifihaven.api.presence.Presence
-          .proportionalHostMinutes(presence, overlap, filter, continuationSeconds)
-
-      val appProp    = scala.collection.mutable.Map.empty[Option[AppId], Long]
-      val hostsByApp =
-        scala.collection.mutable.Map.empty[Option[AppId], List[HostUsage]]
-      for ((h, secs) <- propByHost) {
-        val key = appOfHost(h)
+    val appProp    = scala.collection.mutable.Map.empty[Option[AppId], Long]
+    val hostsByApp = scala.collection.mutable.Map.empty[Option[AppId], List[HostUsage]]
+    for ((h, alloc) <- allocByHost) {
+      val totalSecs = alloc.values.sum
+      val single    = alloc.sizeIs == 1
+      for ((key, secs) <- alloc if key.isDefined) {
         appProp.updateWith(key)(prev => Some(prev.getOrElse(0L) + secs))
-        val hu  = HostUsage(h, seenByHost.getOrElse(h, 0), propMinByHost.getOrElse(h, 0))
+        // Distinctive (single-key) host carries its display minutes verbatim; a split shared host's
+        // proportional minutes follow its allocated seconds, and its `usedMins` (bucket presence) is
+        // scaled by the same fraction so the per-app host row reflects the share.
+        val usedM =
+          if (single) seenByHost.getOrElse(h, 0)
+          else if (totalSecs <= 0L) 0
+          else
+            math
+              .round(seenByHost.getOrElse(h, 0).toDouble * (secs.toDouble / totalSecs.toDouble))
+              .toInt
+        val propM = if (single) propMinByHost.getOrElse(h, 0) else (secs / 60L).toInt
+        val hu    = HostUsage(h, usedM, propM)
         hostsByApp.updateWith(key)(prev => Some(hu :: prev.getOrElse(Nil)))
       }
-      // Per-app bucket-dedup for presence-seconds (heartbeat rows stripped, #1465).
-      val appPresence = scala.collection.mutable.Map.empty[Option[AppId], Long]
-      val activeRows =
-        presence.filterNot(r => wifihaven.api.presence.Presence.isHeartbeat(r, filter))
-      for ((_, bucket) <- activeRows.groupBy(r => (r.mac, r.periodStart))) {
-        val secs = bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
-        val keys = bucket.iterator.map(r => appOfHost(r.host)).toSet
-        for (a <- keys)
-          appPresence.updateWith(a)(prev => Some(prev.getOrElse(0L) + secs))
-      }
+    }
 
-      // #1519: real-app rows ONLY. Drop the `None` key — those hosts surface as
-      // individual orphanHosts entries below.
-      val appKeys = (appProp.keySet ++ appPresence.keySet).iterator.flatten.toList.distinct
-      val rows    = appKeys.map { aid =>
-        val key   = Some(aid)
-        val name  = appById.get(aid).map(_.name).getOrElse(aid.value.toString)
-        val icon  = appById.get(aid).flatMap(_.icon)
-        val it    = appById.get(aid).map(_.iconType)
-        val hosts = hostsByApp
-          .getOrElse(key, Nil)
-          .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
-        ProfileAppUsage(
-          appId = key,
-          appName = name,
-          appIcon = icon,
-          appIconType = it,
-          proportionalSeconds = appProp.getOrElse(key, 0L),
-          presenceSeconds = appPresence.getOrElse(key, 0L),
-          hosts = hosts,
-        )
-      }
+    // Per-app bucket-dedup for presence-seconds (heartbeat rows stripped, #1465). Not additive across
+    // apps by design — a bucket's seconds count once per distinct app key it touches.
+    val appPresence = scala.collection.mutable.Map.empty[Option[AppId], Long]
+    val activeRows  = presence.filterNot(r => Presence.isHeartbeat(r, filter))
+    for ((_, bucket) <- activeRows.groupBy(r => (r.mac, r.periodStart))) {
+      val secs = bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
+      val keys = bucket.iterator.flatMap(r => touchedByHost.getOrElse(r.host, Set.empty)).toSet
+      for (a <- keys if a.isDefined)
+        appPresence.updateWith(a)(prev => Some(prev.getOrElse(0L) + secs))
+    }
 
-      // #1519: orphan rows = non-app hosts, each rendered as its own single-host
-      // pseudo-app. proportional = the per-host attention sum already gathered;
-      // presence = dedupe (mac, periodStart) buckets PER HOST (each host's
-      // presence is its own bucket-deduped wall-clock seconds — same shape as
-      // the per-app presence, but one row per host).
-      val orphanHostSet  = propByHost.keysIterator.filter(h => appOfHost(h).isEmpty).toSet
-      val orphanPresence = scala.collection.mutable.Map.empty[HostId, Long]
-      for ((_, bucket) <- activeRows.groupBy(r => (r.mac, r.periodStart))) {
-        val secs      = bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
-        val hostsHere = bucket.iterator.map(_.host).filter(orphanHostSet.contains).toSet
-        for (h <- hostsHere)
-          orphanPresence.updateWith(h)(prev => Some(prev.getOrElse(0L) + secs))
-      }
-      val orphanRows = orphanHostSet.toList.map { h =>
-        OrphanHostUsage(
-          host = h,
-          proportionalSeconds = propByHost.getOrElse(h, 0L),
-          presenceSeconds = orphanPresence.getOrElse(h, 0L),
-        )
-      }
-
-      ProfileUsageByApp(
-        profileId = pid,
-        profileName = profile.name,
-        from = from.toString,
-        to = to.toString,
-        apps = rows.sortBy(r => (-r.proportionalSeconds, -r.presenceSeconds, r.appName)),
-        orphanHosts = orphanRows
-          .sortBy(o => (-o.proportionalSeconds, -o.presenceSeconds, o.host.value)),
+    // #1519: real-app rows ONLY. The `None` key surfaces as individual orphanHosts entries below.
+    val appKeys = (appProp.keySet ++ appPresence.keySet).iterator.flatten.toList.distinct
+    val rows    = appKeys.map { aid =>
+      val key   = Some(aid)
+      val name  = appById.get(aid).map(_.name).getOrElse(aid.value.toString)
+      val icon  = appById.get(aid).flatMap(_.icon)
+      val it    = appById.get(aid).map(_.iconType)
+      val hosts = hostsByApp
+        .getOrElse(key, Nil)
+        .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
+      ProfileAppUsage(
+        appId = key,
+        appName = name,
+        appIcon = icon,
+        appIconType = it,
+        proportionalSeconds = appProp.getOrElse(key, 0L),
+        presenceSeconds = appPresence.getOrElse(key, 0L),
+        hosts = hosts,
       )
     }
+
+    // #1519: orphan rows = the unattributed portion of each host, each rendered as its own
+    // single-host pseudo-app. #1898: a SHARED host with a "no qualifier" span contributes its
+    // unattributed seconds here (the "Other" fallback) — possibly alongside app rows for its
+    // attributed spans. proportional = the `None`-keyed allocation; presence = dedupe (mac,
+    // periodStart) buckets PER HOST.
+    val orphanHostSet  = allocByHost.iterator.collect {
+      case (h, alloc) if alloc.get(None).exists(_ > 0L) => h
+    }.toSet
+    val orphanPresence = scala.collection.mutable.Map.empty[HostId, Long]
+    for ((_, bucket) <- activeRows.groupBy(r => (r.mac, r.periodStart))) {
+      val secs      = bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
+      val hostsHere = bucket.iterator.map(_.host).filter(orphanHostSet.contains).toSet
+      for (h <- hostsHere)
+        orphanPresence.updateWith(h)(prev => Some(prev.getOrElse(0L) + secs))
+    }
+    val orphanRows = orphanHostSet.toList.map { h =>
+      OrphanHostUsage(
+        host = h,
+        proportionalSeconds = allocByHost.get(h).flatMap(_.get(None)).getOrElse(0L),
+        presenceSeconds = orphanPresence.getOrElse(h, 0L),
+      )
+    }
+
+    val resp = ProfileUsageByApp(
+      profileId = pid,
+      profileName = profile.name,
+      from = from.toString,
+      to = to.toString,
+      apps = rows.sortBy(r => (-r.proportionalSeconds, -r.presenceSeconds, r.appName)),
+      orphanHosts = orphanRows
+        .sortBy(o => (-o.proportionalSeconds, -o.presenceSeconds, o.host.value)),
+    )
+    (resp, counts)
+  }
 
   // #1079 — build the by-app axis used by the unified-axis builder. `appOf` mirrors the
   // deterministic "lowest appId wins" tiebreak from #1061 and the apex-aware match from #1085 so
@@ -605,13 +710,23 @@ object UsageRoutes {
   // the per-app cap aggregate and the #1510 rollup use (via Presence.appSpansForProfile), keyed by
   // slug. Both are built from one `app_hosts` snapshot so the attribution and the span host-set
   // can't drift.
+  //
+  // #1898: SHARED hosts are excluded from BOTH `appOf` and `patternsBySlug` here. The per-app series
+  // span is the gap-bridged union of an app's host-set, and a shared backend folded in would extend
+  // the app's span past its distinctive activity — exactly the inflation S2 removed from the cap
+  // aggregate (TimeStatusService reads `capGroupLabelDistinctiveHosts`). Keeping this axis
+  // distinctive-only keeps the per-app series reconciling with the cap and the #1510 rollup by
+  // construction; a shared host instead surfaces as a standalone host entry (the time-series analog
+  // of the usage-by-app "Other"/orphan bucket). Per-bucket co-presence allocation is not applied to
+  // the time-series; the worked-example allocation lives on the `buildUsageByApp` totals surface.
   private def loadAppLookup(
       appRepo: AppRepo,
   ): IO[ApiError, UsageSeries.AppAxis] =
     for {
-      apps     <- appRepo.listAll.mapError(ApiError.Db(_))
-      mappings <- appRepo.listAllHostMappings.mapError(ApiError.Db(_))
+      apps    <- appRepo.listAll.mapError(ApiError.Db(_))
+      allMaps <- appRepo.listAllHostMappings.mapError(ApiError.Db(_))
     } yield {
+      val mappings       = allMaps.filterNot(_.shared)
       val appById        = apps.iterator.map(a => a.id -> a).toMap
       val byApex         = mappings
         .groupBy(_.host.value)

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -1901,6 +1901,89 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(orphan.proportionalSeconds == 300L) &&
           assertTrue(orphan.presenceSeconds == 300L)
       },
+      test(
+        "#1898: a SHARED host is allocated to the co-present app, split on overlap, else 'Other'",
+      ) {
+        // Feeling Great (distinctive feelinggreat.com, SHARED elevenlabs.io) + Speechify
+        // (distinctive speechify.com). One device, one day:
+        //   feelinggreat.com active 09:00–09:20 → FG distinctive span
+        //   speechify.com    active 11:25–11:40 → Speechify distinctive span
+        //   elevenlabs.io (shared) fires at 09:05 (inside FG), 11:30 (inside Speechify),
+        //                          and 03:00 (neither app active → "Other").
+        // The shared host must split across FG / Speechify by CO-PRESENCE (NOT argmax), and its
+        // un-covered 03:00 span must surface in the orphanHosts "Other" bucket.
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          fgId        <- appRepo.create("Feeling Great", "feeling-great", None, Some("🧠"))
+          spId        <- appRepo.create("Speechify", "speechify", None, Some("🗣"))
+          // Feeling Great: distinctive feelinggreat.com + SHARED elevenlabs.io.
+          _           <- appRepo.setHostEntries(
+            fgId,
+            List(
+              AppHostEntry(Hostname.unsafe("feelinggreat.com"), shared = false),
+              AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+            ),
+          )
+          // Speechify also lists elevenlabs.io as SHARED (the host is multi-tenant across both apps).
+          _           <- appRepo.setHostEntries(
+            spId,
+            List(
+              AppHostEntry(Hostname.unsafe("speechify.com"), shared = false),
+              AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+            ),
+          )
+          // Assignments so both apps reach `listForProfile` (distinctiveSpansByApp is mode-agnostic).
+          _           <- appRepo.upsertAssignment(fgId, kidsId, AppMode.Allowed, None, true)
+          _           <- appRepo.upsertAssignment(spId, kidsId, AppMode.Allowed, None, true)
+          // feelinggreat.com 09:00,09:05,09:10,09:15 → one stitched span [09:00,09:20] (1200 s).
+          _           <- insertRow(routerId, testMac, "feelinggreat.com", today, 9, 0)
+          _           <- insertRow(routerId, testMac, "feelinggreat.com", today, 9, 5)
+          _           <- insertRow(routerId, testMac, "feelinggreat.com", today, 9, 10)
+          _           <- insertRow(routerId, testMac, "feelinggreat.com", today, 9, 15)
+          // speechify.com 11:25,11:30,11:35 → one stitched span [11:25,11:40] (900 s).
+          _           <- insertRow(routerId, testMac, "speechify.com", today, 11, 25)
+          _           <- insertRow(routerId, testMac, "speechify.com", today, 11, 30)
+          _           <- insertRow(routerId, testMac, "speechify.com", today, 11, 35)
+          // elevenlabs.io shared rows: 09:05 → FG, 11:30 → Speechify, 03:00 → Other. Each 300 s.
+          _           <- insertRow(routerId, testMac, "elevenlabs.io", today, 9, 5)
+          _           <- insertRow(routerId, testMac, "elevenlabs.io", today, 11, 30)
+          _           <- insertRow(routerId, testMac, "elevenlabs.io", today, 3, 0)
+          rb          <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL
+                .decode(s"/api/profiles/${kidsId.value}/usage-by-app?from=$today&to=$today")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[ProfileUsageByApp])
+          fg     = out.apps.find(_.appName == "Feeling Great").get
+          sp     = out.apps.find(_.appName == "Speechify").get
+          orphan = out.orphanHosts.find(_.host.value == "elevenlabs.io")
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // FG = feelinggreat.com (1200 s) + elevenlabs.io 09:05 share (300 s).
+          assertTrue(fg.proportionalSeconds == 1500L) &&
+          // Speechify = speechify.com (900 s) + elevenlabs.io 11:30 share (300 s).
+          assertTrue(sp.proportionalSeconds == 1200L) &&
+          // The shared host surfaces under BOTH apps' host rows (co-presence attribution).
+          assertTrue(fg.hosts.exists(_.host.value == "elevenlabs.io")) &&
+          assertTrue(sp.hosts.exists(_.host.value == "elevenlabs.io")) &&
+          // The un-covered 03:00 span lands in "Other" with exactly its 300 s.
+          assertTrue(orphan.exists(_.proportionalSeconds == 300L))
+      },
       test("#1433: an app with usage but no time limit still returns its time-used") {
         // The profile/app page surfaces today's time-used for every app, not
         // just time-limited ones. An app assigned with mode=allowed (no daily

--- a/api/test/src/unit/SharedHostAllocationSpec.scala
+++ b/api/test/src/unit/SharedHostAllocationSpec.scala
@@ -1,0 +1,121 @@
+package wifihaven.api.unit
+
+import wifihaven.api.presence.{Presence, PresenceRow}
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate}
+
+/**
+ * #1898 (shared-hosts S3): the per-host reporting allocation primitive
+ * ([[Presence.allocateSharedHostSeconds]]) attributes a SHARED host's stitched session-seconds to
+ * app(s) by TEMPORAL CO-PRESENCE with each candidate app's DISTINCTIVE spans (the #1897
+ * `distinctiveSpansByApp` seam) — never by byte magnitude (NOT the rejected #842/#715 Path 1
+ * argmax-foreground heuristic). Ties split EQUALLY among co-present qualifiers; a shared span that
+ * overlaps no candidate's distinctive span is unattributed (`None` → "Other").
+ *
+ * Pins the design doc's worked example (docs/design/shared-host-allocation.md §"Worked example"):
+ * Device D, `app.feelinggreat.com` active 09:00–09:20 and 14:00–14:05; `api.elevenlabs.io` rows at
+ * 09:05, 11:30, 14:02; a "Speechify" app distinctive 11:25–11:40.
+ */
+object SharedHostAllocationSpec extends ZIOSpecDefault {
+
+  private val mac      = MacAddress.unsafe("aa:bb:cc:dd:ee:01")
+  private val baseDate = LocalDate.parse("2026-06-23")
+  // t0 = local midnight of baseDate (epoch seconds irrelevant — overlap is relative).
+  private val t0       = Instant.parse("2026-06-23T00:00:00Z")
+
+  private val feelingGreat = AppId(1L)
+  private val speechify    = AppId(2L)
+
+  private val sharedHost = HostId.Fqdn(Hostname.unsafe("api.elevenlabs.io"))
+
+  // A 300 s presence row for the shared host at `atSeconds` past t0.
+  private def sharedRow(atSeconds: Long): PresenceRow =
+    PresenceRow(
+      mac,
+      baseDate,
+      t0.plusSeconds(atSeconds),
+      sharedHost,
+      activeSeconds = 300,
+      bytes = 1_000_000L,
+      periodSeconds = 300,
+    )
+
+  private def span(fromSeconds: Long, toSeconds: Long): Presence.Span =
+    Presence.Span(t0.getEpochSecond + fromSeconds, t0.getEpochSecond + toSeconds)
+
+  private val h = 3600L
+  private val m = 60L
+
+  // FG distinctive spans: 09:00–09:20 and 14:00–14:05.
+  private val fgSpans       = List(span(9 * h, 9 * h + 20 * m), span(14 * h, 14 * h + 5 * m))
+  // Speechify distinctive span: 11:25–11:40.
+  private val speechifySpan = List(span(11 * h + 25 * m, 11 * h + 40 * m))
+
+  def spec = suite("SharedHostAllocationSpec (#1898)")(
+    test(
+      "worked example: each shared row credited to the app whose distinctive session covers it",
+    ) {
+      // elevenlabs rows: 09:05 (inside FG span 1), 11:30 (inside Speechify), 14:02 (inside FG span 2).
+      val rows            = List(
+        sharedRow(9 * h + 5 * m),
+        sharedRow(11 * h + 30 * m),
+        sharedRow(14 * h + 2 * m),
+      )
+      val candidates      = Map(feelingGreat -> fgSpans, speechify -> speechifySpan)
+      val (alloc, counts) =
+        Presence.allocateSharedHostSeconds(rows, sharedHost, candidates)
+      // 09:05 → FG, 14:02 → FG (600 s), 11:30 → Speechify (300 s); nothing unattributed.
+      assertTrue(alloc.getOrElse(Some(feelingGreat), 0L) == 600L) &&
+      assertTrue(alloc.getOrElse(Some(speechify), 0L) == 300L) &&
+      assertTrue(alloc.getOrElse(None, 0L) == 0L) &&
+      assertTrue(counts.attributed == 3L) &&
+      assertTrue(counts.split == 0L) &&
+      assertTrue(counts.other == 0L)
+    },
+    test("tie-break: a shared row inside two apps' distinctive spans splits 50/50 (NOT argmax)") {
+      // Both FG and Speechify distinctive at 11:30; the 11:30 elevenlabs row splits equally.
+      val rows            = List(sharedRow(11 * h + 30 * m))
+      val fgCoversNoon    = List(span(11 * h, 12 * h)) // FG distinctive 11:00–12:00, covers 11:30
+      val candidates      = Map(feelingGreat -> fgCoversNoon, speechify -> speechifySpan)
+      val (alloc, counts) =
+        Presence.allocateSharedHostSeconds(rows, sharedHost, candidates)
+      // 300 s split equally — no winner-by-magnitude, deterministic 150/150.
+      assertTrue(alloc.getOrElse(Some(feelingGreat), 0L) == 150L) &&
+      assertTrue(alloc.getOrElse(Some(speechify), 0L) == 150L) &&
+      assertTrue(alloc.getOrElse(None, 0L) == 0L) &&
+      assertTrue(counts.split == 1L) &&
+      assertTrue(counts.attributed == 0L)
+    },
+    test("no qualifier: a shared row with no live distinctive session falls to 'Other'") {
+      // elevenlabs fires at 03:00 with neither app active.
+      val rows            = List(sharedRow(3 * h))
+      val candidates      = Map(feelingGreat -> fgSpans, speechify -> speechifySpan)
+      val (alloc, counts) =
+        Presence.allocateSharedHostSeconds(rows, sharedHost, candidates)
+      assertTrue(alloc.getOrElse(None, 0L) == 300L) &&
+      assertTrue(alloc.get(Some(feelingGreat)).isEmpty) &&
+      assertTrue(alloc.get(Some(speechify)).isEmpty) &&
+      assertTrue(counts.other == 1L) &&
+      assertTrue(counts.attributed == 0L)
+    },
+    test("allocation conserves the host's proportional seconds (sum == proportionalHostSeconds)") {
+      val rows           = List(
+        sharedRow(9 * h + 5 * m),
+        sharedRow(11 * h + 30 * m),
+        sharedRow(14 * h + 2 * m),
+        sharedRow(3 * h),
+      )
+      val candidates     = Map(feelingGreat -> fgSpans, speechify -> speechifySpan)
+      val (alloc, _)     =
+        Presence.allocateSharedHostSeconds(rows, sharedHost, candidates)
+      val totalAllocated = alloc.values.sum
+      val proportional   =
+        Presence.proportionalHostSeconds(rows).getOrElse(sharedHost, 0L)
+      assertTrue(totalAllocated == proportional) &&
+      assertTrue(totalAllocated == 1200L) // four 300 s rows, all separate sessions
+    },
+  )
+}

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -594,6 +594,80 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Shared-host attribution by outcome — rate (#1898)",
+      "description": "sum by (outcome) (rate(usage_shared_host_attribution_total[5m])) — outcome of each SHARED-host stitched span when usage-by-app attributes it by temporal co-presence with apps' DISTINCTIVE sessions (NOT byte-share/argmax). `attributed` = exactly one co-present app; `split` = ≥2 apps' distinctive sessions overlap, bytes split equally; `other` = no app demonstrably in use → the host's span surfaces in the usage-by-app 'Other'/orphan bucket. Bounded `outcome` enum (3 values). A rising `other` share means shared backends fire with no owning app active; a rising `split` means several apps' sessions co-occur. From AppMetrics.recordSharedHostAttribution (UsageRoutes.buildUsageByApp).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 64 },
+      "id": 17,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (outcome) (rate(usage_shared_host_attribution_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Shared-host 'Other' share (last 24h) (#1898)",
+      "description": "sum(increase(usage_shared_host_attribution_total{outcome=\"other\"}[24h])) / sum(increase(usage_shared_host_attribution_total[24h])) — fraction of shared-host spans that found NO co-present app over the trailing day. A high share is expected for genuinely-shared infra backends but a sudden climb can indicate a mis-authored app (a distinctive host marked shared, or a shared host whose owning app lost its distinctive hosts). From AppMetrics.recordSharedHostAttribution.",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 64 },
+      "id": 18,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(increase(usage_shared_host_attribution_total{env=\"$env\", outcome=\"other\"}[24h])) / clamp_min(sum(increase(usage_shared_host_attribution_total{env=\"$env\"}[24h])), 1)",
+          "legendFormat": "other share (24h)",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/docs/design/shared-host-allocation.md
+++ b/docs/design/shared-host-allocation.md
@@ -345,16 +345,21 @@ runs `/pr-review` before merge.
   Tests pin: shared host inside a distinctive span → 0 added minutes; shared
   host with no distinctive activity → not credited.
 
-- **S3 — Per-host reporting allocation** (depends on S2). In `buildUsageByApp`
-  ([UsageRoutes](../../api/src/routes/UsageRoutes.scala):473-599), route shared
-  hosts through the co-presence overlap rule + equal split + "Other" fallback,
-  replacing `minBy(appId)` for shared hosts only. Extends to the by-app axis
-  builder at :601+. Tests pin the worked example above. Ships with an
-  `AppMetrics` counter for shared-row attribution outcome
-  (`attributed` / `split` / `other`) per
-  [instrument-new-functionality](../process/instrumentation.md#instrument-new-functionality)
-  and the consuming Grafana panel per
-  [metrics-need-a-dashboard](../process/instrumentation.md#metrics-need-a-dashboard).
+- **S3 — Per-host reporting allocation** ✅ shipped
+  ([#1898](https://github.com/wifihaven/wifihaven/issues/1898)). In
+  `buildUsageByApp` ([UsageRoutes](../../api/src/routes/UsageRoutes.scala)), shared
+  hosts route through `Presence.allocateSharedHostSeconds` — co-presence overlap
+  with each candidate app's distinctive spans (the S2
+  `TimeStatusService.distinctiveSpansByApp` seam, now mode-agnostic so an Allowed
+  app earns its shared backends too) + equal split among qualifiers + "Other"
+  fallback — replacing `minBy(appId)` for shared hosts only; distinctive hosts keep
+  the unconditional `minBy`. The by-app axis builder (`loadAppLookup`) excludes
+  shared hosts from both `appOf` and `patternsBySlug` so the per-app *time-series*
+  span stays distinctive-only (reconciling with the S2 cap); a shared host surfaces
+  there as a standalone host entry. No argmax / byte-share anywhere. Ships with the
+  bounded-label `usage_shared_host_attribution_total{outcome}` counter
+  (`attributed` / `split` / `other`) and its Grafana panels on the
+  `data-quality-ingest` dashboard.
 
 - **S4 — Enforcement guardrails** (depends on S1b; parallel to S2/S3).
   Exclude shared hosts from `appCapExhaustedHosts` and `Blocked`-mode

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -367,7 +367,12 @@ case class App(
     createdAt: java.time.Instant,
 ) derives JsonCodec
 
-case class AppHost(appId: AppId, host: Hostname) derives JsonCodec
+// #1898 (shared-hosts S3): `shared` carries the per-(app, host) `app_hosts.shared` flag through the
+// global host→app inventory (`listAllHostMappings`). The usage-by-app reporting path uses it to route
+// SHARED hosts through the co-presence allocation instead of the unconditional `minBy(appId)` mapping
+// that distinctive hosts keep. Default false keeps every legacy construction distinctive and is
+// additive on the wire.
+case class AppHost(appId: AppId, host: Hostname, shared: Boolean = false) derives JsonCodec
 
 /**
  * #1896: an app's host paired with its `shared` flag (`false` == distinctive). Distinctive hosts


### PR DESCRIPTION
## What

Implements **S3** of the shared-host allocation design (parent #1888): the per-host reporting allocation. In the usage-by-app surface, **SHARED** hosts are now attributed by **temporal co-presence** instead of the unconditional `minBy(appId)` mapping that **distinctive** hosts keep.

Depends on S1b (#1896) and S2 (#1897), both merged.

## The rule (co-presence, NOT argmax)

A shared host's stitched session-seconds attribute to the app(s) whose **own DISTINCTIVE session overlaps** the span:

- **one qualifier** → all the span's seconds to that app (`attributed`)
- **≥2 qualifiers** → the seconds **split EQUALLY** among them (`split`) — deterministic, symmetric, **picks no winner by magnitude**
- **no qualifier** → the span surfaces in the existing `orphanHosts` / "Other" bucket (`other`)

This is explicitly **not** the rejected #842/#715 Path 1 argmax/byte-share heuristic — allocation is gated purely on an app's distinctive presence, never on byte magnitude. The worked example from `docs/design/shared-host-allocation.md` is pinned in tests (incl. the 50/50 split and the "Other" fallback).

## Single-source-of-truth

The co-presence test consumes the **S2 seam** `TimeStatusService.distinctiveSpansByApp` rather than re-deriving the distinctive partition — no second time-accounting impl. That seam is broadened to be **mode-agnostic** (`ProfileAppDispositions.appLabelDistinctiveHosts`) so an `Allowed`-mode app (e.g. Feeling Great) earns its shared backends too; the per-app engaged-minutes **cap** still reads the TimeLimited-only subset unchanged.

`Presence.allocateSharedHostSeconds` stitches the host the same way `proportionalHostSeconds` does, so the allocation **conserves** the host's proportional seconds exactly (equal-split remainder rides the lowest-`appId` qualifier).

## Surfaces touched

- **`buildUsageByApp`** — shared hosts routed through the co-presence allocation; distinctive hosts keep `minBy(appId)`.
- **`loadAppLookup`** (the by-app **time-series** axis) — shared hosts excluded from both `appOf` and `patternsBySlug`, so the per-app series span stays distinctive-only and reconciles with the S2 cap; a shared host surfaces there as a standalone host entry (per-bucket co-presence allocation is not applied to the time-series).
- **`AppHost`** gains the `app_hosts.shared` flag via `listAllHostMappings` (additive, defaulted) so shared hosts are classified catalog-wide.

## Instrumentation

`usage_shared_host_attribution_total{outcome=attributed|split|other}` — bounded 3-value label, allowlisted in the cardinality firewall — plus two consuming Grafana panels on the `data-quality-ingest` dashboard (rate-by-outcome + 24h "Other" share).

## Tests (TDD, red → green)

- `SharedHostAllocationSpec` (unit) — pins the worked example: co-presence attribution, equal-split, "Other" fallback, and seconds conservation.
- `UsageApiSpec` (feature, embedded Postgres, real route, no mocked repos) — Feeling Great + Speechify both listing `elevenlabs.io` as shared: the shared host splits to the co-present app and its uncovered span lands in "Other".

Full `mill api.test` green.

Fixes #1898. Relates to #1888, #1897. (Enforcement is S4 #1899 — not in scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)