### PR TITLE
docs(#1860): design SPA-side websocket infrastructure

### DIFF
--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -371,10 +371,12 @@ only, consistent with the rev-2 "glanceable, not analytics" principle.
 > existing read model **streamed**: overall/per-profile = `groupBy ∈ {∅,profile}`,
 > the averaging window = its `bucket`, and the client derives B/s from
 > bytes-over-bucket. No new shape — see [`spa-websocket.md` §1.3](spa-websocket.md)
-> (`trafficUsage` topic). The same stream powers the **Traffic Usage page** live,
-> not just the dashboard gauge. (Granularity floor is `1m`, the `traffic_reports`
-> bucket; a sub-minute "instant" gauge is an optional extra — `spa-websocket.md`
-> §5.3/§10 Q1.)
+> (`trafficUsage` topic). The same topic powers the **Traffic Usage page**, which
+> still loads its **history via the existing `GET`** and only takes the **live
+> edge** (the current bucket advancing) from the socket — the stream isn't a
+> replacement for the historical query. (Granularity floor is `1m`, the
+> `traffic_reports` bucket; a sub-minute "instant" gauge is an optional extra —
+> `spa-websocket.md` §5.3/§10 Q1.)
 
 ### 8.2 The dashboard's live data contract (what streams vs. what stays request/response)
 

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -375,8 +375,9 @@ only, consistent with the rev-2 "glanceable, not analytics" principle.
 > still loads its **history via the existing `GET`** and only takes the **live
 > edge** (the current bucket advancing) from the socket — the stream isn't a
 > replacement for the historical query. (Granularity floor is `1m`, the
-> `traffic_reports` bucket; a sub-minute "instant" gauge is an optional extra —
-> `spa-websocket.md` §5.3/§10 Q1.)
+> `traffic_reports` bucket; fully-realtime uses the `raw` bucket, which streams the
+> live edge at the router's usage-send cadence — no bespoke sample, no router
+> change. `spa-websocket.md` §5.3/§10 Q1.)
 
 ### 8.2 The dashboard's live data contract (what streams vs. what stays request/response)
 
@@ -419,12 +420,11 @@ source in first" step (§7.5) is now concrete:
 - **#747 bandwidth** is **no longer a deferred standalone** — it becomes part of
   the websocket dashboard pilot ([`spa-websocket.md` §9](spa-websocket.md)),
   streaming the existing `GET /api/usage/traffic` read model (`trafficUsage`
-  topic). It needs **no new backend data path** for `1m`-and-coarser bandwidth
-  (the API re-runs the existing traffic-usage query on usage ingest,
-  [`spa-websocket.md` §5.3](spa-websocket.md)); only the optional sub-minute
-  "instant" gauge depends on #1023 (a router conntrack sample). Earlier this note
-  said throughput was #1023-gated — with the read-model reuse, only the sub-minute
-  refinement is.
+  topic). It needs **no new backend data path and no router change**: the API
+  recomputes only the current bucket on usage ingest
+  ([`spa-websocket.md` §5.3](spa-websocket.md)), and fully-realtime uses the `raw`
+  bucket at the router's usage-send cadence. Earlier this note said throughput was
+  #1023-gated — it isn't; it just gets faster as #1023 streams usage.
 
 This revision records the decision; the wire/payload specifics live in
 `spa-websocket.md` (single source of truth for the protocol), and dashboard

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -247,12 +247,21 @@ implementation sub-issues §5 called for were never filed. This section is autho
 ```
 Dashboard (h1)
   Banners            — NewDevicesHint, AccessRequestsBanner (only when present)
-  KPI strip          — Online now · Blocked now · Events (1h) · Blocked (1h)      [above the fold]
-  NOW                — freshness pill; active cards (top-3 devices + expander); idle-collapse row
+  KPI strip          — Online now · Blocked now · Events (1h) · Blocked (1h) · Bandwidth ▲/▼   [above the fold]
+  NOW                — freshness pill; active cards (top-3 devices + expander, per-profile ▲/▼); idle-collapse row
   Most Recently Blocked  — blocked-only trailing-hour feed (#1338), View all → /usage/events
   Blocking activity (24h) — one merged ranked-host panel; one-line empty state
   (no inline log table)
 ```
+
+**Bandwidth tile (rev 3, §8.1).** The 5th KPI tile is the **overall household
+in/out** live gauge (▲ up / ▼ down), with a small **window selector**
+(`1m · 10m · 1h · raw`, §8.1) on the tile; the selected window drives both the
+overall tile and the per-profile ▲/▼ on the NOW cards (one bandwidth window for
+the page). It's a `trafficUsage` stream (§8.2), live like the other realtime
+elements. **Mobile:** the strip is now 5 tiles, so it reflows `grid-cols-2`
+(→ 3 rows) on mobile / `md:grid-cols-5` on desktop (supersedes the rev-1 §3
+`md:grid-cols-4` note).
 
 The two recency/blocking elements sit adjacent and are intentionally distinct: **Most Recently
 Blocked** answers "what just got dropped?" (live, un-aggregated, 1h); **Blocking activity (24h)**
@@ -355,7 +364,9 @@ Rev-2 Q2 de-scoped throughput (#747) as "backend-gated, its own follow-up." **Re
 3 reverses that.** The dashboard must show, updating live:
 
 - **Overall household in/out** — aggregate ▲ upload / ▼ download **rate** (B/s),
-  the headline "how much is the house using right now" gauge.
+  the headline "how much is the house using right now" gauge. **Placement
+  (decided 2026-06-25): the 5th KPI-strip tile** (§7.2), carrying the window
+  selector (`1m · 10m · 1h · raw`) that also governs the per-profile gauges.
 - **Per-profile in/out** — the same ▲▼ **rate** on each active NOW profile-card
   header (the rev-2 §3 wireframe already drew `▲2.4 ▼18` there; rev 3 makes it
   real and live, not deferred).
@@ -388,7 +399,7 @@ they ever diverge. Each dashboard section is classified by how it gets its data:
 
 | Dashboard section | Class | Source after #1860 |
 |---|---|---|
-| **Overall in/out bandwidth** (§8.1) | **streamed read model** | `trafficUsage` (`groupBy:∅`) — streams existing `TrafficUsageResponse`; no new shape |
+| **Overall in/out bandwidth** (§8.1, **5th KPI tile** w/ window selector) | **streamed read model** | `trafficUsage` (`groupBy:∅`) — streams existing `TrafficUsageResponse`; no new shape |
 | **Per-profile in/out bandwidth** (§8.1, on NOW card headers) | **streamed read model** | same `trafficUsage` topic, `groupBy:["profile"]` |
 | **NOW** active cards (who's online / watching) | **pushed live snapshot** | `DashboardNow` body pushed on change (reuses today's `/api/dashboard/now` shape) |
 | **Most Recently Blocked** feed (#1338) | **pushed live append** | `connectionEvents{blocked:true}` — reuses the `/api/logs` row shape; same topic streams the Connection Events page |

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -391,9 +391,18 @@ they ever diverge. Each dashboard section is classified by how it gets its data:
 | **Blocking activity (24h)** panel | request/response | rollup tables (#809); explicitly **not** streamed (rev-2 §7.5 already said so) |
 
 The rule the operator stated: **stream the things that need to move in realtime
-(throughput, NOW, just-blocked); leave everything that is genuinely a cacheable
-resource on request/response.** The websocket design (`spa-websocket.md`) is
-built around exactly this split, not a blanket "invalidate every query."
+(throughput, NOW, just-blocked, live time-usage); leave everything that is
+genuinely a cacheable resource on request/response.** The websocket design
+(`spa-websocket.md`) is built around exactly this split, not a blanket "invalidate
+every query."
+
+> **Live time-usage** (per-profile used/remaining + per-app minutes, counting up
+> in realtime) is also streamed — see [`spa-websocket.md` §1.2](spa-websocket.md)
+> (`timeStatus` / `appUsage`). Its primary home is `/profiles` (the screen-time
+> view), not a `/dashboard` section, so it isn't in the table above — but on the
+> dashboard it backs the "profiles over limit" KPI, which therefore updates live
+> off the same `timeStatus` push. It replaces today's adaptive refetch ladder
+> (`TIME_STATUS_REFETCH_LADDER`), which exists only because there was no push.
 
 ### 8.3 Effect on the locked plan (§7.4)
 

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -249,7 +249,9 @@ Dashboard (h1)
   Banners            — NewDevicesHint, AccessRequestsBanner (only when present)
   KPI strip          — Online now · Blocked now · Events (1h) · Blocked (1h) · Bandwidth ▲/▼   [above the fold]
   NOW                — freshness pill; active cards (top-3 devices + expander, per-profile ▲/▼); idle-collapse row
-  Most Recently Blocked  — blocked-only trailing-hour feed (#1338), View all → /usage/events
+  Recently Blocked   — TOP-LEVEL live panel: blocked-only, newest-first, device · host · reason;
+                       quick device filter; the "why isn't this working on my device?" diagnostic   [above the fold]
+  ── below the fold ──
   Blocking activity (24h) — one merged ranked-host panel; one-line empty state
   (no inline log table)
 ```
@@ -263,10 +265,22 @@ elements. **Mobile:** the strip is now 5 tiles, so it reflows `grid-cols-2`
 (→ 3 rows) on mobile / `md:grid-cols-5` on desktop (supersedes the rev-1 §3
 `md:grid-cols-4` note).
 
-The two recency/blocking elements sit adjacent and are intentionally distinct: **Most Recently
-Blocked** answers "what just got dropped?" (live, un-aggregated, 1h); **Blocking activity (24h)**
-answers "what's been getting blocked today?" (aggregated, ranked). Neither duplicates the other,
-and neither is the firehose.
+The two recency/blocking elements are intentionally distinct: **Recently Blocked** answers "what
+just got dropped?" (live, un-aggregated, 1h); **Blocking activity (24h)** answers "what's been
+getting blocked today?" (aggregated, ranked). Neither duplicates the other, and neither is the
+firehose.
+
+**Recently Blocked is a top-level, above-the-fold panel (rev 3, operator 2026-06-25).** It is the
+primary *diagnostic* surface: when someone says "X isn't working on my iPad," a parent glances here
+to see — within seconds, live — whether that device's traffic is being dropped and why, instead of
+digging through `/usage/events`. To serve that, each row shows **device · host · reason** (the
+`BlockReason`, e.g. Schedule / TimeLimit / category / host-block — `connectionEvents` carries it),
+and the panel offers a **quick filter by device** (and "View all →" deep-links to the device's
+`/usage/events`). It is the live `connectionEvents{blocked:true}` stream (§8.2) — newest-first,
+prepend-on-push, trailing ~1h — so a just-now block appears immediately. Promoting it above the fold
+(right under NOW) is deliberate: NOW answers "who's online," Recently Blocked answers "what's being
+blocked," and together they are the at-a-glance health/diagnosis pair. (Reachability is a
+connection-layer fact — these are real traffic-layer drops, not DNS events; DNS always resolves.)
 
 ### 7.3 Decisions on the §6 open questions
 
@@ -402,7 +416,7 @@ they ever diverge. Each dashboard section is classified by how it gets its data:
 | **Overall in/out bandwidth** (§8.1, **5th KPI tile** w/ window selector) | **streamed read model** | `trafficUsage` (`groupBy:∅`) — streams existing `TrafficUsageResponse`; no new shape |
 | **Per-profile in/out bandwidth** (§8.1, on NOW card headers) | **streamed read model** | same `trafficUsage` topic, `groupBy:["profile"]` |
 | **NOW** active cards (who's online / watching) | **pushed live snapshot** | `DashboardNow` body pushed on change (reuses today's `/api/dashboard/now` shape) |
-| **Most Recently Blocked** feed (#1338) | **pushed live append** | `connectionEvents{blocked:true}` — reuses the `/api/logs` row shape; same topic streams the Connection Events page |
+| **Recently Blocked** — top-level diagnostic panel (#1338) | **pushed live append** | `connectionEvents{blocked:true}` — reuses the `/api/logs` row shape; the quick device filter maps to the topic's `macs` param; same topic streams the Connection Events page |
 | **KPI: Online now / Blocked now** | **derived from the NOW push** | computed client-side off the pushed `DashboardNow`; no separate stream |
 | **KPI: Events (1h) / Blocked (1h)** | request/response | small enough to leave on a slow poll / invalidate; not realtime-critical |
 | **Blocking activity (24h)** panel | request/response | rollup tables (#809); explicitly **not** streamed (rev-2 §7.5 already said so) |

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -337,3 +337,78 @@ streaming-source wiring into chunks 2 and 3 (the live sections) as their first s
 layout changes.
 
 This note records the decision; no further dashboard PRs until #1023 lands.
+
+---
+
+## 8. Revision 3 (2026-06-24) — realtime throughput is a primary NOW element; live data contract
+
+Operator direction while finalizing the SPA-websocket design
+([#1860](https://github.com/wifihaven/wifihaven/issues/1860),
+[`docs/design/spa-websocket.md`](spa-websocket.md)): the websocket is **not** a
+"poll faster / invalidate faster" transport for the whole page — it exists to
+**stream the live surface**. That changes one rev-2 decision and pins the live
+data contract the two docs share.
+
+### 8.1 Reversal of Q2 — live throughput is in scope, as a primary NOW element
+
+Rev-2 Q2 de-scoped throughput (#747) as "backend-gated, its own follow-up." **Rev
+3 reverses that.** The dashboard must show, updating live:
+
+- **Overall household in/out** — aggregate ▲ upload / ▼ download **rate** (B/s),
+  the headline "how much is the house using right now" gauge.
+- **Per-profile in/out** — the same ▲▼ **rate** on each active NOW profile-card
+  header (the rev-2 §3 wireframe already drew `▲2.4 ▼18` there; rev 3 makes it
+  real and live, not deferred).
+
+This is the single most-requested live element and the main reason the dashboard
+is stream-gated. Per-**device** / per-**host** throughput stays **off** the
+dashboard (→ `/devices`, `/profiles`) — the dashboard shows overall + per-profile
+only, consistent with the rev-2 "glanceable, not analytics" principle.
+
+> Throughput is a **rate**, not a resource — there is no "current B/s" you can
+> `GET` and cache; it only exists as a stream. So unlike the NOW snapshot or the
+> blocked feed (which have REST bodies), live throughput is **push-native**: it
+> has no polling fallback beyond "no live gauge while the socket is down" (the
+> 24h volume on `/usage` covers the historical question). This is why it could
+> not ship before the stream — and why it is the clearest justification for the
+> websocket existing at all.
+
+### 8.2 The dashboard's live data contract (what streams vs. what stays request/response)
+
+This table is the **input to the websocket message catalog** in
+[`spa-websocket.md` §1](spa-websocket.md); the two must agree. Each dashboard
+section is classified by how it gets its data:
+
+| Dashboard section | Class | Source after #1860 |
+|---|---|---|
+| **Overall in/out throughput** (§8.1) | **push-native stream** | `throughput` tick — NEW push-only shape (no GET); §8.1 |
+| **Per-profile in/out throughput** (§8.1, on NOW card headers) | **push-native stream** | same `throughput` tick (per-profile entries) |
+| **NOW** active cards (who's online / watching) | **pushed live snapshot** | `DashboardNow` body pushed on change (reuses today's `/api/dashboard/now` shape) |
+| **Most Recently Blocked** feed (#1338) | **pushed live append** | each new blocked event pushed as it lands (reuses the `/api/logs?blocked=true` row shape) |
+| **KPI: Online now / Blocked now** | **derived from the NOW push** | computed client-side off the pushed `DashboardNow`; no separate stream |
+| **KPI: Events (1h) / Blocked (1h)** | request/response | small enough to leave on a slow poll / invalidate; not realtime-critical |
+| **Blocking activity (24h)** panel | request/response | rollup tables (#809); explicitly **not** streamed (rev-2 §7.5 already said so) |
+
+The rule the operator stated: **stream the things that need to move in realtime
+(throughput, NOW, just-blocked); leave everything that is genuinely a cacheable
+resource on request/response.** The websocket design (`spa-websocket.md`) is
+built around exactly this split, not a blanket "invalidate every query."
+
+### 8.3 Effect on the locked plan (§7.4)
+
+No sub-issue is added or removed here; the chunk-2/chunk-3 "fold the streaming
+source in first" step (§7.5) is now concrete:
+
+- **chunk 2/3** (NOW + KPI, #1834/#1835) consume the `DashboardNow` push and the
+  derived KPIs — as already planned.
+- **#747 throughput** is **no longer a deferred standalone** — it becomes the
+  realtime-throughput pilot of the websocket rollout
+  ([`spa-websocket.md` §9](spa-websocket.md)), since it is the push-native element
+  that most exercises the stream. It still needs the backend source (§8.1): the
+  API deriving per-profile + overall byte-rate from the #1023 router→API usage
+  stream, pushed to the SPA. That backend work is specified in
+  [`spa-websocket.md` §5](spa-websocket.md) and filed as a sub-issue there.
+
+This revision records the decision; the wire/payload specifics live in
+`spa-websocket.md` (single source of truth for the protocol), and dashboard
+implementation stays paused on #1860 per §7.5.

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -376,8 +376,9 @@ only, consistent with the rev-2 "glanceable, not analytics" principle.
 ### 8.2 The dashboard's live data contract (what streams vs. what stays request/response)
 
 This table is the **input to the websocket message catalog** in
-[`spa-websocket.md` §1](spa-websocket.md); the two must agree. Each dashboard
-section is classified by how it gets its data:
+[`spa-websocket.md` §1](spa-websocket.md); the two must agree, and
+[`spa-websocket.md` §1.2](spa-websocket.md) is the **authoritative `op` list** if
+they ever diverge. Each dashboard section is classified by how it gets its data:
 
 | Dashboard section | Class | Source after #1860 |
 |---|---|---|

--- a/docs/design/dashboard-redesign.md
+++ b/docs/design/dashboard-redesign.md
@@ -365,13 +365,16 @@ is stream-gated. Per-**device** / per-**host** throughput stays **off** the
 dashboard (→ `/devices`, `/profiles`) — the dashboard shows overall + per-profile
 only, consistent with the rev-2 "glanceable, not analytics" principle.
 
-> Throughput is a **rate**, not a resource — there is no "current B/s" you can
-> `GET` and cache; it only exists as a stream. So unlike the NOW snapshot or the
-> blocked feed (which have REST bodies), live throughput is **push-native**: it
-> has no polling fallback beyond "no live gauge while the socket is down" (the
-> 24h volume on `/usage` covers the historical question). This is why it could
-> not ship before the stream — and why it is the clearest justification for the
-> websocket existing at all.
+> Bandwidth is **not** new data — `traffic_reports` already holds directional
+> bytes, surfaced by `GET /api/usage/traffic` (`TrafficUsageResponse`,
+> `totalBytesIn`/`totalBytesOut` per group). So live bandwidth is just that
+> existing read model **streamed**: overall/per-profile = `groupBy ∈ {∅,profile}`,
+> the averaging window = its `bucket`, and the client derives B/s from
+> bytes-over-bucket. No new shape — see [`spa-websocket.md` §1.3](spa-websocket.md)
+> (`trafficUsage` topic). The same stream powers the **Traffic Usage page** live,
+> not just the dashboard gauge. (Granularity floor is `1m`, the `traffic_reports`
+> bucket; a sub-minute "instant" gauge is an optional extra — `spa-websocket.md`
+> §5.3/§10 Q1.)
 
 ### 8.2 The dashboard's live data contract (what streams vs. what stays request/response)
 
@@ -382,16 +385,16 @@ they ever diverge. Each dashboard section is classified by how it gets its data:
 
 | Dashboard section | Class | Source after #1860 |
 |---|---|---|
-| **Overall in/out throughput** (§8.1) | **push-native stream** | `throughput` tick — NEW push-only shape (no GET); §8.1 |
-| **Per-profile in/out throughput** (§8.1, on NOW card headers) | **push-native stream** | same `throughput` tick (per-profile entries) |
+| **Overall in/out bandwidth** (§8.1) | **streamed read model** | `trafficUsage` (`groupBy:∅`) — streams existing `TrafficUsageResponse`; no new shape |
+| **Per-profile in/out bandwidth** (§8.1, on NOW card headers) | **streamed read model** | same `trafficUsage` topic, `groupBy:["profile"]` |
 | **NOW** active cards (who's online / watching) | **pushed live snapshot** | `DashboardNow` body pushed on change (reuses today's `/api/dashboard/now` shape) |
-| **Most Recently Blocked** feed (#1338) | **pushed live append** | each new blocked event pushed as it lands (reuses the `/api/logs?blocked=true` row shape) |
+| **Most Recently Blocked** feed (#1338) | **pushed live append** | `connectionEvents{blocked:true}` — reuses the `/api/logs` row shape; same topic streams the Connection Events page |
 | **KPI: Online now / Blocked now** | **derived from the NOW push** | computed client-side off the pushed `DashboardNow`; no separate stream |
 | **KPI: Events (1h) / Blocked (1h)** | request/response | small enough to leave on a slow poll / invalidate; not realtime-critical |
 | **Blocking activity (24h)** panel | request/response | rollup tables (#809); explicitly **not** streamed (rev-2 §7.5 already said so) |
 
 The rule the operator stated: **stream the things that need to move in realtime
-(throughput, NOW, just-blocked, live time-usage); leave everything that is
+(bandwidth, NOW, just-blocked, live time-usage); leave everything that is
 genuinely a cacheable resource on request/response.** The websocket design
 (`spa-websocket.md`) is built around exactly this split, not a blanket "invalidate
 every query."
@@ -411,13 +414,15 @@ source in first" step (§7.5) is now concrete:
 
 - **chunk 2/3** (NOW + KPI, #1834/#1835) consume the `DashboardNow` push and the
   derived KPIs — as already planned.
-- **#747 throughput** is **no longer a deferred standalone** — it becomes the
-  realtime-throughput pilot of the websocket rollout
-  ([`spa-websocket.md` §9](spa-websocket.md)), since it is the push-native element
-  that most exercises the stream. It still needs the backend source (§8.1): the
-  API deriving per-profile + overall byte-rate from the #1023 router→API usage
-  stream, pushed to the SPA. That backend work is specified in
-  [`spa-websocket.md` §5](spa-websocket.md) and filed as a sub-issue there.
+- **#747 bandwidth** is **no longer a deferred standalone** — it becomes part of
+  the websocket dashboard pilot ([`spa-websocket.md` §9](spa-websocket.md)),
+  streaming the existing `GET /api/usage/traffic` read model (`trafficUsage`
+  topic). It needs **no new backend data path** for `1m`-and-coarser bandwidth
+  (the API re-runs the existing traffic-usage query on usage ingest,
+  [`spa-websocket.md` §5.3](spa-websocket.md)); only the optional sub-minute
+  "instant" gauge depends on #1023 (a router conntrack sample). Earlier this note
+  said throughput was #1023-gated — with the read-model reuse, only the sub-minute
+  refinement is.
 
 This revision records the decision; the wire/payload specifics live in
 `spa-websocket.md` (single source of truth for the protocol), and dashboard

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -322,7 +322,10 @@ surface); class (3) invalidates.
 Because every payload is an existing REST body (§0.3), a push patches the **same
 React Query key the matching `GET` populates** — so the dashboard and the source
 page share one cache entry, and a later refetch (reconnect §6.1, or paused-poll
-fallback §3.3) reconciles against the `GET` authority:
+fallback §3.3) reconciles against the `GET` authority. (`trafficKey`/`logsKey`
+below are illustrative — they are the Traffic Usage / Connection Events pages'
+existing `useQuery` keys, to be lifted into the shared `qk` factory so the push and
+the page key are produced in one place.)
 
 ```ts
 // trafficUsage → patch the cache for the EXACT (groupBy,bucket,filter) the client subscribed,
@@ -733,7 +736,7 @@ realtime throughput):
 | **S4** | **`trafficUsage` aggregator + push** — on usage ingest, re-run the subscribed `(groupBy,bucket,filter)` traffic-usage queries and push the refreshed `TrafficUsageResponse` to matching subscribers, latest-wins per param-set (§5.3). Reuses the existing query — no new shape. (Sub-minute gauge waits on optional S0.) | yes | additive |
 | **S5** | **SPA ws client + realtime dashboard pilot** — `useWsTrafficUsage(params)` driving the overall + per-profile bandwidth gauges with the **window (bucket) selector** (re-subscribes on change, #747), `now` + `connectionEvents{blocked:true}` cache-patching (§3.1), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), set-cookie-then-connect (§4.2), backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + bandwidth + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
 | **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.1) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
-| **S6b** | **Stream the Traffic Usage + Connection Events pages** — those pages subscribe `trafficUsage` / `connectionEvents` with *their* current filters (the same topics the dashboard uses, different params), live-updating in place; pause their polls when `wsLive`. Plus class-(3) `stale` for alerts / profiles / devices / schedules (§3.2). | yes (per-page) | additive |
+| **S6b** | **Stream the Traffic Usage + Connection Events pages** — those pages subscribe `trafficUsage` / `connectionEvents` with *their* current filters (same topics as the dashboard, different params), live-updating in place; pause their polls when `wsLive`. Streaming prepends only the **live head** (newest rows); cursor-paged history (#862) stays on the existing request/response path — the stream doesn't try to mutate older pages. Plus class-(3) `stale` for alerts / profiles / devices / schedules (§3.2). | yes (per-page) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
 | **S8** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§6.4). | yes, later | additive |
 

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -135,26 +135,32 @@ ride the rollup tables on request/response and are *not* streamed
 
 ### 1.2 Server→SPA message catalog
 
-| `op` | Class | Payload | Drives (dashboard element) | Source |
-|---|---|---|---|---|
-| `throughput` | (1) | `ThroughputTick` (§1.3) | overall in/out gauge **+** per-profile ▲▼ on NOW card headers (#747) | API aggregator over the #1023 usage stream (§5.3) |
-| `now` | (2) | `DashboardNow` (existing body, verbatim) | NOW active cards; derived "Online now / Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
-| `blocked` | (2) | one blocked `QueryLog` row (existing `/api/logs` row shape) | Most Recently Blocked feed (prepend) | connection-events ingest (§5.2) |
-| `timeStatus` | (2) | `ProfileTimeStatus[]` (existing `/api/time/status` body) | per-profile **used / remaining** bars (live), "profiles over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
-| `appUsage` | (2) | per-app engaged-minutes (existing `/api/profiles/{id}/usage-by-app` body) | per-app **minutes-used** rows (live) on the expanded profile / screen-time view | same triggers, via `Presence.appSecondsForProfile` |
-| `stale` | (3) | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query (profiles/devices/schedules/blocklists) | the relevant write site (§5.2) |
-| `ready` | — | `{ role, serverTime }` | flips the live indicator to "live" | upgrade (§4) |
-| `ping`/`pong` | — | `{}` | heartbeat (§6.2) | — |
+Every server→SPA push is **gated on a subscription** (§1.4) — the client receives
+only the topics it asked for, with the parameters it asked for. The `Params`
+column is what the client sends in `subscribe`.
 
-SPA→server: `hello` (`{clientVersion, subscribe?:[…]}`), `reauth` (`{ticket}`,
-§4.3), `ping`/`pong`. **Unknown `op` → ignore + meter**, both directions
-(forward-compat, mirrors [`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
+| `op` | Class | Params (subscription) | Payload | Drives (dashboard element) | Source |
+|---|---|---|---|---|---|
+| `throughput` | (1) | **`window` ∈ {5s,1m,5m,10m}** | `ThroughputTick` (§1.3) | overall in/out gauge **+** per-profile ▲▼ on NOW cards (#747) | API aggregator over the #1023 usage stream (§5.3) |
+| `now` | (2) | — | `DashboardNow` (existing body) | NOW active cards; derived "Online/Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
+| `blocked` | (2) | — | one blocked `QueryLog` row (existing `/api/logs` shape) | Most Recently Blocked feed (prepend) | connection-events ingest (§5.2) |
+| `timeStatus` | (2) | — (all authorized profiles) | `ProfileTimeStatus[]` (existing `/api/time/status` body) | per-profile **used/remaining** bars; "over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
+| `appUsage` | (2) | **`profileId`** (the expanded card) | per-app minutes (existing `/api/profiles/{id}/usage-by-app` body) | per-app **minutes-used** rows (live) | same triggers, via `Presence.appSecondsForProfile` |
+| `stale` | (3) | — | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query | the relevant write site (§5.2) |
+| `ready` | — | — | `{ role, serverTime }` | flips the live indicator to "live" | upgrade (§4) |
+| `ping`/`pong` | — | — | `{}` | heartbeat (§6.2) | — |
+
+SPA→server: `hello` (`{clientVersion}`), **`subscribe` (`{topic, params?}`)**,
+**`unsubscribe` (`{topic}`)**, `reauth` (`{ticket}`, §4.3), `ping`/`pong`.
+**Unknown `op` → ignore + meter**, both directions (forward-compat, mirrors
+[`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
 
 ### 1.3 The one new shape — `ThroughputTick`
 
 ```jsonc
-// op:"throughput" payload — bytes-per-second rates as of `asOf`
+// op:"throughput" payload — bytes-per-second rates averaged over `window`, as of `asOf`
 {
+  "window": "1m",                                  // which averaging window this tick is for
   "asOf": "2026-06-24T14:31:02Z",
   "overall":     { "inBps": 1840000, "outBps": 240000 },
   "perProfile": [
@@ -164,30 +170,79 @@ SPA→server: `hello` (`{clientVersion, subscribe?:[…]}`), `reauth` (`{ticket}
 }
 ```
 
-- **Rates, not cumulative bytes** — the SPA renders a gauge/sparkline, not a
-  counter; the server does the rate math once (§5.3) so every tab doesn't
+- **`window` ∈ {5s, 1m, 5m, 10m}** — the user-choosable averaging window
+  (§1.4). The rate is the mean B/s over the trailing `window`; the field tells the
+  client which display the tick is for (a client may show one window, or hold more
+  than one subscription). The 5 s window reads as near-instantaneous; the 10 m
+  window is a smooth trend.
+- **The window is a *subscription parameter*, not a payload-multiplier.** The
+  server emits only the window(s) a connection subscribed to, **at a
+  window-appropriate cadence** (a 10 m average barely moves in 5 s, so it ticks
+  ~every 30 s, while a 5 s window ticks ~every 5 s) — see §1.4/§5.3. This is the
+  concrete reason subscriptions matter: without them every client would receive
+  every window at the fastest cadence.
+- **Rates, not cumulative bytes** — the SPA renders a gauge/sparkline; the server
+  does the windowed-rate math once per window (§5.3) so every tab doesn't
   re-derive it (single-source-of-truth for the rate).
-- **Overall + per-profile only.** Per-device / per-host throughput is deliberately
+- **Overall + per-profile only.** Per-device/host throughput is deliberately
   **off** the dashboard ([`dashboard-redesign.md` §8.1](dashboard-redesign.md));
   the same tick *shape* could carry a `perDevice` array for a future `/devices`
-  live view, but v1 emits only overall + per-profile.
-- **Bounded size** — one entry per active profile (households have ≤ ~10), well
-  under any frame cap.
-- **A profile absent from `perProfile`** is idle (0 B/s) — the client zeroes it;
-  the tick never grows with history.
+  view, but v1 emits only overall + per-profile.
+- **Bounded size** — one entry per active profile (households ≤ ~10); a profile
+  absent from `perProfile` is idle (client zeroes it); the tick never grows with
+  history.
 
 This is the only addition to `web/src/types/api.ts`; `now`/`blocked`/`stale`
 payloads reuse shapes that already exist there.
 
-### 1.4 hello / subscribe
+### 1.4 Subscriptions — first-class, so a tab gets only what it shows
 
-On connect the SPA sends `hello` once. `subscribe` is an **optional** topic
-filter (a child-role tab rendering only its own time-status need not receive
-`throughput`); omitted → the server pushes everything the role is authorized for
-(§4.4). v1 ships omit-everything-authorized; the filter is the forward-compat seam
-and is honored if sent. The server replies `ready`; the client flips its
-indicator to "live" only after `ready` (a socket that upgrades but never `ready`s
-must not read as live).
+**Subscriptions are a v1 requirement, not a deferred seam.** A connection receives
+a topic **only if it has subscribed to it** (and is authorized, §4.4). This is how
+"only get the data we need over the ws" is achieved: a dashboard tab subscribes
+`throughput`/`now`/`blocked`/`timeStatus`; a `/profiles` tab subscribes
+`timeStatus` + `appUsage{profileId}` for the expanded card; a backgrounded or
+narrow view subscribes little. Nothing is pushed to a connection that didn't ask.
+
+**Protocol.**
+
+```jsonc
+// after `ready`, the client declares what it wants — and updates it as the UI changes
+{ "op": "subscribe",   "payload": { "topic": "throughput", "params": { "window": "1m" } } }
+{ "op": "subscribe",   "payload": { "topic": "appUsage",   "params": { "profileId": 3 } } }
+{ "op": "unsubscribe", "payload": { "topic": "throughput" } }
+```
+
+- **Lifecycle = the mounted UI.** A hook subscribes on mount, unsubscribes on
+  unmount (e.g. the throughput gauge subscribes `throughput{window}` and
+  **re-subscribes with the new `window` when the user picks 5s/1m/5m/10m from the
+  selector** — server replaces that connection's prior `throughput` subscription).
+  Expanding a profile card subscribes `appUsage{profileId}`; collapsing it
+  unsubscribes. So per-connection traffic tracks exactly what's on screen.
+- **Server holds subscriptions per-connection** in the channel's registry state
+  (§5.1) — `{topic → params}`. Fan-out checks the set before sending; the
+  throughput aggregator (§5.3) computes a `(scope, window)` rate only while ≥1
+  connection subscribes that window, and picks the emit cadence from the window.
+- **Authorization still gates** on top of subscription: subscribing a topic the
+  role can't see is rejected (`ack` reject); per-profile rows are filtered to the
+  profiles the role may view (§4.4). Subscription narrows; authz constrains.
+- **`ack` per subscribe** (`{op:"ack", topic, status:"ok"|"reject", reason?}`) so
+  the client knows the subscription took (and isn't silently waiting on a topic
+  the server refused).
+- **Reconnect re-subscribes.** Subscriptions are connection-scoped and **not**
+  durable across a reconnect; on reconnect the client replays its current
+  subscription set (§6.1) — the server starts each connection subscribed to
+  nothing.
+
+**Defaults.** There is no "subscribe to everything" default — the explicit
+opt-in *is* the data-minimization. A view with no subscriptions receives only
+`ready` + heartbeats. (`stale` class-(3) topics may be bundled into a single cheap
+`subscribe{topic:"stale"}` since they are contentless nudges, or subscribed
+individually; either is fine — they are tiny.)
+
+The server replies `ready` right after upgrade; the client flips its indicator to
+"live" only after `ready` (a socket that upgrades but never `ready`s must not read
+as live), then sends its `subscribe` frames.
 
 ---
 
@@ -239,13 +294,17 @@ one-size-fits-all:
 
 ### 3.1 Class (1) throughput — direct to a live store, not the resource cache
 
-A `throughput` tick is a stream sample, not a cache entry. The `useWsThroughput()`
-hook holds the latest tick (a small `useSyncExternalStore` or a dedicated query
-key updated via `setQueryData`) and feeds the overall gauge + per-profile card
+A `throughput` tick is a stream sample, not a cache entry. The
+`useWsThroughput(window)` hook **subscribes `throughput{window}` on mount and
+re-subscribes when the user changes the window selector** (5s/1m/5m/10m, §1.4),
+holds the latest tick (a small `useSyncExternalStore` or a dedicated query key
+updated via `setQueryData`), and feeds the overall gauge + per-profile card
 headers. There is nothing to invalidate and no `GET` to refetch — when the socket
 is down the gauge shows "—" (its only fallback; the 24 h volume on `/usage`
 answers the historical question). Latest-wins: a new tick replaces the prior one
-(§6.3).
+(§6.3). A tick whose `window` doesn't match the current selection is ignored
+(covers the brief overlap right after a window change before the old subscription
+is torn down).
 
 ### 3.2 Class (2) NOW + blocked — push carries data, patch the cache
 
@@ -389,14 +448,18 @@ The two differ on the three axes a registry *is*:
 | Axis | `RouterWsRegistry` (#1846) | `SpaWsRegistry` (this design) |
 |---|---|---|
 | **Key** | `RouterId` | per-connection id + `role` (a user may have N tabs, §6.4) |
-| **Fan-out payload** | full `PolicySnapshot` | the §1.2 op vocabulary (`throughput`/`now`/`blocked`/`stale`), role-filtered |
+| **Per-channel state** | just the channel | channel + **subscription set `{topic → params}`** (§1.4) + `jwtExp` |
+| **Fan-out payload** | full `PolicySnapshot` | the §1.2 op vocabulary, role-filtered **and** subscription-gated |
 | **Event vocabulary** | one event (policy changed) | several (throughput tick, NOW change, new blocked event, class-3 mutations) |
 
 Generalizing one registry across two key types + two payload vocabularies couples
 things that share only the *shape* "a `Ref` of channels with a fan-out method."
 Reuse the **pattern**, not the instance — `SpaWsRegistry` is the same
-`Ref[Map[K, Set[WebSocketChannel]]]` with SPA-appropriate K, payloads, and
-metrics. (Also holds the ticket store, §4.2.)
+`Ref[Map[K, Channel+subscriptions]]` shape with SPA-appropriate K, payloads, and
+metrics. (Also holds the ticket store, §4.2.) **Fan-out is two gates: a topic is
+sent to a channel only if the channel both *subscribed* to it (§1.4) and is
+*authorized* for it (§4.4).** The subscription set is the data-minimization
+mechanism; the registry is where it lives.
 
 ### 5.2 The change sources — consume existing write sites (don't rebuild)
 
@@ -446,13 +509,26 @@ batch. Design:
   idempotent for rollups); the `throughput` sample is high-frequency/low-fidelity
   (per-mac totals, display-only, lossy-OK). Conflating them would make `usage` too
   chatty or throughput too coarse. (Filed as a #1023 sub-issue, §9 **S0**.)
-- **Aggregate.** The API maps `mac → profile` (it already does) and maintains a
-  rolling overall + per-profile B/s (last-sample rate or short EWMA). This is the
-  **one** place the rate is computed (SSOT) — every tab consumes the same tick.
-- **Push.** Emit a `throughput` tick (§1.3) to SPA connections on a fixed cadence
-  (~2 s), latest-wins (§6.3). If #1023's realtime usage isn't available yet, the
-  aggregator simply has no input and emits nothing (the gauge shows "—") — so the
-  SPA endpoint + the rest of the catalog ship independently of S0.
+- **Aggregate into the choosable windows.** The API maps `mac → profile` (it
+  already does) and maintains, from the single ~2–5 s sample stream, a rolling
+  overall + per-profile mean B/s for **each window {5s, 1m, 5m, 10m}** (a short
+  ring buffer of recent samples, or one EWMA per window — cheap: 4 windows × small
+  fixed state). This is the **one** place the rate is computed for all windows
+  (SSOT) — every tab consumes the same windowed numbers; the client never averages
+  raw samples itself (and so can't disagree tab-to-tab, and survives reconnect
+  with no client-side history). The window set {5s,1m,5m,10m} is a small fixed
+  enum, matching the selector.
+- **Compute only subscribed windows; push at a window-appropriate cadence.** A
+  `(scope, window)` rate is maintained and pushed **only while ≥1 connection
+  subscribes that window** (§1.4) — no subscriber, no work. Emit cadence scales
+  with the window: ~5 s for the 5 s window down to ~30 s for the 10 m window (a
+  10-minute average is visually static between 5 s ticks, so ticking that fast is
+  pure waste). Each tick carries its `window` (§1.3); latest-wins per window
+  (§6.3). This per-window cadence is the payoff of making the window a
+  subscription parameter rather than shipping all four to everyone at 5 s.
+- **Degrades cleanly.** If #1023's realtime usage isn't available yet, the
+  aggregator has no input and emits nothing (gauge shows "—") — so the SPA
+  endpoint + the rest of the catalog ship independently of S0.
 
 > **Single-process fan-out**, like the router path — registries, hubs, and the
 > aggregator are in-memory, single-instance (correct for the one-API-process
@@ -468,10 +544,13 @@ batch. Design:
 Exponential backoff + jitter (1 s → 2 s → 4 s → … cap 30 s), reset on `ready`
 (not merely socket `open`). Reconnect *is* the throttle; no per-frame retry. Each
 reconnect mints a **fresh ticket** (§4.2; single-use, so a reconnect can't replay
-the old one). On reconnect the client refetches the class-(2) queries once
-(`now`/`blocked`) so a change missed while disconnected converges; the throughput
-gauge resumes on the next tick. On `4401 token-expired` it stops reconnecting and
-hands off to polling + `/login` (§4.3).
+the old one) and **replays its current subscription set** (§1.4 — subscriptions
+are connection-scoped, not durable; the server starts the new connection
+subscribed to nothing). On reconnect the client also refetches the class-(2)
+queries once (`now`/`blocked`/`timeStatus`) so a change missed while disconnected
+converges; the throughput gauge resumes on the next tick of its subscribed window.
+On `4401 token-expired` it stops reconnecting and hands off to polling + `/login`
+(§4.3).
 
 ### 6.2 Heartbeat / liveness → the real "live / reconnecting" indicator
 
@@ -530,11 +609,12 @@ router-ws families ([`websocket-transport.md` §7](websocket-transport.md)).
 | Metric | Type | Labels (bounded) | Meaning |
 |---|---|---|---|
 | `spa_ws_connections_active` | gauge | `role` (`admin`\|`adult`\|`child`) | open SPA channels, refreshed on register/deregister (ages out on disconnect) |
-| `spa_ws_frames_total` | counter | `op` (enum §1.2), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + unknown-op tripwire |
+| `spa_ws_frames_total` | counter | `op` (enum §1.2, incl. `subscribe`/`unsubscribe`), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + unknown-op tripwire |
+| `spa_ws_subscriptions_active` | gauge | `topic` (`throughput`\|`now`\|`blocked`\|`timeStatus`\|`appUsage`\|`stale`) | live subscriptions per topic — shows what the fleet is actually watching (and, for `throughput`, that windowed work is bounded to demand). **No `window`/`profileId` label** (window is ≤4 values but profileId is unbounded — keep params out of labels) |
 | `spa_ws_auth_total` | counter | `result` (`ticket_ok`\|`ticket_invalid`\|`ticket_expired`\|`ticket_reused`\|`jwt_expired`) | ticket handshake + mid-connection expiry (§4) |
-| `spa_ws_push_total` | counter | `op` (`throughput`\|`now`\|`blocked`\|`stale`), `result` (`ok`\|`coalesced`\|`dropped`\|`channel_closed`) | per-class fan-out health + backpressure (§6.3) |
+| `spa_ws_push_total` | counter | `op` (`throughput`\|`now`\|`blocked`\|`timeStatus`\|`appUsage`\|`stale`), `result` (`ok`\|`coalesced`\|`dropped`\|`channel_closed`) | per-class fan-out health + backpressure (§6.3) |
 
-`role`/`op`/`direction`/`result` are small fixed enums — the same
+`role`/`op`/`direction`/`result`/`topic` are small fixed enums — the same
 cardinality-firewall discipline `Metrics.scala` enforces (an attacker-supplied
 `op` collapses to the literal `unknown` for the label, real value to the log
 only). **No per-entity label.**
@@ -601,11 +681,11 @@ realtime throughput):
 | # | Sub-issue | Independently shippable? | Back-compat |
 |---|---|---|---|
 | **S0** | **(in #1023) router→API lightweight `throughput` sample** — additive per-mac bytes-since-last-sample frame every ~2 s from the conntrack counters (§5.3). The realtime source for live bandwidth. | yes (additive frame; usage path unchanged) | additive |
-| **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry`** — server skeleton, envelope/demux (`hello`→`ready`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry, server metrics §7 + `spa-ws.json`. Reuses `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route |
+| **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry` + subscription model** — server skeleton, envelope/demux (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection subscription state + `ack`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry, server metrics §7 + `spa-ws.json`. Reuses `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route |
 | **S2** | **Ticket handshake + auth** — `POST /api/ws/ticket` (reuses `requireAuth`), single-use short-TTL store, consume-at-upgrade, `Origin` allowlist (§8), `jwtExp` close (§4.3), `reauth` seam, auth metrics. | yes | additive |
 | **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to role-filtered `stale`/`now`/`blocked` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
-| **S4** | **Throughput aggregator + `throughput` push** — consume S0's samples, derive overall + per-profile B/s, push the tick (§5.3/§1.3). Emits nothing (gauge "—") until S0 lands. | yes | additive |
-| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput()` (overall + per-profile gauges, #747), `now`/`blocked` cache-patching (§3.1/§3.2), `useWsLive()` indicator (§6.2), ticket-mint-then-connect, backoff (§6.1), polling-as-paused-fallback for the dashboard live sections. **This lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
+| **S4** | **Throughput aggregator (windowed) + `throughput` push** — consume S0's samples, maintain overall + per-profile B/s for each window {5s,1m,5m,10m}, push the subscribed window(s) at window-appropriate cadence (§5.3/§1.3/§1.4). Emits nothing (gauge "—") until S0 lands. | yes | additive |
+| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput(window)` with the **5s/1m/5m/10m window selector** (re-subscribes on change, #747), `now`/`blocked` cache-patching (§3.1/§3.2), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), ticket-mint-then-connect, backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
 | **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.2) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
 | **S6b** | **Broaden class-(3) `stale` to alerts / profiles / devices / schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
@@ -621,9 +701,13 @@ deliberate once that view's push path is proven, never armed automatically
 
 ## 10. Open questions / risks
 
-1. **Throughput cadence vs. cost.** ~2 s tick is the proposed default; the exact
-   cadence is pinned with S0 against the router's conntrack-read cost and Render's
-   frame budget. Faster than ~1 s buys little for a human-watched gauge.
+1. **Throughput windows + per-window cadence.** The user-choosable windows are
+   {5s, 1m, 5m, 10m} (§1.3/§1.4), each a subscription with its own emit cadence
+   (~5 s for 5s … ~30 s for 10m, §5.3). The exact per-window cadences and the
+   router sample interval (S0) are pinned together against the conntrack-read cost
+   and Render's frame budget. Open sub-question for the operator: is this fixed
+   four-window set right, or do you want a different/continuous set (e.g. 30s, 1h)?
+   Adding a window is additive (a new enum value + one more EWMA).
 2. **#1023 dependency for live bandwidth.** Live throughput (S4/S5's gauge) is the
    one element gated on #1023's realtime usage source (S0). Everything else (NOW,
    blocked, the endpoint, auth) ships without it; the gauge shows "—" until S0

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -144,7 +144,7 @@ column is what the client sends in `subscribe`.
 | `throughput` | (1) | **`window` ∈ {5s,1m,5m,10m}** | `ThroughputTick` (§1.3) | overall in/out gauge **+** per-profile ▲▼ on NOW cards (#747) | API aggregator over the #1023 usage stream (§5.3) |
 | `now` | (2) | — | `DashboardNow` (existing body) | NOW active cards; derived "Online/Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
 | `blocked` | (2) | — | one blocked `QueryLog` row (existing `/api/logs` shape) | Most Recently Blocked feed (prepend) | connection-events ingest (§5.2) |
-| `timeStatus` | (2) | — (all authorized profiles) | `ProfileTimeStatus[]` (existing `/api/time/status` body) | per-profile **used/remaining** bars; "over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
+| `timeStatus` | (2) | — (all authorized profiles in v1; a `profileId` filter is an additive future param like `appUsage`'s) | `ProfileTimeStatus[]` (existing `/api/time/status` body) | per-profile **used/remaining** bars; "over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
 | `appUsage` | (2) | **`profileId`** (the expanded card) | per-app minutes (existing `/api/profiles/{id}/usage-by-app` body) | per-app **minutes-used** rows (live) | same triggers, via `Presence.appSecondsForProfile` |
 | `stale` | (3) | — | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query | the relevant write site (§5.2) |
 | `ready` | — | — | `{ role, serverTime }` | flips the live indicator to "live" | upgrade (§4) |
@@ -228,7 +228,9 @@ narrow view subscribes little. Nothing is pushed to a connection that didn't ask
   profiles the role may view (§4.4). Subscription narrows; authz constrains.
 - **`ack` per subscribe** (`{op:"ack", topic, status:"ok"|"reject", reason?}`) so
   the client knows the subscription took (and isn't silently waiting on a topic
-  the server refused).
+  the server refused). Note this SPA `ack` is keyed by **`topic`**, not by `seq`
+  like the router path's data-frame `ack` ([`RouterWsRoutes`](../../api/src/routes/RouterWsRoutes.scala))
+  — same `op` name, different (separate-endpoint) payload.
 - **Reconnect re-subscribes.** Subscriptions are connection-scoped and **not**
   durable across a reconnect; on reconnect the client replays its current
   subscription set (§6.1) — the server starts each connection subscribed to

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -210,7 +210,10 @@ display the dashboard wants is `GET /api/usage/traffic` streamed:
 > whatever cadence the router sends usage data** (today ~60 s batches; sub-minute
 > and toward real-time as #1023 streams usage as the agent has it) — realtime-ness
 > is bounded by the usage-send rate, with **no bespoke high-frequency sample and no
-> router change**. (`5m`/`10m` display buckets are trivially addable later.)
+> router change**. (Note: a `raw` subscription is still **aggregated per the
+> subscription's `groupBy`** at the ingest-period granularity — the gauge gets one
+> overall/per-profile point per arriving usage period, not ungrouped per-host
+> `rawRows`.) (`5m`/`10m` display buckets are trivially addable later.)
 
 `connectionEvents` likewise reuses the `/api/logs` `QueryLog` row shape and its
 filter params — it is the `blocked`-feed generalized so the **Connection Events

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -425,7 +425,13 @@ SPA                                                    API
   - `SameSite=Strict` — the browser won't attach it to a cross-site-initiated
     request, which (with the `Origin` allowlist, §8) closes cross-site websocket
     hijacking (CSWSH).
-  - `Secure` — HTTPS only (dev/localhost is exempted as today).
+  - `Secure` — HTTPS only. `http://localhost` is a browser "secure context" so
+    `Secure` cookies are accepted there for dev; the self-hosted deploy is HTTPS.
+  - `Max-Age` short (e.g. 60 s) — the cookie is meant to live only across the
+    upgrade. The SPA clears it right after the socket opens, but the short
+    `Max-Age` is the belt-and-suspenders bound: if the tab is killed between
+    set and open, the lingering cookie self-expires in seconds rather than
+    persisting.
   - `Domain=wifihaven.net` in cloud so it reaches `api.` from `app.`; omitted
     (host-only) in the self-hosted same-origin case.
 - **No new persistent exposure.** The JWT already lives in `localStorage`

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -231,6 +231,16 @@ stale for their next mount), so a `stale{time-status}` while the dashboard isn't
 open costs nothing — the exact "poll only what's visible" property the adaptive
 ladder hand-rolls, now for free.
 
+> Four of the five topics map to an existing polled hook in
+> [`queries.ts`](../../web/src/api/queries.ts) (`useDashboardNow`,
+> `useRecentBlocked`, `useAlerts`, `useTimeStatus*`). **`routers` is the
+> exception:** the admin router list is a plain `api.routers.list()` call today,
+> not a TanStack-cached poll, so the `['admin','routers']` key above is
+> *forward-looking* — the `routers` topic (router connect/disconnect, fed by
+> `RouterWsRegistry` register/deregister, §4.2) implies first wrapping the router
+> list/status in a query, not pausing an existing interval. Noted for S5 so the
+> implementer doesn't assume a poll to retire.
+
 ### 2.3 The thick-push exception (deferred, measured)
 
 `data{topic, body}` exists in the protocol (§1.3) for **one** future case:
@@ -509,6 +519,12 @@ value to the log only, exactly as `RouterWsRoutes` does). **No `router_id`-style
 per-entity label** — the SPA has no fleet-bounded entity, so unlike
 `router_connected` there is no per-id gauge here.
 
+> **Registration (S1/S6 implementer note):** each new `spa_ws_*` series needs its
+> `(name -> allowed keys)` entry added to `MetricGuard.Allowed`
+> ([`api/src/metrics/Metrics.scala`](../../api/src/metrics/Metrics.scala), the
+> `Allowed` map) or `MetricGuard` rejects the emit — exactly as the `router_ws_*`
+> families were registered. Do not rely on the discipline being implicit.
+
 ### 6.1 Grafana panel
 
 Add a **`spa-ws.json`** dashboard under
@@ -532,7 +548,11 @@ Panels:
 
 The dashboard ships in the **same PR** as the metric-emitting code for each
 phase, targeting only series that phase actually emits (no no-data panels), per
-the dashboard rule. CI gate: `grafana-terraform`.
+the dashboard rule. CI gate: `grafana-terraform`. As a *new* dashboard,
+`spa-ws.json` must also be added to the `local.dashboards` list in
+[`infra/grafana/main.tf`](../../infra/grafana/main.tf) (sibling to the existing
+`router-ws-transport` entry) — that list is what the `grafana-terraform` gate
+provisions from.
 
 ---
 

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -339,8 +339,9 @@ the page key are produced in one place.)
 
 ```ts
 // trafficUsage → MERGE the live-edge bucket into the GET-loaded series (history stays put);
-// replace the head bucket while it accumulates, append when it rolls over — never refetch history
-queryClient.setQueryData(trafficKey(params), prev => mergeHeadBucket(prev, liveBucket))
+// join on windowStart (TrafficUsageAggregateRow.windowStart) — replace the row with the same
+// windowStart while it accumulates, prepend when a new windowStart rolls over. Never refetch history.
+queryClient.setQueryData(trafficKey(params), prev => mergeHeadBucket(prev, liveBucket)) // by windowStart
 // connectionEvents → prepend new head rows (bounded, dedup by id); cursor-paged history untouched
 queryClient.setQueryData(logsKey(filter), prev => prependHead(prev, rows))
 // now → replace the dashboard-now cache (singular resource, pushed whole)

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -204,16 +204,13 @@ display the dashboard wants is `GET /api/usage/traffic` streamed:
   re-streams historical buckets, so a 24 h × 1 h chart isn't re-sent every minute —
   just its newest bar advances.
 
-> **Granularity note (reconciling the 5s/1m/5m/10m ask).** `traffic_reports` is
-> period-batched from the router's ~60 s usage cycle, so the **finest aggregated
-> bucket is `1m`** — the window set the existing read model gives for free is
-> `{1m, 10m, 1h, …}`. Two follow-ups, both additive and **decided with the
-> operator** (§10 Q1): (a) `5m`/`10m` display windows are cheap re-aggregations of
-> 1 m data — add them as bucket values if wanted; (b) a true **sub-minute (5 s)
-> "instant" gauge** is *not* available from `traffic_reports` and would need the
-> optional high-frequency conntrack sample (§5.3 / §9 **S0**, kept optional, not
-> the primary path). The primary, no-new-data design streams the existing
-> `1m`-and-coarser buckets.
+> **Granularity (decided with the operator, §10 Q1).** Aggregated floor is **`1m`**
+> (the `traffic_reports` minimum), so `{1m, 10m, 1h, …}` come free. For
+> **fully-realtime**, the existing **`raw` bucket** streams the live edge **at
+> whatever cadence the router sends usage data** (today ~60 s batches; sub-minute
+> and toward real-time as #1023 streams usage as the agent has it) — realtime-ness
+> is bounded by the usage-send rate, with **no bespoke high-frequency sample and no
+> router change**. (`5m`/`10m` display buckets are trivially addable later.)
 
 `connectionEvents` likewise reuses the `/api/logs` `QueryLog` row shape and its
 filter params — it is the `blocked`-feed generalized so the **Connection Events
@@ -574,21 +571,16 @@ matching subscribers. Design:
   buckets advance less often. Latest-wins per `(groupBy,bucket,filter)` (§6.3) — a
   slow client gets the freshest head bucket, never a backlog. Recompute only for
   subscribed param-sets — no subscriber, no query.
-- **Granularity floor = the data.** Because `traffic_reports` is period-batched
-  from the router's ~60 s usage cycle, the finest *aggregated* bucket is `1m`; the
-  window set the existing read model gives for free is `{1m, 10m, 1h, …}` (§1.3).
-  `5m`/`10m` display windows are additive re-aggregations if wanted (§10 Q1).
-- **Optional sub-minute (5 s) instant gauge — only if the operator wants it
-  (§10 Q1).** A true 5 s rate is below the `traffic_reports` floor and would need a
-  dedicated lightweight per-`mac` bytes-since-last-sample frame on the router→API
-  ws (additive to #1023, from the conntrack counters the agent already reads,
-  `conntrack.lua`) feeding a small EWMA — kept as **optional** sub-issue **S0**,
-  not the primary path. The default design ships `1m`-and-coarser from the
-  existing pipeline with **no router change**.
-- **Degrades cleanly.** With no realtime usage source the aggregator still serves
-  whatever `traffic_reports` holds at the REST cadence; the optional sub-minute
-  gauge simply shows "—" until S0 lands. The endpoint + full catalog ship
-  independently of S0.
+- **Granularity floor = the data; `raw` = ingest-rate realtime (§10 Q1).** The
+  aggregated floor is `1m` (`traffic_reports` minimum), giving `{1m, 10m, 1h, …}`
+  for free. A **`raw`-bucket** subscription instead pushes the live edge **as each
+  usage report lands** — so "fully-realtime" is just the usage-send cadence (today
+  ~60 s; sub-minute and toward real-time as #1023 streams usage). **No bespoke
+  conntrack sample and no router change** — realtime-ness rides the existing usage
+  path. (`5m`/`10m` display buckets are additive re-aggregations later.)
+- **Degrades cleanly.** With usage arriving only at the REST cadence the live edge
+  simply advances that often; it gets faster automatically as #1023 streams usage.
+  Nothing here is gated on #1023.
 
 > **Single-process fan-out**, like the router path — registries, hubs, and the
 > aggregator are in-memory, single-instance (correct for the one-API-process
@@ -743,11 +735,10 @@ realtime throughput):
 
 | # | Sub-issue | Independently shippable? | Back-compat |
 |---|---|---|---|
-| **S0** | **(optional, in #1023) router→API sub-minute `throughput` sample** — additive per-mac bytes-since-last-sample frame ~every 2 s from the conntrack counters (§5.3), feeding the optional 5 s "instant" gauge. **Not required** for the `1m`-and-coarser bandwidth stream, which comes from the existing `traffic_reports`. | yes (additive frame; usage path unchanged) | additive |
 | **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry` + subscription model** — server skeleton, envelope/demux (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection subscription state + `ack`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry, server metrics §7 + `spa-ws.json`. Reuses `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route |
 | **S2** | **Upgrade auth** — verify the `wh_ws` JWT cookie at upgrade via the existing `AuthService.verify` (no new auth surface), `Origin` allowlist (§8), `SameSite=Strict; Path=/api/ws; Secure` cookie scoping, `jwtExp` mid-connection close (§4.3), `reauth` seam, auth metrics. SPA-side: set-cookie-before-connect + clear-after helper. | yes | additive |
 | **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to subscription-gated `now`/`connectionEvents`/`stale` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
-| **S4** | **`trafficUsage` aggregator + push** — on usage ingest, re-run the subscribed `(groupBy,bucket,filter)` traffic-usage queries and push the refreshed `TrafficUsageResponse` to matching subscribers, latest-wins per param-set (§5.3). Reuses the existing query — no new shape. (Sub-minute gauge waits on optional S0.) | yes | additive |
+| **S4** | **`trafficUsage` aggregator + live-edge push** — on usage ingest, recompute only the **current bucket** for subscribed `(groupBy,filter)` and push it (merge head, §3.1), latest-wins per param-set (§5.3); a `raw`-bucket subscription pushes at the usage-ingest cadence (fully-realtime, §10 Q1). Reuses the existing query — no new shape, no router change. | yes | additive |
 | **S5** | **SPA ws client + realtime dashboard pilot** — `useWsTrafficUsage(params)` driving the overall + per-profile bandwidth gauges with the **window (bucket) selector** (re-subscribes on change, #747), `now` + `connectionEvents{blocked:true}` cache-patching (§3.1), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), set-cookie-then-connect (§4.2), backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + bandwidth + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
 | **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.1) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
 | **S6b** | **Stream the Traffic Usage + Connection Events pages** — those pages keep loading **history via their existing `GET`** (initial window + cursor paging, #862); they additionally subscribe `trafficUsage` / `connectionEvents` with *their* current filters (same topics as the dashboard, different params) for the **live edge only** — `trafficUsage` merges the head bucket, `connectionEvents` prepends new head rows; older/paged data is never mutated by the stream. Pause the page's poll when `wsLive`. Plus class-(3) `stale` for alerts / profiles / devices / schedules (§3.2). | yes (per-page) | additive |
@@ -756,9 +747,9 @@ realtime throughput):
 
 **Critical path to the operator-visible win:** S1 → S2 → S3 → S5 (dashboard NOW +
 blocked live), with **S4 → S5** adding live bandwidth from the existing
-`traffic_reports` (no router change); the optional **S0** only adds the sub-minute
-instant gauge. **Parallel:** S3/S4 can land alongside S2. **S7 is last and
-per-view-gated** — each cutover off polling is
+`traffic_reports` (no router change; realtime-ness scales with the usage-send rate
+and approaches real-time as #1023 streams usage). **Parallel:** S3/S4 can land
+alongside S2. **S7 is last and per-view-gated** — each cutover off polling is
 deliberate once that view's push path is proven, never armed automatically
 ([`pr-review-checklist.md#monitor-to-merged`](../pr-review-checklist.md)).
 
@@ -766,29 +757,36 @@ deliberate once that view's push path is proven, never armed automatically
 
 ## 10. Open questions / risks
 
-1. **Bandwidth windows = traffic buckets, and the 5 s question.** The window
-   selector maps to the existing `TrafficUsageBucket` enum, whose finest
-   *aggregated* value is **`1m`** (the `traffic_reports` floor, §1.3/§5.3) — so
-   `{1m, 10m, 1h, …}` come free with no new data path. Two operator decisions:
-   (a) add `5m`/`10m` display buckets (cheap re-aggregations of 1 m data)? and
-   (b) is a **sub-minute (5 s) "instant" gauge** wanted — which requires the
-   optional router conntrack sample (S0)? If 1 m-granular live bandwidth is
-   acceptable, S0 is unnecessary and there is **no router change** at all.
-2. **No hard #1023 dependency for bandwidth (changed).** The `1m`-and-coarser
-   bandwidth stream comes from the existing `traffic_reports` re-query (S4), so it
-   does **not** block on #1023 — it just refreshes at the current usage-ingest
-   cadence and gets *faster* (sub-minute) once #1023's realtime usage + the
-   optional S0 sample land. Earlier this doc said throughput was gated on #1023;
-   with the read-model reuse, only the *sub-minute* gauge is.
-3. **Multi-instance.** Cookie upgrade-auth is **stateless** (any instance verifies
-   the JWT — no ticket store to share), so auth is multi-instance-clean. The only
-   single-process assumption left is the in-memory registry/aggregator fan-out
-   (§5) — correct for the one-API-process household model; cross-instance pub/sub
-   is out of scope, same as the router path. Documented limit, not a TODO.
-4. **Thick-push filtering (class 2).** Per-role filtering of a pushed `now` body is
-   the one place class-(1)/(3)'s contentless safety is absent; it reuses the
-   `DashboardNowRoutes` filter (§3.1/§5.2) so there is one filter implementation,
-   bounding the risk.
-5. **Observability parity.** Per-frame structured logging (`op`/`role`/`result` on
-   the MDC, mirroring `RouterWsRoutes`' `LogContext`) so a transport fault is as
-   debuggable as REST. Built into S1.
+1. **Bandwidth windows — RESOLVED (operator, 2026-06-25).** Floor is **`1m`** (the
+   `traffic_reports` aggregated minimum), giving `{1m, 10m, 1h, …}` from the
+   existing read model with no new data path. **Plus a "raw" / ingest-rate mode for
+   fully-realtime:** the live edge is pushed **at whatever cadence the router sends
+   usage data** (today ~60 s batches; sub-minute and approaching real-time as
+   #1023 streams usage as the agent has it), surfaced via the existing `raw`
+   `TrafficUsageBucket` value. So realtime-ness is bounded by the usage-send rate,
+   **not** by a bespoke high-frequency sample — the conntrack-sample idea (former
+   S0) is **dropped** (no router-side throughput frame, nothing new on the agent).
+   `5m`/`10m` display buckets remain trivially addable later if wanted.
+2. **No hard #1023 dependency for bandwidth — confirmed.** The `1m`-and-coarser
+   stream comes from the existing `traffic_reports` (S4) and refreshes at the
+   usage-ingest cadence; it simply gets *faster* (toward the `raw` ingest-rate
+   mode) as #1023 streams usage. Nothing here blocks on #1023.
+3. **Multi-instance — FILED as [#1952](https://github.com/wifihaven/wifihaven/issues/1952).**
+   This is the **first feature whose correctness requires cross-instance
+   engineering**, so it gets its own issue rather than a buried caveat. Auth is
+   already multi-instance-clean (stateless cookie/bearer verify — no ticket store).
+   The single-process state that needs a story before a 2nd API instance: the
+   `SpaWsRegistry` + per-connection **subscription set**, the `RouterWsRegistry`,
+   the `SpaEventHub`/publisher hub, and the `trafficUsage` aggregator (§5) — a push
+   computed on instance A can't reach a client on instance B. Options (sticky
+   routing vs cross-instance pub/sub vs hybrid), and the fact that subscription
+   state rebuilds on reconnect (§6.1) so it need not be replicated, are documented
+   in #1952. Correct as-is for the single-instance deployment; #1952 is the home
+   for the scaling work.
+4. **Thick-push filtering (class 2) — accepted.** Per-role filtering of a pushed
+   `now` body is the one place class-(1)/(3)'s contentless safety is absent; it
+   reuses the `DashboardNowRoutes` filter (§3.1/§5.2) so there is one filter
+   implementation, bounding the risk.
+5. **Observability parity — accepted.** Per-frame structured logging
+   (`op`/`role`/`result` on the MDC, mirroring `RouterWsRoutes`' `LogContext`) so a
+   transport fault is as debuggable as REST. Built into S1.

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -80,8 +80,14 @@ The three structural wins, restated against that framing:
 A browser `WebSocket` is not `curl` and not a server socket:
 
 1. **It cannot set request headers** on the upgrade — no `Authorization: Bearer`.
-   This is *the* reason the SPA auth handshake (§4) differs from the router's
-   bearer-on-upgrade ([`websocket-transport.md` §4.1](websocket-transport.md)).
+   This is specific to the `WebSocket` **constructor API**: `fetch`/`XMLHttpRequest`
+   *can* set arbitrary headers, which is exactly how REST auth works today
+   (`client.ts:41` sets `Authorization: Bearer <jwt>` on every `fetch`). The
+   `WebSocket(url, protocols)` constructor simply exposes no header argument — so
+   the JWT that rides a header on REST has to ride something else on the ws
+   upgrade. This is *the* reason the SPA auth (§4) differs from the router's
+   bearer-on-upgrade ([`websocket-transport.md` §4.1](websocket-transport.md)) —
+   the router is not a browser and sets the header directly.
 2. **It cannot send ping/pong control frames** from JS — the heartbeat (§6.2) is
    an app-level text frame.
 3. **It is per-tab and dies on background/sleep** — reconnect, backoff, and
@@ -93,23 +99,31 @@ We **reuse the router transport's patterns** (envelope, demux, registry shape,
 metric discipline) and **fork where the two genuinely differ** (auth, key,
 payload vocabulary) — "share patterns, not code," same call #1023 makes.
 
-### 0.3 Read-model discipline — reuse bodies for resources, ONE new shape for the stream
+### 0.3 Read-model discipline — ZERO new read-model shapes; every topic reuses a REST body + its filters
 
 Per the single-source-of-truth discipline
 ([`AGENTS.md#single-source-of-truth`](../../AGENTS.md), wire-shape carve-out):
+**every server→SPA payload is an existing REST body, verbatim, and every
+subscription's parameters are that endpoint's existing query params.** The socket
+is a *transport for change over the existing read models*, not a new data model:
 
-- **Pushed snapshots of existing resources carry the existing REST body,
-  verbatim.** A NOW push is the exact `GET /api/dashboard/now` body
-  (`DashboardNow`, [`shared/src/Models.scala`](../../shared/src/Models.scala)); a
-  blocked-event push is the exact `/api/logs?blocked=true` row shape. **Zero new
-  serializers** for these — the `GET` stays the schema authority and a refetch
-  reconciles.
-- **The one genuinely-new shape is the throughput tick** (§1.3), and it is new
-  *because the data is new*: no REST endpoint produces a current byte-rate today
-  (`DashboardNow*` carries no bytes — confirmed in `Models.scala`). A push-native
-  telemetry stream has no existing body to reuse; inventing a minimal one is
-  correct, not a violation. It is deliberately tiny and is **not** mirrored into a
-  REST resource (you would never poll it).
+- **Bandwidth is not new data** — `traffic_reports` already carries directional
+  bytes per `(mac, host, period)`, surfaced by `GET /api/usage/traffic` as
+  `TrafficUsageResponse` ([`shared/src/Models.scala`](../../shared/src/Models.scala):
+  `totalBytesIn`/`totalBytesOut` per group). Overall / per-profile / per-device
+  bandwidth is just that endpoint with `groupBy ∈ {∅, profile, device}`; the
+  averaging window is its `bucket`. So the **`trafficUsage` topic streams
+  `TrafficUsageResponse` verbatim** — no `ThroughputTick`, no new shape. (An
+  earlier draft invented a `ThroughputTick`; that was wrong — the read model
+  already exists.)
+- **NOW / blocked / connection-events / time-usage** likewise reuse
+  `DashboardNow`, the `/api/logs` row (`QueryLog`), and the `/api/time/status` /
+  `/api/profiles/{id}/usage-by-app` bodies verbatim.
+- **The win:** because each topic *is* an existing endpoint-plus-filters, the same
+  subscription powers the dashboard **and** the page it came from — `trafficUsage`
+  drives the dashboard bandwidth gauge *and* live-updates the Traffic Usage page;
+  `connectionEvents` drives the dashboard "recently blocked" *and* the Connection
+  Events page. One stream, many consumers, one schema authority (the `GET`).
 
 ---
 
@@ -123,14 +137,17 @@ the input contract); every item is classified by **why** it is on the socket.
 
 | Class | What | Examples | How it rides the socket |
 |---|---|---|---|
-| **(1) Push-native realtime stream** | a *rate/stream* with no cacheable REST form | **live throughput** (overall + per-profile in/out B/s) | server pushes a `throughput` tick on a fixed cadence; client renders a live gauge — **not** in the React Query resource cache |
-| **(2) Pushed live snapshot/append** | a real REST resource that changes fast enough to push instead of poll | **NOW** (`DashboardNow`), **Most Recently Blocked** feed, **live time-usage** (per-profile used/remaining + per-app minutes) | server pushes the (changed) body / the new row; client patches the existing React Query cache for that key (§3) |
+| **(1) Live read-model stream** | an existing read endpoint whose result changes fast and is worth pushing as it changes | **live bandwidth** (`trafficUsage` — overall/per-profile/per-device bytes), **live connection events** (`connectionEvents`) | server re-runs the subscribed query when new data lands and pushes the refreshed body; client patches the matching React Query cache (§3) |
+| **(2) Pushed live snapshot/append** | a real REST resource that changes fast enough to push instead of poll | **NOW** (`DashboardNow`), **live time-usage** (per-profile used/remaining + per-app minutes) | server pushes the (changed) body / the new row; client patches the existing React Query cache for that key (§3) |
 | **(3) Occasionally-changing resource** | a cacheable resource that changes rarely | profiles, devices, schedules, blocklists, 24 h rollup panels | **stays request/response.** At most a `stale` nudge on a relevant mutation; many need nothing (their mutation already invalidates locally) |
 
-The websocket is for **(1) and (2)**. **(3) stays on queries** — the explicit
-correction to the "invalidate everything" framing. The dashboard's "Blocking
-activity (24 h)" panel and the "Events (1h)/Blocked (1h)" KPIs are class (3): they
-ride the rollup tables on request/response and are *not* streamed
+(Classes 1 and 2 are both "push the data, patch the cache" — they differ only in
+that class 1 is a *filtered query result* the client subscribes with parameters,
+while class 2 is a singular resource. The split that matters is **vs. class 3**,
+which stays on queries.) The websocket is for **(1) and (2)**; **(3) stays on
+queries** — the correction to the "invalidate everything" framing. The dashboard's
+"Blocking activity (24 h)" panel and the "Events (1h)/Blocked (1h)" KPIs are class
+(3): rollup-backed request/response, *not* streamed
 ([`dashboard-redesign.md` §7.5/§8.2](dashboard-redesign.md)).
 
 ### 1.2 Server→SPA message catalog
@@ -139,13 +156,13 @@ Every server→SPA push is **gated on a subscription** (§1.4) — the client re
 only the topics it asked for, with the parameters it asked for. The `Params`
 column is what the client sends in `subscribe`.
 
-| `op` | Class | Params (subscription) | Payload | Drives (dashboard element) | Source |
+| `op` | Class | Params (subscription) = the endpoint's query params | Payload (existing body) | Drives | Source |
 |---|---|---|---|---|---|
-| `throughput` | (1) | **`window` ∈ {5s,1m,5m,10m}** | `ThroughputTick` (§1.3) | overall in/out gauge **+** per-profile ▲▼ on NOW cards (#747) | API aggregator over the #1023 usage stream (§5.3) |
-| `now` | (2) | — | `DashboardNow` (existing body) | NOW active cards; derived "Online/Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
-| `blocked` | (2) | — | one blocked `QueryLog` row (existing `/api/logs` shape) | Most Recently Blocked feed (prepend) | connection-events ingest (§5.2) |
-| `timeStatus` | (2) | — (all authorized profiles in v1; a `profileId` filter is an additive future param like `appUsage`'s) | `ProfileTimeStatus[]` (existing `/api/time/status` body) | per-profile **used/remaining** bars; "over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
-| `appUsage` | (2) | **`profileId`** (the expanded card) | per-app minutes (existing `/api/profiles/{id}/usage-by-app` body) | per-app **minutes-used** rows (live) | same triggers, via `Presence.appSecondsForProfile` |
+| `trafficUsage` | (1) | `{ groupBy ∈ {∅,profile,device,…}, bucket (window), macs?, profileIds? }` (= `GET /api/usage/traffic` params) | `TrafficUsageResponse` | dashboard **overall + per-profile bandwidth** gauges (#747) **and** the **Traffic Usage page** (live) | re-run the query on usage ingest (§5.3) |
+| `connectionEvents` | (1) | `{ blocked?, macs?, profileIds?, domain? }` (= `GET /api/logs` params) | `QueryLog` rows (append/refresh) | dashboard **Most Recently Blocked** (`blocked:true`) **and** the **Connection Events page** (live) | connection-events ingest (§5.2) |
+| `now` | (2) | — | `DashboardNow` | NOW active cards; derived "Online/Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
+| `timeStatus` | (2) | — (all authorized profiles in v1; `profileId` filter is an additive future param) | `ProfileTimeStatus[]` (`/api/time/status`) | per-profile **used/remaining** bars; "over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
+| `appUsage` | (2) | `profileId` (the expanded card) | per-app minutes (`/api/profiles/{id}/usage-by-app`) | per-app **minutes-used** rows (live) | same triggers, via `Presence.appSecondsForProfile` |
 | `stale` | (3) | — | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query | the relevant write site (§5.2) |
 | `ready` | — | — | `{ role, serverTime }` | flips the live indicator to "live" | upgrade (§4) |
 | `ping`/`pong` | — | — | `{}` | heartbeat (§6.2) | — |
@@ -156,74 +173,76 @@ SPA→server: `hello` (`{clientVersion}`), **`subscribe` (`{topic, params?}`)**,
 **Unknown `op` → ignore + meter**, both directions (forward-compat, mirrors
 [`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
 
-### 1.3 The one new shape — `ThroughputTick`
+### 1.3 No new shapes — `trafficUsage` is the existing `TrafficUsageResponse`
 
-```jsonc
-// op:"throughput" payload — bytes-per-second rates averaged over `window`, as of `asOf`
-{
-  "window": "1m",                                  // which averaging window this tick is for
-  "asOf": "2026-06-24T14:31:02Z",
-  "overall":     { "inBps": 1840000, "outBps": 240000 },
-  "perProfile": [
-    { "profileId": 3, "inBps": 1510000, "outBps": 90000 },
-    { "profileId": 7, "inBps":  330000, "outBps": 150000 }
-  ]
-}
-```
+There is **no `ThroughputTick` and no new read-model**. The "live bandwidth"
+display the dashboard wants is `GET /api/usage/traffic` streamed:
 
-- **`window` ∈ {5s, 1m, 5m, 10m}** — the user-choosable averaging window
-  (§1.4). The rate is the mean B/s over the trailing `window`; the field tells the
-  client which display the tick is for (a client may show one window, or hold more
-  than one subscription). The 5 s window reads as near-instantaneous; the 10 m
-  window is a smooth trend.
-- **The window is a *subscription parameter*, not a payload-multiplier.** The
-  server emits only the window(s) a connection subscribed to, **at a
-  window-appropriate cadence** (a 10 m average barely moves in 5 s, so it ticks
-  ~every 30 s, while a 5 s window ticks ~every 5 s) — see §1.4/§5.3. This is the
-  concrete reason subscriptions matter: without them every client would receive
-  every window at the fastest cadence.
-- **Rates, not cumulative bytes** — the SPA renders a gauge/sparkline; the server
-  does the windowed-rate math once per window (§5.3) so every tab doesn't
-  re-derive it (single-source-of-truth for the rate).
-- **Overall + per-profile only.** Per-device/host throughput is deliberately
-  **off** the dashboard ([`dashboard-redesign.md` §8.1](dashboard-redesign.md));
-  the same tick *shape* could carry a `perDevice` array for a future `/devices`
-  view, but v1 emits only overall + per-profile.
-- **Bounded size** — one entry per active profile (households ≤ ~10); a profile
-  absent from `perProfile` is idle (client zeroes it); the tick never grows with
-  history.
+- **`groupBy` selects the breakdown** — empty = overall household; `["profile"]` =
+  per-profile; `["device"]` = per-device. `TrafficUsageAggregateRow` already
+  carries `totalBytesIn`/`totalBytesOut`/`totalSeconds` per group
+  ([`Models.scala`](../../shared/src/Models.scala)). The dashboard subscribes
+  overall + per-profile; the Traffic Usage page subscribes with whatever groupBy
+  the user has selected — **same topic, same body, different params**.
+- **`bucket` is the window** — the choosable averaging window is the existing
+  `TrafficUsageBucket` enum (`raw | 1m | 10m | 1h | 12h | 1d | 1w`,
+  [`web/src/types/api.ts`](../../web/src/types/api.ts)). The client converts
+  bytes-over-bucket → a B/s rate for the gauge; the server ships the same row the
+  page already renders.
+- **Bandwidth is a derived view, not a counter we invent** — the client divides
+  `totalBytes / bucketSeconds` (the page already does this kind of math), so the
+  server stays the single source of the *bytes* and there's no second "rate"
+  serializer.
 
-This is the only addition to `web/src/types/api.ts`; `now`/`blocked`/`stale`
-payloads reuse shapes that already exist there.
+> **Granularity note (reconciling the 5s/1m/5m/10m ask).** `traffic_reports` is
+> period-batched from the router's ~60 s usage cycle, so the **finest aggregated
+> bucket is `1m`** — the window set the existing read model gives for free is
+> `{1m, 10m, 1h, …}`. Two follow-ups, both additive and **decided with the
+> operator** (§10 Q1): (a) `5m`/`10m` display windows are cheap re-aggregations of
+> 1 m data — add them as bucket values if wanted; (b) a true **sub-minute (5 s)
+> "instant" gauge** is *not* available from `traffic_reports` and would need the
+> optional high-frequency conntrack sample (§5.3 / §9 **S0**, kept optional, not
+> the primary path). The primary, no-new-data design streams the existing
+> `1m`-and-coarser buckets.
+
+`connectionEvents` likewise reuses the `/api/logs` `QueryLog` row shape and its
+filter params — it is the `blocked`-feed generalized so the **Connection Events
+page** can stream too (subscribe with the page's current filters), and the
+dashboard "Most Recently Blocked" is just `connectionEvents{blocked:true}`. **Zero
+additions to `web/src/types/api.ts`.**
 
 ### 1.4 Subscriptions — first-class, so a tab gets only what it shows
 
 **Subscriptions are a v1 requirement, not a deferred seam.** A connection receives
 a topic **only if it has subscribed to it** (and is authorized, §4.4). This is how
-"only get the data we need over the ws" is achieved: a dashboard tab subscribes
-`throughput`/`now`/`blocked`/`timeStatus`; a `/profiles` tab subscribes
-`timeStatus` + `appUsage{profileId}` for the expanded card; a backgrounded or
-narrow view subscribes little. Nothing is pushed to a connection that didn't ask.
+"only get the data we need over the ws" is achieved: the dashboard subscribes
+`trafficUsage{groupBy:profile}` + `now` + `connectionEvents{blocked:true}` +
+`timeStatus`; the **Traffic Usage page** subscribes `trafficUsage` with *its*
+current groupBy/bucket/filters; the **Connection Events page** subscribes
+`connectionEvents` with its filters; a `/profiles` tab subscribes `timeStatus` +
+`appUsage{profileId}`. Nothing is pushed to a connection that didn't ask.
 
 **Protocol.**
 
 ```jsonc
 // after `ready`, the client declares what it wants — and updates it as the UI changes
-{ "op": "subscribe",   "payload": { "topic": "throughput", "params": { "window": "1m" } } }
-{ "op": "subscribe",   "payload": { "topic": "appUsage",   "params": { "profileId": 3 } } }
-{ "op": "unsubscribe", "payload": { "topic": "throughput" } }
+{ "op": "subscribe",   "payload": { "topic": "trafficUsage", "params": { "groupBy": ["profile"], "bucket": "1m" } } }
+{ "op": "subscribe",   "payload": { "topic": "appUsage",     "params": { "profileId": 3 } } }
+{ "op": "unsubscribe", "payload": { "topic": "trafficUsage" } }
 ```
 
 - **Lifecycle = the mounted UI.** A hook subscribes on mount, unsubscribes on
-  unmount (e.g. the throughput gauge subscribes `throughput{window}` and
-  **re-subscribes with the new `window` when the user picks 5s/1m/5m/10m from the
-  selector** — server replaces that connection's prior `throughput` subscription).
-  Expanding a profile card subscribes `appUsage{profileId}`; collapsing it
-  unsubscribes. So per-connection traffic tracks exactly what's on screen.
+  unmount (e.g. the bandwidth gauge subscribes `trafficUsage{groupBy,bucket}` and
+  **re-subscribes with the new `bucket` when the user picks the window from the
+  selector**, or a new `groupBy` when the Traffic page changes breakdown — the
+  server replaces that connection's prior `trafficUsage` subscription). Expanding a
+  profile card subscribes `appUsage{profileId}`; collapsing it unsubscribes. So
+  per-connection traffic tracks exactly what's on screen.
 - **Server holds subscriptions per-connection** in the channel's registry state
-  (§5.1) — `{topic → params}`. Fan-out checks the set before sending; the
-  throughput aggregator (§5.3) computes a `(scope, window)` rate only while ≥1
-  connection subscribes that window, and picks the emit cadence from the window.
+  (§5.1) — `{topic → params}`. Fan-out checks the set (and the params) before
+  sending; the `trafficUsage` aggregator (§5.3) maintains/pushes a given
+  `(groupBy, bucket, filter)` result only while ≥1 connection subscribes it, at a
+  bucket-appropriate cadence.
 - **Authorization still gates** on top of subscription: subscribing a topic the
   role can't see is rejected (`ack` reject); per-profile rows are filtered to the
   profiles the role may view (§4.4). Subscription narrows; authz constrains.
@@ -292,37 +311,28 @@ Identical envelope discipline to
 
 ---
 
-## 3. Client integration — push-data for the live surface, invalidate for the rest
+## 3. Client integration — patch the cache for the live surface, invalidate for the rest
 
-The central client-side decision, now made **per data class** (§1.1) rather than
-one-size-fits-all:
+The central client-side decision, made **per data class** (§1.1): classes (1) and
+(2) push the data and **patch the React Query cache** (no refetch RTT on the live
+surface); class (3) invalidates.
 
-### 3.1 Class (1) throughput — direct to a live store, not the resource cache
+### 3.1 Classes (1) + (2) — push carries the (existing) body, patch the matching key
 
-A `throughput` tick is a stream sample, not a cache entry. The
-`useWsThroughput(window)` hook **subscribes `throughput{window}` on mount and
-re-subscribes when the user changes the window selector** (5s/1m/5m/10m, §1.4),
-holds the latest tick (a small `useSyncExternalStore` or a dedicated query key
-updated via `setQueryData`), and feeds the overall gauge + per-profile card
-headers. There is nothing to invalidate and no `GET` to refetch — when the socket
-is down the gauge shows "—" (its only fallback; the 24 h volume on `/usage`
-answers the historical question). Latest-wins: a new tick replaces the prior one
-(§6.3). A tick whose `window` doesn't match the current selection is ignored
-(covers the brief overlap right after a window change before the old subscription
-is torn down).
-
-### 3.2 Class (2) NOW + blocked — push carries data, patch the cache
-
-For the live snapshots we **push the data and patch the React Query cache**
-directly — the *opposite* of the default for class (3), and correct here because
-the entire point is to remove the refetch RTT on the live surface:
+Because every payload is an existing REST body (§0.3), a push patches the **same
+React Query key the matching `GET` populates** — so the dashboard and the source
+page share one cache entry, and a later refetch (reconnect §6.1, or paused-poll
+fallback §3.3) reconciles against the `GET` authority:
 
 ```ts
-// on `now`  → replace the dashboard-now cache with the pushed body
-queryClient.setQueryData(qk.dashboardNow(), tick.payload)
-// on `blocked` → prepend the new row to the recent-blocked cache (bounded, dedup by id)
-queryClient.setQueryData(qk.recentBlocked(), prev => prependCapped(prev, row))
-// on `timeStatus` → replace the per-profile used/remaining cache with the pushed body
+// trafficUsage → patch the cache for the EXACT (groupBy,bucket,filter) the client subscribed,
+// i.e. the same query key the Traffic Usage page / dashboard gauge already reads for those params
+queryClient.setQueryData(trafficKey(params), body)
+// connectionEvents → prepend new rows (bounded, dedup by id) to the matching /logs query key
+queryClient.setQueryData(logsKey(filter), prev => prependCapped(prev, rows))
+// now → replace the dashboard-now cache
+queryClient.setQueryData(qk.dashboardNow(), body)
+// timeStatus → replace the per-profile used/remaining cache
 queryClient.setQueryData(qk.timeStatusToday(), rows)
 // on `appUsage` → patch only the LIVE (today) per-app cache entry; past windows
 // are immutable, so the push targets today's [from,to] key, not every cached window
@@ -331,14 +341,14 @@ queryClient.setQueryData(qk.profileUsageByApp(profileId, todayFrom, todayTo), ap
 
 Justification this is safe despite (3)'s SSOT argument: the pushed body **is** the
 exact `GET` body (§0.3), written through the **same** query key, so a later
-refetch (on reconnect, §6.1, or the paused-poll fallback, §3.4) reconciles against
+refetch (on reconnect, §6.1, or the paused-poll fallback, §3.3) reconciles against
 the authority. The server applies the *same* per-role visibility filter the `GET`
 uses before fan-out (§4.4 / §5.2) — for the household's small fan-out this is one
 filtered build, not a per-recipient risk surface. The derived KPIs ("Online now /
 Blocked now") are computed client-side off the pushed `DashboardNow`, so they
 update with the same push — no separate stream.
 
-### 3.3 Class (3) everything else — `stale` → invalidate (or nothing)
+### 3.2 Class (3) everything else — `stale` → invalidate (or nothing)
 
 For occasionally-changing resources, a `stale{topic}` frame triggers
 `queryClient.invalidateQueries` on the mapped key, reusing the existing `qk`
@@ -350,7 +360,7 @@ costs nothing. Many class-(3) changes already invalidate locally via a mutation'
 *another* operator/tab made the change. **No thick push for class (3):** it keeps
 the `GET` as the sole producer and gets per-recipient authz for free.
 
-### 3.4 Polling stays the paused fallback
+### 3.3 Polling stays the paused fallback
 
 `refetchInterval` is **not removed** — it is gated on socket health via a
 `useWsLive()` signal (§6.2):
@@ -386,7 +396,7 @@ cookie — those are the only two things a browser controls on a ws upgrade.
 
 | Mechanism | Verdict |
 |---|---|
-| **`Authorization` header** | **Impossible** — the browser `WebSocket` API cannot set request headers (§0.2.1). This is the whole reason the others exist. |
+| **`Authorization` header** | **Impossible *for the `WebSocket` API*** — unlike `fetch` (which carries the bearer on every REST call, `client.ts:41`), the `WebSocket` constructor exposes no way to set headers (§0.2.1). This is the whole reason the others exist. |
 | **JWT in the query string** | **Rejected.** It *does* authorize pre-upgrade, but the full JWT lands in access/proxy logs, browser history, and `Referer` — valid for its multi-hour life if leaked. |
 | **Subprotocol** (`Sec-WebSocket-Protocol`) | **Rejected.** Abuses a negotiation header to smuggle a secret; same log-exposure problem. |
 | **Short-lived single-use ticket** (query string) | Viable — keeps the JWT out of the URL via a 30 s one-shot token, but needs an extra round-trip + a server-side ticket store. **Not chosen** (see below). |
@@ -454,7 +464,7 @@ JWT's `exp`, captured at upgrade.
 - **Re-auth.** The SPA has **no silent token refresh** today — an expired JWT
   means 401 → `localStorage` clear → `/login` ([`client.ts`](../../web/src/api/client.ts)).
   v1 mirrors this: on `4401` the SPA stops reconnecting, falls back to polling
-  (§3.4); the next REST call 401s → the existing `/login` redirect; after
+  (§3.3); the next REST call 401s → the existing `/login` redirect; after
   re-login it re-sets the cookie and reconnects. The **`reauth` op** (§1.2) is the
   forward-compat seam: when silent refresh lands, the SPA can present the refreshed
   JWT on the open socket and the server advances `jwtExp` — no reconnect. v1 server
@@ -467,13 +477,13 @@ key: the server only pushes a topic to a connection whose role may see it
 (`stale{...}` for an admin-only resource → admin connections only; per-profile
 throughput → filtered to the profiles the role may view). For class-(2) thick
 pushes the body is filtered per-role *before* send, exactly as the matching `GET`
-filters (§3.2 / §5.2). For class-(3) `stale` signals the worst case of a fan-out
+filters (§3.1 / §5.2). For class-(3) `stale` signals the worst case of a fan-out
 bug is a needless refetch the `GET`'s own `requireAuth` then scopes — defense in
 depth.
 
 ---
 
-## 5. Server side — registries, change sources, the throughput aggregator
+## 5. Server side — registries, change sources, the `trafficUsage` aggregator
 
 ### 5.1 Decision: fork a parallel `SpaWsRegistry`; share the change sources
 
@@ -486,7 +496,7 @@ The two differ on the three axes a registry *is*:
 | **Key** | `RouterId` | per-connection id + `role` (a user may have N tabs, §6.4) |
 | **Per-channel state** | just the channel | channel + **subscription set `{topic → params}`** (§1.4) + `jwtExp` |
 | **Fan-out payload** | full `PolicySnapshot` | the §1.2 op vocabulary, role-filtered **and** subscription-gated |
-| **Event vocabulary** | one event (policy changed) | several (throughput tick, NOW change, new blocked event, class-3 mutations) |
+| **Event vocabulary** | one event (policy changed) | several (new traffic-usage data, NOW change, new connection event, time-usage change, class-3 mutations) |
 
 Generalizing one registry across two key types + two payload vocabularies couples
 things that share only the *shape* "a `Ref` of channels with a fan-out method."
@@ -513,9 +523,9 @@ change — no new polling/diffing loop:
 2. **A `SpaEventHub`** (`Hub[SpaEvent]`) fed by existing write sites, each a
    one-line publish:
    - connection-events ingest (`RouterIngestService`, the shared handler both REST
-     and router-ws ingest call) → a `blocked` push (the new row) + a `now`
-     recompute trigger.
-   - usage ingest → feeds the throughput aggregator (§5.3); a `now` trigger; and a
+     and router-ws ingest call) → a `connectionEvents` push (the new row(s), to
+     subscribers whose filter matches) + a `now` recompute trigger.
+   - usage ingest → feeds the `trafficUsage` aggregator (§5.3); a `now` trigger; and a
      `timeStatus` + `appUsage` recompute (newly-credited minutes move used/
      remaining) via `TimeStatusService.dayStateAllLive` / `Presence.appSecondsForProfile`.
    - policy reevaluate (#1849) → `now` recompute. The #1849 time-boundary **ticker**
@@ -529,43 +539,39 @@ change — no new polling/diffing loop:
    pushes reuse the existing `DashboardNowRoutes` builder** (one implementation of
    the NOW snapshot — SSOT), recomputed on change rather than per-poll.
 
-### 5.3 The throughput aggregator — derive the rate from the #1023 usage stream
+### 5.3 The `trafficUsage` aggregator — re-run the existing query on new usage
 
-Live throughput is the one element needing a genuinely new server path, and it
-**depends on [#1023](https://github.com/wifihaven/wifihaven/issues/1023)** — the
-router→API leg that pushes usage as the agent has it, rather than the ~60 s REST
-batch. Design:
+Live bandwidth is **not** a new data path — it is the existing
+`GET /api/usage/traffic` query, re-run when new usage lands and pushed to
+matching subscribers. Design:
 
-- **Source.** The router already accounts directional bytes per `(mac, host)` —
-  `UsageRecord{bytesIn,bytesOut}` ([`Models.scala`](../../shared/src/Models.scala)).
-  The ~60 s `usage` batch is too coarse for a live gauge. **Recommend a dedicated
-  lightweight `throughput` sample on the router→API ws** (additive to #1023):
-  per-`mac` bytes-since-last-sample, every ~2 s, sourced from the conntrack byte
-  counters the agent already reads (`conntrack.lua`). This separates concerns —
-  the `usage` records stay low-frequency/high-fidelity (per-host, period-accurate,
-  idempotent for rollups); the `throughput` sample is high-frequency/low-fidelity
-  (per-mac totals, display-only, lossy-OK). Conflating them would make `usage` too
-  chatty or throughput too coarse. (Filed as a #1023 sub-issue, §9 **S0**.)
-- **Aggregate into the choosable windows.** The API maps `mac → profile` (it
-  already does) and maintains, from the single ~2–5 s sample stream, a rolling
-  overall + per-profile mean B/s for **each window {5s, 1m, 5m, 10m}** (a short
-  ring buffer of recent samples, or one EWMA per window — cheap: 4 windows × small
-  fixed state). This is the **one** place the rate is computed for all windows
-  (SSOT) — every tab consumes the same windowed numbers; the client never averages
-  raw samples itself (and so can't disagree tab-to-tab, and survives reconnect
-  with no client-side history). The window set {5s,1m,5m,10m} is a small fixed
-  enum, matching the selector.
-- **Compute only subscribed windows; push at a window-appropriate cadence.** A
-  `(scope, window)` rate is maintained and pushed **only while ≥1 connection
-  subscribes that window** (§1.4) — no subscriber, no work. Emit cadence scales
-  with the window: ~5 s for the 5 s window down to ~30 s for the 10 m window (a
-  10-minute average is visually static between 5 s ticks, so ticking that fast is
-  pure waste). Each tick carries its `window` (§1.3); latest-wins per window
-  (§6.3). This per-window cadence is the payoff of making the window a
-  subscription parameter rather than shipping all four to everyone at 5 s.
-- **Degrades cleanly.** If #1023's realtime usage isn't available yet, the
-  aggregator has no input and emits nothing (gauge shows "—") — so the SPA
-  endpoint + the rest of the catalog ship independently of S0.
+- **Source = the same `traffic_reports` the page reads.** When usage ingest writes
+  new `traffic_reports` rows (the shared ingest handler, fed by the REST poll or
+  the #1023 router-ws), the aggregator re-runs the **distinct `(groupBy, bucket,
+  filter)` queries that currently have ≥1 subscriber** (§1.4) and pushes the
+  refreshed `TrafficUsageResponse` to those connections. There is **one** query
+  implementation — the existing traffic-usage query — so the stream and the page's
+  `GET` can't disagree (SSOT). No bespoke rate state, no `ThroughputTick`.
+- **Cadence = bucket-appropriate**, coalesced. A `1m`-bucket subscription is
+  re-pushed at most ~once per usage-ingest cycle (~every minute, when the data
+  actually advances); coarser buckets less often. Latest-wins per
+  `(groupBy,bucket,filter)` (§6.3) — a slow client gets the freshest result, never
+  a backlog. Recompute only for subscribed param-sets — no subscriber, no query.
+- **Granularity floor = the data.** Because `traffic_reports` is period-batched
+  from the router's ~60 s usage cycle, the finest *aggregated* bucket is `1m`; the
+  window set the existing read model gives for free is `{1m, 10m, 1h, …}` (§1.3).
+  `5m`/`10m` display windows are additive re-aggregations if wanted (§10 Q1).
+- **Optional sub-minute (5 s) instant gauge — only if the operator wants it
+  (§10 Q1).** A true 5 s rate is below the `traffic_reports` floor and would need a
+  dedicated lightweight per-`mac` bytes-since-last-sample frame on the router→API
+  ws (additive to #1023, from the conntrack counters the agent already reads,
+  `conntrack.lua`) feeding a small EWMA — kept as **optional** sub-issue **S0**,
+  not the primary path. The default design ships `1m`-and-coarser from the
+  existing pipeline with **no router change**.
+- **Degrades cleanly.** With no realtime usage source the aggregator still serves
+  whatever `traffic_reports` holds at the REST cadence; the optional sub-minute
+  gauge simply shows "—" until S0 lands. The endpoint + full catalog ship
+  independently of S0.
 
 > **Single-process fan-out**, like the router path — registries, hubs, and the
 > aggregator are in-memory, single-instance (correct for the one-API-process
@@ -583,11 +589,11 @@ Exponential backoff + jitter (1 s → 2 s → 4 s → … cap 30 s), reset on `r
 reconnect **re-sets the auth cookie** (§4.2) from the current JWT before opening,
 and **replays its current subscription set** (§1.4 — subscriptions
 are connection-scoped, not durable; the server starts the new connection
-subscribed to nothing). On reconnect the client also refetches the class-(2)
-queries once (`now`/`blocked`/`timeStatus`) so a change missed while disconnected
-converges; the throughput gauge resumes on the next tick of its subscribed window.
-On `4401 token-expired` it stops reconnecting and hands off to polling + `/login`
-(§4.3).
+subscribed to nothing). On reconnect the client also refetches its live queries
+once (`now` / `timeStatus` / the subscribed `trafficUsage` + `connectionEvents`
+keys) so a change missed while disconnected converges; the streams then resume on
+their next push. On `4401 token-expired` it stops reconnecting and hands off to
+polling + `/login` (§4.3).
 
 ### 6.2 Heartbeat / liveness → the real "live / reconnecting" indicator
 
@@ -600,7 +606,7 @@ The payoff the silent poll can't give (§0.1).
   closes + deregisters.
 - **The indicator.** `useWsLive()` exposes `'live' | 'reconnecting' | 'offline'`
   from the socket state machine. It backs a small "Live / Reconnecting…" badge on
-  the dashboard, gates the polling fallback (§3.4), and feeds
+  the dashboard, gates the polling fallback (§3.3), and feeds
   [`ApiUnreachableBanner`](../../web/src/components/ApiUnreachableBanner.tsx):
   - socket reconnecting **and** REST polls failing → the existing red banner.
   - socket reconnecting **but** polls succeeding → a softer "Reconnecting live
@@ -609,12 +615,12 @@ The payoff the silent poll can't give (§0.1).
 
 ### 6.3 Backpressure
 
-- **`throughput`** — latest-wins: a slow client's mailbox keeps only the newest
-  tick (older rates are worthless). Never queues.
-- **`now`** — coalesce to the latest snapshot (same: only the freshest matters).
-- **`blocked`** — small append frames; a bounded per-channel mailbox, drop-oldest
-  past the cap (the feed is "recent" anyway), metered. A persistently-wedged
-  channel is closed and left to reconnect.
+- **`trafficUsage` / `now` / `timeStatus`** — latest-wins per
+  `(topic, params)`: a slow client's mailbox keeps only the newest result (older
+  snapshots/rates are worthless). Never queues.
+- **`connectionEvents`** — small append frames; a bounded per-channel mailbox,
+  drop-oldest past the cap (the feed is "recent" anyway), metered. A
+  persistently-wedged channel is closed and left to reconnect.
 - **`stale`** — idempotent; coalesce by topic (N `stale{X}` → one).
 - **Inbound (SPA→server)** — tiny control frames only; no concern.
 
@@ -631,7 +637,7 @@ latest-wins ticks. **SharedWorker is the documented future optimization** (§9,
 ### 6.5 Failure independence
 
 A dead socket never breaks the app: class (2)/(3) degrade to today's polling
-(§3.4); class (1) throughput shows "—". No enforcement or correctness depends on
+(§3.3); class (1) throughput shows "—". No enforcement or correctness depends on
 the socket — it is a latency/UX layer over a fully-live REST baseline.
 
 ---
@@ -647,9 +653,9 @@ router-ws families ([`websocket-transport.md` §7](websocket-transport.md)).
 |---|---|---|---|
 | `spa_ws_connections_active` | gauge | `role` (`admin`\|`adult`\|`child`) | open SPA channels, refreshed on register/deregister (ages out on disconnect) |
 | `spa_ws_frames_total` | counter | `op` (enum §1.2, incl. `subscribe`/`unsubscribe`), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + unknown-op tripwire |
-| `spa_ws_subscriptions_active` | gauge | `topic` (`throughput`\|`now`\|`blocked`\|`timeStatus`\|`appUsage`\|`stale`) | live subscriptions per topic — shows what the fleet is actually watching (and, for `throughput`, that windowed work is bounded to demand). **No `window`/`profileId` label** (window is ≤4 values but profileId is unbounded — keep params out of labels) |
+| `spa_ws_subscriptions_active` | gauge | `topic` (`trafficUsage`\|`now`\|`connectionEvents`\|`timeStatus`\|`appUsage`\|`stale`) | live subscriptions per topic — shows what the fleet is actually watching (and that `trafficUsage` query work is bounded to demand). **No `bucket`/`groupBy`/`profileId` label** — params (esp. profileId) are unbounded; keep them out of labels |
 | `spa_ws_auth_total` | counter | `result` (`ok`\|`no_cookie`\|`invalid_jwt`\|`expired_jwt`\|`bad_origin`\|`jwt_expired_midconn`) | upgrade-auth outcomes (cookie verify + Origin check) + mid-connection expiry (§4) |
-| `spa_ws_push_total` | counter | `op` (`throughput`\|`now`\|`blocked`\|`timeStatus`\|`appUsage`\|`stale`), `result` (`ok`\|`coalesced`\|`dropped`\|`channel_closed`) | per-class fan-out health + backpressure (§6.3) |
+| `spa_ws_push_total` | counter | `op` (`trafficUsage`\|`now`\|`connectionEvents`\|`timeStatus`\|`appUsage`\|`stale`), `result` (`ok`\|`coalesced`\|`dropped`\|`channel_closed`) | per-topic fan-out health + backpressure (§6.3) |
 
 `role`/`op`/`direction`/`result`/`topic` are small fixed enums — the same
 cardinality-firewall discipline `Metrics.scala` enforces (an attacker-supplied
@@ -713,27 +719,29 @@ where the ws endpoint lives:
 ## 9. Phased, independently-shippable rollout
 
 Each phase **ships independently and back-compat**: polling stays live throughout
-(§3.4), the ws path is additive until the final per-view retirement, **no flag
+(§3.3), the ws path is additive until the final per-view retirement, **no flag
 day**. The pilot is the **realtime dashboard surface** (the actual goal), not an
 arbitrary view. Sub-issues to file against this doc (+ the #1023 dependency for
 realtime throughput):
 
 | # | Sub-issue | Independently shippable? | Back-compat |
 |---|---|---|---|
-| **S0** | **(in #1023) router→API lightweight `throughput` sample** — additive per-mac bytes-since-last-sample frame every ~2 s from the conntrack counters (§5.3). The realtime source for live bandwidth. | yes (additive frame; usage path unchanged) | additive |
+| **S0** | **(optional, in #1023) router→API sub-minute `throughput` sample** — additive per-mac bytes-since-last-sample frame ~every 2 s from the conntrack counters (§5.3), feeding the optional 5 s "instant" gauge. **Not required** for the `1m`-and-coarser bandwidth stream, which comes from the existing `traffic_reports`. | yes (additive frame; usage path unchanged) | additive |
 | **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry` + subscription model** — server skeleton, envelope/demux (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection subscription state + `ack`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry, server metrics §7 + `spa-ws.json`. Reuses `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route |
 | **S2** | **Upgrade auth** — verify the `wh_ws` JWT cookie at upgrade via the existing `AuthService.verify` (no new auth surface), `Origin` allowlist (§8), `SameSite=Strict; Path=/api/ws; Secure` cookie scoping, `jwtExp` mid-connection close (§4.3), `reauth` seam, auth metrics. SPA-side: set-cookie-before-connect + clear-after helper. | yes | additive |
-| **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to role-filtered `stale`/`now`/`blocked` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
-| **S4** | **Throughput aggregator (windowed) + `throughput` push** — consume S0's samples, maintain overall + per-profile B/s for each window {5s,1m,5m,10m}, push the subscribed window(s) at window-appropriate cadence (§5.3/§1.3/§1.4). Emits nothing (gauge "—") until S0 lands. | yes | additive |
-| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput(window)` with the **5s/1m/5m/10m window selector** (re-subscribes on change, #747), `now`/`blocked` cache-patching (§3.1/§3.2), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), set-cookie-then-connect (§4.2), backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
-| **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.2) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
-| **S6b** | **Broaden class-(3) `stale` to alerts / profiles / devices / schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
+| **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to subscription-gated `now`/`connectionEvents`/`stale` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
+| **S4** | **`trafficUsage` aggregator + push** — on usage ingest, re-run the subscribed `(groupBy,bucket,filter)` traffic-usage queries and push the refreshed `TrafficUsageResponse` to matching subscribers, latest-wins per param-set (§5.3). Reuses the existing query — no new shape. (Sub-minute gauge waits on optional S0.) | yes | additive |
+| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsTrafficUsage(params)` driving the overall + per-profile bandwidth gauges with the **window (bucket) selector** (re-subscribes on change, #747), `now` + `connectionEvents{blocked:true}` cache-patching (§3.1), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), set-cookie-then-connect (§4.2), backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + bandwidth + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
+| **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.1) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
+| **S6b** | **Stream the Traffic Usage + Connection Events pages** — those pages subscribe `trafficUsage` / `connectionEvents` with *their* current filters (the same topics the dashboard uses, different params), live-updating in place; pause their polls when `wsLive`. Plus class-(3) `stale` for alerts / profiles / devices / schedules (§3.2). | yes (per-page) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
 | **S8** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§6.4). | yes, later | additive |
 
-**Critical path to the operator-visible win:** S1 → S2 → S5 (dashboard NOW +
-blocked live), with **S0 → S4 → S5** adding live throughput. **Parallel:** S3 can
-land alongside S2. **S7 is last and per-view-gated** — each cutover off polling is
+**Critical path to the operator-visible win:** S1 → S2 → S3 → S5 (dashboard NOW +
+blocked live), with **S4 → S5** adding live bandwidth from the existing
+`traffic_reports` (no router change); the optional **S0** only adds the sub-minute
+instant gauge. **Parallel:** S3/S4 can land alongside S2. **S7 is last and
+per-view-gated** — each cutover off polling is
 deliberate once that view's push path is proven, never armed automatically
 ([`pr-review-checklist.md#monitor-to-merged`](../pr-review-checklist.md)).
 
@@ -741,17 +749,20 @@ deliberate once that view's push path is proven, never armed automatically
 
 ## 10. Open questions / risks
 
-1. **Throughput windows + per-window cadence.** The user-choosable windows are
-   {5s, 1m, 5m, 10m} (§1.3/§1.4), each a subscription with its own emit cadence
-   (~5 s for 5s … ~30 s for 10m, §5.3). The exact per-window cadences and the
-   router sample interval (S0) are pinned together against the conntrack-read cost
-   and Render's frame budget. Open sub-question for the operator: is this fixed
-   four-window set right, or do you want a different/continuous set (e.g. 30s, 1h)?
-   Adding a window is additive (a new enum value + one more EWMA).
-2. **#1023 dependency for live bandwidth.** Live throughput (S4/S5's gauge) is the
-   one element gated on #1023's realtime usage source (S0). Everything else (NOW,
-   blocked, the endpoint, auth) ships without it; the gauge shows "—" until S0
-   lands. Sequence S0 with the #1023 epic, not as a blocker for S1–S3.
+1. **Bandwidth windows = traffic buckets, and the 5 s question.** The window
+   selector maps to the existing `TrafficUsageBucket` enum, whose finest
+   *aggregated* value is **`1m`** (the `traffic_reports` floor, §1.3/§5.3) — so
+   `{1m, 10m, 1h, …}` come free with no new data path. Two operator decisions:
+   (a) add `5m`/`10m` display buckets (cheap re-aggregations of 1 m data)? and
+   (b) is a **sub-minute (5 s) "instant" gauge** wanted — which requires the
+   optional router conntrack sample (S0)? If 1 m-granular live bandwidth is
+   acceptable, S0 is unnecessary and there is **no router change** at all.
+2. **No hard #1023 dependency for bandwidth (changed).** The `1m`-and-coarser
+   bandwidth stream comes from the existing `traffic_reports` re-query (S4), so it
+   does **not** block on #1023 — it just refreshes at the current usage-ingest
+   cadence and gets *faster* (sub-minute) once #1023's realtime usage + the
+   optional S0 sample land. Earlier this doc said throughput was gated on #1023;
+   with the read-model reuse, only the *sub-minute* gauge is.
 3. **Multi-instance.** Cookie upgrade-auth is **stateless** (any instance verifies
    the JWT — no ticket store to share), so auth is multi-instance-clean. The only
    single-process assumption left is the in-memory registry/aggregator fan-out
@@ -759,7 +770,7 @@ deliberate once that view's push path is proven, never armed automatically
    is out of scope, same as the router path. Documented limit, not a TODO.
 4. **Thick-push filtering (class 2).** Per-role filtering of a pushed `now` body is
    the one place class-(1)/(3)'s contentless safety is absent; it reuses the
-   `DashboardNowRoutes` filter (§3.2/§5.2) so there is one filter implementation,
+   `DashboardNowRoutes` filter (§3.1/§5.2) so there is one filter implementation,
    bounding the risk.
 5. **Observability parity.** Per-frame structured logging (`op`/`role`/`result` on
    the MDC, mirroring `RouterWsRoutes`' `LogContext`) so a transport fault is as

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -1,0 +1,620 @@
+# Design — SPA-side websocket (live browser updates)
+
+Status: **proposed** (design only — no code in this PR).
+
+Relates to [#1023](https://github.com/wifihaven/wifihaven/issues/1023) (the
+router↔API transport epic this is the browser-facing sibling of),
+[#1846](https://github.com/wifihaven/wifihaven/issues/1846) (the server
+connection registry + `{op,payload}` envelope this **consumes the pattern of**),
+[#1849](https://github.com/wifihaven/wifihaven/issues/1849) (push-on-change —
+the change-event source this **consumes**, not rebuilds), and
+[#1860](https://github.com/wifihaven/wifihaven/issues/1860) (this issue).
+
+> **Scope of this doc.** This is the umbrella design for the SPA-websocket work.
+> It does NOT implement anything. It (a) fixes the browser-facing wire protocol,
+> (b) decides the contentious choices — auth handshake, registry reuse-vs-fork,
+> patch-vs-invalidate — with justification rather than a menu, and (c) lays out a
+> phased, independently-shippable rollout in which **polling stays the fallback
+> throughout (no flag day)**. The implementation sub-issues this doc files are
+> listed in §8.
+
+---
+
+## 0. Why, and the one shaping constraint
+
+### 0.1 What the SPA does today
+
+The SPA live-updates by **TanStack Query `refetchInterval` polling**
+([`web/src/api/queries.ts`](../../web/src/api/queries.ts)):
+
+| Hook | Endpoint | Cadence | Pain |
+| --- | --- | --- | --- |
+| `useDashboardNow` | `GET /api/dashboard/now` | 10 s | up-to-10 s lag; a kid gets blocked, the parent's screen trails |
+| `useRecentBlocked` | `GET /api/logs?blocked=true` | 10 s | same lag on the "what just got dropped" feed |
+| `useAlerts` | `GET /api/alerts` | 30 s | a freshly-raised access request waits up to 30 s |
+| `useTimeStatus*` | `GET /api/time/status*` | adaptive 10 s–5 m ([`TIME_STATUS_REFETCH_LADDER`](../../web/src/api/queries.ts)) | the whole adaptive ladder exists *only because* there is no push |
+
+Three structural problems, all of which a push connection removes:
+
+- **Staleness** — bounded only by the poll cadence (≤10 s on the hot views).
+- **A fixed poll tax per open tab**, paid whether or not anything changed, that
+  scales with concurrent admins/tabs rather than with the actual change rate.
+- **No "is my data live?" signal.** A silently-dead poll (laptop asleep, API
+  unreachable, token expired) looks *identical* to "nothing changed." The
+  [`ApiUnreachableBanner`](../../web/src/components/ApiUnreachableBanner.tsx) only
+  fires on an *active* request failure ([`apiHealth`](../../web/src/api/apiHealth.ts)
+  is driven by `client.req()`); a poll that never fires because the tab is
+  backgrounded reports nothing.
+
+### 0.2 The one shaping constraint — the browser `WebSocket` is impoverished
+
+The dominant design force, stated up front so the rest follows from it. A browser
+`WebSocket` is **not** `curl` and **not** a server socket:
+
+1. **It cannot set request headers** on the upgrade. There is no way to send
+   `Authorization: Bearer <jwt>`. This is *the* reason the SPA auth handshake
+   (§3) differs from the router's (which rides a bearer header,
+   [`docs/design/websocket-transport.md` §4.1](websocket-transport.md)). Every
+   browser-ws auth scheme is a workaround for this single fact.
+2. **It cannot send ping/pong control frames** from JS. The heartbeat (§5.2)
+   must be an application-level `{op:"ping"}` text frame, or rely on the
+   server's control-frame ping + the browser's automatic pong + `onclose`.
+3. **It is per-tab and dies on background/sleep.** Reconnect, backoff, and
+   multi-tab behavior (§5) are SPA concerns the router never had.
+
+The server side, by contrast, is the *easy* half — `zio-http`'s
+`Handler.webSocket` already backs `GET /api/router/ws`
+([`RouterWsRoutes.scala`](../../api/src/routes/RouterWsRoutes.scala)); the SPA
+endpoint is the same machinery with a different auth gate and a different fan-out
+payload. **We therefore reuse the router transport's *patterns* (envelope, demux,
+registry shape, metric discipline) and explicitly do not reuse its *code* where
+the two genuinely differ (auth, key, payload vocabulary).**
+
+### 0.3 The non-negotiable: no new read-model shapes
+
+Per the same single-source-of-truth discipline as #1023
+([`AGENTS.md#single-source-of-truth`](../../AGENTS.md), wire-shape carve-out),
+**every server→SPA payload is an existing REST response body, verbatim.** A
+push that carries data carries the *exact* JSON the matching `GET` already emits
+(`DashboardNow`, the `/api/logs` page, etc.). The socket introduces **zero** new
+serializers, DTOs, or `web/src/types/api.ts` shapes. This is what lets §2 keep
+React Query as the one client-side cache and the REST endpoints as the schema
+authority — the socket is a *transport for change*, not a parallel data model.
+
+---
+
+## 1. Endpoint & protocol
+
+### 1.1 Endpoint
+
+```
+wss://<api-host>/api/ws
+```
+
+One endpoint for the operator SPA (admin / adult / child — role scoping is
+applied per-frame from the authenticated claims, §3.4; there is no separate
+`/api/admin/ws`). `<api-host>` is the **same host the REST client already
+targets** — `VITE_API_BASE_URL` ([`web/src/api/client.ts`](../../web/src/api/client.ts)):
+empty (same-origin) for the JVM-bundled self-hosted build, and the absolute
+`https://api.wifihaven.net` / `https://api-staging.wifihaven.net` for the
+Cloudflare-Pages cloud build. The SPA derives the ws URL from the same base:
+
+```ts
+const wsBase = (VITE_API_BASE_URL || location.origin).replace(/^http/, 'ws')
+const url = `${wsBase}/api/ws?ticket=${ticket}`   // ticket: §3.2
+```
+
+The Cloudflare-Pages-vs-Render hosting split is a real deployment consideration
+and is covered in §7.
+
+### 1.2 Frame envelope — mirror the router transport's framing discipline
+
+Identical envelope discipline to
+[`docs/design/websocket-transport.md` §1.2](websocket-transport.md), so the two
+share patterns (and a future shared `WsFrame` codec) without sharing semantics:
+
+```json
+{ "op": "<string>", "payload": <existing REST JSON | small control object>, "seq": <int?> }
+```
+
+- **One JSON text message per frame.** Never split a frame across messages,
+  never batch two frames into one. Same rule as the router path.
+- **`op`** — the discriminator the receiver demuxes on. Server→SPA ops name a
+  *topic that changed* (or, for a thick push, the topic whose body rides in
+  `payload`); SPA→server ops are control (`hello`, `ping`, `reauth`).
+- **`payload`** — for a thin "stale" frame, a tiny control object (the topic
+  key, optional hints). For a thick data frame (§2, the measured exception), the
+  **exact** REST body — byte-for-byte what the matching `GET` returns.
+- **`seq`** — optional monotonic per-sender counter, observability only
+  (gap/dup logging); ignored if absent (forward-compat).
+
+**Unknown `op` → ignore + meter** on both ends (forward-compat), exactly as the
+router demux does ([`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
+This is what lets a future topic ship without a flag day.
+
+### 1.3 Message types
+
+| `op` | Dir | Payload | Meaning / maps to |
+| --- | --- | --- | --- |
+| `hello` | SPA→S | `{clientVersion, topics?:[…]}` | first frame after connect; optional subscription filter (§1.4) |
+| `ready` | S→SPA | `{role, serverTime}` | server confirms auth + role; SPA flips the indicator to "live" |
+| `stale` | S→SPA | `{topic:"dashboard-now"\|"recent-blocked"\|"alerts"\|"time-status"\|"routers", scope?}` | **the canonical push** (§2): "this React Query key is stale, refetch it" |
+| `data` | S→SPA | `{topic, body:<exact REST body>}` | the **opt-in thick push** (§2.3), used only where measured to matter (dashboard-now) |
+| `reauth` | SPA→S | `{ticket}` | present a fresh ticket to extend the connection past JWT expiry without a reconnect (§3.3) |
+| `ping` / `pong` | both | `{}` | app-level heartbeat (§5.2) |
+
+`topic` is a **bounded enum** — it doubles as the metric label space (§6) and
+maps 1:1 to a React Query key prefix (§2.2). It is never a free-form string and
+never carries a per-entity id as a label (a `scope` field inside the payload may
+narrow *which* rows changed for a future targeted invalidation, but it is data,
+not a metric label).
+
+### 1.4 Subscribe / hello
+
+On connect the SPA sends `hello` once. `topics` is an **optional** filter — if
+present, the server only pushes those topics to this connection (a child-role tab
+that renders only its own time-status need not receive `routers` frames). If
+omitted, the server pushes every topic the connection's role is authorized for
+(§3.4). v1 ships the **omit-everything-authorized** default; the `topics` filter
+is the forward-compat seam for per-view subscriptions and is honored if sent.
+The server replies `ready` with the resolved role; the SPA flips its
+live-indicator to "live" only after `ready` (a socket that upgrades but never
+`ready`s — e.g. a wedged server — must not read as live).
+
+---
+
+## 2. React Query integration — **invalidate by default, thick-push by exception**
+
+This is the central client-side decision. The two candidates:
+
+- **(A) Thin "stale" push → `queryClient.invalidateQueries`.** The frame carries
+  only the topic key; React Query refetches the canonical `GET`.
+- **(B) Thick "data" push → `queryClient.setQueryData`.** The frame carries the
+  new body; the cache is patched directly, no refetch.
+
+### 2.1 Decision: (A) invalidate is the canonical pattern; (B) is an opt-in optimization
+
+**Recommend (A) as the default for every topic.** Justification:
+
+1. **Single source of truth (the decisive reason).** With (A), the `GET`
+   endpoint stays the *only* place a read-model body is produced, and the socket
+   carries no data shape at all — it cannot drift from the REST body because it
+   contains no body. (B) creates a second producer of the same bytes; even though
+   the architecture's wire-shape carve-out *permits* reusing an existing body
+   verbatim, every thick topic is a place where a server-side filter/derivation
+   (e.g. `DashboardNow`'s per-role device visibility,
+   [`DashboardNowRoutes`](../../api/src/routes/DashboardNowRoutes.scala)) must be
+   re-applied identically on the push path or the pushed body silently differs
+   from the polled one. (A) has no such path to keep in sync.
+2. **Authz correctness for free.** A refetch goes through the normal
+   `requireAuth` + per-role visibility filter on the `GET`. A pushed body must
+   re-implement that filtering *before* fan-out (you cannot push one household's
+   `DashboardNow` to a child whose visible device set is a subset). (A) sidesteps
+   the entire "did we filter the push correctly per recipient?" risk: the server
+   pushes a *contentless* "stale" signal to every authorized connection, and each
+   client's refetch is filtered by its own token.
+3. **Coalescing is trivial.** Many rapid changes collapse to one refetch:
+   React Query dedups concurrent invalidations of the same key, and the server
+   can drop-oldest-coalesce `stale{topic}` frames in a wedged connection's
+   mailbox (§5.3) because they are identical and idempotent. Thick frames cannot
+   be coalesced as cheaply (each carries distinct bytes).
+4. **It reuses the existing, battle-tested fetch path** — `cache:'no-store'`,
+   the 10 s timeout, `apiHealth` reporting, the 401→/login redirect
+   ([`client.ts`](../../web/src/api/client.ts)) — none of which a thick push
+   would exercise.
+
+The cost of (A) is **one refetch round-trip of latency** after the signal. For
+the household model (LAN or a nearby cloud region, sub-100 ms RTT) this is
+negligible against the 10 s poll lag it replaces.
+
+### 2.2 The canonical handler
+
+A single `useWsInvalidation()` hook, mounted once in the app shell, owns the
+socket and maps `stale{topic}` → the right invalidation. The topic→key map is the
+**one** place the mapping lives (single-source-of-truth), reusing the existing
+`qk` key factory and `useInvalidators` helpers in
+[`queries.ts`](../../web/src/api/queries.ts):
+
+```ts
+// topic (bounded enum, §1.3) → React Query key prefix (reuses qk/useInvalidators)
+const TOPIC_INVALIDATORS: Record<WsTopic, (qc: QueryClient) => Promise<unknown>> = {
+  'dashboard-now':  qc => qc.invalidateQueries({ queryKey: qk.dashboardNow() }),
+  'recent-blocked': qc => qc.invalidateQueries({ queryKey: qk.recentBlocked() }),
+  'alerts':         qc => qc.invalidateQueries({ queryKey: ['alerts'] }),
+  'time-status':    qc => qc.invalidateQueries({ queryKey: ['time', 'status'] }),
+  'routers':        qc => qc.invalidateQueries({ queryKey: ['admin', 'routers'] }),
+}
+```
+
+`invalidateQueries` only refetches **mounted** queries (and marks unmounted ones
+stale for their next mount), so a `stale{time-status}` while the dashboard isn't
+open costs nothing — the exact "poll only what's visible" property the adaptive
+ladder hand-rolls, now for free.
+
+### 2.3 The thick-push exception (deferred, measured)
+
+`data{topic, body}` exists in the protocol (§1.3) for **one** future case:
+`dashboard-now`, the hottest view, where the push body *is already* the exact
+`GET /api/dashboard/now` output and the refetch RTT is the visible lag. It is
+**not built in v1.** It is enumerated as a later, independently-shippable
+optimization (§8, sub-issue **S5**) gated on a measurement showing the refetch
+RTT actually matters, and even then it writes through `setQueryData` for the
+**same** query key so a subsequent refetch reconciles — the `GET` stays the
+schema authority. Shipping (A) first and (B) only-if-measured is the cautious
+order; we do not pay (B)'s per-recipient-filtering complexity speculatively.
+
+### 2.4 Polling stays as the paused fallback
+
+`refetchInterval` is **not removed** — it is made conditional on socket health.
+A small `useWsLive()` signal (§5.2) gates the interval:
+
+```ts
+useDashboardNow({ refetchInterval: wsLive ? false : 10_000 })
+```
+
+When the socket is healthy, the interval is `false` (paused) and pushes drive
+updates; when the socket is down/reconnecting, the interval resumes at its
+current cadence so the view keeps updating exactly as today. This is
+belt-and-suspenders: an un-migrated view, an offline window, or a server that
+stops pushing all degrade to polling with no user-visible cliff. The redundant
+intervals are retired only at the *end* of the rollout (§8, **S6**), per-view,
+after the push path is proven for that view.
+
+---
+
+## 3. Auth
+
+The SPA authenticates with the **operator JWT** (`AuthService` /
+[`useAuth`](../../web/src/hooks/useAuth.tsx) — `localStorage.token`, HS256,
+`{sub, role, iat, exp}`,
+[`AuthService.scala`](../../api/src/auth/AuthService.scala)). The browser
+`WebSocket` cannot send the `Authorization` header that carries it (§0.2.1), so
+the upgrade needs a different mechanism.
+
+### 3.1 The three options
+
+| Mechanism | How | Why rejected / chosen |
+| --- | --- | --- |
+| **Cookie** | Set an auth cookie; browser sends it on the ws upgrade automatically | **Rejected.** The SPA's whole auth model is a `localStorage` bearer token, not cookies ([`client.ts`](../../web/src/api/client.ts)). Introducing an auth cookie means CSRF defenses, a `Set-Cookie`/SameSite story, and a second credential to keep in sync with the bearer — a large surface for one endpoint. |
+| **Subprotocol** | Smuggle the JWT in `Sec-WebSocket-Protocol` (the one header `new WebSocket(url, protocols)` can set) | **Rejected.** Abuses a negotiation header to carry a secret; the full JWT lands in server access logs and proxy logs; awkward to echo back the selected subprotocol correctly. Works, but it's a hack with a long-lived-secret-in-logs footgun. |
+| **Short-lived single-use ticket** | Authenticated `POST /api/ws/ticket` (normal bearer) → opaque short-TTL ticket → `wss://…/api/ws?ticket=…` | **Chosen.** ✓ |
+
+### 3.2 Decision: short-lived, single-use ticket
+
+```
+SPA                                              API
+ │  POST /api/ws/ticket   Authorization: Bearer <jwt>   │  requireAuth(req)  → JwtClaims
+ │ ───────────────────────────────────────────────────▶ │  mint ticket: random 256-bit,
+ │                                                       │  store {ticket → (sub, role, jwtExp)} TTL=30s, single-use
+ │  { "ticket": "<opaque>", "expiresInSec": 30 }         │
+ │ ◀─────────────────────────────────────────────────── │
+ │                                                       │
+ │  GET /api/ws?ticket=<opaque>   Upgrade: websocket     │  consume ticket (atomic delete);
+ │ ───────────────────────────────────────────────────▶ │  invalid/expired/used → 401, no 101
+ │  101 Switching Protocols                              │  → resolve (sub, role) → register channel (§4)
+ │ ◀─────────────────────────────────────────────────── │
+```
+
+- **The ticket is not the JWT.** It is an opaque random token, single-use, TTL
+  ~30 s, stored server-side (a `Ref[Map[Ticket, TicketEntry]]` in the SPA
+  registry — single-process is fine for the household model, §4) bound to the
+  authenticated `(sub, role)` and the originating JWT's `exp`. The query-string
+  exposure that makes "JWT in the URL" unacceptable is bounded to a 30 s,
+  one-shot, non-replayable, non-JWT token. Minting reuses the existing
+  `requireAuth` on the `POST`, so there is **one** JWT-validation implementation
+  (single-source-of-truth) — the ws path is not a second auth surface.
+- **Consume-at-upgrade is atomic** (delete-returns-old) so a ticket cannot be
+  used twice (a replay attacker who sniffs the URL loses the race with the
+  legitimate upgrade, and after either consumes it the ticket is gone).
+- **A bad/expired/used ticket → reject the upgrade with 401** (no 101), exactly
+  the router-path semantics ([`RouterWsRoutes`](../../api/src/routes/RouterWsRoutes.scala)).
+  Metered `spa_ws_auth_total{result=ticket_invalid|ticket_expired}` (§6).
+
+### 3.3 Token expiry mid-connection + re-auth
+
+The ticket gates only the *upgrade*; the **connection's authz deadline is the
+JWT's `exp`**, captured at upgrade (`TicketEntry.jwtExp`). Two cases:
+
+- **Expiry while connected.** The server tracks `jwtExp` per channel; on the
+  heartbeat tick where `now ≥ jwtExp`, it closes the channel with a
+  `4401 token-expired` close code and metered `spa_ws_auth_total{result=jwt_expired}`.
+  The bound on stale-authz carry-over is one heartbeat interval — same property
+  the router path gives for token revocation
+  ([`docs/design/websocket-transport.md` §4.2](websocket-transport.md)).
+- **Re-auth.** Today the SPA has **no silent token refresh** — an expired JWT
+  means a 401 → `localStorage` clear → `/login`
+  ([`client.ts`](../../web/src/api/client.ts)). The ws design mirrors this exactly
+  and adds a seam for when refresh lands:
+  - **v1 (no refresh):** on `4401 token-expired`, the SPA stops reconnecting and
+    falls back to polling (§2.4); the next REST call 401s and triggers the
+    existing `/login` redirect. The user re-logs in; on the new session the SPA
+    mints a fresh ticket and reconnects. No new logout path is invented.
+  - **Forward-compat (`reauth` op):** when a future silent-refresh mechanism
+    exists, the SPA mints a new ticket from the refreshed JWT and sends
+    `{op:"reauth", payload:{ticket}}` on the **open** socket; the server
+    validates+consumes it and advances the channel's `jwtExp` — extending the
+    connection without a reconnect. The op is in the protocol now (§1.3) so the
+    server can accept it the moment refresh exists; v1 server may `ack`-reject it.
+
+### 3.4 Role scoping per frame
+
+The resolved `role` (from the ticket → claims) is captured on the channel at
+upgrade and is the authz key for fan-out: the server only pushes a topic to a
+connection whose role may see it (e.g. `routers` → admin only, matching the
+`requireAdmin` on `GET /api/admin/routers`). Because the canonical push is the
+*contentless* `stale` signal (§2.1), the worst case of a fan-out bug is a
+needless refetch that the `GET`'s own `requireAuth`/role-filter then rejects or
+scopes — defense in depth, not a leak. Thick pushes (§2.3), if ever built, must
+filter the body per recipient role *before* sending; this asymmetry is a further
+reason (A) is the default.
+
+---
+
+## 4. Reuse vs. separate registry — **separate `SpaWsRegistry`, shared event source**
+
+### 4.1 Decision
+
+**Fork a parallel `SpaWsRegistry`; do not generalize
+[`RouterWsRegistry`](../../api/src/routes/RouterWsRegistry.scala) to hold both.**
+Justification — the two registries differ on the three axes a registry *is*:
+
+| Axis | `RouterWsRegistry` (#1846) | `SpaWsRegistry` (this design) |
+| --- | --- | --- |
+| **Key** | `RouterId` | a session/connection id, with `role` for authz fan-out (keyed per-connection, not per-user — a user may have N tabs, §5.4) |
+| **Fan-out payload** | full `PolicySnapshot` as a `policy` frame | contentless `stale{topic}` frames (§2.1), role-filtered (§3.4) |
+| **Event vocabulary** | one event: "policy snapshot changed" | several: policy change, new connection event, usage tick, router connected/disconnected |
+
+Generalizing one registry to two key types, two payload vocabularies, and two
+fan-out filters would couple two things that share only the *shape* of "a `Ref`
+of channels with a fan-out method." The `RouterWsRegistry` is a clean, small,
+single-purpose class
+([`RouterWsRegistry.scala`](../../api/src/routes/RouterWsRegistry.scala)); the
+right reuse is **the pattern, not the instance** — `SpaWsRegistry` is the same
+`Ref[Map[K, Set[WebSocketChannel]]]` shape with SPA-appropriate K, payload, and
+metrics. (Same call the router doc makes: "share patterns, not code.")
+
+### 4.2 What IS shared — the change-event source (consume #1849, don't rebuild)
+
+The reuse point is the **event source**, not the registry. #1849's
+push-on-change ([`PolicyService.reevaluate`](../../api/src/policy/PolicyService.scala)
+→ [`PolicySnapshotPublisher`](../../api/src/policy/PolicySnapshotPublisher.scala))
+already fires exactly when policy changes. The SPA needs that signal **plus**
+three others the router never cared about (new connection events, usage ticks,
+router connect/disconnect). So:
+
+1. **Generalize the single-sink `PolicySnapshotPublisher` into a small
+   multi-subscriber hub.** Today it is an `AtomicReference[PolicySnapshotPublisher]`
+   with one sink ([`PolicyService.setPublisher`](../../api/src/policy/PolicyService.scala)).
+   Replace the single sink with a ZIO `Hub` (or a subscriber list) so **both**
+   the `RouterWsRegistry` (which wants the full snapshot) **and** the
+   `SpaWsRegistry` (which wants a `stale{topic:"time-status"|"dashboard-now"}`
+   derived from "policy changed") subscribe. This is a behavior-preserving
+   widening of an existing seam — the router subscriber is unchanged.
+2. **Introduce a server-side `SpaEventHub`** (a `Hub[SpaTopic]`) that the SPA
+   registry subscribes to, fed by the existing write paths — each is a one-line
+   publish at a point that *already* runs on the relevant change:
+   - policy reevaluate (#1849) → `time-status`, `dashboard-now`
+   - connection-events ingest (`RouterIngestService`, the same handler the REST
+     and router-ws paths share) → `recent-blocked`, `dashboard-now`
+   - usage ingest → `dashboard-now`
+   - alert raised (access-request created) → `alerts`
+   - `RouterWsRegistry` register/deregister → `routers`
+   The hub is the **one** place "a thing the SPA renders changed" is named;
+   `SpaWsRegistry` translates a `SpaTopic` into role-filtered `stale` frames.
+   This keeps the change-detection logic at the existing write sites (no new
+   polling/diffing loop) — it consumes #1849's discipline and extends it to the
+   non-policy topics.
+
+> **Single-process fan-out, like the router path.** Both registries and the hub
+> are in-memory, single-instance. This is correct for the single-household model
+> (one API process); cross-instance pub/sub is explicitly out of scope, same as
+> [`docs/design/websocket-transport.md` §6.1](websocket-transport.md).
+
+---
+
+## 5. Reliability
+
+### 5.1 Reconnect / backoff (browser)
+
+The SPA ws client reconnects with **exponential backoff + jitter** (1 s → 2 s →
+4 s → … cap 30 s), reset on a successful `ready` (not merely the socket
+`open` — a socket that opens but never `ready`s, e.g. ticket consumed but server
+wedged, must not reset the backoff). Reconnect *is* the throttle; there is no
+per-frame retry. On `4401 token-expired` (§3.3) the client stops reconnecting and
+hands off to polling + the existing `/login` path; on any other close it backs
+off and retries. Each reconnect mints a **fresh ticket** (§3.2) — tickets are
+single-use, so a reconnect cannot replay the old one.
+
+### 5.2 Heartbeat / liveness → the real "live / reconnecting" indicator
+
+This is the payoff that the silent poll cannot give (§0.1).
+
+- **Heartbeat.** App-level `{op:"ping"}`/`{op:"pong"}` every ~30 s (the browser
+  can't send WS control-frame pings, §0.2.2). The server also sends control-frame
+  pings; the browser auto-pongs and surfaces a drop via `onclose`. A missed
+  app-level `pong` for `2×interval` → the client treats the socket as dead and
+  reconnects (§5.1); server-side, a missed pong closes + deregisters the channel.
+- **The indicator.** A `useWsLive()` hook exposes `'live' | 'reconnecting' |
+  'offline'`, driven by the socket state machine (`ready` → live; backoff →
+  reconnecting; gave-up/expired → offline). This **replaces the silent-poll
+  ambiguity**: the UI shows a small "Live"/"Reconnecting…" badge, and the
+  signal also gates the polling fallback (§2.4) and feeds
+  [`ApiUnreachableBanner`](../../web/src/components/ApiUnreachableBanner.tsx):
+  - socket reconnecting **and** REST polls failing (`apiHealth.unreachable`) →
+    the existing red "can't reach the API" banner (unchanged).
+  - socket reconnecting **but** REST polls succeeding → a softer "Reconnecting
+    live updates… (still refreshing every 10 s)" state — *degraded, not down*,
+    a distinction the current banner cannot draw. (Implementation folds a
+    `wsLive` input into `apiHealth`/the banner; the banner's existing
+    `unreachable` path is untouched.)
+
+### 5.3 Backpressure
+
+- **Server outbound.** Each channel has a **bounded mailbox**; because the
+  canonical frame is the idempotent contentless `stale{topic}` (§2.1), a slow
+  client's mailbox **coalesces by topic** — N pending `stale{dashboard-now}`
+  collapse to one (the newest is all that matters). A persistently-wedged channel
+  (mailbox full of *distinct* topics and not draining) is closed and left to
+  reconnect, metered `spa_ws_policy_push_total{result=channel_closed}`-style
+  (§6). This is strictly simpler than the router path's snapshot mailbox because
+  the payloads are coalescible signals, not distinct bytes.
+- **Inbound (SPA→server).** Only tiny control frames (`hello`/`ping`/`reauth`);
+  no inbound backpressure concern.
+
+### 5.4 Multi-tab — **socket per tab (v1); SharedWorker deferred**
+
+**Recommend one socket per tab for v1.** Justification:
+
+- Each tab has its own React Query cache (`QueryClient`); a per-tab socket maps
+  cleanly to "invalidate *this* tab's cache." A SharedWorker would hold one
+  socket for N tabs and then must broadcast each `stale` to every tab's client —
+  more moving parts (worker lifecycle, `BroadcastChannel`, message routing) for a
+  workload that is tiny: a household has a handful of admin tabs, and the
+  per-connection cost is one idle socket + a ~30 s heartbeat + coalesced
+  contentless signals. The poll tax this removes scaled per-tab too, so per-tab
+  sockets are already strictly better than today.
+- **SharedWorker is the documented future optimization** (§8, **S7**), worth it
+  only if a deployment shows many tabs per browser; its tradeoff (one socket,
+  fewer server connections, but broadcast complexity + no clean per-tab role
+  story when tabs differ) is recorded, not a TODO.
+
+### 5.5 Failure independence
+
+A dead socket never breaks the app: it degrades to the polling that runs today
+(§2.4). There is no enforcement or correctness dependency on the socket — it is a
+pure latency/UX optimization over a REST baseline that stays fully live.
+
+---
+
+## 6. Metrics
+
+All via the `AppMetrics`/`MetricGuard` facade
+([`api/src/metrics/Metrics.scala`](../../api/src/metrics/Metrics.scala)),
+**bounded labels only — never per-user / per-session / per-mac**
+([`docs/process/instrumentation.md`](../process/instrumentation.md)). Mirrors the
+router-ws metric families ([`websocket-transport.md` §7](websocket-transport.md))
+so the two dashboards read alike.
+
+| Metric | Type | Labels (bounded) | Meaning |
+| --- | --- | --- | --- |
+| `spa_ws_connections_active` | gauge | `role` (`admin`\|`adult`\|`child`) | currently-open SPA channels, refreshed on every register/deregister so it ages out on disconnect (same discipline as `router_ws_connections_active`) |
+| `spa_ws_frames_total` | counter | `op` (bounded enum §1.3), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + the unknown-op forward-compat counter |
+| `spa_ws_auth_total` | counter | `result` (`ticket_ok`\|`ticket_invalid`\|`ticket_expired`\|`ticket_reused`\|`jwt_expired`) | the ticket-handshake + mid-connection-expiry outcomes (§3) |
+| `spa_ws_push_total` | counter | `topic` (bounded enum), `result` (`ok`\|`coalesced`\|`channel_closed`) | per-topic fan-out health + backpressure coalescing (§5.3) |
+
+`role`, `op`, `direction`, `result`, `topic` are all small fixed enums — the same
+cardinality-firewall discipline `Metrics.scala` already enforces (an
+attacker-supplied `op` is collapsed to the literal `unknown` for the label, real
+value to the log only, exactly as `RouterWsRoutes` does). **No `router_id`-style
+per-entity label** — the SPA has no fleet-bounded entity, so unlike
+`router_connected` there is no per-id gauge here.
+
+### 6.1 Grafana panel
+
+Add a **`spa-ws.json`** dashboard under
+[`deploy/grafana/dashboards/`](../../deploy/grafana/dashboards/) (sibling to the
+existing `router-ws-transport.json`), authored against the series above —
+**grepped from `api/src`, not a design-doc catalog**
+([`docs/process/instrumentation.md#metrics-need-a-dashboard`](../process/instrumentation.md)).
+Panels:
+
+1. **SPA connections active** — `sum(spa_ws_connections_active)` stat + a
+   `by (role)` timeseries (the "how many browser tabs are live right now" signal,
+   the SPA analogue of router connections active).
+2. **Frame throughput** — `sum by (op,direction) (rate(spa_ws_frames_total[5m]))`
+   timeseries; a separate stat on
+   `rate(spa_ws_frames_total{result="unknown_op"}[5m])` (forward-compat tripwire).
+3. **Auth outcomes** — `sum by (result) (rate(spa_ws_auth_total[5m]))`; alert-worthy
+   if `ticket_invalid`/`ticket_reused` spikes (replay attempt) — noted for the
+   alerting epic, not built here.
+4. **Push health** — `sum by (topic,result) (rate(spa_ws_push_total[5m]))`; a
+   rising `coalesced`/`channel_closed` rate flags slow/wedged clients (§5.3).
+
+The dashboard ships in the **same PR** as the metric-emitting code for each
+phase, targeting only series that phase actually emits (no no-data panels), per
+the dashboard rule. CI gate: `grafana-terraform`.
+
+---
+
+## 7. Deployment consideration — Cloudflare-Pages-vs-Render hosting split
+
+The SPA hosting split ([`AGENTS.md`](../../AGENTS.md) "SPA hosting split")
+directly shapes where the ws endpoint lives:
+
+- **Self-hosted (JVM-bundled SPA).** The SPA is served by the API process at the
+  same origin (`VITE_API_BASE_URL` empty). `wss://<same-origin>/api/ws` is
+  same-origin; no CORS, no cross-host concern. The common case, upgrades cleanly.
+- **Cloud (SPA on Cloudflare Pages, API on Render).** The SPA is static assets on
+  `app.wifihaven.net` (Cloudflare Pages); the API — and therefore the ws
+  endpoint — is on `api.wifihaven.net` (Render). Consequences:
+  1. **The ws connection goes browser → Render directly**, *not* through
+     Cloudflare Pages (Pages serves static assets only; it does not proxy the
+     `/api/*` origin). So Cloudflare Pages config is irrelevant to the socket —
+     it is purely a Render concern.
+  2. **Render terminates websockets** — confirmed for the router transport on the
+     Render web-service plan ([`websocket-transport.md` §3.3](websocket-transport.md));
+     the SPA endpoint inherits that, including the same idle-timeout/heartbeat
+     pinning (§5.2). The 30 s app-level heartbeat must stay under Render's idle
+     timeout, the same constant the router path pins.
+  3. **Cross-origin upgrade → an `Origin` allowlist.** Unlike the router (a
+     non-browser client that sends no `Origin`), the browser **does** send an
+     `Origin` header on the ws upgrade. The server should check it against an
+     allowlist (`app.wifihaven.net`, `staging.*`, `localhost` for dev) and reject
+     a mismatched origin at upgrade — a CSWSH (cross-site websocket hijacking)
+     defense the same-origin self-hosted case gets for free. The ticket (§3.2)
+     is the primary credential, but the Origin check is cheap defense-in-depth
+     and is the one server-side ws config that differs by hosting mode.
+  4. **The SPA derives the ws host from `VITE_API_BASE_URL`** (§1.1) — the same
+     env var that already points the REST client at the right API host per
+     environment ([`client.ts`](../../web/src/api/client.ts)), so no new
+     deployment config is introduced; the ws URL falls out of the existing one.
+
+---
+
+## 8. Phased, independently-shippable rollout
+
+Each phase **ships independently and back-compat**: polling stays live
+throughout (§2.4), the ws path is purely additive until the final per-view
+retirement, and **no phase is a flag day**. Server-first (exercisable by a test
+ws client before any SPA code), then one pilot view, then broaden, then retire
+redundant intervals last. Sub-issues to file against this doc:
+
+| # | Sub-issue | Independently shippable? | Back-compat |
+| --- | --- | --- | --- |
+| **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry`** — the server half: ticket-less skeleton refused for now, envelope/demux (`hello`→`ready`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry keyed by session, server metrics §6, `spa-ws.json` panels for the series it emits. Reuses the `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route only |
+| **S2** | **Ticket handshake + auth** — `POST /api/ws/ticket` (reuses `requireAuth`), single-use short-TTL ticket store, consume-at-upgrade, `Origin` allowlist (§7), mid-connection `jwtExp` close (§3.3), `reauth` op accepted (or ack-rejected) as the forward-compat seam, auth metrics. | yes (completes server auth; still no SPA client) | additive |
+| **S3** | **Generalize the change-event source** — widen `PolicySnapshotPublisher`'s single sink to a multi-subscriber hub so both registries consume #1849; add `SpaEventHub` (`Hub[SpaTopic]`) fed by the existing write sites (policy reevaluate, events/usage ingest, alert raise, router connect/disconnect); `SpaWsRegistry` translates topics → role-filtered `stale` frames (§4.2). | yes (the hub + fan-out are exercisable by a test client; behavior-preserving for the router subscriber) | behavior-preserving |
+| **S4** | **SPA ws client + pilot view (dashboard "now") off polling** — the `useWsInvalidation()` hook (§2.2), ticket-mint-then-connect, reconnect/backoff (§5.1), heartbeat + `useWsLive()` indicator (§5.2), polling-as-paused-fallback wiring for **dashboard-now only** (§2.4). One view migrated; everything else still polls. | yes (one view) | additive — other views unchanged |
+| **S5** | **Broaden to recent-blocked, alerts, time-status** — add their topic→invalidator entries (§2.2) and pause their intervals when `wsLive`; optionally the **thick-push** measurement + `data{topic}` for dashboard-now *iff* the refetch RTT is shown to matter (§2.3). | yes (per-view) | additive |
+| **S6** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven on the fleet, drop the now-paused interval (keep the `wsLive ? false : …` fallback only where a view still has no push). The only "removal" step; per-view, operator-gated, never a flag day. | yes, last | the only subtractive step, gated per-view |
+| **S7** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§5.4). Records the broadcast-complexity tradeoff; not a TODO. | yes, later | additive |
+
+**Critical path:** S1 → S2 → S4 (the first user-visible win). **Parallel:** S3
+(the event source) can land alongside S2 since it improves nothing user-facing
+until S4 consumes it, but is independently testable. **S6 is last and
+per-view-gated** — the cutover off polling for each view is a deliberate step
+once that view's push path is proven, never armed automatically
+([`docs/pr-review-checklist.md#monitor-to-merged`](../pr-review-checklist.md)
+discipline).
+
+---
+
+## 9. Open questions / risks
+
+1. **Ticket store durability.** v1's single-process in-memory ticket store
+   (§3.2) is correct for one API instance; a multi-instance API would need the
+   ticket validated on the instance that terminates the upgrade (sticky routing
+   or a shared store). Same single-process assumption as the registries (§4) —
+   documented limit, not a TODO, and consistent with the router path.
+2. **Thick-push filtering (if S5 ever builds it).** Per-recipient role filtering
+   of a thick `data{dashboard-now}` body is the one place (A)'s
+   contentless-signal safety is lost; the measurement gate (§2.3) and the
+   "writes through the same key, GET reconciles" rule bound the risk, but it is
+   the riskiest optional piece and stays deferred until measured.
+3. **Render idle-timeout vs. heartbeat.** The 30 s app-level heartbeat (§5.2)
+   must stay under Render's ws idle timeout — pinned to the same constant the
+   router transport's D0 spike established, re-confirmed for the SPA endpoint.
+4. **Observability parity.** Per-frame structured logging
+   (`op`/`role`/`result` on the MDC, mirroring `RouterWsRoutes`' `LogContext`
+   annotations) so a transport fault is as debuggable as the REST path. Built
+   into S1.

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -151,7 +151,8 @@ column is what the client sends in `subscribe`.
 | `ping`/`pong` | — | — | `{}` | heartbeat (§6.2) | — |
 
 SPA→server: `hello` (`{clientVersion}`), **`subscribe` (`{topic, params?}`)**,
-**`unsubscribe` (`{topic}`)**, `reauth` (`{ticket}`, §4.3), `ping`/`pong`.
+**`unsubscribe` (`{topic}`)**, `reauth` (`{jwt}` on the open socket, §4.3),
+`ping`/`pong`.
 **Unknown `op` → ignore + meter**, both directions (forward-compat, mirrors
 [`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
 
@@ -265,7 +266,9 @@ Cloudflare-Pages cloud build. The SPA derives the ws URL from the same base:
 
 ```ts
 const wsBase = (VITE_API_BASE_URL || location.origin).replace(/^http/, 'ws')
-const url = `${wsBase}/api/ws?ticket=${ticket}`   // ticket: §4.2
+// auth rides a tightly-scoped cookie set just before connect (§4.2), not the URL
+setWsAuthCookie(getToken())
+const url = `${wsBase}/api/ws`
 ```
 
 The Cloudflare-Pages-vs-Render hosting split is covered in §8.
@@ -373,44 +376,70 @@ disconnected.
 The SPA authenticates with the **operator JWT** (`AuthService` /
 [`useAuth`](../../web/src/hooks/useAuth.tsx) — `localStorage.token`, HS256,
 `{sub, role, iat, exp}`, [`AuthService.scala`](../../api/src/auth/AuthService.scala)).
-The browser `WebSocket` can't send the `Authorization` header that carries it
-(§0.2.1), so the upgrade needs a different mechanism.
+We **authorize the upgrade request itself, pre-upgrade** (exactly like the router
+path authorizes its bearer before the `101`). The only wrinkle is *how the
+credential rides that request*: the browser `WebSocket` API can't set an
+`Authorization` header (§0.2.1), so the JWT must travel in either the URL or a
+cookie — those are the only two things a browser controls on a ws upgrade.
 
-### 4.1 The three options
+### 4.1 The options
 
-| Mechanism | Why rejected / chosen |
+| Mechanism | Verdict |
 |---|---|
-| **Cookie** | **Rejected.** The SPA's auth model is a `localStorage` bearer, not cookies; an auth cookie means CSRF defenses + a second credential to sync. |
-| **Subprotocol** (JWT in `Sec-WebSocket-Protocol`) | **Rejected.** Abuses a negotiation header to carry a secret; the full JWT lands in access/proxy logs. |
-| **Short-lived single-use ticket** | **Chosen.** ✓ |
+| **`Authorization` header** | **Impossible** — the browser `WebSocket` API cannot set request headers (§0.2.1). This is the whole reason the others exist. |
+| **JWT in the query string** | **Rejected.** It *does* authorize pre-upgrade, but the full JWT lands in access/proxy logs, browser history, and `Referer` — valid for its multi-hour life if leaked. |
+| **Subprotocol** (`Sec-WebSocket-Protocol`) | **Rejected.** Abuses a negotiation header to smuggle a secret; same log-exposure problem. |
+| **Short-lived single-use ticket** (query string) | Viable — keeps the JWT out of the URL via a 30 s one-shot token, but needs an extra round-trip + a server-side ticket store. **Not chosen** (see below). |
+| **Cookie carrying the JWT** | **Chosen.** ✓ Rides the upgrade automatically → direct pre-upgrade authorization, no extra round-trip, no ticket store, JWT never in a URL. |
 
-### 4.2 Decision: short-lived, single-use ticket
+> **Why a cookie works for both deployments (the call I initially got wrong).**
+> The concern with cookies is third-party-cookie blocking. It does **not** apply
+> here: `app.wifihaven.net` and `api.wifihaven.net` are subdomains of the **same
+> registrable domain** (`wifihaven.net`), so a cookie scoped to `wifihaven.net` is
+> **first-party / same-site** for both the cloud split *and* the self-hosted
+> same-origin case. No third-party-cookie problem, so no need for the ticket's
+> URL-indirection.
+
+### 4.2 Decision: a tightly-scoped JWT cookie, set just before connect
 
 ```
-SPA                                              API
- │  POST /api/ws/ticket   Authorization: Bearer <jwt>   │  requireAuth(req) → JwtClaims
- │ ───────────────────────────────────────────────────▶ │  mint random 256-bit ticket,
- │  { "ticket": "<opaque>", "expiresInSec": 30 }         │  store {ticket → (sub, role, jwtExp)} TTL=30s, single-use
- │  GET /api/ws?ticket=<opaque>   Upgrade: websocket     │  consume ticket (atomic delete);
- │ ───────────────────────────────────────────────────▶ │  invalid/expired/used → 401, no 101
- │  101 Switching Protocols  → register channel (§5)     │  → resolve (sub, role)
+SPA                                                    API
+ │  document.cookie = "wh_ws=<jwt>; Domain=wifihaven.net;                 │
+ │                     Path=/api/ws; SameSite=Strict; Secure"             │
+ │  new WebSocket("wss://api.wifihaven.net/api/ws")  (cookie rides it)    │
+ │ ─────────────────────────────────────────────────────────────────────▶ │  authenticate(upgradeReq):
+ │                                                                         │  read wh_ws cookie → AuthService.verify
+ │  101 Switching Protocols  → register channel (§5)                       │  + Origin allowlist (§8);
+ │ ◀───────────────────────────────────────────────────────────────────── │  bad/missing/expired → 401, no 101
+ │  (SPA clears the cookie immediately after the socket opens)            │
 ```
 
-- **The ticket is not the JWT** — opaque, single-use, TTL ~30 s, stored
-  server-side (a `Ref[Map[Ticket, TicketEntry]]` in the SPA registry §5.1) bound
-  to `(sub, role, jwtExp)`. The query-string exposure that makes "JWT in the URL"
-  unacceptable is bounded to a 30 s one-shot non-JWT token. Minting reuses
-  `requireAuth` on the `POST`, so there is **one** JWT-validation implementation —
-  the ws path is not a second auth surface.
-- **Consume-at-upgrade is atomic** (delete-returns-old) → a ticket can't be used
-  twice; a URL-sniffing replayer loses the race and finds it already gone.
-- **Bad/expired/used ticket → reject the upgrade with 401** (no 101), the
-  router-path semantics, metered `spa_ws_auth_total{result=…}` (§7).
+- **The credential is the existing JWT, validated by the existing `AuthService.verify`**
+  — one JWT-validation implementation; the ws path is not a second auth surface
+  (`AGENTS.md#single-source-of-truth`). A bad/missing/expired cookie → reject the
+  upgrade with **401, no 101**, identical to the router path and to a REST 401.
+- **Cookie scoping is the security boundary, not secrecy:**
+  - `Path=/api/ws` — the cookie is sent **only** on the ws upgrade, not on every
+    REST call (REST keeps using the `localStorage` bearer, unchanged — no broad
+    cookie, so **no CSRF surface added to the REST API**).
+  - `SameSite=Strict` — the browser won't attach it to a cross-site-initiated
+    request, which (with the `Origin` allowlist, §8) closes cross-site websocket
+    hijacking (CSWSH).
+  - `Secure` — HTTPS only (dev/localhost is exempted as today).
+  - `Domain=wifihaven.net` in cloud so it reaches `api.` from `app.`; omitted
+    (host-only) in the self-hosted same-origin case.
+- **No new persistent exposure.** The JWT already lives in `localStorage`
+  (XSS-readable); a JS-set, path-scoped cookie set transiently around connect is
+  no worse, and the SPA clears it right after the socket opens so it isn't sitting
+  around. (`HttpOnly` isn't usable here because JS sets it; that's acceptable
+  given the existing `localStorage` exposure.)
+- **No ticket, no `/api/ws/ticket` endpoint, no ticket store, no extra
+  round-trip** — the simplification the cookie buys over the ticket.
 
 ### 4.3 Token expiry mid-connection + re-auth
 
-The ticket gates only the *upgrade*; the connection's authz deadline is the JWT's
-`exp`, captured at upgrade.
+The cookie authorizes only the *upgrade*; the connection's authz deadline is the
+JWT's `exp`, captured at upgrade.
 
 - **Expiry while connected.** The server tracks `jwtExp` per channel; on the
   heartbeat tick where `now ≥ jwtExp` it closes with `4401 token-expired`
@@ -420,11 +449,10 @@ The ticket gates only the *upgrade*; the connection's authz deadline is the JWT'
   means 401 → `localStorage` clear → `/login` ([`client.ts`](../../web/src/api/client.ts)).
   v1 mirrors this: on `4401` the SPA stops reconnecting, falls back to polling
   (§3.4); the next REST call 401s → the existing `/login` redirect; after
-  re-login it mints a fresh ticket and reconnects. The **`reauth` op** (§1.2) is
-  the forward-compat seam: when silent refresh lands, the SPA mints a ticket from
-  the refreshed JWT and sends `reauth` on the open socket; the server
-  validates+consumes it and advances `jwtExp` — no reconnect. v1 server may
-  `ack`-reject `reauth`.
+  re-login it re-sets the cookie and reconnects. The **`reauth` op** (§1.2) is the
+  forward-compat seam: when silent refresh lands, the SPA can present the refreshed
+  JWT on the open socket and the server advances `jwtExp` — no reconnect. v1 server
+  may `ack`-reject `reauth`.
 
 ### 4.4 Role scoping per frame
 
@@ -458,7 +486,8 @@ Generalizing one registry across two key types + two payload vocabularies couple
 things that share only the *shape* "a `Ref` of channels with a fan-out method."
 Reuse the **pattern**, not the instance — `SpaWsRegistry` is the same
 `Ref[Map[K, Channel+subscriptions]]` shape with SPA-appropriate K, payloads, and
-metrics. (Also holds the ticket store, §4.2.) **Fan-out is two gates: a topic is
+metrics. (Auth is stateless cookie-verified at upgrade, §4.2 — no ticket store to
+hold.) **Fan-out is two gates: a topic is
 sent to a channel only if the channel both *subscribed* to it (§1.4) and is
 *authorized* for it (§4.4).** The subscription set is the data-minimization
 mechanism; the registry is where it lives.
@@ -545,8 +574,8 @@ batch. Design:
 
 Exponential backoff + jitter (1 s → 2 s → 4 s → … cap 30 s), reset on `ready`
 (not merely socket `open`). Reconnect *is* the throttle; no per-frame retry. Each
-reconnect mints a **fresh ticket** (§4.2; single-use, so a reconnect can't replay
-the old one) and **replays its current subscription set** (§1.4 — subscriptions
+reconnect **re-sets the auth cookie** (§4.2) from the current JWT before opening,
+and **replays its current subscription set** (§1.4 — subscriptions
 are connection-scoped, not durable; the server starts the new connection
 subscribed to nothing). On reconnect the client also refetches the class-(2)
 queries once (`now`/`blocked`/`timeStatus`) so a change missed while disconnected
@@ -613,7 +642,7 @@ router-ws families ([`websocket-transport.md` §7](websocket-transport.md)).
 | `spa_ws_connections_active` | gauge | `role` (`admin`\|`adult`\|`child`) | open SPA channels, refreshed on register/deregister (ages out on disconnect) |
 | `spa_ws_frames_total` | counter | `op` (enum §1.2, incl. `subscribe`/`unsubscribe`), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + unknown-op tripwire |
 | `spa_ws_subscriptions_active` | gauge | `topic` (`throughput`\|`now`\|`blocked`\|`timeStatus`\|`appUsage`\|`stale`) | live subscriptions per topic — shows what the fleet is actually watching (and, for `throughput`, that windowed work is bounded to demand). **No `window`/`profileId` label** (window is ≤4 values but profileId is unbounded — keep params out of labels) |
-| `spa_ws_auth_total` | counter | `result` (`ticket_ok`\|`ticket_invalid`\|`ticket_expired`\|`ticket_reused`\|`jwt_expired`) | ticket handshake + mid-connection expiry (§4) |
+| `spa_ws_auth_total` | counter | `result` (`ok`\|`no_cookie`\|`invalid_jwt`\|`expired_jwt`\|`bad_origin`\|`jwt_expired_midconn`) | upgrade-auth outcomes (cookie verify + Origin check) + mid-connection expiry (§4) |
 | `spa_ws_push_total` | counter | `op` (`throughput`\|`now`\|`blocked`\|`timeStatus`\|`appUsage`\|`stale`), `result` (`ok`\|`coalesced`\|`dropped`\|`channel_closed`) | per-class fan-out health + backpressure (§6.3) |
 
 `role`/`op`/`direction`/`result`/`topic` are small fixed enums — the same
@@ -634,7 +663,7 @@ grepped from `api/src`, not a catalog
 ([`instrumentation.md#metrics-need-a-dashboard`](../process/instrumentation.md)).
 Panels: connections-active `by (role)`; frame throughput `by (op,direction)` + an
 `unknown_op` rate stat; auth outcomes `by (result)` (alert-worthy on
-`ticket_reused`/`ticket_invalid`); push health `by (op,result)` (rising
+`bad_origin`/`invalid_jwt` spikes — a CSWSH/forgery probe); push health `by (op,result)` (rising
 `coalesced`/`dropped`/`channel_closed` ⇒ slow clients). Each phase ships its
 panels in the **same PR**; a *new* dashboard must also join the `local.dashboards`
 list in [`infra/grafana/main.tf`](../../infra/grafana/main.tf) (what the
@@ -659,13 +688,16 @@ where the ws endpoint lives:
      ([`websocket-transport.md` §3.3](websocket-transport.md)); the SPA endpoint
      inherits the same idle-timeout/heartbeat pinning (§6.2 — the 30 s heartbeat
      stays under Render's idle timeout).
-  3. **Cross-origin upgrade → an `Origin` allowlist.** Unlike the router (no
-     `Origin`), the browser sends `Origin` on the upgrade. The server checks it
-     against an allowlist (`app.wifihaven.net`, `staging.*`, `localhost` for dev)
-     and rejects a mismatch — a CSWSH defense the same-origin self-hosted case
-     gets free. The ticket (§4.2) is the primary credential; the Origin check is
-     cheap defense-in-depth and the one server-side ws config that differs by
-     hosting mode.
+  3. **Cross-origin upgrade → `Origin` allowlist + `SameSite=Strict` cookie.**
+     Unlike the router (no `Origin`), the browser sends `Origin` on the upgrade.
+     The server checks it against an allowlist (`app.wifihaven.net`, `staging.*`,
+     `localhost` for dev) and rejects a mismatch. This pairs with the
+     `SameSite=Strict` auth cookie (§4.2) as the CSWSH defense: `SameSite=Strict`
+     stops the cookie riding a cross-site-initiated upgrade, and the `Origin` check
+     is the server-side backstop. The cookie is scoped `Domain=wifihaven.net` so it
+     reaches `api.` from `app.` (same registrable domain — first-party, §4.1); the
+     self-hosted same-origin case uses a host-only cookie. The Origin allowlist is
+     the one server-side ws config that differs by hosting mode.
   4. **The SPA derives the ws host from `VITE_API_BASE_URL`** (§2.1) — the same
      env var that already points the REST client per environment, so no new
      deployment config.
@@ -684,10 +716,10 @@ realtime throughput):
 |---|---|---|---|
 | **S0** | **(in #1023) router→API lightweight `throughput` sample** — additive per-mac bytes-since-last-sample frame every ~2 s from the conntrack counters (§5.3). The realtime source for live bandwidth. | yes (additive frame; usage path unchanged) | additive |
 | **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry` + subscription model** — server skeleton, envelope/demux (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection subscription state + `ack`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry, server metrics §7 + `spa-ws.json`. Reuses `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route |
-| **S2** | **Ticket handshake + auth** — `POST /api/ws/ticket` (reuses `requireAuth`), single-use short-TTL store, consume-at-upgrade, `Origin` allowlist (§8), `jwtExp` close (§4.3), `reauth` seam, auth metrics. | yes | additive |
+| **S2** | **Upgrade auth** — verify the `wh_ws` JWT cookie at upgrade via the existing `AuthService.verify` (no new auth surface), `Origin` allowlist (§8), `SameSite=Strict; Path=/api/ws; Secure` cookie scoping, `jwtExp` mid-connection close (§4.3), `reauth` seam, auth metrics. SPA-side: set-cookie-before-connect + clear-after helper. | yes | additive |
 | **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to role-filtered `stale`/`now`/`blocked` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
 | **S4** | **Throughput aggregator (windowed) + `throughput` push** — consume S0's samples, maintain overall + per-profile B/s for each window {5s,1m,5m,10m}, push the subscribed window(s) at window-appropriate cadence (§5.3/§1.3/§1.4). Emits nothing (gauge "—") until S0 lands. | yes | additive |
-| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput(window)` with the **5s/1m/5m/10m window selector** (re-subscribes on change, #747), `now`/`blocked` cache-patching (§3.1/§3.2), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), ticket-mint-then-connect, backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
+| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput(window)` with the **5s/1m/5m/10m window selector** (re-subscribes on change, #747), `now`/`blocked` cache-patching (§3.1/§3.2), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), set-cookie-then-connect (§4.2), backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
 | **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.2) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
 | **S6b** | **Broaden class-(3) `stale` to alerts / profiles / devices / schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
@@ -714,10 +746,11 @@ deliberate once that view's push path is proven, never armed automatically
    one element gated on #1023's realtime usage source (S0). Everything else (NOW,
    blocked, the endpoint, auth) ships without it; the gauge shows "—" until S0
    lands. Sequence S0 with the #1023 epic, not as a blocker for S1–S3.
-3. **Ticket store durability.** v1's single-process in-memory ticket store (§4.2)
-   is correct for one API instance; multi-instance would need sticky routing or a
-   shared store — same single-process assumption as the registries/aggregator
-   (§5), documented limit, not a TODO.
+3. **Multi-instance.** Cookie upgrade-auth is **stateless** (any instance verifies
+   the JWT — no ticket store to share), so auth is multi-instance-clean. The only
+   single-process assumption left is the in-memory registry/aggregator fan-out
+   (§5) — correct for the one-API-process household model; cross-instance pub/sub
+   is out of scope, same as the router path. Documented limit, not a TODO.
 4. **Thick-push filtering (class 2).** Per-role filtering of a pushed `now` body is
    the one place class-(1)/(3)'s contentless safety is absent; it reuses the
    `DashboardNowRoutes` filter (§3.2/§5.2) so there is one filter implementation,

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -137,14 +137,15 @@ the input contract); every item is classified by **why** it is on the socket.
 
 | Class | What | Examples | How it rides the socket |
 |---|---|---|---|
-| **(1) Live read-model stream** | an existing read endpoint whose result changes fast and is worth pushing as it changes | **live bandwidth** (`trafficUsage` — overall/per-profile/per-device bytes), **live connection events** (`connectionEvents`) | server re-runs the subscribed query when new data lands and pushes the refreshed body; client patches the matching React Query cache (§3) |
+| **(1) Live-edge stream over a paged read model** | an existing read endpoint whose **newest** data changes fast; history stays on the `GET` | **live bandwidth** (`trafficUsage` — overall/per-profile/per-device bytes), **live connection events** (`connectionEvents`) | the page/gauge loads its window via the existing `GET` (incl. cursor paging); the socket pushes **only the live edge** (the current bucket advancing / new head rows), which the client merges into the cached query result (§3) |
 | **(2) Pushed live snapshot/append** | a real REST resource that changes fast enough to push instead of poll | **NOW** (`DashboardNow`), **live time-usage** (per-profile used/remaining + per-app minutes) | server pushes the (changed) body / the new row; client patches the existing React Query cache for that key (§3) |
 | **(3) Occasionally-changing resource** | a cacheable resource that changes rarely | profiles, devices, schedules, blocklists, 24 h rollup panels | **stays request/response.** At most a `stale` nudge on a relevant mutation; many need nothing (their mutation already invalidates locally) |
 
-(Classes 1 and 2 are both "push the data, patch the cache" — they differ only in
-that class 1 is a *filtered query result* the client subscribes with parameters,
-while class 2 is a singular resource. The split that matters is **vs. class 3**,
-which stays on queries.) The websocket is for **(1) and (2)**; **(3) stays on
+(Classes 1 and 2 are both "push the data, patch the cache." Class 1 is a
+*live-edge delta* over a paged/filtered query the client still loads from the
+`GET` — the socket only keeps the newest slice fresh, it does **not** replace the
+historical query. Class 2 is a singular resource pushed whole. The split that
+matters is **vs. class 3**, which stays on queries.) The websocket is for **(1) and (2)**; **(3) stays on
 queries** — the correction to the "invalidate everything" framing. The dashboard's
 "Blocking activity (24 h)" panel and the "Events (1h)/Blocked (1h)" KPIs are class
 (3): rollup-backed request/response, *not* streamed
@@ -158,8 +159,8 @@ column is what the client sends in `subscribe`.
 
 | `op` | Class | Params (subscription) = the endpoint's query params | Payload (existing body) | Drives | Source |
 |---|---|---|---|---|---|
-| `trafficUsage` | (1) | `{ groupBy ∈ {∅,profile,device,…}, bucket (window), macs?, profileIds? }` (= `GET /api/usage/traffic` params) | `TrafficUsageResponse` | dashboard **overall + per-profile bandwidth** gauges (#747) **and** the **Traffic Usage page** (live) | re-run the query on usage ingest (§5.3) |
-| `connectionEvents` | (1) | `{ blocked?, macs?, profileIds?, domain? }` (= `GET /api/logs` params) | `QueryLog` rows (append/refresh) | dashboard **Most Recently Blocked** (`blocked:true`) **and** the **Connection Events page** (live) | connection-events ingest (§5.2) |
+| `trafficUsage` | (1) | `{ groupBy ∈ {∅,profile,device,…}, bucket (window), macs?, profileIds? }` (= `GET /api/usage/traffic` params) | `TrafficUsageResponse` containing **only the current/most-recent bucket** for those params (live edge) | dashboard **overall + per-profile bandwidth** gauges (#747) **and** the live tail of the **Traffic Usage page** (history via the `GET`) | recompute the current bucket on usage ingest (§5.3) |
+| `connectionEvents` | (1) | `{ blocked?, macs?, profileIds?, domain? }` (= `GET /api/logs` params) | **new head** `QueryLog` rows (append) | dashboard **Most Recently Blocked** (`blocked:true`) **and** the live head of the **Connection Events page** (history/paging via the `GET`) | connection-events ingest (§5.2) |
 | `now` | (2) | — | `DashboardNow` | NOW active cards; derived "Online/Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
 | `timeStatus` | (2) | — (all authorized profiles in v1; `profileId` filter is an additive future param) | `ProfileTimeStatus[]` (`/api/time/status`) | per-profile **used/remaining** bars; "over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
 | `appUsage` | (2) | `profileId` (the expanded card) | per-app minutes (`/api/profiles/{id}/usage-by-app`) | per-app **minutes-used** rows (live) | same triggers, via `Presence.appSecondsForProfile` |
@@ -193,6 +194,15 @@ display the dashboard wants is `GET /api/usage/traffic` streamed:
   `totalBytes / bucketSeconds` (the page already does this kind of math), so the
   server stays the single source of the *bytes* and there's no second "rate"
   serializer.
+- **History is the `GET`; the socket is the live edge.** The page (and the
+  dashboard gauge) loads its window — and pages older data — via
+  `GET /api/usage/traffic` exactly as today. The `trafficUsage` push carries
+  **only the current/most-recent bucket** for the subscribed params (a
+  `TrafficUsageResponse` whose window is just that bucket); the client **merges**
+  it into the cached series — replace the head bucket while it's still
+  accumulating, append a new head when the bucket rolls over. The socket never
+  re-streams historical buckets, so a 24 h × 1 h chart isn't re-sent every minute —
+  just its newest bar advances.
 
 > **Granularity note (reconciling the 5s/1m/5m/10m ask).** `traffic_reports` is
 > period-batched from the router's ~60 s usage cycle, so the **finest aggregated
@@ -328,12 +338,12 @@ existing `useQuery` keys, to be lifted into the shared `qk` factory so the push 
 the page key are produced in one place.)
 
 ```ts
-// trafficUsage → patch the cache for the EXACT (groupBy,bucket,filter) the client subscribed,
-// i.e. the same query key the Traffic Usage page / dashboard gauge already reads for those params
-queryClient.setQueryData(trafficKey(params), body)
-// connectionEvents → prepend new rows (bounded, dedup by id) to the matching /logs query key
-queryClient.setQueryData(logsKey(filter), prev => prependCapped(prev, rows))
-// now → replace the dashboard-now cache
+// trafficUsage → MERGE the live-edge bucket into the GET-loaded series (history stays put);
+// replace the head bucket while it accumulates, append when it rolls over — never refetch history
+queryClient.setQueryData(trafficKey(params), prev => mergeHeadBucket(prev, liveBucket))
+// connectionEvents → prepend new head rows (bounded, dedup by id); cursor-paged history untouched
+queryClient.setQueryData(logsKey(filter), prev => prependHead(prev, rows))
+// now → replace the dashboard-now cache (singular resource, pushed whole)
 queryClient.setQueryData(qk.dashboardNow(), body)
 // timeStatus → replace the per-profile used/remaining cache
 queryClient.setQueryData(qk.timeStatusToday(), rows)
@@ -548,18 +558,21 @@ Live bandwidth is **not** a new data path — it is the existing
 `GET /api/usage/traffic` query, re-run when new usage lands and pushed to
 matching subscribers. Design:
 
-- **Source = the same `traffic_reports` the page reads.** When usage ingest writes
-  new `traffic_reports` rows (the shared ingest handler, fed by the REST poll or
-  the #1023 router-ws), the aggregator re-runs the **distinct `(groupBy, bucket,
-  filter)` queries that currently have ≥1 subscriber** (§1.4) and pushes the
-  refreshed `TrafficUsageResponse` to those connections. There is **one** query
-  implementation — the existing traffic-usage query — so the stream and the page's
-  `GET` can't disagree (SSOT). No bespoke rate state, no `ThroughputTick`.
-- **Cadence = bucket-appropriate**, coalesced. A `1m`-bucket subscription is
-  re-pushed at most ~once per usage-ingest cycle (~every minute, when the data
-  actually advances); coarser buckets less often. Latest-wins per
-  `(groupBy,bucket,filter)` (§6.3) — a slow client gets the freshest result, never
-  a backlog. Recompute only for subscribed param-sets — no subscriber, no query.
+- **Source = the same `traffic_reports` the page reads — but only the live edge.**
+  The page/gauge has already loaded its history via `GET /api/usage/traffic`
+  (incl. paging). When usage ingest writes new `traffic_reports` rows (the shared
+  ingest handler, fed by the REST poll or the #1023 router-ws), the aggregator
+  recomputes **only the current/most-recent bucket** for each distinct
+  `(groupBy, filter)` that has ≥1 subscriber (§1.4) and pushes that one bucket as a
+  `TrafficUsageResponse`. It does **not** re-run the full historical window — the
+  client merges the head bucket (§3.1). Still the **one** existing query
+  implementation, scoped to the head — so the stream and the page's `GET` can't
+  disagree (SSOT), and the per-push cost is one bucket, not the whole chart.
+- **Cadence = bucket-appropriate**, coalesced. The current `1m` bucket is re-pushed
+  at most ~once per usage-ingest cycle (~every minute, as it accumulates); coarser
+  buckets advance less often. Latest-wins per `(groupBy,bucket,filter)` (§6.3) — a
+  slow client gets the freshest head bucket, never a backlog. Recompute only for
+  subscribed param-sets — no subscriber, no query.
 - **Granularity floor = the data.** Because `traffic_reports` is period-batched
   from the router's ~60 s usage cycle, the finest *aggregated* bucket is `1m`; the
   window set the existing read model gives for free is `{1m, 10m, 1h, …}` (§1.3).
@@ -736,7 +749,7 @@ realtime throughput):
 | **S4** | **`trafficUsage` aggregator + push** — on usage ingest, re-run the subscribed `(groupBy,bucket,filter)` traffic-usage queries and push the refreshed `TrafficUsageResponse` to matching subscribers, latest-wins per param-set (§5.3). Reuses the existing query — no new shape. (Sub-minute gauge waits on optional S0.) | yes | additive |
 | **S5** | **SPA ws client + realtime dashboard pilot** — `useWsTrafficUsage(params)` driving the overall + per-profile bandwidth gauges with the **window (bucket) selector** (re-subscribes on change, #747), `now` + `connectionEvents{blocked:true}` cache-patching (§3.1), subscription wiring (subscribe-on-mount/unsubscribe-on-unmount), `useWsLive()` indicator (§6.2), set-cookie-then-connect (§4.2), backoff + re-subscribe (§6.1), polling-as-paused-fallback. **Lights up the redesigned NOW + bandwidth + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
 | **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.1) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
-| **S6b** | **Stream the Traffic Usage + Connection Events pages** — those pages subscribe `trafficUsage` / `connectionEvents` with *their* current filters (same topics as the dashboard, different params), live-updating in place; pause their polls when `wsLive`. Streaming prepends only the **live head** (newest rows); cursor-paged history (#862) stays on the existing request/response path — the stream doesn't try to mutate older pages. Plus class-(3) `stale` for alerts / profiles / devices / schedules (§3.2). | yes (per-page) | additive |
+| **S6b** | **Stream the Traffic Usage + Connection Events pages** — those pages keep loading **history via their existing `GET`** (initial window + cursor paging, #862); they additionally subscribe `trafficUsage` / `connectionEvents` with *their* current filters (same topics as the dashboard, different params) for the **live edge only** — `trafficUsage` merges the head bucket, `connectionEvents` prepends new head rows; older/paged data is never mutated by the stream. Pause the page's poll when `wsLive`. Plus class-(3) `stale` for alerts / profiles / devices / schedules (§3.2). | yes (per-page) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
 | **S8** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§6.4). | yes, later | additive |
 

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -3,638 +3,612 @@
 Status: **proposed** (design only — no code in this PR).
 
 Relates to [#1023](https://github.com/wifihaven/wifihaven/issues/1023) (the
-router↔API transport epic this is the browser-facing sibling of),
+router↔API transport epic — its push-on-change core and **realtime usage stream**
+are the data sources this consumes),
 [#1846](https://github.com/wifihaven/wifihaven/issues/1846) (the server
-connection registry + `{op,payload}` envelope this **consumes the pattern of**),
-[#1849](https://github.com/wifihaven/wifihaven/issues/1849) (push-on-change —
-the change-event source this **consumes**, not rebuilds), and
-[#1860](https://github.com/wifihaven/wifihaven/issues/1860) (this issue).
+connection-registry pattern this reuses),
+[#1849](https://github.com/wifihaven/wifihaven/issues/1849) (push-on-change — one
+of the event sources this consumes),
+[#747](https://github.com/wifihaven/wifihaven/issues/747) (live bytes in/out — the
+realtime throughput element this finally makes shippable),
+[#1148](https://github.com/wifihaven/wifihaven/issues/1148) /
+[`docs/design/dashboard-redesign.md`](dashboard-redesign.md) (the dashboard whose
+live sections **consume** this stream; its §8 data-contract is the input to §1
+here), and [#1860](https://github.com/wifihaven/wifihaven/issues/1860) (this issue).
 
-> **Scope of this doc.** This is the umbrella design for the SPA-websocket work.
-> It does NOT implement anything. It (a) fixes the browser-facing wire protocol,
-> (b) decides the contentious choices — auth handshake, registry reuse-vs-fork,
-> patch-vs-invalidate — with justification rather than a menu, and (c) lays out a
-> phased, independently-shippable rollout in which **polling stays the fallback
-> throughout (no flag day)**. The implementation sub-issues this doc files are
-> listed in §8.
+> **Scope of this doc.** Design only, no implementation. It (a) **specifies what
+> data flows over the socket and why each item is on it** (§1 — the heart of this
+> design), (b) decides the contentious choices — push-vs-invalidate per data
+> class, auth handshake, registry reuse-vs-fork — with justification, and (c)
+> lays out a phased rollout in which **polling stays the fallback throughout (no
+> flag day)**. Implementation sub-issues are in §9.
 
 ---
 
-## 0. Why, and the one shaping constraint
+## 0. Why, and what the socket is *for*
 
-### 0.1 What the SPA does today
+### 0.1 The socket exists to stream the live surface — not to "poll faster"
 
-The SPA live-updates by **TanStack Query `refetchInterval` polling**
-([`web/src/api/queries.ts`](../../web/src/api/queries.ts)):
+The crucial framing, because the first draft of this doc got it wrong. The SPA
+today live-updates by **TanStack Query `refetchInterval` polling**
+([`web/src/api/queries.ts`](../../web/src/api/queries.ts)): dashboard "now" every
+10 s, recent-blocked every 10 s, alerts every 30 s, an adaptive time-status
+ladder. The websocket is **not** a generic "invalidate every query faster"
+transport bolted under all of that. It exists to **stream the handful of facts
+that must move in realtime** — and most of those are *not* things the SPA can
+poll well, or at all:
 
-| Hook | Endpoint | Cadence | Pain |
-| --- | --- | --- | --- |
-| `useDashboardNow` | `GET /api/dashboard/now` | 10 s | up-to-10 s lag; a kid gets blocked, the parent's screen trails |
-| `useRecentBlocked` | `GET /api/logs?blocked=true` | 10 s | same lag on the "what just got dropped" feed |
-| `useAlerts` | `GET /api/alerts` | 30 s | a freshly-raised access request waits up to 30 s |
-| `useTimeStatus*` | `GET /api/time/status*` | adaptive 10 s–5 m ([`TIME_STATUS_REFETCH_LADDER`](../../web/src/api/queries.ts)) | the whole adaptive ladder exists *only because* there is no push |
+- **Live in/out throughput** (overall + per-profile bandwidth, B/s) — the headline
+  the dashboard redesign asks for ([#747](https://github.com/wifihaven/wifihaven/issues/747),
+  [`dashboard-redesign.md` §8.1](dashboard-redesign.md)). **This is a rate, not a
+  resource** — there is no body you can `GET` and cache; it only exists as a
+  stream. It has *no good polling implementation at all*. It is the single
+  clearest reason the websocket needs to exist.
+- **"NOW" — who's online and what they're watching** (`DashboardNow`), the heart
+  of the dashboard, today polled every 10 s with visible lag.
+- **"Most Recently Blocked"** — the live "what just got dropped" feed
+  ([#1338](https://github.com/wifihaven/wifihaven/issues/1338)), today polled
+  every 10 s.
 
-Three structural problems, all of which a push connection removes:
+Everything else the SPA shows — profiles, devices, schedules, blocklists, the 24 h
+rollup panels, time-status caps — is a **cacheable resource that changes
+occasionally**. Those stay on request/response (with at most an invalidate nudge
+on the rare change). **The websocket carries the live surface; it does not
+replace queries that should stay queries.** This split is the spine of the whole
+design (§1).
 
-- **Staleness** — bounded only by the poll cadence (≤10 s on the hot views).
-- **A fixed poll tax per open tab**, paid whether or not anything changed, that
-  scales with concurrent admins/tabs rather than with the actual change rate.
-- **No "is my data live?" signal.** A silently-dead poll (laptop asleep, API
-  unreachable, token expired) looks *identical* to "nothing changed." The
-  [`ApiUnreachableBanner`](../../web/src/components/ApiUnreachableBanner.tsx) only
-  fires on an *active* request failure ([`apiHealth`](../../web/src/api/apiHealth.ts)
-  is driven by `client.req()`); a poll that never fires because the tab is
-  backgrounded reports nothing.
+The three structural wins, restated against that framing:
+
+- **Realtime data that polling cannot serve** (throughput) becomes possible.
+- **Sub-second freshness** on NOW / blocked, vs. the 10 s poll lag.
+- **A liveness signal** — the connection's health *is* the "is my dashboard
+  live?" indicator, replacing the silent-poll ambiguity (a dead 10 s poll looks
+  identical to "nothing changed"; [`ApiUnreachableBanner`](../../web/src/components/ApiUnreachableBanner.tsx)
+  only fires on an *active* request failure, not a poll that never ran).
 
 ### 0.2 The one shaping constraint — the browser `WebSocket` is impoverished
 
-The dominant design force, stated up front so the rest follows from it. A browser
-`WebSocket` is **not** `curl` and **not** a server socket:
+A browser `WebSocket` is not `curl` and not a server socket:
 
-1. **It cannot set request headers** on the upgrade. There is no way to send
-   `Authorization: Bearer <jwt>`. This is *the* reason the SPA auth handshake
-   (§3) differs from the router's (which rides a bearer header,
-   [`docs/design/websocket-transport.md` §4.1](websocket-transport.md)). Every
-   browser-ws auth scheme is a workaround for this single fact.
-2. **It cannot send ping/pong control frames** from JS. The heartbeat (§5.2)
-   must be an application-level `{op:"ping"}` text frame, or rely on the
-   server's control-frame ping + the browser's automatic pong + `onclose`.
-3. **It is per-tab and dies on background/sleep.** Reconnect, backoff, and
-   multi-tab behavior (§5) are SPA concerns the router never had.
+1. **It cannot set request headers** on the upgrade — no `Authorization: Bearer`.
+   This is *the* reason the SPA auth handshake (§4) differs from the router's
+   bearer-on-upgrade ([`websocket-transport.md` §4.1](websocket-transport.md)).
+2. **It cannot send ping/pong control frames** from JS — the heartbeat (§6.2) is
+   an app-level text frame.
+3. **It is per-tab and dies on background/sleep** — reconnect, backoff, and
+   multi-tab behavior (§6) are SPA concerns the router never had.
 
-The server side, by contrast, is the *easy* half — `zio-http`'s
-`Handler.webSocket` already backs `GET /api/router/ws`
-([`RouterWsRoutes.scala`](../../api/src/routes/RouterWsRoutes.scala)); the SPA
-endpoint is the same machinery with a different auth gate and a different fan-out
-payload. **We therefore reuse the router transport's *patterns* (envelope, demux,
-registry shape, metric discipline) and explicitly do not reuse its *code* where
-the two genuinely differ (auth, key, payload vocabulary).**
+The server side is the easy half — `zio-http`'s `Handler.webSocket` already backs
+`GET /api/router/ws` ([`RouterWsRoutes.scala`](../../api/src/routes/RouterWsRoutes.scala)).
+We **reuse the router transport's patterns** (envelope, demux, registry shape,
+metric discipline) and **fork where the two genuinely differ** (auth, key,
+payload vocabulary) — "share patterns, not code," same call #1023 makes.
 
-### 0.3 The non-negotiable: no new read-model shapes
+### 0.3 Read-model discipline — reuse bodies for resources, ONE new shape for the stream
 
-Per the same single-source-of-truth discipline as #1023
-([`AGENTS.md#single-source-of-truth`](../../AGENTS.md), wire-shape carve-out),
-**every server→SPA payload is an existing REST response body, verbatim.** A
-push that carries data carries the *exact* JSON the matching `GET` already emits
-(`DashboardNow`, the `/api/logs` page, etc.). The socket introduces **zero** new
-serializers, DTOs, or `web/src/types/api.ts` shapes. This is what lets §2 keep
-React Query as the one client-side cache and the REST endpoints as the schema
-authority — the socket is a *transport for change*, not a parallel data model.
+Per the single-source-of-truth discipline
+([`AGENTS.md#single-source-of-truth`](../../AGENTS.md), wire-shape carve-out):
+
+- **Pushed snapshots of existing resources carry the existing REST body,
+  verbatim.** A NOW push is the exact `GET /api/dashboard/now` body
+  (`DashboardNow`, [`shared/src/Models.scala`](../../shared/src/Models.scala)); a
+  blocked-event push is the exact `/api/logs?blocked=true` row shape. **Zero new
+  serializers** for these — the `GET` stays the schema authority and a refetch
+  reconciles.
+- **The one genuinely-new shape is the throughput tick** (§1.3), and it is new
+  *because the data is new*: no REST endpoint produces a current byte-rate today
+  (`DashboardNow*` carries no bytes — confirmed in `Models.scala`). A push-native
+  telemetry stream has no existing body to reuse; inventing a minimal one is
+  correct, not a violation. It is deliberately tiny and is **not** mirrored into a
+  REST resource (you would never poll it).
 
 ---
 
-## 1. Endpoint & protocol
+## 1. What flows over the socket — the message catalog
 
-### 1.1 Endpoint
+This is the section the design turns on. Every server→SPA payload maps to a
+dashboard live element ([`dashboard-redesign.md` §8.2](dashboard-redesign.md) is
+the input contract); every item is classified by **why** it is on the socket.
+
+### 1.1 Three data classes
+
+| Class | What | Examples | How it rides the socket |
+|---|---|---|---|
+| **(1) Push-native realtime stream** | a *rate/stream* with no cacheable REST form | **live throughput** (overall + per-profile in/out B/s) | server pushes a `throughput` tick on a fixed cadence; client renders a live gauge — **not** in the React Query resource cache |
+| **(2) Pushed live snapshot/append** | a real REST resource that changes fast enough to push instead of poll | **NOW** (`DashboardNow`), **Most Recently Blocked** feed | server pushes the (changed) body / the new row; client patches the existing React Query cache for that key (§3) |
+| **(3) Occasionally-changing resource** | a cacheable resource that changes rarely | profiles, devices, schedules, blocklists, 24 h rollups, time-status caps | **stays request/response.** At most a `stale` nudge on a relevant mutation; many need nothing (their mutation already invalidates locally) |
+
+The websocket is for **(1) and (2)**. **(3) stays on queries** — the explicit
+correction to the "invalidate everything" framing. The dashboard's "Blocking
+activity (24 h)" panel and the "Events (1h)/Blocked (1h)" KPIs are class (3): they
+ride the rollup tables on request/response and are *not* streamed
+([`dashboard-redesign.md` §7.5/§8.2](dashboard-redesign.md)).
+
+### 1.2 Server→SPA message catalog
+
+| `op` | Class | Payload | Drives (dashboard element) | Source |
+|---|---|---|---|---|
+| `throughput` | (1) | `ThroughputTick` (§1.3) | overall in/out gauge **+** per-profile ▲▼ on NOW card headers (#747) | API aggregator over the #1023 usage stream (§5.3) |
+| `now` | (2) | `DashboardNow` (existing body, verbatim) | NOW active cards; derived "Online now / Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
+| `blocked` | (2) | one blocked `QueryLog` row (existing `/api/logs` row shape) | Most Recently Blocked feed (prepend) | connection-events ingest (§5.2) |
+| `stale` | (3) | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query (profiles/devices/schedules/time-status) | the relevant write site (§5.2) |
+| `ready` | — | `{ role, serverTime }` | flips the live indicator to "live" | upgrade (§4) |
+| `ping`/`pong` | — | `{}` | heartbeat (§6.2) | — |
+
+SPA→server: `hello` (`{clientVersion, subscribe?:[…]}`), `reauth` (`{ticket}`,
+§4.3), `ping`/`pong`. **Unknown `op` → ignore + meter**, both directions
+(forward-compat, mirrors [`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
+
+### 1.3 The one new shape — `ThroughputTick`
+
+```jsonc
+// op:"throughput" payload — bytes-per-second rates as of `asOf`
+{
+  "asOf": "2026-06-24T14:31:02Z",
+  "overall":     { "inBps": 1840000, "outBps": 240000 },
+  "perProfile": [
+    { "profileId": 3, "inBps": 1510000, "outBps": 90000 },
+    { "profileId": 7, "inBps":  330000, "outBps": 150000 }
+  ]
+}
+```
+
+- **Rates, not cumulative bytes** — the SPA renders a gauge/sparkline, not a
+  counter; the server does the rate math once (§5.3) so every tab doesn't
+  re-derive it (single-source-of-truth for the rate).
+- **Overall + per-profile only.** Per-device / per-host throughput is deliberately
+  **off** the dashboard ([`dashboard-redesign.md` §8.1](dashboard-redesign.md));
+  the same tick *shape* could carry a `perDevice` array for a future `/devices`
+  live view, but v1 emits only overall + per-profile.
+- **Bounded size** — one entry per active profile (households have ≤ ~10), well
+  under any frame cap.
+- **A profile absent from `perProfile`** is idle (0 B/s) — the client zeroes it;
+  the tick never grows with history.
+
+This is the only addition to `web/src/types/api.ts`; `now`/`blocked`/`stale`
+payloads reuse shapes that already exist there.
+
+### 1.4 hello / subscribe
+
+On connect the SPA sends `hello` once. `subscribe` is an **optional** topic
+filter (a child-role tab rendering only its own time-status need not receive
+`throughput`); omitted → the server pushes everything the role is authorized for
+(§4.4). v1 ships omit-everything-authorized; the filter is the forward-compat seam
+and is honored if sent. The server replies `ready`; the client flips its
+indicator to "live" only after `ready` (a socket that upgrades but never `ready`s
+must not read as live).
+
+---
+
+## 2. Endpoint & protocol
+
+### 2.1 Endpoint
 
 ```
 wss://<api-host>/api/ws
 ```
 
-One endpoint for the operator SPA (admin / adult / child — role scoping is
-applied per-frame from the authenticated claims, §3.4; there is no separate
-`/api/admin/ws`). `<api-host>` is the **same host the REST client already
-targets** — `VITE_API_BASE_URL` ([`web/src/api/client.ts`](../../web/src/api/client.ts)):
-empty (same-origin) for the JVM-bundled self-hosted build, and the absolute
-`https://api.wifihaven.net` / `https://api-staging.wifihaven.net` for the
+One endpoint for the operator SPA (role scoping applied per-frame from the
+authenticated claims, §4.4 — no separate `/api/admin/ws`). `<api-host>` is the
+**same host the REST client already targets** — `VITE_API_BASE_URL`
+([`client.ts`](../../web/src/api/client.ts)): empty (same-origin) for the
+JVM-bundled self-hosted build, absolute `https://api.wifihaven.net` for the
 Cloudflare-Pages cloud build. The SPA derives the ws URL from the same base:
 
 ```ts
 const wsBase = (VITE_API_BASE_URL || location.origin).replace(/^http/, 'ws')
-const url = `${wsBase}/api/ws?ticket=${ticket}`   // ticket: §3.2
+const url = `${wsBase}/api/ws?ticket=${ticket}`   // ticket: §4.2
 ```
 
-The Cloudflare-Pages-vs-Render hosting split is a real deployment consideration
-and is covered in §7.
+The Cloudflare-Pages-vs-Render hosting split is covered in §8.
 
-### 1.2 Frame envelope — mirror the router transport's framing discipline
+### 2.2 Frame envelope — mirror the router transport
 
 Identical envelope discipline to
-[`docs/design/websocket-transport.md` §1.2](websocket-transport.md), so the two
-share patterns (and a future shared `WsFrame` codec) without sharing semantics:
+[`websocket-transport.md` §1.2](websocket-transport.md), so the two share patterns
+(and a future shared `WsFrame` codec) without sharing semantics:
 
 ```json
-{ "op": "<string>", "payload": <existing REST JSON | small control object>, "seq": <int?> }
+{ "op": "<string>", "payload": <existing REST JSON | small control/tick object>, "seq": <int?> }
 ```
 
-- **One JSON text message per frame.** Never split a frame across messages,
-  never batch two frames into one. Same rule as the router path.
-- **`op`** — the discriminator the receiver demuxes on. Server→SPA ops name a
-  *topic that changed* (or, for a thick push, the topic whose body rides in
-  `payload`); SPA→server ops are control (`hello`, `ping`, `reauth`).
-- **`payload`** — for a thin "stale" frame, a tiny control object (the topic
-  key, optional hints). For a thick data frame (§2, the measured exception), the
-  **exact** REST body — byte-for-byte what the matching `GET` returns.
-- **`seq`** — optional monotonic per-sender counter, observability only
-  (gap/dup logging); ignored if absent (forward-compat).
-
-**Unknown `op` → ignore + meter** on both ends (forward-compat), exactly as the
-router demux does ([`RouterWsRoutes.dispatch`](../../api/src/routes/RouterWsRoutes.scala)).
-This is what lets a future topic ship without a flag day.
-
-### 1.3 Message types
-
-| `op` | Dir | Payload | Meaning / maps to |
-| --- | --- | --- | --- |
-| `hello` | SPA→S | `{clientVersion, topics?:[…]}` | first frame after connect; optional subscription filter (§1.4) |
-| `ready` | S→SPA | `{role, serverTime}` | server confirms auth + role; SPA flips the indicator to "live" |
-| `stale` | S→SPA | `{topic:"dashboard-now"\|"recent-blocked"\|"alerts"\|"time-status"\|"routers", scope?}` | **the canonical push** (§2): "this React Query key is stale, refetch it" |
-| `data` | S→SPA | `{topic, body:<exact REST body>}` | the **opt-in thick push** (§2.3), used only where measured to matter (dashboard-now) |
-| `reauth` | SPA→S | `{ticket}` | present a fresh ticket to extend the connection past JWT expiry without a reconnect (§3.3) |
-| `ping` / `pong` | both | `{}` | app-level heartbeat (§5.2) |
-
-`topic` is a **bounded enum** — it doubles as the metric label space (§6) and
-maps 1:1 to a React Query key prefix (§2.2). It is never a free-form string and
-never carries a per-entity id as a label (a `scope` field inside the payload may
-narrow *which* rows changed for a future targeted invalidation, but it is data,
-not a metric label).
-
-### 1.4 Subscribe / hello
-
-On connect the SPA sends `hello` once. `topics` is an **optional** filter — if
-present, the server only pushes those topics to this connection (a child-role tab
-that renders only its own time-status need not receive `routers` frames). If
-omitted, the server pushes every topic the connection's role is authorized for
-(§3.4). v1 ships the **omit-everything-authorized** default; the `topics` filter
-is the forward-compat seam for per-view subscriptions and is honored if sent.
-The server replies `ready` with the resolved role; the SPA flips its
-live-indicator to "live" only after `ready` (a socket that upgrades but never
-`ready`s — e.g. a wedged server — must not read as live).
+- **One JSON text message per frame.** Never split a frame across messages, never
+  batch two frames into one.
+- **`op`** — the discriminator the receiver demuxes on (§1.2). `seq` is optional,
+  observability only (gap/dup logging), ignored if absent.
+- **Unknown `op` → ignore + meter**, both ends — the forward-compat rule that lets
+  a future op ship without a flag day.
 
 ---
 
-## 2. React Query integration — **invalidate by default, thick-push by exception**
+## 3. Client integration — push-data for the live surface, invalidate for the rest
 
-This is the central client-side decision. The two candidates:
+The central client-side decision, now made **per data class** (§1.1) rather than
+one-size-fits-all:
 
-- **(A) Thin "stale" push → `queryClient.invalidateQueries`.** The frame carries
-  only the topic key; React Query refetches the canonical `GET`.
-- **(B) Thick "data" push → `queryClient.setQueryData`.** The frame carries the
-  new body; the cache is patched directly, no refetch.
+### 3.1 Class (1) throughput — direct to a live store, not the resource cache
 
-### 2.1 Decision: (A) invalidate is the canonical pattern; (B) is an opt-in optimization
+A `throughput` tick is a stream sample, not a cache entry. The `useWsThroughput()`
+hook holds the latest tick (a small `useSyncExternalStore` or a dedicated query
+key updated via `setQueryData`) and feeds the overall gauge + per-profile card
+headers. There is nothing to invalidate and no `GET` to refetch — when the socket
+is down the gauge shows "—" (its only fallback; the 24 h volume on `/usage`
+answers the historical question). Latest-wins: a new tick replaces the prior one
+(§6.3).
 
-**Recommend (A) as the default for every topic.** Justification:
+### 3.2 Class (2) NOW + blocked — push carries data, patch the cache
 
-1. **Single source of truth (the decisive reason).** With (A), the `GET`
-   endpoint stays the *only* place a read-model body is produced, and the socket
-   carries no data shape at all — it cannot drift from the REST body because it
-   contains no body. (B) creates a second producer of the same bytes; even though
-   the architecture's wire-shape carve-out *permits* reusing an existing body
-   verbatim, every thick topic is a place where a server-side filter/derivation
-   (e.g. `DashboardNow`'s per-role device visibility,
-   [`DashboardNowRoutes`](../../api/src/routes/DashboardNowRoutes.scala)) must be
-   re-applied identically on the push path or the pushed body silently differs
-   from the polled one. (A) has no such path to keep in sync.
-2. **Authz correctness for free.** A refetch goes through the normal
-   `requireAuth` + per-role visibility filter on the `GET`. A pushed body must
-   re-implement that filtering *before* fan-out (you cannot push one household's
-   `DashboardNow` to a child whose visible device set is a subset). (A) sidesteps
-   the entire "did we filter the push correctly per recipient?" risk: the server
-   pushes a *contentless* "stale" signal to every authorized connection, and each
-   client's refetch is filtered by its own token.
-3. **Coalescing is trivial.** Many rapid changes collapse to one refetch:
-   React Query dedups concurrent invalidations of the same key, and the server
-   can drop-oldest-coalesce `stale{topic}` frames in a wedged connection's
-   mailbox (§5.3) because they are identical and idempotent. Thick frames cannot
-   be coalesced as cheaply (each carries distinct bytes).
-4. **It reuses the existing, battle-tested fetch path** — `cache:'no-store'`,
-   the 10 s timeout, `apiHealth` reporting, the 401→/login redirect
-   ([`client.ts`](../../web/src/api/client.ts)) — none of which a thick push
-   would exercise.
-
-The cost of (A) is **one refetch round-trip of latency** after the signal. For
-the household model (LAN or a nearby cloud region, sub-100 ms RTT) this is
-negligible against the 10 s poll lag it replaces.
-
-### 2.2 The canonical handler
-
-A single `useWsInvalidation()` hook, mounted once in the app shell, owns the
-socket and maps `stale{topic}` → the right invalidation. The topic→key map is the
-**one** place the mapping lives (single-source-of-truth), reusing the existing
-`qk` key factory and `useInvalidators` helpers in
-[`queries.ts`](../../web/src/api/queries.ts):
+For the live snapshots we **push the data and patch the React Query cache**
+directly — the *opposite* of the default for class (3), and correct here because
+the entire point is to remove the refetch RTT on the live surface:
 
 ```ts
-// topic (bounded enum, §1.3) → React Query key prefix (reuses qk/useInvalidators)
-const TOPIC_INVALIDATORS: Record<WsTopic, (qc: QueryClient) => Promise<unknown>> = {
-  'dashboard-now':  qc => qc.invalidateQueries({ queryKey: qk.dashboardNow() }),
-  'recent-blocked': qc => qc.invalidateQueries({ queryKey: qk.recentBlocked() }),
-  'alerts':         qc => qc.invalidateQueries({ queryKey: ['alerts'] }),
-  'time-status':    qc => qc.invalidateQueries({ queryKey: ['time', 'status'] }),
-  'routers':        qc => qc.invalidateQueries({ queryKey: ['admin', 'routers'] }),
-}
+// on `now`  → replace the dashboard-now cache with the pushed body
+queryClient.setQueryData(qk.dashboardNow(), tick.payload)
+// on `blocked` → prepend the new row to the recent-blocked cache (bounded, dedup by id)
+queryClient.setQueryData(qk.recentBlocked(), prev => prependCapped(prev, row))
 ```
 
-`invalidateQueries` only refetches **mounted** queries (and marks unmounted ones
-stale for their next mount), so a `stale{time-status}` while the dashboard isn't
-open costs nothing — the exact "poll only what's visible" property the adaptive
-ladder hand-rolls, now for free.
+Justification this is safe despite (3)'s SSOT argument: the pushed body **is** the
+exact `GET` body (§0.3), written through the **same** query key, so a later
+refetch (on reconnect, §6.1, or the paused-poll fallback, §3.4) reconciles against
+the authority. The server applies the *same* per-role visibility filter the `GET`
+uses before fan-out (§4.4 / §5.2) — for the household's small fan-out this is one
+filtered build, not a per-recipient risk surface. The derived KPIs ("Online now /
+Blocked now") are computed client-side off the pushed `DashboardNow`, so they
+update with the same push — no separate stream.
 
-> Four of the five topics map to an existing polled hook in
-> [`queries.ts`](../../web/src/api/queries.ts) (`useDashboardNow`,
-> `useRecentBlocked`, `useAlerts`, `useTimeStatus*`). **`routers` is the
-> exception:** the admin router list is a plain `api.routers.list()` call today,
-> not a TanStack-cached poll, so the `['admin','routers']` key above is
-> *forward-looking* — the `routers` topic (router connect/disconnect, fed by
-> `RouterWsRegistry` register/deregister, §4.2) implies first wrapping the router
-> list/status in a query, not pausing an existing interval. Noted for S5 so the
-> implementer doesn't assume a poll to retire.
+### 3.3 Class (3) everything else — `stale` → invalidate (or nothing)
 
-### 2.3 The thick-push exception (deferred, measured)
+For occasionally-changing resources, a `stale{topic}` frame triggers
+`queryClient.invalidateQueries` on the mapped key, reusing the existing `qk`
+factory / `useInvalidators` ([`queries.ts`](../../web/src/api/queries.ts)). The
+topic→key map is the one place the mapping lives. `invalidateQueries` only
+refetches **mounted** queries, so a `stale{time-status}` while that view is closed
+costs nothing. Many class-(3) changes already invalidate locally via a mutation's
+`onSuccess` and need no socket frame at all — the `stale` op is for the case where
+*another* operator/tab made the change. **No thick push for class (3):** it keeps
+the `GET` as the sole producer and gets per-recipient authz for free.
 
-`data{topic, body}` exists in the protocol (§1.3) for **one** future case:
-`dashboard-now`, the hottest view, where the push body *is already* the exact
-`GET /api/dashboard/now` output and the refetch RTT is the visible lag. It is
-**not built in v1.** It is enumerated as a later, independently-shippable
-optimization (§8, sub-issue **S5**) gated on a measurement showing the refetch
-RTT actually matters, and even then it writes through `setQueryData` for the
-**same** query key so a subsequent refetch reconciles — the `GET` stays the
-schema authority. Shipping (A) first and (B) only-if-measured is the cautious
-order; we do not pay (B)'s per-recipient-filtering complexity speculatively.
+### 3.4 Polling stays the paused fallback
 
-### 2.4 Polling stays as the paused fallback
-
-`refetchInterval` is **not removed** — it is made conditional on socket health.
-A small `useWsLive()` signal (§5.2) gates the interval:
+`refetchInterval` is **not removed** — it is gated on socket health via a
+`useWsLive()` signal (§6.2):
 
 ```ts
 useDashboardNow({ refetchInterval: wsLive ? false : 10_000 })
 ```
 
-When the socket is healthy, the interval is `false` (paused) and pushes drive
-updates; when the socket is down/reconnecting, the interval resumes at its
-current cadence so the view keeps updating exactly as today. This is
-belt-and-suspenders: an un-migrated view, an offline window, or a server that
-stops pushing all degrade to polling with no user-visible cliff. The redundant
-intervals are retired only at the *end* of the rollout (§8, **S6**), per-view,
-after the push path is proven for that view.
+Socket healthy → interval paused, pushes drive updates; socket down/reconnecting →
+interval resumes at today's cadence. The redundant intervals are retired only at
+the *end* of the rollout (§9, **S7**), per-view, after each view's push path is
+proven. Live throughput (class 1) has no poll fallback — it simply shows "—" while
+disconnected.
 
 ---
 
-## 3. Auth
+## 4. Auth
 
 The SPA authenticates with the **operator JWT** (`AuthService` /
 [`useAuth`](../../web/src/hooks/useAuth.tsx) — `localStorage.token`, HS256,
-`{sub, role, iat, exp}`,
-[`AuthService.scala`](../../api/src/auth/AuthService.scala)). The browser
-`WebSocket` cannot send the `Authorization` header that carries it (§0.2.1), so
-the upgrade needs a different mechanism.
+`{sub, role, iat, exp}`, [`AuthService.scala`](../../api/src/auth/AuthService.scala)).
+The browser `WebSocket` can't send the `Authorization` header that carries it
+(§0.2.1), so the upgrade needs a different mechanism.
 
-### 3.1 The three options
+### 4.1 The three options
 
-| Mechanism | How | Why rejected / chosen |
-| --- | --- | --- |
-| **Cookie** | Set an auth cookie; browser sends it on the ws upgrade automatically | **Rejected.** The SPA's whole auth model is a `localStorage` bearer token, not cookies ([`client.ts`](../../web/src/api/client.ts)). Introducing an auth cookie means CSRF defenses, a `Set-Cookie`/SameSite story, and a second credential to keep in sync with the bearer — a large surface for one endpoint. |
-| **Subprotocol** | Smuggle the JWT in `Sec-WebSocket-Protocol` (the one header `new WebSocket(url, protocols)` can set) | **Rejected.** Abuses a negotiation header to carry a secret; the full JWT lands in server access logs and proxy logs; awkward to echo back the selected subprotocol correctly. Works, but it's a hack with a long-lived-secret-in-logs footgun. |
-| **Short-lived single-use ticket** | Authenticated `POST /api/ws/ticket` (normal bearer) → opaque short-TTL ticket → `wss://…/api/ws?ticket=…` | **Chosen.** ✓ |
+| Mechanism | Why rejected / chosen |
+|---|---|
+| **Cookie** | **Rejected.** The SPA's auth model is a `localStorage` bearer, not cookies; an auth cookie means CSRF defenses + a second credential to sync. |
+| **Subprotocol** (JWT in `Sec-WebSocket-Protocol`) | **Rejected.** Abuses a negotiation header to carry a secret; the full JWT lands in access/proxy logs. |
+| **Short-lived single-use ticket** | **Chosen.** ✓ |
 
-### 3.2 Decision: short-lived, single-use ticket
+### 4.2 Decision: short-lived, single-use ticket
 
 ```
 SPA                                              API
- │  POST /api/ws/ticket   Authorization: Bearer <jwt>   │  requireAuth(req)  → JwtClaims
- │ ───────────────────────────────────────────────────▶ │  mint ticket: random 256-bit,
- │                                                       │  store {ticket → (sub, role, jwtExp)} TTL=30s, single-use
- │  { "ticket": "<opaque>", "expiresInSec": 30 }         │
- │ ◀─────────────────────────────────────────────────── │
- │                                                       │
+ │  POST /api/ws/ticket   Authorization: Bearer <jwt>   │  requireAuth(req) → JwtClaims
+ │ ───────────────────────────────────────────────────▶ │  mint random 256-bit ticket,
+ │  { "ticket": "<opaque>", "expiresInSec": 30 }         │  store {ticket → (sub, role, jwtExp)} TTL=30s, single-use
  │  GET /api/ws?ticket=<opaque>   Upgrade: websocket     │  consume ticket (atomic delete);
  │ ───────────────────────────────────────────────────▶ │  invalid/expired/used → 401, no 101
- │  101 Switching Protocols                              │  → resolve (sub, role) → register channel (§4)
- │ ◀─────────────────────────────────────────────────── │
+ │  101 Switching Protocols  → register channel (§5)     │  → resolve (sub, role)
 ```
 
-- **The ticket is not the JWT.** It is an opaque random token, single-use, TTL
-  ~30 s, stored server-side (a `Ref[Map[Ticket, TicketEntry]]` in the SPA
-  registry — single-process is fine for the household model, §4) bound to the
-  authenticated `(sub, role)` and the originating JWT's `exp`. The query-string
-  exposure that makes "JWT in the URL" unacceptable is bounded to a 30 s,
-  one-shot, non-replayable, non-JWT token. Minting reuses the existing
-  `requireAuth` on the `POST`, so there is **one** JWT-validation implementation
-  (single-source-of-truth) — the ws path is not a second auth surface.
-- **Consume-at-upgrade is atomic** (delete-returns-old) so a ticket cannot be
-  used twice (a replay attacker who sniffs the URL loses the race with the
-  legitimate upgrade, and after either consumes it the ticket is gone).
-- **A bad/expired/used ticket → reject the upgrade with 401** (no 101), exactly
-  the router-path semantics ([`RouterWsRoutes`](../../api/src/routes/RouterWsRoutes.scala)).
-  Metered `spa_ws_auth_total{result=ticket_invalid|ticket_expired}` (§6).
+- **The ticket is not the JWT** — opaque, single-use, TTL ~30 s, stored
+  server-side (a `Ref[Map[Ticket, TicketEntry]]` in the SPA registry §5.1) bound
+  to `(sub, role, jwtExp)`. The query-string exposure that makes "JWT in the URL"
+  unacceptable is bounded to a 30 s one-shot non-JWT token. Minting reuses
+  `requireAuth` on the `POST`, so there is **one** JWT-validation implementation —
+  the ws path is not a second auth surface.
+- **Consume-at-upgrade is atomic** (delete-returns-old) → a ticket can't be used
+  twice; a URL-sniffing replayer loses the race and finds it already gone.
+- **Bad/expired/used ticket → reject the upgrade with 401** (no 101), the
+  router-path semantics, metered `spa_ws_auth_total{result=…}` (§7).
 
-### 3.3 Token expiry mid-connection + re-auth
+### 4.3 Token expiry mid-connection + re-auth
 
-The ticket gates only the *upgrade*; the **connection's authz deadline is the
-JWT's `exp`**, captured at upgrade (`TicketEntry.jwtExp`). Two cases:
+The ticket gates only the *upgrade*; the connection's authz deadline is the JWT's
+`exp`, captured at upgrade.
 
 - **Expiry while connected.** The server tracks `jwtExp` per channel; on the
-  heartbeat tick where `now ≥ jwtExp`, it closes the channel with a
-  `4401 token-expired` close code and metered `spa_ws_auth_total{result=jwt_expired}`.
-  The bound on stale-authz carry-over is one heartbeat interval — same property
-  the router path gives for token revocation
-  ([`docs/design/websocket-transport.md` §4.2](websocket-transport.md)).
-- **Re-auth.** Today the SPA has **no silent token refresh** — an expired JWT
-  means a 401 → `localStorage` clear → `/login`
-  ([`client.ts`](../../web/src/api/client.ts)). The ws design mirrors this exactly
-  and adds a seam for when refresh lands:
-  - **v1 (no refresh):** on `4401 token-expired`, the SPA stops reconnecting and
-    falls back to polling (§2.4); the next REST call 401s and triggers the
-    existing `/login` redirect. The user re-logs in; on the new session the SPA
-    mints a fresh ticket and reconnects. No new logout path is invented.
-  - **Forward-compat (`reauth` op):** when a future silent-refresh mechanism
-    exists, the SPA mints a new ticket from the refreshed JWT and sends
-    `{op:"reauth", payload:{ticket}}` on the **open** socket; the server
-    validates+consumes it and advances the channel's `jwtExp` — extending the
-    connection without a reconnect. The op is in the protocol now (§1.3) so the
-    server can accept it the moment refresh exists; v1 server may `ack`-reject it.
+  heartbeat tick where `now ≥ jwtExp` it closes with `4401 token-expired`
+  (metered `jwt_expired`). Stale-authz carry-over is bounded by one heartbeat
+  interval — same property the router path gives for revocation.
+- **Re-auth.** The SPA has **no silent token refresh** today — an expired JWT
+  means 401 → `localStorage` clear → `/login` ([`client.ts`](../../web/src/api/client.ts)).
+  v1 mirrors this: on `4401` the SPA stops reconnecting, falls back to polling
+  (§3.4); the next REST call 401s → the existing `/login` redirect; after
+  re-login it mints a fresh ticket and reconnects. The **`reauth` op** (§1.2) is
+  the forward-compat seam: when silent refresh lands, the SPA mints a ticket from
+  the refreshed JWT and sends `reauth` on the open socket; the server
+  validates+consumes it and advances `jwtExp` — no reconnect. v1 server may
+  `ack`-reject `reauth`.
 
-### 3.4 Role scoping per frame
+### 4.4 Role scoping per frame
 
-The resolved `role` (from the ticket → claims) is captured on the channel at
-upgrade and is the authz key for fan-out: the server only pushes a topic to a
-connection whose role may see it (e.g. `routers` → admin only, matching the
-`requireAdmin` on `GET /api/admin/routers`). Because the canonical push is the
-*contentless* `stale` signal (§2.1), the worst case of a fan-out bug is a
-needless refetch that the `GET`'s own `requireAuth`/role-filter then rejects or
-scopes — defense in depth, not a leak. Thick pushes (§2.3), if ever built, must
-filter the body per recipient role *before* sending; this asymmetry is a further
-reason (A) is the default.
+The resolved `role` is captured on the channel at upgrade and is the fan-out authz
+key: the server only pushes a topic to a connection whose role may see it
+(`stale{...}` for an admin-only resource → admin connections only; per-profile
+throughput → filtered to the profiles the role may view). For class-(2) thick
+pushes the body is filtered per-role *before* send, exactly as the matching `GET`
+filters (§3.2 / §5.2). For class-(3) `stale` signals the worst case of a fan-out
+bug is a needless refetch the `GET`'s own `requireAuth` then scopes — defense in
+depth.
 
 ---
 
-## 4. Reuse vs. separate registry — **separate `SpaWsRegistry`, shared event source**
+## 5. Server side — registries, change sources, the throughput aggregator
 
-### 4.1 Decision
+### 5.1 Decision: fork a parallel `SpaWsRegistry`; share the change sources
 
-**Fork a parallel `SpaWsRegistry`; do not generalize
+**Fork `SpaWsRegistry`; do not generalize
 [`RouterWsRegistry`](../../api/src/routes/RouterWsRegistry.scala) to hold both.**
-Justification — the two registries differ on the three axes a registry *is*:
+The two differ on the three axes a registry *is*:
 
 | Axis | `RouterWsRegistry` (#1846) | `SpaWsRegistry` (this design) |
-| --- | --- | --- |
-| **Key** | `RouterId` | a session/connection id, with `role` for authz fan-out (keyed per-connection, not per-user — a user may have N tabs, §5.4) |
-| **Fan-out payload** | full `PolicySnapshot` as a `policy` frame | contentless `stale{topic}` frames (§2.1), role-filtered (§3.4) |
-| **Event vocabulary** | one event: "policy snapshot changed" | several: policy change, new connection event, usage tick, router connected/disconnected |
+|---|---|---|
+| **Key** | `RouterId` | per-connection id + `role` (a user may have N tabs, §6.4) |
+| **Fan-out payload** | full `PolicySnapshot` | the §1.2 op vocabulary (`throughput`/`now`/`blocked`/`stale`), role-filtered |
+| **Event vocabulary** | one event (policy changed) | several (throughput tick, NOW change, new blocked event, class-3 mutations) |
 
-Generalizing one registry to two key types, two payload vocabularies, and two
-fan-out filters would couple two things that share only the *shape* of "a `Ref`
-of channels with a fan-out method." The `RouterWsRegistry` is a clean, small,
-single-purpose class
-([`RouterWsRegistry.scala`](../../api/src/routes/RouterWsRegistry.scala)); the
-right reuse is **the pattern, not the instance** — `SpaWsRegistry` is the same
-`Ref[Map[K, Set[WebSocketChannel]]]` shape with SPA-appropriate K, payload, and
-metrics. (Same call the router doc makes: "share patterns, not code.")
+Generalizing one registry across two key types + two payload vocabularies couples
+things that share only the *shape* "a `Ref` of channels with a fan-out method."
+Reuse the **pattern**, not the instance — `SpaWsRegistry` is the same
+`Ref[Map[K, Set[WebSocketChannel]]]` with SPA-appropriate K, payloads, and
+metrics. (Also holds the ticket store, §4.2.)
 
-### 4.2 What IS shared — the change-event source (consume #1849, don't rebuild)
+### 5.2 The change sources — consume existing write sites (don't rebuild)
 
-The reuse point is the **event source**, not the registry. #1849's
-push-on-change ([`PolicyService.reevaluate`](../../api/src/policy/PolicyService.scala)
-→ [`PolicySnapshotPublisher`](../../api/src/policy/PolicySnapshotPublisher.scala))
-already fires exactly when policy changes. The SPA needs that signal **plus**
-three others the router never cared about (new connection events, usage ticks,
-router connect/disconnect). So:
+The reuse point is the **event source**, not the registry. The SPA registry
+subscribes to changes published at write sites that already run on the relevant
+change — no new polling/diffing loop:
 
-1. **Generalize the single-sink `PolicySnapshotPublisher` into a small
-   multi-subscriber hub.** Today it is an `AtomicReference[PolicySnapshotPublisher]`
-   with one sink ([`PolicyService.setPublisher`](../../api/src/policy/PolicyService.scala)).
-   Replace the single sink with a ZIO `Hub` (or a subscriber list) so **both**
-   the `RouterWsRegistry` (which wants the full snapshot) **and** the
-   `SpaWsRegistry` (which wants a `stale{topic:"time-status"|"dashboard-now"}`
-   derived from "policy changed") subscribe. This is a behavior-preserving
-   widening of an existing seam — the router subscriber is unchanged.
-2. **Introduce a server-side `SpaEventHub`** (a `Hub[SpaTopic]`) that the SPA
-   registry subscribes to, fed by the existing write paths — each is a one-line
-   publish at a point that *already* runs on the relevant change:
-   - policy reevaluate (#1849) → `time-status`, `dashboard-now`
-   - connection-events ingest (`RouterIngestService`, the same handler the REST
-     and router-ws paths share) → `recent-blocked`, `dashboard-now`
-   - usage ingest → `dashboard-now`
-   - alert raised (access-request created) → `alerts`
-   - `RouterWsRegistry` register/deregister → `routers`
-   The hub is the **one** place "a thing the SPA renders changed" is named;
-   `SpaWsRegistry` translates a `SpaTopic` into role-filtered `stale` frames.
-   This keeps the change-detection logic at the existing write sites (no new
-   polling/diffing loop) — it consumes #1849's discipline and extends it to the
-   non-policy topics.
+1. **Generalize the single-sink `PolicySnapshotPublisher` to a multi-subscriber
+   hub.** Today it's an `AtomicReference[PolicySnapshotPublisher]` with one sink
+   ([`PolicyService.setPublisher`](../../api/src/policy/PolicyService.scala)).
+   Widen to a `Hub` so both `RouterWsRegistry` (wants the full snapshot) and
+   `SpaWsRegistry` (wants `stale{topic:"time-status"|...}` derived from "policy
+   changed") subscribe. Behavior-preserving for the router subscriber.
+2. **A `SpaEventHub`** (`Hub[SpaEvent]`) fed by existing write sites, each a
+   one-line publish:
+   - connection-events ingest (`RouterIngestService`, the shared handler both REST
+     and router-ws ingest call) → a `blocked` push (the new row) + a `now`
+     recompute trigger.
+   - usage ingest → feeds the throughput aggregator (§5.3) + a `now` trigger.
+   - policy reevaluate (#1849) → `now` recompute + `stale{time-status}`.
+   - alert raised → `stale{alerts}`; profile/device/schedule mutations →
+     `stale{profiles|devices|schedules}`.
+   `SpaWsRegistry` translates each `SpaEvent` into role-filtered frames. **`now`
+   pushes reuse the existing `DashboardNowRoutes` builder** (one implementation of
+   the NOW snapshot — SSOT), recomputed on change rather than per-poll.
 
-> **Single-process fan-out, like the router path.** Both registries and the hub
-> are in-memory, single-instance. This is correct for the single-household model
-> (one API process); cross-instance pub/sub is explicitly out of scope, same as
-> [`docs/design/websocket-transport.md` §6.1](websocket-transport.md).
+### 5.3 The throughput aggregator — derive the rate from the #1023 usage stream
+
+Live throughput is the one element needing a genuinely new server path, and it
+**depends on [#1023](https://github.com/wifihaven/wifihaven/issues/1023)** — the
+router→API leg that pushes usage as the agent has it, rather than the ~60 s REST
+batch. Design:
+
+- **Source.** The router already accounts directional bytes per `(mac, host)` —
+  `UsageRecord{bytesIn,bytesOut}` ([`Models.scala`](../../shared/src/Models.scala)).
+  The ~60 s `usage` batch is too coarse for a live gauge. **Recommend a dedicated
+  lightweight `throughput` sample on the router→API ws** (additive to #1023):
+  per-`mac` bytes-since-last-sample, every ~2 s, sourced from the conntrack byte
+  counters the agent already reads (`conntrack.lua`). This separates concerns —
+  the `usage` records stay low-frequency/high-fidelity (per-host, period-accurate,
+  idempotent for rollups); the `throughput` sample is high-frequency/low-fidelity
+  (per-mac totals, display-only, lossy-OK). Conflating them would make `usage` too
+  chatty or throughput too coarse. (Filed as a #1023 sub-issue, §9 **S0**.)
+- **Aggregate.** The API maps `mac → profile` (it already does) and maintains a
+  rolling overall + per-profile B/s (last-sample rate or short EWMA). This is the
+  **one** place the rate is computed (SSOT) — every tab consumes the same tick.
+- **Push.** Emit a `throughput` tick (§1.3) to SPA connections on a fixed cadence
+  (~2 s), latest-wins (§6.3). If #1023's realtime usage isn't available yet, the
+  aggregator simply has no input and emits nothing (the gauge shows "—") — so the
+  SPA endpoint + the rest of the catalog ship independently of S0.
+
+> **Single-process fan-out**, like the router path — registries, hubs, and the
+> aggregator are in-memory, single-instance (correct for the one-API-process
+> household model; cross-instance pub/sub is out of scope, same as
+> [`websocket-transport.md` §6.1](websocket-transport.md)).
 
 ---
 
-## 5. Reliability
+## 6. Reliability
 
-### 5.1 Reconnect / backoff (browser)
+### 6.1 Reconnect / backoff (browser)
 
-The SPA ws client reconnects with **exponential backoff + jitter** (1 s → 2 s →
-4 s → … cap 30 s), reset on a successful `ready` (not merely the socket
-`open` — a socket that opens but never `ready`s, e.g. ticket consumed but server
-wedged, must not reset the backoff). Reconnect *is* the throttle; there is no
-per-frame retry. On `4401 token-expired` (§3.3) the client stops reconnecting and
-hands off to polling + the existing `/login` path; on any other close it backs
-off and retries. Each reconnect mints a **fresh ticket** (§3.2) — tickets are
-single-use, so a reconnect cannot replay the old one.
+Exponential backoff + jitter (1 s → 2 s → 4 s → … cap 30 s), reset on `ready`
+(not merely socket `open`). Reconnect *is* the throttle; no per-frame retry. Each
+reconnect mints a **fresh ticket** (§4.2; single-use, so a reconnect can't replay
+the old one). On reconnect the client refetches the class-(2) queries once
+(`now`/`blocked`) so a change missed while disconnected converges; the throughput
+gauge resumes on the next tick. On `4401 token-expired` it stops reconnecting and
+hands off to polling + `/login` (§4.3).
 
-### 5.2 Heartbeat / liveness → the real "live / reconnecting" indicator
+### 6.2 Heartbeat / liveness → the real "live / reconnecting" indicator
 
-This is the payoff that the silent poll cannot give (§0.1).
+The payoff the silent poll can't give (§0.1).
 
-- **Heartbeat.** App-level `{op:"ping"}`/`{op:"pong"}` every ~30 s (the browser
-  can't send WS control-frame pings, §0.2.2). The server also sends control-frame
-  pings; the browser auto-pongs and surfaces a drop via `onclose`. A missed
-  app-level `pong` for `2×interval` → the client treats the socket as dead and
-  reconnects (§5.1); server-side, a missed pong closes + deregisters the channel.
-- **The indicator.** A `useWsLive()` hook exposes `'live' | 'reconnecting' |
-  'offline'`, driven by the socket state machine (`ready` → live; backoff →
-  reconnecting; gave-up/expired → offline). This **replaces the silent-poll
-  ambiguity**: the UI shows a small "Live"/"Reconnecting…" badge, and the
-  signal also gates the polling fallback (§2.4) and feeds
+- **Heartbeat.** App-level `{op:"ping"}`/`{op:"pong"}` ~30 s (browsers can't send
+  WS control pings, §0.2.2); the server also control-pings and the browser
+  auto-pongs, surfacing drops via `onclose`. A missed app-pong for `2×interval` →
+  client treats the socket as dead and reconnects; server-side a missed pong
+  closes + deregisters.
+- **The indicator.** `useWsLive()` exposes `'live' | 'reconnecting' | 'offline'`
+  from the socket state machine. It backs a small "Live / Reconnecting…" badge on
+  the dashboard, gates the polling fallback (§3.4), and feeds
   [`ApiUnreachableBanner`](../../web/src/components/ApiUnreachableBanner.tsx):
-  - socket reconnecting **and** REST polls failing (`apiHealth.unreachable`) →
-    the existing red "can't reach the API" banner (unchanged).
-  - socket reconnecting **but** REST polls succeeding → a softer "Reconnecting
-    live updates… (still refreshing every 10 s)" state — *degraded, not down*,
-    a distinction the current banner cannot draw. (Implementation folds a
-    `wsLive` input into `apiHealth`/the banner; the banner's existing
-    `unreachable` path is untouched.)
+  - socket reconnecting **and** REST polls failing → the existing red banner.
+  - socket reconnecting **but** polls succeeding → a softer "Reconnecting live
+    updates…" state — *degraded, not down*, a distinction the current banner
+    can't draw.
 
-### 5.3 Backpressure
+### 6.3 Backpressure
 
-- **Server outbound.** Each channel has a **bounded mailbox**; because the
-  canonical frame is the idempotent contentless `stale{topic}` (§2.1), a slow
-  client's mailbox **coalesces by topic** — N pending `stale{dashboard-now}`
-  collapse to one (the newest is all that matters). A persistently-wedged channel
-  (mailbox full of *distinct* topics and not draining) is closed and left to
-  reconnect, metered `spa_ws_policy_push_total{result=channel_closed}`-style
-  (§6). This is strictly simpler than the router path's snapshot mailbox because
-  the payloads are coalescible signals, not distinct bytes.
-- **Inbound (SPA→server).** Only tiny control frames (`hello`/`ping`/`reauth`);
-  no inbound backpressure concern.
+- **`throughput`** — latest-wins: a slow client's mailbox keeps only the newest
+  tick (older rates are worthless). Never queues.
+- **`now`** — coalesce to the latest snapshot (same: only the freshest matters).
+- **`blocked`** — small append frames; a bounded per-channel mailbox, drop-oldest
+  past the cap (the feed is "recent" anyway), metered. A persistently-wedged
+  channel is closed and left to reconnect.
+- **`stale`** — idempotent; coalesce by topic (N `stale{X}` → one).
+- **Inbound (SPA→server)** — tiny control frames only; no concern.
 
-### 5.4 Multi-tab — **socket per tab (v1); SharedWorker deferred**
+### 6.4 Multi-tab — socket per tab (v1); SharedWorker deferred
 
-**Recommend one socket per tab for v1.** Justification:
+**One socket per tab for v1.** Each tab has its own `QueryClient`, so a per-tab
+socket maps cleanly to "patch *this* tab's cache." A SharedWorker (one socket for
+N tabs + broadcast) is more machinery (worker lifecycle, `BroadcastChannel`,
+per-tab role routing) for a tiny workload — a household has a handful of admin
+tabs, and per-tab cost is one idle socket + a 30 s heartbeat + coalesced
+latest-wins ticks. **SharedWorker is the documented future optimization** (§9,
+**S8**), recorded with its tradeoff, not a TODO.
 
-- Each tab has its own React Query cache (`QueryClient`); a per-tab socket maps
-  cleanly to "invalidate *this* tab's cache." A SharedWorker would hold one
-  socket for N tabs and then must broadcast each `stale` to every tab's client —
-  more moving parts (worker lifecycle, `BroadcastChannel`, message routing) for a
-  workload that is tiny: a household has a handful of admin tabs, and the
-  per-connection cost is one idle socket + a ~30 s heartbeat + coalesced
-  contentless signals. The poll tax this removes scaled per-tab too, so per-tab
-  sockets are already strictly better than today.
-- **SharedWorker is the documented future optimization** (§8, **S7**), worth it
-  only if a deployment shows many tabs per browser; its tradeoff (one socket,
-  fewer server connections, but broadcast complexity + no clean per-tab role
-  story when tabs differ) is recorded, not a TODO.
+### 6.5 Failure independence
 
-### 5.5 Failure independence
-
-A dead socket never breaks the app: it degrades to the polling that runs today
-(§2.4). There is no enforcement or correctness dependency on the socket — it is a
-pure latency/UX optimization over a REST baseline that stays fully live.
+A dead socket never breaks the app: class (2)/(3) degrade to today's polling
+(§3.4); class (1) throughput shows "—". No enforcement or correctness depends on
+the socket — it is a latency/UX layer over a fully-live REST baseline.
 
 ---
 
-## 6. Metrics
+## 7. Metrics
 
-All via the `AppMetrics`/`MetricGuard` facade
-([`api/src/metrics/Metrics.scala`](../../api/src/metrics/Metrics.scala)),
-**bounded labels only — never per-user / per-session / per-mac**
+Via `AppMetrics`/`MetricGuard` ([`Metrics.scala`](../../api/src/metrics/Metrics.scala)),
+**bounded labels only — never per-user/session/mac/profile**
 ([`docs/process/instrumentation.md`](../process/instrumentation.md)). Mirrors the
-router-ws metric families ([`websocket-transport.md` §7](websocket-transport.md))
-so the two dashboards read alike.
+router-ws families ([`websocket-transport.md` §7](websocket-transport.md)).
 
 | Metric | Type | Labels (bounded) | Meaning |
-| --- | --- | --- | --- |
-| `spa_ws_connections_active` | gauge | `role` (`admin`\|`adult`\|`child`) | currently-open SPA channels, refreshed on every register/deregister so it ages out on disconnect (same discipline as `router_ws_connections_active`) |
-| `spa_ws_frames_total` | counter | `op` (bounded enum §1.3), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + the unknown-op forward-compat counter |
-| `spa_ws_auth_total` | counter | `result` (`ticket_ok`\|`ticket_invalid`\|`ticket_expired`\|`ticket_reused`\|`jwt_expired`) | the ticket-handshake + mid-connection-expiry outcomes (§3) |
-| `spa_ws_push_total` | counter | `topic` (bounded enum), `result` (`ok`\|`coalesced`\|`channel_closed`) | per-topic fan-out health + backpressure coalescing (§5.3) |
+|---|---|---|---|
+| `spa_ws_connections_active` | gauge | `role` (`admin`\|`adult`\|`child`) | open SPA channels, refreshed on register/deregister (ages out on disconnect) |
+| `spa_ws_frames_total` | counter | `op` (enum §1.2), `direction` (`in`\|`out`), `result` (`ok`\|`reject`\|`unknown_op`) | frame throughput + unknown-op tripwire |
+| `spa_ws_auth_total` | counter | `result` (`ticket_ok`\|`ticket_invalid`\|`ticket_expired`\|`ticket_reused`\|`jwt_expired`) | ticket handshake + mid-connection expiry (§4) |
+| `spa_ws_push_total` | counter | `op` (`throughput`\|`now`\|`blocked`\|`stale`), `result` (`ok`\|`coalesced`\|`dropped`\|`channel_closed`) | per-class fan-out health + backpressure (§6.3) |
 
-`role`, `op`, `direction`, `result`, `topic` are all small fixed enums — the same
-cardinality-firewall discipline `Metrics.scala` already enforces (an
-attacker-supplied `op` is collapsed to the literal `unknown` for the label, real
-value to the log only, exactly as `RouterWsRoutes` does). **No `router_id`-style
-per-entity label** — the SPA has no fleet-bounded entity, so unlike
-`router_connected` there is no per-id gauge here.
+`role`/`op`/`direction`/`result` are small fixed enums — the same
+cardinality-firewall discipline `Metrics.scala` enforces (an attacker-supplied
+`op` collapses to the literal `unknown` for the label, real value to the log
+only). **No per-entity label.**
 
-> **Registration (S1/S6 implementer note):** each new `spa_ws_*` series needs its
-> `(name -> allowed keys)` entry added to `MetricGuard.Allowed`
-> ([`api/src/metrics/Metrics.scala`](../../api/src/metrics/Metrics.scala), the
-> `Allowed` map) or `MetricGuard` rejects the emit — exactly as the `router_ws_*`
-> families were registered. Do not rely on the discipline being implicit.
+> **Registration (implementer note):** each new `spa_ws_*` series needs its
+> `(name -> allowed keys)` entry in `MetricGuard.Allowed`
+> ([`Metrics.scala`](../../api/src/metrics/Metrics.scala)) or the emit is rejected
+> — exactly as the `router_ws_*` families were registered.
 
-### 6.1 Grafana panel
+### 7.1 Grafana panel
 
-Add a **`spa-ws.json`** dashboard under
-[`deploy/grafana/dashboards/`](../../deploy/grafana/dashboards/) (sibling to the
-existing `router-ws-transport.json`), authored against the series above —
-**grepped from `api/src`, not a design-doc catalog**
-([`docs/process/instrumentation.md#metrics-need-a-dashboard`](../process/instrumentation.md)).
-Panels:
-
-1. **SPA connections active** — `sum(spa_ws_connections_active)` stat + a
-   `by (role)` timeseries (the "how many browser tabs are live right now" signal,
-   the SPA analogue of router connections active).
-2. **Frame throughput** — `sum by (op,direction) (rate(spa_ws_frames_total[5m]))`
-   timeseries; a separate stat on
-   `rate(spa_ws_frames_total{result="unknown_op"}[5m])` (forward-compat tripwire).
-3. **Auth outcomes** — `sum by (result) (rate(spa_ws_auth_total[5m]))`; alert-worthy
-   if `ticket_invalid`/`ticket_reused` spikes (replay attempt) — noted for the
-   alerting epic, not built here.
-4. **Push health** — `sum by (topic,result) (rate(spa_ws_push_total[5m]))`; a
-   rising `coalesced`/`channel_closed` rate flags slow/wedged clients (§5.3).
-
-The dashboard ships in the **same PR** as the metric-emitting code for each
-phase, targeting only series that phase actually emits (no no-data panels), per
-the dashboard rule. CI gate: `grafana-terraform`. As a *new* dashboard,
-`spa-ws.json` must also be added to the `local.dashboards` list in
-[`infra/grafana/main.tf`](../../infra/grafana/main.tf) (sibling to the existing
-`router-ws-transport` entry) — that list is what the `grafana-terraform` gate
-provisions from.
+Add **`spa-ws.json`** under [`deploy/grafana/dashboards/`](../../deploy/grafana/dashboards/)
+(sibling to `router-ws-transport.json`), authored against the series above —
+grepped from `api/src`, not a catalog
+([`instrumentation.md#metrics-need-a-dashboard`](../process/instrumentation.md)).
+Panels: connections-active `by (role)`; frame throughput `by (op,direction)` + an
+`unknown_op` rate stat; auth outcomes `by (result)` (alert-worthy on
+`ticket_reused`/`ticket_invalid`); push health `by (op,result)` (rising
+`coalesced`/`dropped`/`channel_closed` ⇒ slow clients). Each phase ships its
+panels in the **same PR**; a *new* dashboard must also join the `local.dashboards`
+list in [`infra/grafana/main.tf`](../../infra/grafana/main.tf) (what the
+`grafana-terraform` gate provisions from).
 
 ---
 
-## 7. Deployment consideration — Cloudflare-Pages-vs-Render hosting split
+## 8. Deployment — Cloudflare-Pages-vs-Render hosting split
 
-The SPA hosting split ([`AGENTS.md`](../../AGENTS.md) "SPA hosting split")
-directly shapes where the ws endpoint lives:
+The SPA hosting split ([`AGENTS.md`](../../AGENTS.md) "SPA hosting split") shapes
+where the ws endpoint lives:
 
-- **Self-hosted (JVM-bundled SPA).** The SPA is served by the API process at the
-  same origin (`VITE_API_BASE_URL` empty). `wss://<same-origin>/api/ws` is
-  same-origin; no CORS, no cross-host concern. The common case, upgrades cleanly.
-- **Cloud (SPA on Cloudflare Pages, API on Render).** The SPA is static assets on
-  `app.wifihaven.net` (Cloudflare Pages); the API — and therefore the ws
-  endpoint — is on `api.wifihaven.net` (Render). Consequences:
-  1. **The ws connection goes browser → Render directly**, *not* through
-     Cloudflare Pages (Pages serves static assets only; it does not proxy the
-     `/api/*` origin). So Cloudflare Pages config is irrelevant to the socket —
-     it is purely a Render concern.
-  2. **Render terminates websockets** — confirmed for the router transport on the
-     Render web-service plan ([`websocket-transport.md` §3.3](websocket-transport.md));
-     the SPA endpoint inherits that, including the same idle-timeout/heartbeat
-     pinning (§5.2). The 30 s app-level heartbeat must stay under Render's idle
-     timeout, the same constant the router path pins.
-  3. **Cross-origin upgrade → an `Origin` allowlist.** Unlike the router (a
-     non-browser client that sends no `Origin`), the browser **does** send an
-     `Origin` header on the ws upgrade. The server should check it against an
-     allowlist (`app.wifihaven.net`, `staging.*`, `localhost` for dev) and reject
-     a mismatched origin at upgrade — a CSWSH (cross-site websocket hijacking)
-     defense the same-origin self-hosted case gets for free. The ticket (§3.2)
-     is the primary credential, but the Origin check is cheap defense-in-depth
-     and is the one server-side ws config that differs by hosting mode.
-  4. **The SPA derives the ws host from `VITE_API_BASE_URL`** (§1.1) — the same
-     env var that already points the REST client at the right API host per
-     environment ([`client.ts`](../../web/src/api/client.ts)), so no new
-     deployment config is introduced; the ws URL falls out of the existing one.
+- **Self-hosted (JVM-bundled SPA).** Served by the API at the same origin
+  (`VITE_API_BASE_URL` empty). `wss://<same-origin>/api/ws` is same-origin — no
+  CORS, no cross-host concern. The common case; upgrades cleanly.
+- **Cloud (SPA on Cloudflare Pages, API on Render).** SPA static assets on
+  `app.wifihaven.net`; the API — and the ws endpoint — on `api.wifihaven.net`:
+  1. **The ws goes browser → Render directly**, *not* through Cloudflare Pages
+     (Pages serves static assets, doesn't proxy `/api/*`). So CF Pages config is
+     irrelevant to the socket — purely a Render concern.
+  2. **Render terminates websockets** — confirmed for the router transport
+     ([`websocket-transport.md` §3.3](websocket-transport.md)); the SPA endpoint
+     inherits the same idle-timeout/heartbeat pinning (§6.2 — the 30 s heartbeat
+     stays under Render's idle timeout).
+  3. **Cross-origin upgrade → an `Origin` allowlist.** Unlike the router (no
+     `Origin`), the browser sends `Origin` on the upgrade. The server checks it
+     against an allowlist (`app.wifihaven.net`, `staging.*`, `localhost` for dev)
+     and rejects a mismatch — a CSWSH defense the same-origin self-hosted case
+     gets free. The ticket (§4.2) is the primary credential; the Origin check is
+     cheap defense-in-depth and the one server-side ws config that differs by
+     hosting mode.
+  4. **The SPA derives the ws host from `VITE_API_BASE_URL`** (§2.1) — the same
+     env var that already points the REST client per environment, so no new
+     deployment config.
 
 ---
 
-## 8. Phased, independently-shippable rollout
+## 9. Phased, independently-shippable rollout
 
-Each phase **ships independently and back-compat**: polling stays live
-throughout (§2.4), the ws path is purely additive until the final per-view
-retirement, and **no phase is a flag day**. Server-first (exercisable by a test
-ws client before any SPA code), then one pilot view, then broaden, then retire
-redundant intervals last. Sub-issues to file against this doc:
+Each phase **ships independently and back-compat**: polling stays live throughout
+(§3.4), the ws path is additive until the final per-view retirement, **no flag
+day**. The pilot is the **realtime dashboard surface** (the actual goal), not an
+arbitrary view. Sub-issues to file against this doc (+ the #1023 dependency for
+realtime throughput):
 
 | # | Sub-issue | Independently shippable? | Back-compat |
-| --- | --- | --- | --- |
-| **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry`** — the server half: ticket-less skeleton refused for now, envelope/demux (`hello`→`ready`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry keyed by session, server metrics §6, `spa-ws.json` panels for the series it emits. Reuses the `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route only |
-| **S2** | **Ticket handshake + auth** — `POST /api/ws/ticket` (reuses `requireAuth`), single-use short-TTL ticket store, consume-at-upgrade, `Origin` allowlist (§7), mid-connection `jwtExp` close (§3.3), `reauth` op accepted (or ack-rejected) as the forward-compat seam, auth metrics. | yes (completes server auth; still no SPA client) | additive |
-| **S3** | **Generalize the change-event source** — widen `PolicySnapshotPublisher`'s single sink to a multi-subscriber hub so both registries consume #1849; add `SpaEventHub` (`Hub[SpaTopic]`) fed by the existing write sites (policy reevaluate, events/usage ingest, alert raise, router connect/disconnect); `SpaWsRegistry` translates topics → role-filtered `stale` frames (§4.2). | yes (the hub + fan-out are exercisable by a test client; behavior-preserving for the router subscriber) | behavior-preserving |
-| **S4** | **SPA ws client + pilot view (dashboard "now") off polling** — the `useWsInvalidation()` hook (§2.2), ticket-mint-then-connect, reconnect/backoff (§5.1), heartbeat + `useWsLive()` indicator (§5.2), polling-as-paused-fallback wiring for **dashboard-now only** (§2.4). One view migrated; everything else still polls. | yes (one view) | additive — other views unchanged |
-| **S5** | **Broaden to recent-blocked, alerts, time-status** — add their topic→invalidator entries (§2.2) and pause their intervals when `wsLive`; optionally the **thick-push** measurement + `data{topic}` for dashboard-now *iff* the refetch RTT is shown to matter (§2.3). | yes (per-view) | additive |
-| **S6** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven on the fleet, drop the now-paused interval (keep the `wsLive ? false : …` fallback only where a view still has no push). The only "removal" step; per-view, operator-gated, never a flag day. | yes, last | the only subtractive step, gated per-view |
-| **S7** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§5.4). Records the broadcast-complexity tradeoff; not a TODO. | yes, later | additive |
+|---|---|---|---|
+| **S0** | **(in #1023) router→API lightweight `throughput` sample** — additive per-mac bytes-since-last-sample frame every ~2 s from the conntrack counters (§5.3). The realtime source for live bandwidth. | yes (additive frame; usage path unchanged) | additive |
+| **S1** | **API `/api/ws` endpoint + `{op,payload}` demux + `SpaWsRegistry`** — server skeleton, envelope/demux (`hello`→`ready`, `ping`/`pong`, unknown-op ignore+meter), per-connection registry, server metrics §7 + `spa-ws.json`. Reuses `RouterWsRoutes` patterns. REST untouched. | yes (test ws client) | additive — new route |
+| **S2** | **Ticket handshake + auth** — `POST /api/ws/ticket` (reuses `requireAuth`), single-use short-TTL store, consume-at-upgrade, `Origin` allowlist (§8), `jwtExp` close (§4.3), `reauth` seam, auth metrics. | yes | additive |
+| **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to role-filtered `stale`/`now`/`blocked` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
+| **S4** | **Throughput aggregator + `throughput` push** — consume S0's samples, derive overall + per-profile B/s, push the tick (§5.3/§1.3). Emits nothing (gauge "—") until S0 lands. | yes | additive |
+| **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput()` (overall + per-profile gauges, #747), `now`/`blocked` cache-patching (§3.1/§3.2), `useWsLive()` indicator (§6.2), ticket-mint-then-connect, backoff (§6.1), polling-as-paused-fallback for the dashboard live sections. **This lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
+| **S6** | **Broaden class-(3) `stale` to alerts / time-status / profiles-devices-schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
+| **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
+| **S8** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§6.4). | yes, later | additive |
 
-**Critical path:** S1 → S2 → S4 (the first user-visible win). **Parallel:** S3
-(the event source) can land alongside S2 since it improves nothing user-facing
-until S4 consumes it, but is independently testable. **S6 is last and
-per-view-gated** — the cutover off polling for each view is a deliberate step
-once that view's push path is proven, never armed automatically
-([`docs/pr-review-checklist.md#monitor-to-merged`](../pr-review-checklist.md)
-discipline).
+**Critical path to the operator-visible win:** S1 → S2 → S5 (dashboard NOW +
+blocked live), with **S0 → S4 → S5** adding live throughput. **Parallel:** S3 can
+land alongside S2. **S7 is last and per-view-gated** — each cutover off polling is
+deliberate once that view's push path is proven, never armed automatically
+([`pr-review-checklist.md#monitor-to-merged`](../pr-review-checklist.md)).
 
 ---
 
-## 9. Open questions / risks
+## 10. Open questions / risks
 
-1. **Ticket store durability.** v1's single-process in-memory ticket store
-   (§3.2) is correct for one API instance; a multi-instance API would need the
-   ticket validated on the instance that terminates the upgrade (sticky routing
-   or a shared store). Same single-process assumption as the registries (§4) —
-   documented limit, not a TODO, and consistent with the router path.
-2. **Thick-push filtering (if S5 ever builds it).** Per-recipient role filtering
-   of a thick `data{dashboard-now}` body is the one place (A)'s
-   contentless-signal safety is lost; the measurement gate (§2.3) and the
-   "writes through the same key, GET reconciles" rule bound the risk, but it is
-   the riskiest optional piece and stays deferred until measured.
-3. **Render idle-timeout vs. heartbeat.** The 30 s app-level heartbeat (§5.2)
-   must stay under Render's ws idle timeout — pinned to the same constant the
-   router transport's D0 spike established, re-confirmed for the SPA endpoint.
-4. **Observability parity.** Per-frame structured logging
-   (`op`/`role`/`result` on the MDC, mirroring `RouterWsRoutes`' `LogContext`
-   annotations) so a transport fault is as debuggable as the REST path. Built
-   into S1.
+1. **Throughput cadence vs. cost.** ~2 s tick is the proposed default; the exact
+   cadence is pinned with S0 against the router's conntrack-read cost and Render's
+   frame budget. Faster than ~1 s buys little for a human-watched gauge.
+2. **#1023 dependency for live bandwidth.** Live throughput (S4/S5's gauge) is the
+   one element gated on #1023's realtime usage source (S0). Everything else (NOW,
+   blocked, the endpoint, auth) ships without it; the gauge shows "—" until S0
+   lands. Sequence S0 with the #1023 epic, not as a blocker for S1–S3.
+3. **Ticket store durability.** v1's single-process in-memory ticket store (§4.2)
+   is correct for one API instance; multi-instance would need sticky routing or a
+   shared store — same single-process assumption as the registries/aggregator
+   (§5), documented limit, not a TODO.
+4. **Thick-push filtering (class 2).** Per-role filtering of a pushed `now` body is
+   the one place class-(1)/(3)'s contentless safety is absent; it reuses the
+   `DashboardNowRoutes` filter (§3.2/§5.2) so there is one filter implementation,
+   bounding the risk.
+5. **Observability parity.** Per-frame structured logging (`op`/`role`/`result` on
+   the MDC, mirroring `RouterWsRoutes`' `LogContext`) so a transport fault is as
+   debuggable as REST. Built into S1.

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -260,8 +260,9 @@ queryClient.setQueryData(qk.dashboardNow(), tick.payload)
 queryClient.setQueryData(qk.recentBlocked(), prev => prependCapped(prev, row))
 // on `timeStatus` → replace the per-profile used/remaining cache with the pushed body
 queryClient.setQueryData(qk.timeStatusToday(), rows)
-// on `appUsage` → replace the per-app minutes cache for that profile/window
-queryClient.setQueryData(qk.profileUsageByApp(profileId, from, to), appRows)
+// on `appUsage` → patch only the LIVE (today) per-app cache entry; past windows
+// are immutable, so the push targets today's [from,to] key, not every cached window
+queryClient.setQueryData(qk.profileUsageByApp(profileId, todayFrom, todayTo), appRows)
 ```
 
 Justification this is safe despite (3)'s SSOT argument: the pushed body **is** the
@@ -605,7 +606,7 @@ realtime throughput):
 | **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to role-filtered `stale`/`now`/`blocked` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
 | **S4** | **Throughput aggregator + `throughput` push** — consume S0's samples, derive overall + per-profile B/s, push the tick (§5.3/§1.3). Emits nothing (gauge "—") until S0 lands. | yes | additive |
 | **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput()` (overall + per-profile gauges, #747), `now`/`blocked` cache-patching (§3.1/§3.2), `useWsLive()` indicator (§6.2), ticket-mint-then-connect, backoff (§6.1), polling-as-paused-fallback for the dashboard live sections. **This lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
-| **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.2) and pauses the adaptive ladder when `wsLive`. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
+| **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.2) and pauses the adaptive ladder when `wsLive`. The `appUsage` push targets only the **live (today) window** key — past windows are immutable. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
 | **S6b** | **Broaden class-(3) `stale` to alerts / profiles / devices / schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
 | **S8** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§6.4). | yes, later | additive |

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -49,6 +49,15 @@ poll well, or at all:
 - **"Most Recently Blocked"** — the live "what just got dropped" feed
   ([#1338](https://github.com/wifihaven/wifihaven/issues/1338)), today polled
   every 10 s.
+- **Live time-usage — per-profile and per-app minutes** (used / remaining,
+  counting up as time accrues). Today this is the one surface with a hand-rolled
+  *adaptive* refetch ladder (`TIME_STATUS_REFETCH_LADDER`,
+  [`queries.ts`](../../web/src/api/queries.ts)) — polling at 10 s when a profile
+  is near its cap, slowing to 5 m otherwise — which exists *only* because there is
+  no push. The whole ladder collapses into a push: the server already computes the
+  live, continuation-adjusted minutes (`TimeStatusService.dayStateAllLive`,
+  per-app via `Presence.appSecondsForProfile`), so it can emit them when they move
+  instead of the SPA guessing a poll rate.
 
 Everything else the SPA shows — profiles, devices, schedules, blocklists, the 24 h
 rollup panels, time-status caps — is a **cacheable resource that changes
@@ -115,8 +124,8 @@ the input contract); every item is classified by **why** it is on the socket.
 | Class | What | Examples | How it rides the socket |
 |---|---|---|---|
 | **(1) Push-native realtime stream** | a *rate/stream* with no cacheable REST form | **live throughput** (overall + per-profile in/out B/s) | server pushes a `throughput` tick on a fixed cadence; client renders a live gauge — **not** in the React Query resource cache |
-| **(2) Pushed live snapshot/append** | a real REST resource that changes fast enough to push instead of poll | **NOW** (`DashboardNow`), **Most Recently Blocked** feed | server pushes the (changed) body / the new row; client patches the existing React Query cache for that key (§3) |
-| **(3) Occasionally-changing resource** | a cacheable resource that changes rarely | profiles, devices, schedules, blocklists, 24 h rollups, time-status caps | **stays request/response.** At most a `stale` nudge on a relevant mutation; many need nothing (their mutation already invalidates locally) |
+| **(2) Pushed live snapshot/append** | a real REST resource that changes fast enough to push instead of poll | **NOW** (`DashboardNow`), **Most Recently Blocked** feed, **live time-usage** (per-profile used/remaining + per-app minutes) | server pushes the (changed) body / the new row; client patches the existing React Query cache for that key (§3) |
+| **(3) Occasionally-changing resource** | a cacheable resource that changes rarely | profiles, devices, schedules, blocklists, 24 h rollup panels | **stays request/response.** At most a `stale` nudge on a relevant mutation; many need nothing (their mutation already invalidates locally) |
 
 The websocket is for **(1) and (2)**. **(3) stays on queries** — the explicit
 correction to the "invalidate everything" framing. The dashboard's "Blocking
@@ -131,7 +140,9 @@ ride the rollup tables on request/response and are *not* streamed
 | `throughput` | (1) | `ThroughputTick` (§1.3) | overall in/out gauge **+** per-profile ▲▼ on NOW card headers (#747) | API aggregator over the #1023 usage stream (§5.3) |
 | `now` | (2) | `DashboardNow` (existing body, verbatim) | NOW active cards; derived "Online now / Blocked now" KPIs | recompute on change (§5.2), reusing the `/api/dashboard/now` builder |
 | `blocked` | (2) | one blocked `QueryLog` row (existing `/api/logs` row shape) | Most Recently Blocked feed (prepend) | connection-events ingest (§5.2) |
-| `stale` | (3) | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query (profiles/devices/schedules/time-status) | the relevant write site (§5.2) |
+| `timeStatus` | (2) | `ProfileTimeStatus[]` (existing `/api/time/status` body) | per-profile **used / remaining** bars (live), "profiles over limit" KPI | usage credit + #1849 ticker + extension grant (§5.2), via `TimeStatusService.dayStateAllLive` |
+| `appUsage` | (2) | per-app engaged-minutes (existing `/api/profiles/{id}/usage-by-app` body) | per-app **minutes-used** rows (live) on the expanded profile / screen-time view | same triggers, via `Presence.appSecondsForProfile` |
+| `stale` | (3) | `{ topic, scope? }` (bounded `topic` enum) | invalidate a class-(3) query (profiles/devices/schedules/blocklists) | the relevant write site (§5.2) |
 | `ready` | — | `{ role, serverTime }` | flips the live indicator to "live" | upgrade (§4) |
 | `ping`/`pong` | — | `{}` | heartbeat (§6.2) | — |
 
@@ -247,6 +258,10 @@ the entire point is to remove the refetch RTT on the live surface:
 queryClient.setQueryData(qk.dashboardNow(), tick.payload)
 // on `blocked` → prepend the new row to the recent-blocked cache (bounded, dedup by id)
 queryClient.setQueryData(qk.recentBlocked(), prev => prependCapped(prev, row))
+// on `timeStatus` → replace the per-profile used/remaining cache with the pushed body
+queryClient.setQueryData(qk.timeStatusToday(), rows)
+// on `appUsage` → replace the per-app minutes cache for that profile/window
+queryClient.setQueryData(qk.profileUsageByApp(profileId, from, to), appRows)
 ```
 
 Justification this is safe despite (3)'s SSOT argument: the pushed body **is** the
@@ -280,9 +295,13 @@ useDashboardNow({ refetchInterval: wsLive ? false : 10_000 })
 ```
 
 Socket healthy → interval paused, pushes drive updates; socket down/reconnecting →
-interval resumes at today's cadence. The redundant intervals are retired only at
-the *end* of the rollout (§9, **S7**), per-view, after each view's push path is
-proven. Live throughput (class 1) has no poll fallback — it simply shows "—" while
+interval resumes at today's cadence. The **time-usage adaptive ladder**
+(`TIME_STATUS_REFETCH_LADDER`) is the clearest case: it stays exactly as-is as the
+disconnected fallback, but goes dormant while the `timeStatus` push is live —
+and is the prime candidate for full retirement (§9, **S7**) since its entire
+reason for existing is the absence of a push. The redundant intervals are retired
+only at the *end* of the rollout, per-view, after each view's push path is proven.
+Live throughput (class 1) has no poll fallback — it simply shows "—" while
 disconnected.
 
 ---
@@ -395,8 +414,14 @@ change — no new polling/diffing loop:
    - connection-events ingest (`RouterIngestService`, the shared handler both REST
      and router-ws ingest call) → a `blocked` push (the new row) + a `now`
      recompute trigger.
-   - usage ingest → feeds the throughput aggregator (§5.3) + a `now` trigger.
-   - policy reevaluate (#1849) → `now` recompute + `stale{time-status}`.
+   - usage ingest → feeds the throughput aggregator (§5.3); a `now` trigger; and a
+     `timeStatus` + `appUsage` recompute (newly-credited minutes move used/
+     remaining) via `TimeStatusService.dayStateAllLive` / `Presence.appSecondsForProfile`.
+   - policy reevaluate (#1849) → `now` recompute. The #1849 time-boundary **ticker**
+     (schedule boundary, cap exhaustion) → a `timeStatus` push, since those
+     transitions change remaining-minutes / over-limit without new usage.
+   - time-extension grant (`POST /api/time/extend`) → a `timeStatus` push (the
+     grant immediately changes remaining-minutes).
    - alert raised → `stale{alerts}`; profile/device/schedule mutations →
      `stale{profiles|devices|schedules}`.
    `SpaWsRegistry` translates each `SpaEvent` into role-filtered frames. **`now`
@@ -580,7 +605,8 @@ realtime throughput):
 | **S3** | **Change sources** — widen `PolicySnapshotPublisher` to a hub; add `SpaEventHub` fed by existing write sites; translate to role-filtered `stale`/`now`/`blocked` frames (§5.2). | yes (behavior-preserving for the router subscriber; testable via a probe client) | behavior-preserving |
 | **S4** | **Throughput aggregator + `throughput` push** — consume S0's samples, derive overall + per-profile B/s, push the tick (§5.3/§1.3). Emits nothing (gauge "—") until S0 lands. | yes | additive |
 | **S5** | **SPA ws client + realtime dashboard pilot** — `useWsThroughput()` (overall + per-profile gauges, #747), `now`/`blocked` cache-patching (§3.1/§3.2), `useWsLive()` indicator (§6.2), ticket-mint-then-connect, backoff (§6.1), polling-as-paused-fallback for the dashboard live sections. **This lights up the redesigned NOW + throughput + Most-Recently-Blocked** ([`dashboard-redesign.md` §8](dashboard-redesign.md), unblocks #1834/#1835). | yes (dashboard only) | additive — other views poll |
-| **S6** | **Broaden class-(3) `stale` to alerts / time-status / profiles-devices-schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
+| **S6a** | **Live time-usage push** — `timeStatus` (per-profile used/remaining) + `appUsage` (per-app minutes) class-(2) pushes (§1.2) wired to usage-credit / #1849-ticker / extension-grant (§5.2); SPA patches the time-status + per-app caches (§3.2) and pauses the adaptive ladder when `wsLive`. Lights up the **live screen-time surface** (per-profile + per-app, /profiles). | yes | additive |
+| **S6b** | **Broaden class-(3) `stale` to alerts / profiles / devices / schedules** — add topic→invalidator entries (§3.3); pause their intervals when `wsLive`. | yes (per-view) | additive |
 | **S7** | **Retire redundant `refetchInterval`s** — per migrated view, after its push path is proven; keep the `wsLive ? false : …` fallback only where a view still has no push. The only subtractive step, per-view, operator-gated. | yes, last | per-view subtractive |
 | **S8** | **(optional) SharedWorker single-socket multi-tab** — only if a deployment shows many tabs/browser (§6.4). | yes, later | additive |
 


### PR DESCRIPTION
## Summary

Two co-dependent design docs for the **browser-facing websocket** ([#1860](https://github.com/wifihaven/wifihaven/issues/1860)), the SPA half of the websocket epic ([#1023](https://github.com/wifihaven/wifihaven/issues/1023)). **Design only, no implementation.** Consumes the router transport's registry pattern ([#1846](https://github.com/wifihaven/wifihaven/issues/1846)) and push-on-change core ([#1849](https://github.com/wifihaven/wifihaven/issues/1849)) rather than rebuilding them.

> **Reframe (after operator review):** the socket is **not** a "poll/invalidate everything faster" transport. It exists to **stream the live surface** — live in/out bandwidth, NOW, just-blocked — while genuinely cacheable resources stay request/response. The doc now leads with **what data flows and why**.

### `docs/design/spa-websocket.md` — key decisions

- **§1 What flows over the socket** (the heart of the design) — a message catalog classified into three data classes:
  - **(1) push-native realtime streams** — **live throughput** (overall + per-profile in/out B/s, [#747](https://github.com/wifihaven/wifihaven/issues/747)). Genuinely new data: a *rate*, not a resource — no `GET` to cache (`DashboardNow*` carries no bytes). The clearest reason the socket must exist.
  - **(2) pushed live snapshots/appends** — **NOW** (`DashboardNow`) + **Most Recently Blocked**, reusing the existing REST bodies verbatim.
  - **(3) occasionally-changing resources** — profiles, devices, 24h rollups, time-status — **stay queries**, with at most a `stale` nudge.
- **One new shape: `ThroughputTick`** (overall + per-profile B/s) — justified because throughput has no cacheable REST form; per-device/host throughput stays off the dashboard.
- **Client integration per class** — push-data + `setQueryData` patch for the live surface (1/2); `invalidateQueries` for class (3). Replaces the earlier "invalidate everything." `refetchInterval` stays as the paused fallback.
- **Throughput aggregator (§5.3)** — derive overall/per-profile B/s **server-side, once** from the [#1023](https://github.com/wifihaven/wifihaven/issues/1023) router→API usage stream (a new lightweight ~2s `throughput` sample off the conntrack counters), pushed to the SPA.
- **Auth** — short-lived single-use ticket (`POST /api/ws/ticket`) over cookie/subprotocol; `jwtExp`-bounded mid-connection close + `reauth` seam.
- **Registry** — fork `SpaWsRegistry` (different key/payload/event vocab); share the **change sources** (widen `PolicySnapshotPublisher` to a hub + add `SpaEventHub`).
- **Reliability/Metrics/Hosting/Rollout** — backoff+jitter, live/reconnecting indicator, latest-wins throughput backpressure, socket-per-tab; bounded `spa_ws_*` metrics + `spa-ws.json`; Cloudflare-Pages-vs-Render split (ws → Render directly, `Origin` allowlist). Rollout pilot is the **realtime dashboard** (S0 router sample → S4 aggregator → S5 dashboard).

### `docs/design/dashboard-redesign.md` — Revision 3

- **Reverses rev-2 Q2:** live throughput (overall + per-profile in/out) is now a **primary NOW element**, not a deferred follow-up.
- Adds the **dashboard live data contract** (which sections stream vs. stay request/response) — the input to `spa-websocket.md` §1. Unblocks the stream-gated dashboard sub-issues (#1834/#1835).

## Scope

Design docs only. Implementation sub-issues (S0–S8, incl. the #1023 router throughput sample) are enumerated in the rollout section as follow-ups.

Fixes #1860. Relates to #1023, #1148, #747, #1846, #1849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
