### PR TITLE
fix(#1943): v6 block-page e2e flake — harden uhttpd-readiness race (not a #1933 regression)

### DIFF
--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -787,6 +787,46 @@ describe("render.nft #1865 block page is never dropped", function()
       "ether saddr @blocked_macs tcp dport 443 dnat ip to 127.0.0.1:8443", 1, true))
   end)
 
+  -- #1943: the exact shape the Gate-2 e2e (test_v6_block_page.py::
+  -- test_whole_mac_block_serves_block_page_over_v6) exercises — a whole-MAC
+  -- block (paused, NO ea_ carve) — must render BOTH halves of the v6
+  -- block-page delivery together: the `redirect to :8081`/`:8443` (which #1868
+  -- made actually deliver, vs the old `dnat ip6 to ::1` that forwarded out the
+  -- WAN), AND the `fib daddr type local` never-drop guard that keeps the
+  -- redirected (now router-local) packet from being dropped by the whole-MAC
+  -- forward drop. The two live in different chains (block_nat prerouting vs
+  -- wifihaven_block forward) and were pinned in separate `it` blocks above, so
+  -- an edit could drop one while keeping the other and still pass the others.
+  -- Co-lock them for the paused no-carve case so the v6 round-trip the e2e
+  -- proves can't be half-unfixed at the render layer.
+  it("#1943: whole-MAC paused block renders the v6 redirect (80+443) AND the never-drop guard together", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Paused"
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    local nft = render.nft(s)
+    -- v6 block-page redirect on both ports (the delivering path, not ::1 DNAT).
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 redirect to :8081", 1, true),
+      "expected v6 block-page redirect for the paused whole-MAC block on :80")
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 443 redirect to :8443", 1, true),
+      "expected v6 block-page redirect for the paused whole-MAC block on :443")
+    -- The broken v6 path must be gone (it forwarded out the WAN; #1865).
+    assert.is_nil(nft:find("dnat ip6 to ::1", 1, true))
+    -- The never-drop guard must be present AND precede the whole-MAC drop, so
+    -- the redirected router-local packet is accepted before any drop fires.
+    local body = filter_chain_body(nft)
+    assert.truthy(body)
+    local guard = body:find("fib daddr type local counter accept", 1, true)
+    local drop  = body:find("counter drop", 1, true)
+    assert.truthy(guard, "expected the #1865 never-drop guard for the paused block")
+    assert.truthy(drop, "expected the whole-MAC drop for the paused block")
+    assert.is_true(guard < drop,
+      "the never-drop guard must precede the whole-MAC drop so the v6 redirect delivers")
+  end)
+
   -- #1929: #1865 (block page never dropped / v6 redirect that now DELIVERS) and
   -- #421 (extraAllowed carve under a whole-MAC block) must COEXIST: a blocked
   -- MAC's allowed host must be carved out of the block-page DNAT/redirect in

--- a/scripts/e2e/scenarios_fake/test_v6_block_page.py
+++ b/scripts/e2e/scenarios_fake/test_v6_block_page.py
@@ -63,6 +63,35 @@ def _wait_mac_blocked(mac: str, *, timeout_s: float = 180) -> None:
     )
 
 
+def _v6_uhttpd_listener_ready() -> bool | None:
+    """True iff uhttpd's v6 block-page listener is bound (`[::]:8081` AND
+    `[::]:8443`), else None — for `wait_until`.
+
+    #1943: the round-trip below was racing uhttpd readiness. PolicyApply (#341)
+    re-runs setup-uhttpd-block-page.sh and bounces uhttpd, so there is a window
+    after the snapshot lands — and even after the MAC appears in `blocked_macs`,
+    which is all `_wait_mac_blocked` gates on — where the v6 wildcard listener
+    isn't bound yet. The #1868 redirect rewrites the dest to a br-lan v6
+    address:8081; if uhttpd hasn't (re)bound `[::]:8081` at that instant the SYN
+    lands on no listener and the probe just times out — which reads as a "v6
+    delivery regression" on a degraded-network window (the #1935 egress flake)
+    even though render, the ruleset and the listener are all correct. Gate on
+    the listener explicitly so a not-yet-bound socket is a labelled precondition
+    wait, not an opaque round-trip timeout. busybox `netstat`/`ss` render a v6
+    wildcard bind as `:::8081`; bindv6only=0 means that one socket also serves
+    v4, so we only assert the v6 form. Verified sound on a real OpenWRT box
+    (openwrt.lan, nft 1.1.6): the rendered paused ruleset's v6 `redirect` +
+    never-drop guard load via `nft -c -f -`, and a `[::]` wildcard listener
+    serves v6 to the router's real br-lan GUA (200) — so the delivery mechanism
+    is not the bug; the readiness race is."""
+    out = router_ssh(
+        "ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null || true",
+        check=False, timeout=15,
+    ).stdout or ""
+    bound = lambda port: f":::{port}" in out or f"[::]:{port}" in out
+    return True if bound(8081) and bound(8443) else None
+
+
 def _v6_block_page_probe(client):
     """Return the HttpProbe iff a v6 request to a blocked dest yields the block
     page (200 + marker). None otherwise — caller polls. The bracketed v6 literal
@@ -117,14 +146,36 @@ def test_whole_mac_block_serves_block_page_over_v6(router, client, fake_api):
         f"chain was:\n{block_chain}"
     )
 
+    # #1943: gate on uhttpd's v6 listener readiness BEFORE the round-trip.
+    # PolicyApply (#341) bounces uhttpd, so `blocked_macs` membership (above) can
+    # be present while `[::]:8081`/`[::]:8443` is mid-rebind — the round-trip
+    # would then race the listener and time out opaquely. Make it a labelled
+    # precondition wait instead. (Delivery itself is sound — see the helper.)
+    try:
+        wait_until(
+            _v6_uhttpd_listener_ready,
+            timeout_s=120, interval_s=3,
+            description="uhttpd v6 block-page listener ([::]:8081 + [::]:8443) bound",
+        )
+    except AssertionError:
+        listeners = router_ssh(
+            "ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null || true",
+            check=False, timeout=15,
+        ).stdout or ""
+        pytest.fail(
+            "uhttpd v6 block-page listener never bound for "
+            f"{mac} — the redirect has no v6 listener to deliver to.\n{listeners}"
+        )
+
     # The round-trip the bug broke: a v6 request from the whole-MAC-blocked
     # client must render the block page (delivered locally via redirect), not
     # hang. dnsmasq restarts on PolicyApply (#341) and the agent's apply lags
-    # the etag flip, so poll.
+    # the etag flip, so poll. Timeout has headroom (#1943) so a degraded-network
+    # window (cf. the #1935 egress flake) doesn't redden a sound delivery path.
     try:
         probe = wait_until(
             lambda: _v6_block_page_probe(client),
-            timeout_s=120, interval_s=3,
+            timeout_s=180, interval_s=3,
             description=f"v6 block page for whole-MAC-blocked {mac}",
         )
     except AssertionError:


### PR DESCRIPTION
## Classification: TEST FLAKE / TIMING — not a #1933 regression, not a real v6-delivery regression

`scenarios_fake/test_v6_block_page.py::test_whole_mac_block_serves_block_page_over_v6` reddened Gate-2 in the 14:05 run (sha `3da50362`, after #1933) and **passed** in the 03:07 run (sha `3f565d8f`, before #1933 — even while that run hit the #1935 egress flake).

### Diff review — #1933 provably cannot have regressed this test
- **render.lua: zero lines changed by #1933** (`git show 3da50362 -- '*render.lua'` is empty). The "no render.lua enforcement change" claim holds for the v6 path.
- **This test's code path is behaviorally unchanged.** It calls `http_get` directly (not `wait_block_page`/`wait_http_succeeds`), and #1933's shared-lib edits are purely additive: a new `ipv4_only` arg defaulting to `False` (the pre-#1933 behavior); `wait_block_page` only gained a comment. The test file itself was untouched.

### Real-router evidence the v6 delivery mechanism is sound
Validated on a real OpenWRT box (openwrt.lan, nft 1.1.6, kernel 6.12):
- current-source `render.lua` under the router's **real Lua 5.1** emits the paused whole-MAC v6 `redirect to :8081`/`:8443` + the `fib daddr type local` never-drop guard, and **no** `dnat ip6 to ::1` (the broken pre-#1868 path);
- the full rendered ruleset loads via `nft -c -f -` (exit 0);
- a `[::]` wildcard v6 listener (main uhttpd `:::80`) serves a v6 connection to the router's real br-lan GUA → **http_code 200** — the exact delivery half the #1865 `::1` bug broke. #1865's `[::]` bind keeps it sound.

### Root cause of the flake
The round-trip raced **uhttpd readiness**. PolicyApply (#341) bounces uhttpd (`setup-uhttpd-block-page.sh` re-runs), so the MAC can be in `blocked_macs` (all `_wait_mac_blocked` gates on) while `[::]:8081`/`[::]:8443` is mid-rebind; the #1868 redirect then lands on no listener and the probe times out opaquely — read as a "v6 delivery regression" in the degraded-network 14:05 window (the #1935 egress flake co-fired).

## Fix (test reliability only — no agent/render change; #1865 untouched)
- **Gate** the round-trip on uhttpd v6 listener readiness (`[::]:8081` **and** `[::]:8443`) so a not-yet-bound socket is a labelled precondition wait, not an opaque round-trip timeout (with a diagnostic dump on miss).
- **Headroom:** round-trip timeout 120s → 180s so a degraded-network window doesn't redden a sound delivery path.
- **render_spec pin:** co-lock the paused whole-MAC v6 `redirect` (80+443) **with** the never-drop guard in one `it` (they live in different chains — block_nat prerouting vs wifihaven_block forward — and were pinned in *separate* `it` blocks, so an edit could half-unfix them). Proven to catch a `::1`-DNAT regression (red) and green on current render; the render companion to this e2e.

### How #1865 stays fixed
No change to render.lua or `setup-uhttpd-block-page.sh`. The `[::]` listener bind and the v6 `redirect` delivery are unchanged and re-validated on real hardware (200 over the router GUA). The new render pin actively *locks* the `redirect`-not-`::1` shape together with the never-drop guard.

## Testing
- `busted test/render_spec.lua` → 203 successes / 0 failures (new pin included); pin shown red when v6 path regresses to `::1` DNAT, green after revert.
- New pin's asserted strings validated against **real Lua 5.1** render output on openwrt.lan.
- `python3 -m py_compile` on the e2e clean.
- Full Gate-2 KVM e2e runs on the self-hosted plex runner (Master Router CD) — watching `test_whole_mac_block_serves_block_page_over_v6`.

Fixes #1943
Relates to #1868 (#1865 v6 redirect), #1933 (#1929), #1935

🤖 Generated with [Claude Code](https://claude.com/claude-code)