### PR TITLE
feat(#1899): most-permissive enforcement for shared hosts (allow-in, never block)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -711,7 +711,10 @@ class PolicyServiceLive(
     // Time-limit blocks expire at the next household daily-reset Instant.
     val resetAt     = PolicyService.nextDailyResetAfter(settings, now).toString
     val appLimitHit = state.perApp.find { sd =>
-      sd.hosts.exists(hp => HostMatch.matchesPattern(hostname, hp)) &&
+      // #1899 (shared-hosts S4): match only the app's DISTINCTIVE hosts — a shared backend is never
+      // app-cap-blocked, so the /decision fallback agrees with the snapshot's `appCapExhaustedHosts`
+      // (which also reads `distinctiveHosts`). Keeps the two paths from diverging (#1532).
+      sd.distinctiveHosts.exists(hp => HostMatch.matchesPattern(hostname, hp)) &&
       // #1627: same Option-aware exhaustion check as `appCapExhaustedHosts`.
       sd.dailyLimitMinutes.exists(lim => sd.usedMinutes >= lim)
     }
@@ -1011,8 +1014,12 @@ object PolicyService {
       // #1627: `dailyLimitMinutes = None` means "no per-app cap configured" —
       // never exhausted. Only an app with `Some(lim)` and `usedMinutes >= lim`
       // contributes hosts to extraBlocked here.
+      // #1899 (shared-hosts S4): only the app's DISTINCTIVE hosts are block-eligible. A shared
+      // backend is NEVER dropped on cap exhaustion — dropping it because THIS app hit its cap would
+      // drop it for every OTHER app on the device (the #1636 collateral failure). The cap is still
+      // enforced through the distinctive hosts; `usedMinutes` already aggregates the whole host-set.
       case sd if sd.dailyLimitMinutes.exists(lim => sd.usedMinutes >= lim) =>
-        sd.hosts.map(Hostname.unsafe)
+        sd.distinctiveHosts.map(Hostname.unsafe)
     }.flatten
 
   /**

--- a/api/src/policy/ProfileAppDispositions.scala
+++ b/api/src/policy/ProfileAppDispositions.scala
@@ -126,6 +126,13 @@ final case class ProfileAppDispositions(
     val blocked = scala.collection.mutable.ListBuffer.empty[Hostname]
     perApp.foreach { d =>
       val hosts                      = d.hosts.map(Hostname.unsafe)
+      // #1899 (shared-hosts S4): the BLOCK side is restricted to an app's DISTINCTIVE hosts. A
+      // shared backend (e.g. `elevenlabs.io`) is listed on many apps; dropping it because THIS app
+      // is blocked would drop it for every OTHER app on the device — the #1636 collateral failure.
+      // The ALLOW side keeps the full host-set (`hosts`): over-allowing a shared backend is safe
+      // (extraAllowed already beats every block path at the router; design §"most-permissive"), and
+      // a shared host belonging to an allowed app must stay reachable for that app to work.
+      val distinctive                = d.distinctiveHosts.map(Hostname.unsafe)
       val pairs                      = schedWindows.getOrElse(d.assignmentId, Nil)
       val allowedActive              = pairs.exists { case (m, w) =>
         m == AppScheduleMode.AllowedDuring && PolicyService.windowActiveAt(w, now)
@@ -140,12 +147,12 @@ final case class ProfileAppDispositions(
         if (!(capExhausted && !d.exemptFromDaily) && !suppressedByScheduleToggle)
           allowed ++= hosts
       } else if (blockedActive) {
-        blocked ++= hosts
+        blocked ++= distinctive
       } else
         d.mode match {
           case AppMode.Allowed     =>
             if (!suppressedByScheduleToggle) allowed ++= hosts
-          case AppMode.Blocked     => blocked ++= hosts
+          case AppMode.Blocked     => blocked ++= distinctive
           case AppMode.TimeLimited => () // surfaces via the per-app cap path
         }
     }

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -51,6 +51,13 @@ final case class AppDayState(
     // every host so off-domain asset/CDN traffic ticks the *same* app limit and is exempted from the
     // daily total just like the apex. For a single-host app this is `List(domainPattern)`.
     hosts: List[String] = Nil,
+    // #1899 (shared-hosts S4): the subset of `hosts` whose `app_hosts.shared` flag is false — the
+    // app's DISTINCTIVE host-set. The BLOCK side of per-app cap enforcement
+    // (`PolicyService.appCapExhaustedHosts`, `timeLimitBlockFromState`) reads THIS, never `hosts`,
+    // so a shared backend is never dropped when one app's cap exhausts (the #1636 collateral
+    // failure). The exempt-carve ALLOW side (`exemptUnderCapHosts`) keeps reading `hosts` — allow
+    // wins on shared hosts. An app with no shared hosts has `distinctiveHosts == hosts`.
+    distinctiveHosts: List[String] = Nil,
     // #1564: the typed FK to apps(id) the cap/rollup surface keys on internally. `label` and
     // `domainPattern` stay as display text; `appId` is the canonical identity that joins to
     // `app_used_daily.app_id` directly — no slug round-trip.
@@ -422,10 +429,12 @@ object TimeStatusService {
    */
   private[policy] def groupAppLimits(
       appLimits: List[AppTimeLimit],
-  ): List[(AppId, String, Option[Int], Boolean, List[String], String)] =
+  ): List[(AppId, String, Option[Int], Boolean, List[String], String, List[String])] =
     ProfileAppDispositions.from(appLimits).capGroups.map { d =>
       val rep = d.hosts.minByOption(_.length).getOrElse(d.label)
-      (d.appId, d.label, d.dailyMinutes, d.exemptFromDaily, d.hosts, rep)
+      // #1899: carry the distinctive subset alongside the full host-set so the per-app cap's BLOCK
+      // side (`PolicyService.appCapExhaustedHosts`) can omit shared hosts from extraBlocked.
+      (d.appId, d.label, d.dailyMinutes, d.exemptFromDaily, d.hosts, rep, d.distinctiveHosts)
     }
 
   /**
@@ -477,7 +486,7 @@ object TimeStatusService {
       appLimits: List[AppTimeLimit],
       minutesByAppId: Map[AppId, Int],
   ): List[AppDayState] =
-    groupAppLimits(appLimits).map { case (appId, label, daily, exempt, hosts, rep) =>
+    groupAppLimits(appLimits).map { case (appId, label, daily, exempt, hosts, rep, distinctive) =>
       AppDayState(
         label = label,
         domainPattern = rep,
@@ -485,6 +494,7 @@ object TimeStatusService {
         usedMinutes = minutesByAppId.getOrElse(appId, 0),
         exemptFromDaily = exempt,
         hosts = hosts,
+        distinctiveHosts = distinctive,
         appId = appId,
       )
     }

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -819,5 +819,128 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       } yield assertTrue(kidEa.contains("khanacademy.org")) &&
         assertTrue(!adultEa.contains("khanacademy.org"))
     },
+    // ── #1899 (shared-hosts S4): most-permissive enforcement for shared hosts ──
+    // A shared host follows the MOST PERMISSIVE disposition of any app that lists it: allow wins
+    // (added to extraAllowed unconditionally), block is withheld (never enters a drop set). This
+    // does NOT depend on co-presence (that gates attribution only, S2/S3). Reuses extraAllowed — no
+    // new wire field; the router stays a dumb applier.
+    test("#1899 allowed-mode app: distinctive AND shared hosts both carve into extraAllowed") {
+      for {
+        _     <- cleanDb
+        ar    <- ZIO.service[AppRepo]
+        kids  <- kidsId
+        appId <- ar.create("Feeling Great", "feeling-great", None, None)
+        // feelinggreat.com distinctive; elevenlabs.io shared backend.
+        _     <- ar.setHostEntries(
+          appId,
+          List(
+            AppHostEntry(Hostname.unsafe("feelinggreat.com"), shared = false),
+            AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+          ),
+        )
+        _     <- ar.upsertAssignment(appId, kids, AppMode.Allowed, None, true)
+        svc   <- makePs
+        snap  <- svc.snapshot
+      } yield {
+        val ea = snap.profiles(kids).rules.extraAllowed.map(_.value).toSet
+        val eb = snap.profiles(kids).rules.extraBlocked.map(_.value).toSet
+        // Allow wins for both host kinds; nothing is dropped.
+        assertTrue(ea.contains("feelinggreat.com")) &&
+        assertTrue(ea.contains("elevenlabs.io")) &&
+        assertTrue(!eb.contains("elevenlabs.io"))
+      }
+    },
+    test(
+      "#1899 blocked-mode app: distinctive host blocked, shared host omitted from extraBlocked",
+    ) {
+      // Blocking elevenlabs.io because one app is blocked would drop TTS for every OTHER app on the
+      // device — the #1636 collateral failure. Only the distinctive host is block-eligible.
+      for {
+        _     <- cleanDb
+        ar    <- ZIO.service[AppRepo]
+        kids  <- kidsId
+        appId <- ar.create("Some Blocked App", "blocked-app", None, None)
+        _     <- ar.setHostEntries(
+          appId,
+          List(
+            AppHostEntry(Hostname.unsafe("blockedapp.com"), shared = false),
+            AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+          ),
+        )
+        _     <- ar.upsertAssignment(appId, kids, AppMode.Blocked, None, true)
+        svc   <- makePs
+        snap  <- svc.snapshot
+      } yield {
+        val eb = snap.profiles(kids).rules.extraBlocked.map(_.value).toSet
+        assertTrue(eb.contains("blockedapp.com")) &&
+        assertTrue(!eb.contains("elevenlabs.io"))
+      }
+    },
+    test(
+      "#1899 time_limited app cap exhausted: distinctive host blocked, shared host NEVER dropped",
+    ) {
+      // The per-app cap exhausts on the distinctive host and the WHOLE distinctive host-set goes to
+      // extraBlocked — but the shared backend stays reachable (it belongs to other apps too). The
+      // cap is still enforced through the distinctive hosts.
+      for {
+        _     <- cleanDb
+        ar    <- ZIO.service[AppRepo]
+        kids  <- kidsId
+        dr    <- ZIO.service[DeviceRepo]
+        _     <- dr.upsert(MacAddress.unsafe("aa:bb:cc:dd:ee:99"), "iPad", Some(kids), "10.0.0.99")
+        rid   <- seedRouterRow
+        appId <- ar.create("Feeling Great", "feeling-great", None, None)
+        _     <- ar.setHostEntries(
+          appId,
+          List(
+            AppHostEntry(Hostname.unsafe("feelinggreat.com"), shared = false),
+            AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+          ),
+        )
+        _     <- ar.upsertAssignment(appId, kids, AppMode.TimeLimited, Some(30), true)
+        today = TestClock.schoolDayAfternoon.toLocalDate
+        // 30 m on the distinctive host → aggregate hits the 30 m cap.
+        _    <- seedTraffic(rid, "aa:bb:cc:dd:ee:99", "feelinggreat.com", today, 30)
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val eb = snap.profiles(kids).rules.extraBlocked.map(_.value).toSet
+        assertTrue(eb.contains("feelinggreat.com")) &&
+        assertTrue(!eb.contains("elevenlabs.io"))
+      }
+    },
+    test(
+      "#1899 shared host on a blocked app AND an allowed app: allow wins, never dropped",
+    ) {
+      // Most-permissive across apps: elevenlabs.io is shared on a Blocked app and an Allowed app.
+      // The Allowed app puts it in extraAllowed; the Blocked app never drops it. Net: allowed.
+      for {
+        _     <- cleanDb
+        ar    <- ZIO.service[AppRepo]
+        kids  <- kidsId
+        block <- ar.create("Blocked App", "blocked-app", None, None)
+        allow <- ar.create("Feeling Great", "feeling-great", None, None)
+        _     <- ar.setHostEntries(
+          block,
+          List(
+            AppHostEntry(Hostname.unsafe("blockedapp.com"), shared = false),
+            AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+          ),
+        )
+        _     <- ar.setHostEntries(
+          allow,
+          List(
+            AppHostEntry(Hostname.unsafe("feelinggreat.com"), shared = false),
+            AppHostEntry(Hostname.unsafe("elevenlabs.io"), shared = true),
+          ),
+        )
+        _     <- ar.upsertAssignment(block, kids, AppMode.Blocked, None, true)
+        _     <- ar.upsertAssignment(allow, kids, AppMode.Allowed, None, true)
+        svc   <- makePs
+        snap  <- svc.snapshot
+        rules = snap.profiles(kids).rules
+      } yield assertTrue(rules.extraAllowed.map(_.value).toSet.contains("elevenlabs.io")) &&
+        assertTrue(!rules.extraBlocked.map(_.value).toSet.contains("elevenlabs.io"))
+    },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/unit/SharedHostEnforcementSpec.scala
+++ b/api/test/src/unit/SharedHostEnforcementSpec.scala
@@ -1,0 +1,134 @@
+package wifihaven.api.policy
+
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate}
+
+/**
+ * #1899 (shared-hosts S4): enforcement for shared hosts follows the MOST-PERMISSIVE rule — allow
+ * wins, block is withheld — and does NOT depend on co-presence (that gates attribution only). For a
+ * shared host `S`:
+ *
+ *   - ALLOW side: `S` enters `extraAllowed` whenever an app listing it resolves to `Allowed`
+ *     enforcement (subject to `allowed_during_schedule_block`, #1679). Over-allowing a shared
+ *     backend is safe — `extraAllowed` already beats every block path at the router.
+ *   - BLOCK side: `S` is NEVER added to a drop set — not to a `Blocked`-mode app's `extraBlocked`,
+ *     and not to per-app cap-exhaustion's `appCapExhaustedHosts`. Dropping a shared backend because
+ *     ONE app blocked/cap-exhausted would drop it for every OTHER app — the #1636 collateral
+ *     failure. The cap is still enforced through the app's DISTINCTIVE hosts.
+ *
+ * Pure spec — `ProfileAppDispositions.enforcement`, `PolicyService.appCapExhaustedHosts`, and
+ * `PolicyService.computeBlockRules` are pure projections, so no DB / Clock is needed. The DB
+ * round-trip of the `app_hosts.shared` flag through `listForProfile` into the snapshot is pinned
+ * end-to-end in `PolicySnapshotAppsSpec`.
+ */
+object SharedHostEnforcementSpec extends ZIOSpecDefault {
+
+  private val pid          = ProfileId(1L)
+  private val appId        = AppId(10L)
+  private val assignmentId = AppPolicyAssignmentId(1L)
+  private val today        = LocalDate.parse("2026-06-24")
+  private val now          = Instant.parse("2026-06-24T18:00:00Z")
+
+  // Feeling Great: distinctive `feelinggreat.com`, shared `elevenlabs.io`.
+  private val distinctive = "feelinggreat.com"
+  private val sharedHost  = "elevenlabs.io"
+
+  private def disposition(
+      mode: AppMode,
+      exempt: Boolean = false,
+      dailyMinutes: Option[Int] = None,
+  ): AppDisposition =
+    AppDisposition(
+      appId = appId,
+      assignmentId = assignmentId,
+      mode = mode,
+      exemptFromDaily = exempt,
+      dailyMinutes = dailyMinutes,
+      label = "app:feeling-great",
+      hosts = List(distinctive, sharedHost),
+      distinctiveHosts = List(distinctive),
+    )
+
+  private val profile = Profile(pid, "Kid", Nil, paused = false)
+
+  // One per-app cap entry carrying both the distinctive and the shared host.
+  private def appDayState(used: Int, cap: Option[Int], exempt: Boolean = false): AppDayState =
+    AppDayState(
+      label = "app:feeling-great",
+      domainPattern = distinctive,
+      dailyLimitMinutes = cap,
+      usedMinutes = used,
+      exemptFromDaily = exempt,
+      hosts = List(distinctive, sharedHost),
+      distinctiveHosts = List(distinctive),
+      appId = appId,
+    )
+
+  private def stateWith(app: AppDayState): ProfileDayState =
+    ProfileDayState(pid, today, None, 0, 0, None, blocked = false, None, List(app))
+
+  def spec = suite("SharedHostEnforcementSpec (#1899)")(
+    // ── ALLOW side: most-permissive — allow wins, unconditional ──
+    test("Allowed-mode app: shared host carves into extraAllowed alongside the distinctive host") {
+      val (allowed, blocked) =
+        ProfileAppDispositions(List(disposition(AppMode.Allowed)))
+          .enforcement(Map.empty, capExhausted = false, now)
+      val a                  = allowed.map(_.value).toSet
+      assertTrue(a.contains(distinctive)) &&
+      assertTrue(a.contains(sharedHost)) &&
+      assertTrue(blocked.isEmpty)
+    },
+    // ── BLOCK side: shared host never enters a drop set ──
+    test("Blocked-mode app: distinctive host blocked, shared host omitted from extraBlocked") {
+      val (allowed, blocked) =
+        ProfileAppDispositions(List(disposition(AppMode.Blocked)))
+          .enforcement(Map.empty, capExhausted = false, now)
+      val b                  = blocked.map(_.value).toSet
+      assertTrue(b.contains(distinctive)) &&
+      assertTrue(!b.contains(sharedHost)) &&
+      assertTrue(allowed.isEmpty)
+    },
+    test(
+      "appCapExhaustedHosts: exhausted app contributes its distinctive hosts only, never shared",
+    ) {
+      val hosts = PolicyService
+        .appCapExhaustedHosts(stateWith(appDayState(used = 30, cap = Some(30))))
+        .map(_.value)
+        .toSet
+      assertTrue(hosts.contains(distinctive)) && assertTrue(!hosts.contains(sharedHost))
+    },
+    test("appCapExhaustedHosts: under-cap app contributes nothing (neither host)") {
+      val hosts = PolicyService
+        .appCapExhaustedHosts(stateWith(appDayState(used = 10, cap = Some(30))))
+        .map(_.value)
+        .toSet
+      assertTrue(hosts.isEmpty)
+    },
+    test(
+      "computeBlockRules: cap-exhausted app blocks the distinctive host but NEVER the shared one",
+    ) {
+      val rules = PolicyService.computeBlockRules(
+        profile = profile,
+        state = stateWith(appDayState(used = 30, cap = Some(30))),
+      )
+      val eb    = rules.extraBlocked.map(_.value).toSet
+      assertTrue(eb.contains(distinctive)) && assertTrue(!eb.contains(sharedHost))
+    },
+    test("computeBlockRules: Allowed-mode shared host lands in extraAllowed (most-permissive)") {
+      val (allowed, blocked) =
+        ProfileAppDispositions(List(disposition(AppMode.Allowed)))
+          .enforcement(Map.empty, capExhausted = false, now)
+      val rules              = PolicyService.computeBlockRules(
+        profile = profile,
+        state = stateWith(appDayState(used = 0, cap = Some(30))),
+        appExtraAllowed = allowed,
+        appExtraBlocked = blocked,
+      )
+      val ea                 = rules.extraAllowed.map(_.value).toSet
+      assertTrue(ea.contains(distinctive)) && assertTrue(ea.contains(sharedHost))
+    },
+  )
+}

--- a/docs/design/shared-host-allocation.md
+++ b/docs/design/shared-host-allocation.md
@@ -361,12 +361,16 @@ runs `/pr-review` before merge.
   (`attributed` / `split` / `other`) and its Grafana panels on the
   `data-quality-ingest` dashboard.
 
-- **S4 — Enforcement guardrails** (depends on S1b; parallel to S2/S3).
-  Exclude shared hosts from `appCapExhaustedHosts` and `Blocked`-mode
-  `extraBlocked` in `PolicyService.computeBlockRules`
-  ([PolicyService](../../api/src/policy/PolicyService.scala):771-885); keep the
-  unconditional allow path for shared hosts on `Allowed`-mode apps. Tests pin:
-  cap exhaustion never drops a shared host; allow-mode shared host carves.
+- **S4 — Enforcement guardrails** ✅ shipped
+  ([#1899](https://github.com/wifihaven/wifihaven/issues/1899)) — the BLOCK side
+  is restricted to each app's DISTINCTIVE hosts: `ProfileAppDispositions
+  .enforcement` blocks only `distinctiveHosts`, and `appCapExhaustedHosts` (plus
+  the `/decision` fallback `timeLimitBlockFromState`) read a new
+  `AppDayState.distinctiveHosts` threaded from the single
+  `ProfileAppDispositions.from` fold. The ALLOW side is unchanged — a shared host
+  rides the full host-set into `extraAllowed` whenever an app resolves to
+  `Allowed` (subject to #1679). No wire change. Tests pin: cap exhaustion /
+  manual block never drops a shared host; an allow-mode shared host carves.
 
 - **S5 — Feeling Great app, first consumer**
   ([#1889](https://github.com/wifihaven/wifihaven/issues/1889), depends on


### PR DESCRIPTION
## What

Shared-hosts **S4** — the last core slice of the shared-host work (parent #1888;
S1b #1896, S2 #1897, S3 #1898 merged). Implements the **most-permissive**
enforcement rule for shared hosts in `PolicyService` / `ProfileAppDispositions`.

A shared host follows the most permissive disposition of any app that lists it.
This is **independent of co-presence** — co-presence gates *attribution* (S2/S3)
only, never enforcement.

### Enforcement decision table

| App disposition | Distinctive host | Shared host |
|---|---|---|
| **Allowed** | `extraAllowed` | **`extraAllowed`** (unconditional) |
| **Blocked** (manual) | `extraBlocked` | **omitted** (never dropped) |
| **TimeLimited**, cap exhausted | `extraBlocked` | **omitted** (never dropped) |
| **TimeLimited**, under cap (exempt) | `extraAllowed` carve | `extraAllowed` if exempt-carve applies |

## Why

- **Over-allowing is safe.** `extraAllowed` already beats every block path at the
  router (an architectural invariant — admin allow overrides `@blocked_macs`
  too). Keeping a shared backend reachable breaks nothing and lets an Allowed-mode
  app actually work (e.g. Feeling Great carved around a Schedule block still needs
  `elevenlabs.io` for TTS).
- **Over-blocking is collateral.** Dropping a shared backend because *one* app is
  blocked / cap-exhausted would drop it for *every other* app on the device — the
  precise #1636 collateral failure. So a shared host **never** enters a drop set;
  only the app's **distinctive** hosts are block-eligible, and the cap is still
  enforced through them.

## How — no wire change

Reuses the existing `extraAllowed` / `extraBlocked` vocabulary; the router stays a
dumb applier (it can't express a co-presence-conditional allow, and per the
minimal-functional-shape rule we don't push one onto it).

- `ProfileAppDispositions.enforcement` now blocks only `distinctiveHosts` (both
  the `Blocked` base-mode and the `BlockedDuring` schedule-window branches). The
  allow side is unchanged — it keeps the full host-set.
- New `AppDayState.distinctiveHosts`, threaded from the single
  `ProfileAppDispositions.from` fold (`AppDisposition.distinctiveHosts`, #1897)
  through `groupAppLimits` → `appDayStatesFromMinutes`. `appCapExhaustedHosts`
  and the `/decision` fallback `timeLimitBlockFromState` read it, so a shared
  host is never per-app-cap-blocked and the two paths can't diverge (#1532).
- **Single-source-of-truth:** there is no second definition of "distinctive" — it
  comes from the same per-`(app, host)` `app_hosts.shared` partition S2/S3 use.

## Tests (TDD — red commit then green)

- `SharedHostEnforcementSpec` (unit): `enforcement` block side omits shared;
  `appCapExhaustedHosts` returns distinctive only; `computeBlockRules` never
  drops a shared host on cap exhaustion and carves an Allowed-mode shared host
  into `extraAllowed`.
- `PolicySnapshotAppsSpec` (feature, embedded Postgres): same rules end-to-end
  through the `app_hosts.shared` DB round-trip → snapshot — allowed app carves
  both host kinds; blocked app omits the shared host; cap-exhausted time-limited
  app blocks the distinctive host but never the shared backend; a shared host on
  a blocked *and* an allowed app ends up allowed.

Fixes #1899. Relates to #1888, #1898, #1636, #1679.
