### PR TITLE
fix(#1941): single-device per-app usage view counts distinctive hosts only

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1522,13 +1522,21 @@ object TimeRoutes {
           .usedSecondsByMac(p, List(device), appLimits, presence, settings)
           .getOrElse(device.mac, 0L) / 60L).toInt,
       )
-      // #1505 + #1504: per-device per-app usage via the #1464 session-stitch primitive, aggregated
-      // across each app's whole host-set (one bar per app). Single-device view, so cross-device
-      // overlap mode is moot — Sum and Dedup coincide.
+      // #1505 + #1504: per-device per-app usage via the #1464 session-stitch primitive (one bar per
+      // app). Single-device view, so cross-device overlap mode is moot — Sum and Dedup coincide.
+      // #1897 (shared-hosts S2): stitch each app's DISTINCTIVE host-set only — the SAME source the
+      // canonical per-profile stitch reads (`TimeStatusService.appDayStates` →
+      // `ProfileAppDispositions.capGroupLabelDistinctiveHosts`). A shared backend overlapping a
+      // distinctive span is already counted there, and a shared firing without distinctive activity
+      // must not inflate the app's minutes; reading the full host-set here over-counted. Routes
+      // through the one canonical distinctive-host projection (AGENTS.md §single-source-of-truth)
+      // rather than re-deriving a host-set locally — `appLimits` is already loaded above.
       perApp    = wifihaven.api.presence.Presence
         .patternGroupMinutesForProfile(
           presence,
-          stateOpt.toList.flatMap(_.perApp).map(s => s.label -> s.hosts),
+          wifihaven.api.policy.ProfileAppDispositions
+            .from(appLimits)
+            .capGroupLabelDistinctiveHosts,
           wifihaven.shared.CrossDeviceOverlapMode.Sum,
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,

--- a/api/test/src/feature/AppHostSetAttributionSpec.scala
+++ b/api/test/src/feature/AppHostSetAttributionSpec.scala
@@ -158,6 +158,86 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
         assertTrue(status.usedMins == 60)
       }
     },
+    test(
+      "single-device per-app view counts DISTINCTIVE hosts only — a shared host firing without distinctive activity does not inflate the app's minutes (#1897)",
+    ) {
+      // #1897 shared-hosts S2: the canonical per-app engaged-minutes stitch reads each app's
+      // distinctive (`shared = false`) host-set only — a shared backend (e.g. elevenlabs.io behind
+      // multiple apps) overlapping a distinctive span is already counted there, and a shared firing
+      // WITHOUT any distinctive activity must NOT create/extend the app's minutes. The single-device
+      // view (`GET /api/time/status/{mac}`) re-derives per-app minutes against this device's presence
+      // rows, so it must read the SAME distinctive-only source as the profile view, not the full
+      // host-set.
+      val distinctiveHost = "elevenlabs-app.example"
+      val sharedHost      = "elevenlabs.io"
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        atlRepo     <- ZIO.service[AppTimeLimitRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        trafficRepo <- ZIO.service[TrafficReportRepo]
+        extRepo     <- ZIO.service[TimeExtensionRepo]
+        appRepo     <- ZIO.service[AppRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        kidsId      <- TestLayers.seedKidsProfile(profileRepo)
+        _           <- tlRepo.upsert(kidsId, 120)
+        appId       <- appRepo.create("ElevenLabs", "elevenlabs", None, None)
+        // Distinctive app host + a SHARED backend host (e.g. shared across multiple AI apps).
+        _           <- appRepo.setHostEntries(
+          appId,
+          List(
+            AppHostEntry(Hostname.unsafe(distinctiveHost), shared = false),
+            AppHostEntry(Hostname.unsafe(sharedHost), shared = true),
+          ),
+        )
+        _           <- appRepo.upsertAssignment(appId, kidsId, AppMode.TimeLimited, Some(30), false)
+        _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+        routerId    <- seedRouter
+        today = TestClock.schoolDayAfternoon.toLocalDate
+        // 10 m on the distinctive host (buckets 0–1), then 10 m on the SHARED host an hour later
+        // (buckets 12–13) — a separate, non-overlapping span with no distinctive activity around it.
+        _               <- seedTraffic(routerId, testMac, distinctiveHost, today, 10)
+        _               <- seedTraffic(routerId, testMac, sharedHost, today, 10, 12)
+        userProfileRepo <- ZIO.service[UserProfileRepo]
+        hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+        clock           <- ZIO.service[Clock]
+        tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+          profileRepo,
+          tlRepo,
+          atlRepo,
+          deviceRepo,
+          trafficRepo,
+          extRepo,
+        )
+        routes = TimeRoutes.routes(
+          auth,
+          deviceRepo,
+          tlRepo,
+          atlRepo,
+          trafficRepo,
+          extRepo,
+          profileRepo,
+          userProfileRepo,
+          hsRepo,
+          tss,
+          clock,
+        )
+        req    = Request
+          .get(URL.decode(s"/api/time/status/$testMac").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp   <- routes.runZIO(req)
+        body   <- resp.body.asString
+        status <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
+      } yield {
+        val bars = status.appUsage.filter(_.label == "app:elevenlabs")
+        assertTrue(bars.size == 1) &&
+        // Distinctive-only: the 10 m of shared-host traffic must NOT be added on top of the 10 m of
+        // distinctive activity. Reading the full host-set (the bug) yields 20.
+        assertTrue(bars.head.usedMins == 10)
+      }
+    },
     test("off-domain asset host attributes to the app, not the 'Other' bucket") {
       // Pure attribution guardrail (Fix C): once the off-domain host is in the app's host-set, the
       // group-by-app aggregation buckets its traffic under the app rather than __other__.
@@ -195,5 +275,7 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
           assertTrue(agg.flatMap(_.groups.get("app")).toSet == Set(appSlug)),
       )
     },
-  )
+    // The DB-backed tests each clone the migration template into a fixed-named scratch DB, so they
+    // must not run concurrently within this suite.
+  ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
Closes #1941. Related: #1897 (shared-hosts S2), #1899/#1940 (S4).

## Problem

`api/src/routes/Routes.scala` (`buildDeviceTimeStatus`, the `GET /api/time/status/{mac}` single-device view) re-derived each app's per-app engaged minutes against the app's **full** host-set (`s.hosts`, including SHARED hosts):

```scala
stateOpt.toList.flatMap(_.perApp).map(s => s.label -> s.hosts) // full set incl. shared
```

Since shared-hosts S2 (#1897) the canonical per-app engaged-minutes stitch (`TimeStatusService.appDayStates` → `ProfileAppDispositions.capGroupLabelDistinctiveHosts`) reads each app's **distinctive** host-set only: a shared host overlapping a distinctive span is already counted (no-op), and a shared firing **without** distinctive activity must NOT inflate the app's minutes. The single-device display path was missed, so it over-counted when a shared backend (e.g. `elevenlabs.io`, shared across multiple AI apps) was active without the app's distinctive host. The per-profile view (line ~1258) was already correct — it reads `s.usedMinutes` directly.

## Fix

Route the per-device recompute through the one canonical distinctive-host projection `ProfileAppDispositions.from(appLimits).capGroupLabelDistinctiveHosts` — the method `ProfileAppDispositions`/AGENTS.md declares as *the* single definition of an app's distinctive host-set for presence. `appLimits` is already loaded in `buildDeviceTimeStatus`, so no new field/data is needed.

The per-device recompute itself is retained and correct: presence here is scoped to a single MAC, whereas the profile-level `s.usedMinutes` is profile-wide.

### Why not `AppDayState.distinctiveHosts` (per the original ask)?

The deferred-fix note suggested mapping `s.distinctiveHosts` once PR #1940 lands that field. #1940 is still **open**, and routing through the existing `capGroupLabelDistinctiveHosts` projection is strictly better here: it is the true single source (no copied field), uses data the handler already has, and does **not** collide with #1940's addition of the same-named field for enforcement. When #1940 merges, both remain correct independently.

## Tests

Added a feature test to `AppHostSetAttributionSpec` (embedded Postgres, real repos, `TestClock` — no mocks): an app with a distinctive host + a shared backend host, 10m distinctive activity + 10m shared activity in a separate non-overlapping window. Asserts the single-device app bar reads **10** (distinctive-only), not 20. Committed failing first (red→green visible in history). Suite marked `@@ sequential` (its DB-backed tests clone the migration template into a fixed-named scratch DB).

`mill api.test` green; `scalafmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)