### PR TITLE
test(#1939): Gate-2 e2e — ws policy snapshot push→apply through the real agent

### DIFF
--- a/scripts/e2e/fake-api/fake_api/app.py
+++ b/scripts/e2e/fake-api/fake_api/app.py
@@ -9,9 +9,10 @@ Test-control endpoints (`/test/*`) let pytest scenarios drive the fake.
 from __future__ import annotations
 
 import copy
+import json
 from typing import Any
 
-from aiohttp import web
+from aiohttp import WSMsgType, web
 
 from .state import State
 
@@ -130,6 +131,83 @@ async def get_blocklist(request: web.Request) -> web.Response:
     )
 
 
+# --- Websocket transport (#1939: server-side push for the Gate-2 e2e) --------
+#
+# Mirrors the real API's GET /api/router/ws (api/src/routes/RouterWsRoutes.scala)
+# closely enough to exercise the agent's wifihaven-ws sidecar end-to-end:
+#   - auth at upgrade: a missing/empty bearer is rejected 401 BEFORE the 101,
+#     exactly like the REST routes (and the real ws route),
+#   - on connect: push exactly one `policy` frame with the current snapshot
+#     (the #1849 first-policy-on-connect push),
+#   - on change: POST /test/snapshot fans a fresh `policy` frame to every
+#     connected channel (the #1849 push-on-change),
+#   - inbound: the agent's outbound usage/events/metrics frames and control
+#     pings are drained and discarded. The real server acks data frames; the
+#     agent's drain does NOT gate on an ack (ws_loop.drain_and_send), so the
+#     fake omits acks and lets aiohttp auto-pong the control pings. Keeping the
+#     fake a read-and-discard sink avoids a second concurrent sender on the
+#     socket (only the policy pushes send), so frames never interleave.
+
+
+def _policy_frame_text(snapshot: dict[str, Any]) -> str:
+    """The `{op:"policy", payload:<snapshot>}` envelope a pushed snapshot rides.
+
+    Byte-for-byte the shape RouterWsRegistry.policyFrameText produces, so the
+    agent's ws_loop sees an identical frame whether the push came from the real
+    Scala API or this fake.
+    """
+    return json.dumps({"op": "policy", "payload": snapshot})
+
+
+async def _push_policy(state: State, ws: web.WebSocketResponse) -> bool:
+    """Send one `policy` frame to a single channel; True on success.
+
+    A send failure (a racing disconnect) returns False so the caller can drop
+    the dead channel — same posture as the real registry's channel_closed path.
+    """
+    try:
+        await ws.send_str(_policy_frame_text(state.snapshot))
+        state.note_policy_frame_sent()
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def _push_policy_to_all(state: State) -> int:
+    """Fan the current snapshot to every connected channel; return push count."""
+    pushed = 0
+    for ws in list(state.ws_connections):
+        if await _push_policy(state, ws):
+            pushed += 1
+        else:
+            state.deregister_ws(ws)
+    return pushed
+
+
+async def get_ws(request: web.Request) -> web.StreamResponse:
+    # Auth at upgrade time. Reject a missing/empty bearer with the SAME 401 the
+    # REST routes produce (no 101) before preparing the websocket.
+    if _bearer_token(request) is None:
+        return web.json_response({"error": "Missing router token"}, status=401)
+    state: State = request.app[STATE_KEY]
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+    state.register_ws(ws)
+    # #1849 first-policy-on-connect push.
+    await _push_policy(state, ws)
+    try:
+        async for msg in ws:
+            if msg.type == WSMsgType.ERROR:
+                break
+            # TEXT/BINARY (agent usage/events/metrics) are drained + discarded;
+            # control pings are auto-ponged by aiohttp. The fake never needs the
+            # inbound payloads — the Gate-2 ingest-parity coverage is Gate 3
+            # (ws_send.py against the real API).
+    finally:
+        state.deregister_ws(ws)
+    return ws
+
+
 # --- Test-control endpoints --------------------------------------------------
 
 
@@ -137,7 +215,12 @@ async def test_post_snapshot(request: web.Request) -> web.Response:
     body = await _read_json(request)
     state: State = request.app[STATE_KEY]
     state.replace_snapshot(body)
-    return web.json_response({"ok": True, "etag": state.etag})
+    # #1939/#1849: a snapshot change pushes ONE fresh `policy` frame to every
+    # connected ws channel. The HTTP poll path (GET /api/router/policy) is
+    # unchanged; a scenario that wants to prove the push specifically widens the
+    # agent's poll interval so only this push can deliver the new etag.
+    pushed = await _push_policy_to_all(state)
+    return web.json_response({"ok": True, "etag": state.etag, "wsPushed": pushed})
 
 
 async def test_get_events(request: web.Request) -> web.Response:
@@ -255,6 +338,24 @@ async def test_post_blocklist(request: web.Request) -> web.Response:
     return web.json_response({"ok": True, "id": bl_id, "host_count": len(hosts)})
 
 
+async def test_get_ws_status(request: web.Request) -> web.Response:
+    """Report ws push state so scenarios can sync on "the agent connected".
+
+    `connections` is the live channel count; `policyFramesSent` is the
+    cumulative count of `policy` frames the fake has pushed (on-connect +
+    on-change). Added by #1939 so the Gate-2 ws-push scenario can wait for the
+    sidecar to upgrade before triggering a change, and assert the server side
+    of the push independently of the router-side receive observables.
+    """
+    state: State = request.app[STATE_KEY]
+    return web.json_response(
+        {
+            "connections": len(state.ws_connections),
+            "policyFramesSent": state.ws_policy_frames_sent,
+        }
+    )
+
+
 async def test_post_reset(request: web.Request) -> web.Response:
     state: State = request.app[STATE_KEY]
     state.reset()
@@ -283,7 +384,9 @@ def make_app(state: State | None = None) -> web.Application:
     app.router.add_post("/api/router/events", post_events)
     app.router.add_post("/api/router/usage", post_usage)
     app.router.add_get("/api/blocklists/{id}", get_blocklist)
+    app.router.add_get("/api/router/ws", get_ws)
     app.router.add_post("/test/snapshot", test_post_snapshot)
+    app.router.add_get("/test/ws_status", test_get_ws_status)
     app.router.add_post("/test/blocklist", test_post_blocklist)
     app.router.add_get("/test/events", test_get_events)
     app.router.add_get("/test/usage", test_get_usage)

--- a/scripts/e2e/fake-api/fake_api/state.py
+++ b/scripts/e2e/fake-api/fake_api/state.py
@@ -57,6 +57,16 @@ class State:
     # Persists across resets so tests don't have to re-register them after each
     # router restore; a test that needs a clean slate can POST an empty body.
     blocklists: dict[str, str] = field(default_factory=dict)
+    # #1939: live websocket connections (aiohttp WebSocketResponse objects) the
+    # agent's wifihaven-ws sidecar has opened against GET /api/router/ws. The fake
+    # pushes a `policy` frame to each on connect and on every snapshot change, the
+    # server-side end of the #1849 push path. Not a dataclass-copyable value —
+    # never deep-copied; managed purely by register_ws/deregister_ws.
+    ws_connections: set = field(default_factory=set)
+    # #1939: cumulative count of `policy` frames the fake has successfully sent
+    # over ws (on-connect + on-change). Lets a scenario assert "the server pushed"
+    # from the fake side, complementing the router-side receive observables.
+    ws_policy_frames_sent: int = 0
     _next_event_id: int = 1
     _next_usage_id: int = 1
     _next_policy_fetch_id: int = 1
@@ -131,6 +141,20 @@ class State:
         """Return the content for a blocklist id, or None if not registered."""
         return self.blocklists.get(id)
 
+    # ── #1939: ws connection registry + policy-push bookkeeping ──────────────
+
+    def register_ws(self, ws) -> None:
+        """Record a freshly-upgraded /api/router/ws channel."""
+        self.ws_connections.add(ws)
+
+    def deregister_ws(self, ws) -> None:
+        """Drop a closed/closing /api/router/ws channel (idempotent)."""
+        self.ws_connections.discard(ws)
+
+    def note_policy_frame_sent(self) -> None:
+        """Count one `policy` frame the fake successfully pushed over ws."""
+        self.ws_policy_frames_sent += 1
+
     def reset(self) -> None:
         self.snapshot = copy.deepcopy(self.initial_snapshot)
         self.registers.clear()
@@ -141,4 +165,12 @@ class State:
         self._next_usage_id = 1
         self._next_policy_fetch_id = 1
         self.clock_base = None
+        # #1939: drop ws bookkeeping. The per-function `router` fixture restores
+        # the VM to the base (ws-OFF) snapshot before each scenario, so any
+        # channels left here are dead sockets from a prior ws-enabled scenario;
+        # clearing keeps the connection count + push tally honest for the next
+        # test. We do NOT close them — the restore already severed the socket and
+        # the handler's finally deregisters on its own.
+        self.ws_connections.clear()
+        self.ws_policy_frames_sent = 0
         # Note: blocklists are intentionally NOT cleared here — see set_blocklist.

--- a/scripts/e2e/fake-api/tests/test_ws.py
+++ b/scripts/e2e/fake-api/tests/test_ws.py
@@ -84,7 +84,7 @@ async def test_ws_status_tracks_connections_and_pushes(client, auth_headers):
         await ws.close()
 
 
-async def test_ws_push_to_all_with_no_connections_is_noop(client, auth_headers):
+async def test_ws_push_to_all_with_no_connections_is_noop(client):
     # A snapshot change with nobody connected must not error and reports 0 pushes.
     new_snap = {
         "etag": '"sha256:ws-noconn-0001"',

--- a/scripts/e2e/fake-api/tests/test_ws.py
+++ b/scripts/e2e/fake-api/tests/test_ws.py
@@ -1,0 +1,98 @@
+"""Unit coverage for the fake's GET /api/router/ws server-side push (#1939).
+
+The Gate-2 qemu scenario (scripts/e2e/scenarios_fake/test_ws_push_apply.py)
+drives the real agent's wifihaven-ws sidecar against this endpoint; these tests
+pin the fake's behaviour without a VM so a regression surfaces in seconds:
+
+  - auth at upgrade (missing/empty bearer → 401 before the 101),
+  - first-policy-on-connect push (#1849),
+  - push-on-change when /test/snapshot swaps the snapshot (#1849),
+  - the /test/ws_status bookkeeping the scenario syncs on.
+"""
+from __future__ import annotations
+
+import aiohttp
+import pytest
+
+from fake_api.fixtures import load_initial_snapshot
+
+
+async def test_ws_pushes_current_snapshot_on_connect(client, auth_headers):
+    ws = await client.ws_connect("/api/router/ws", headers=auth_headers)
+    try:
+        frame = await ws.receive_json(timeout=5)
+        assert frame["op"] == "policy"
+        assert frame["payload"] == load_initial_snapshot()
+    finally:
+        await ws.close()
+
+
+async def test_ws_missing_bearer_rejected_at_upgrade(client):
+    with pytest.raises(aiohttp.WSServerHandshakeError) as exc:
+        await client.ws_connect("/api/router/ws")
+    assert exc.value.status == 401
+
+
+async def test_ws_empty_bearer_rejected_at_upgrade(client):
+    with pytest.raises(aiohttp.WSServerHandshakeError) as exc:
+        await client.ws_connect(
+            "/api/router/ws", headers={"Authorization": "Bearer "}
+        )
+    assert exc.value.status == 401
+
+
+async def test_ws_pushes_on_snapshot_change(client, auth_headers):
+    ws = await client.ws_connect("/api/router/ws", headers=auth_headers)
+    try:
+        # Drain the on-connect push first.
+        first = await ws.receive_json(timeout=5)
+        assert first["op"] == "policy"
+
+        new_snap = {
+            "etag": '"sha256:ws-change-0001"',
+            "generatedAt": "2026-05-19T12:00:00Z",
+            "devices": {},
+            "profiles": {},
+            "blocklists": {},
+        }
+        resp = await client.post("/test/snapshot", json=new_snap)
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["wsPushed"] == 1
+        assert body["etag"] == new_snap["etag"]
+
+        pushed = await ws.receive_json(timeout=5)
+        assert pushed["op"] == "policy"
+        assert pushed["payload"] == new_snap
+    finally:
+        await ws.close()
+
+
+async def test_ws_status_tracks_connections_and_pushes(client, auth_headers):
+    status = await (await client.get("/test/ws_status")).json()
+    assert status["connections"] == 0
+    assert status["policyFramesSent"] == 0
+
+    ws = await client.ws_connect("/api/router/ws", headers=auth_headers)
+    try:
+        await ws.receive_json(timeout=5)  # on-connect push
+        status = await (await client.get("/test/ws_status")).json()
+        assert status["connections"] == 1
+        # On-connect push counts toward the cumulative tally.
+        assert status["policyFramesSent"] >= 1
+    finally:
+        await ws.close()
+
+
+async def test_ws_push_to_all_with_no_connections_is_noop(client, auth_headers):
+    # A snapshot change with nobody connected must not error and reports 0 pushes.
+    new_snap = {
+        "etag": '"sha256:ws-noconn-0001"',
+        "generatedAt": "2026-05-19T12:00:00Z",
+        "devices": {},
+        "profiles": {},
+        "blocklists": {},
+    }
+    resp = await client.post("/test/snapshot", json=new_snap)
+    assert resp.status == 200
+    assert (await resp.json())["wsPushed"] == 0

--- a/scripts/e2e/lib/fake_client.py
+++ b/scripts/e2e/lib/fake_client.py
@@ -117,6 +117,30 @@ class FakeAPIClient:
             path += f"?since_id={since_id}"
         return self._get_json(path)
 
+    # ── /test/ws_status (#1939) ─────────────────────────────────────────────
+
+    def ws_status(self) -> dict[str, Any]:
+        """{connections, policyFramesSent} — server side of the ws push path."""
+        return self._get_json("/test/ws_status")
+
+    def wait_for_ws_connected(
+        self,
+        *,
+        timeout_s: float = 180,
+        interval_s: float = 2.0,
+    ) -> dict[str, Any]:
+        """Block until the agent's wifihaven-ws sidecar has upgraded the socket."""
+        deadline = time.monotonic() + timeout_s
+        last: dict[str, Any] = {}
+        while time.monotonic() < deadline:
+            last = self.ws_status()
+            if last.get("connections", 0) >= 1:
+                return last
+            time.sleep(interval_s)
+        raise TimeoutError(
+            f"agent ws sidecar never connected in {timeout_s}s (last={last!r})"
+        )
+
     # ── internal ───────────────────────────────────────────────────────────
 
     def _post_json(self, path: str, body: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -25,6 +25,7 @@ markers =
     v6_usage_attribution: #1804 — v6 per-device usage round-trip surfaces by FQDN with non-zero bytes (e2e gate for #1796 / #1802)
     global_policy: suite H (#1460) — @global_allow / @global_block fleet-wide enforcement (gate for #1321)
     encrypted_dns: suite J (#1911) — network-wide blockEncryptedDns toggle (NODATA relay/DoH hosts + nft drop DoT/853 & :53-to-resolver-IPs; opportunistic LAN-resolver fallback survives)
+    ws_push: suite K (#1939) — ws policy-snapshot push transport: the real agent's wifihaven-ws sidecar receives a server-pushed snapshot on connect + on change and saves it, independent of the HTTP poll
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO

--- a/scripts/e2e/scenarios_fake/test_ws_push_apply.py
+++ b/scripts/e2e/scenarios_fake/test_ws_push_apply.py
@@ -1,0 +1,172 @@
+"""Suite K — ws policy-snapshot push transport, real agent (#1939).
+
+The gap this closes: every other ws check exercises only PART of the push path —
+the API emits to a test client (RouterWsSpec), the agent ws machinery is unit-
+tested in isolation (busted ws_*_spec.lua), and ingest parity uses the stdlib
+ws_send.py fake client (Gate 3). NONE drives a *server push* through the *real*
+OpenWRT agent's wifihaven-ws sidecar.
+
+This scenario does. With the sidecar enabled (UCI `wifihaven.ws.enabled=1`,
+default-off everywhere else) and pointed at the Gate-2 fake API, it asserts the
+two legs of the push path end-to-end through the real agent:
+
+  Leg A — policy-on-connect (#1849): on upgrade the fake pushes the current
+    snapshot; the sidecar receives it (`ws_frames_recv_total{op=policy}` ticks)
+    and saves it to /etc/wifihaven/policy.json.
+  Leg B — push-on-change (#1849): a server-side snapshot change pushes ONE fresh
+    `policy` frame; the sidecar receives it and the on-disk snapshot's etag flips
+    to the new value — and because the HTTP poll interval is widened to 3600s for
+    this scenario, that flip can ONLY have arrived over the websocket, not a poll.
+
+SCOPE (per #1939 + the operator's "test-only, defer wiring" decision): this
+verifies the push *transport* reaches the real agent and the snapshot is
+*saved*. It deliberately does NOT assert a live enforcement flip from the push:
+the running agent applies policy only from its HTTP poll (the sidecar's on_policy
+saves the snapshot file but the agent never re-reads it mid-run), so a pushed
+snapshot does not change nft/dnsmasq state until the next poll or a restart.
+Wiring agent-side apply-on-push (and extending this scenario with an
+enforcement-flip assertion) is tracked in #1945.
+Asserting only local file/metric observables also keeps the scenario clear of the
+known intermittent runner→public-resolver egress flake (#1935) — no external
+reachability is probed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lib.vm import router_ssh
+from lib.wait import wait_until
+
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.ws_push
+
+SNAPSHOT_PATH = "/etc/wifihaven/policy.json"
+WS_METRICS_PATH = "/tmp/wifihaven-ws-metrics.txt"
+WS_HEALTH_PATH = "/tmp/wifihaven-ws-health"
+
+# A phantom device MAC — no client VM is booted because this scenario asserts
+# router-side file/metric observables only (snapshot saved + frame received), not
+# client traffic enforcement.
+DEV_MAC = "02:e2:9c:00:19:39"
+PID = 1939
+ETAG_ON_CONNECT = '"sha256:ws-push-onconnect-v1"'
+ETAG_ON_CHANGE = '"sha256:ws-push-onchange-v2"'
+
+
+def _snapshot(*, etag: str, extra_blocked: list[str]) -> dict:
+    return (
+        SnapshotBuilder()
+        .add_profile(id=PID, name="e2e-ws-push", extra_blocked=extra_blocked)
+        .add_device(mac=DEV_MAC, name="e2e-ws-push-dev", profile_id=PID)
+        .build(etag=etag)
+    )
+
+
+def _enable_ws_and_freeze_poll() -> None:
+    """Turn the ws sidecar on and widen the HTTP poll so only the push delivers.
+
+    Setting `policy_poll_interval=3600` neutralises the poll for the scenario's
+    lifetime (the agent still does ONE startup poll, then sleeps an hour), so any
+    policy.json change observed after the socket is up is attributable to the ws
+    push and nothing else. The settings live in the VM disk and are reverted by
+    the next test's `router` fixture (router_restore to the ws-off base snapshot).
+    """
+    router_ssh(
+        "uci set wifihaven.ws.enabled=1; "
+        "uci set wifihaven.wifihaven.policy_poll_interval=3600; "
+        "uci commit wifihaven; "
+        "/etc/init.d/wifihaven restart",
+        timeout=60,
+    )
+
+
+def _router_snapshot_etag() -> str | None:
+    res = router_ssh(f"cat {SNAPSHOT_PATH} 2>/dev/null || true", check=False, timeout=10)
+    out = (res.stdout or "").strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out).get("etag")
+    except (ValueError, AttributeError):
+        return None
+
+
+def _ws_recv_policy_count() -> int:
+    """Parse ws_frames_recv_total{op=policy} from the sidecar's tmpfs tally.
+
+    Format (ws_metrics.lua): `<name>\\t<label>\\t<count>` per counter line.
+    Returns 0 when the file/line is absent (sidecar not up yet / no frame yet).
+    """
+    res = router_ssh(f"cat {WS_METRICS_PATH} 2>/dev/null || true", check=False, timeout=10)
+    for line in (res.stdout or "").splitlines():
+        parts = line.split("\t")
+        if len(parts) == 3 and parts[0] == "ws_frames_recv_total" and parts[1] == "policy":
+            try:
+                return int(parts[2])
+            except ValueError:
+                return 0
+    return 0
+
+
+def _ws_health_present() -> bool:
+    res = router_ssh(
+        f"[ -s {WS_HEALTH_PATH} ] && echo yes || echo no",
+        check=False, timeout=10,
+    )
+    return (res.stdout or "").strip() == "yes"
+
+
+def test_ws_policy_push_received_and_saved(router, fake_api):
+    # The fake serves the on-connect snapshot before the sidecar upgrades.
+    fake_api.serve_snapshot(
+        _snapshot(etag=ETAG_ON_CONNECT, extra_blocked=["example.com"])
+    )
+
+    # Enable the sidecar + freeze the poll, then wait for the agent to upgrade
+    # the socket (the fake sees the connection).
+    _enable_ws_and_freeze_poll()
+    fake_api.wait_for_ws_connected(timeout_s=180)
+
+    # ── Leg A — policy-on-connect ───────────────────────────────────────────
+    # The on-connect push lands: the sidecar counts a received `policy` frame and
+    # the ws-health sentinel is live.
+    wait_until(
+        lambda: True if _ws_recv_policy_count() >= 1 else None,
+        timeout_s=90, interval_s=3,
+        description="sidecar receives the on-connect policy frame "
+                    "(ws_frames_recv_total{op=policy} >= 1)",
+    )
+    assert _ws_health_present(), "ws-health sentinel should be live once connected"
+    # The pushed snapshot is saved to flash with the served etag. (The startup
+    # poll also writes this etag; the push-specific proof is Leg B below, where
+    # the frozen poll can't be the source.)
+    wait_until(
+        lambda: True if _router_snapshot_etag() == ETAG_ON_CONNECT else None,
+        timeout_s=90, interval_s=3,
+        description=f"policy.json carries the on-connect etag {ETAG_ON_CONNECT}",
+    )
+    baseline_recv = _ws_recv_policy_count()
+
+    # ── Leg B — push-on-change, independent of the poll ─────────────────────
+    # Swap the served snapshot. The fake fans ONE fresh `policy` frame to the
+    # connected agent; the HTTP poll is frozen at 3600s, so the only path that
+    # can move policy.json to the new etag is the ws push.
+    push = fake_api.serve_snapshot(
+        _snapshot(etag=ETAG_ON_CHANGE, extra_blocked=["example.com", "example.net"])
+    )
+    assert push == ETAG_ON_CHANGE
+
+    wait_until(
+        lambda: True if _router_snapshot_etag() == ETAG_ON_CHANGE else None,
+        timeout_s=90, interval_s=3,
+        description=f"policy.json etag flips to {ETAG_ON_CHANGE} via the ws push "
+                    "(poll frozen at 3600s — push is the only possible source)",
+    )
+    wait_until(
+        lambda: True if _ws_recv_policy_count() > baseline_recv else None,
+        timeout_s=60, interval_s=3,
+        description="sidecar receives a second policy frame (push-on-change)",
+    )

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -267,7 +267,18 @@ HOST_GID=$(id -g)
 # render.lua DNATs blocked HTTP/80 traffic there; without uhttpd in
 # the image, the DNAT lands on a dead port and curl times out
 # instead of receiving the block page.
-PACKAGES_LIST="wifihaven -dnsmasq dnsmasq-full uhttpd"
+#
+# cqueues + luaossl: the wifihaven-ws sidecar's hard runtime deps (the async
+# event loop + TLS/crypto the agent lacks, #1845/#1848). They are NOT a package
+# DEPENDS of wifihaven (ws is opt-in, default-off — see openwrt/files/etc/config/
+# wifihaven), so they are not pulled in automatically. The Gate-2 ws push→apply
+# scenario (scripts/e2e/scenarios_fake/test_ws_push_apply.py, #1939) flips
+# `wifihaven.ws.enabled=1`, which only starts a *working* sidecar when these are
+# present. Both are in the official OpenWrt feeds for Lua 5.1 on the 23.05 (ipk)
+# and snapshot (apk) generations the matrix builds (verified by the #1845 spike),
+# so the Image Builder pulls them from the upstream feed. e2e image only —
+# production routers install these out-of-band when an operator opts into ws.
+PACKAGES_LIST="wifihaven -dnsmasq dnsmasq-full uhttpd cqueues luaossl"
 
 # Per-flavor IB prep script — chosen branch is run inside the container.
 case "$PKG_FORMAT" in


### PR DESCRIPTION
## What & why

Closes the gap (#1939): the websocket transport's **server→agent push path was never exercised end-to-end through the real OpenWRT agent**. Existing coverage only hit parts — the API emits to a *test* client (`RouterWsSpec`), the agent ws machinery is unit-tested in isolation (busted `ws_*_spec.lua`), and ingest parity uses the stdlib `ws_send.py` *fake* client (Gate 3). None drove a server **push** through the real `wifihaven-ws` sidecar.

## Scope (operator decision: test-only, defer the wiring)

While implementing this I found the push→apply→**enforce** path isn't actually wired in the agent: the sidecar's `on_policy` only `save_snapshot`s the pushed frame to `/etc/wifihaven/policy.json`, and the running agent reads that file **only at startup** — its tick loop applies policy exclusively from the HTTP poll. So a pushed snapshot updates the on-disk cache but doesn't change live enforcement until the next poll/restart.

Per the operator's call, this PR is **test-only**: it proves the push **transport** reaches the real agent and the snapshot is **saved**, but does **not** assert a live enforcement flip. Agent-side apply-on-push wiring + an enforcement-flip assertion are tracked in **#1945** (filed, Epic: Router Agent & Release).

## Changes

**Fake-API ws push (prerequisite).** The Gate-2 fake had no ws server, so the agent (which talks to the fake) had nothing to upgrade against. Adds `GET /api/router/ws`:
- 401-before-101 auth at upgrade (mirrors the REST routes + the real ws route),
- first-policy-on-connect push (#1849),
- push-on-change fan-out from `POST /test/snapshot`.

The `{"op":"policy","payload":<snapshot>}` frame is byte-identical to `RouterWsRegistry.policyFrameText`, so the agent's `ws_loop` sees the same frame whether the push came from the real Scala API or the fake. Inbound agent frames (usage/events/metrics) are drained+discarded; control pings are auto-ponged. Adds `/test/ws_status` so a scenario can sync on "agent connected" and assert the server side of the push.

**Gate-2 scenario** (`scenarios_fake/test_ws_push_apply.py`, marker `ws_push`): enables the sidecar via UCI (`wifihaven.ws.enabled=1`, default-off everywhere else) and **freezes the HTTP poll** (`policy_poll_interval=3600`) so any `policy.json` change after connect is attributable to the push alone.
- **Leg A — policy-on-connect:** the sidecar receives the on-connect frame (`ws_frames_recv_total{op=policy}` ticks, ws-health sentinel live) and saves it to `policy.json`.
- **Leg B — push-on-change:** a snapshot swap pushes ONE frame; `policy.json`'s etag flips to the new value **with the poll frozen** — proof the websocket, not a poll, delivered it.

Enforcement observables are deliberately local file/metric reads (no external reachability), which also sidesteps the known intermittent runner→public-resolver egress flake (#1935).

**Gate-2 image:** adds `cqueues` + `luaossl` to the qemu router image's `PACKAGES_LIST` — the sidecar's hard runtime deps. They're not a `wifihaven` package DEPENDS (ws is opt-in/default-off), so the toggle only starts a *working* sidecar when they're present. Both are in the 23.05 (ipk) + snapshot (apk) feeds the matrix builds (verified by the #1845 spike). e2e image only; production routers install them out-of-band when opting into ws.

## Validation

- `scripts/e2e/fake-api` pytest: **27 passed** (incl. 6 new `test_ws.py` — on-connect push, push-on-change, 401-at-upgrade, status bookkeeping, no-connection no-op).
- Scenario collects under `--strict-markers` (new `ws_push` marker registered).
- Real-router ws validation not feasible right now: the deployed test router (agent 0.3.13) ships **neither** the `wifihaven-ws` binary nor cqueues/luaossl — which also confirms the image-package addition is genuinely required. Authoritative validation is the **KVM Gate-2 run on Master Router CD** (both ipk + apk arms boot the new image and run the scenario).

Fixes #1939. Relates to #1023, #1846, #1848, #1849; follow-up #1945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)