### PR TITLE
fix(#1949): keep lua-openssl for quic.lua alongside luaossl (sni-tail openssl.cipher nil)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/quic.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/quic.lua
@@ -32,6 +32,8 @@
 --   quic.parse_initial(eth_frame, crypto)
 --     → { dst_ip, src_mac, sni } | nil, reason
 --   quic.QUIC_V1_SALT  — HKDF salt for the v1 initial_secret derivation.
+--   quic.resolve_openssl() → the lua-openssl module, resolved even when luaossl
+--     shadows the bare `openssl` module name (#1949).
 --   quic.openssl_crypto(openssl) → crypto table backed by lua-openssl, for
 --     the sidecar to wire in.
 --
@@ -561,6 +563,75 @@ function M.parse_initial(eth_frame, crypto)
     return { dst_ip = dst_ip, src_mac = src_mac, sni = sni_str }, reason
   end
   return { dst_ip = dst_ip, src_mac = src_mac, sni = sni_str }
+end
+
+-- ---------------------------------------------------------------------------
+-- resolve_openssl([env]) — return the lua-openssl (zhaozg) monolithic module
+-- (the one whose table carries `.cipher` / `.hmac` directly), even when luaossl
+-- is also installed and shadows a bare require"openssl" (#1949).
+--
+-- Both feed packages claim the `openssl` module name:
+--   * lua-openssl (zhaozg) ships /usr/lib/lua/openssl.so   — found on cpath (C)
+--   * luaossl              ships /usr/lib/lua/openssl.lua   — found on path (Lua)
+-- Lua's Lua-file searcher (package.path) runs BEFORE the C searcher
+-- (package.cpath), so on any router that ALSO has luaossl installed (the ws
+-- sidecar's runtime dep #1848/#1845, and the Gate-2 e2e image which installs it
+-- explicitly) a bare require"openssl" returns luaossl's top table — which has no
+-- `.cipher`/`.hmac` field — and openssl_crypto below crashed sni-tail in a procd
+-- respawn loop (the QUIC SNI attribution path went dark). A default, ws-off
+-- router has only lua-openssl, so the fast path below returns it unchanged.
+--
+-- We do NOT touch DNS or remove luaossl: luaossl is required for the ws
+-- sidecar's TLS (require"openssl.ssl.context") and its submodules
+-- (require"openssl.cipher" etc.) resolve independently of which module the bare
+-- name `openssl` binds to, so they are unaffected. We simply force-load
+-- lua-openssl's openssl.so by path when the bare require is shadowed.
+--
+-- `env` is an injection seam for unit tests (require/loadlib/cpath/exists);
+-- production calls resolve_openssl() with no args.
+-- ---------------------------------------------------------------------------
+function M.resolve_openssl(env)
+  env = env or {}
+  local req     = env.require or require
+  local loadlib = env.loadlib or package.loadlib
+  local cpath   = env.cpath or package.cpath
+  local exists  = env.exists or function(p)
+    local fh = io.open(p, "rb")
+    if fh then fh:close(); return true end
+    return false
+  end
+
+  -- lua-openssl exposes the AES + HMAC primitives openssl_crypto needs as
+  -- fields on one table; luaossl's top module exposes neither.
+  local function is_lua_openssl(m)
+    return type(m) == "table" and m.cipher ~= nil and m.hmac ~= nil
+  end
+
+  -- Fast path: nothing shadows it (default ws-off router has only lua-openssl).
+  local ok, mod = pcall(req, "openssl")
+  if ok and is_lua_openssl(mod) then
+    return mod
+  end
+
+  -- Shadowed (luaossl won the bare name) or require failed: force-load
+  -- lua-openssl's monolithic C module directly off package.cpath.
+  for tmpl in cpath:gmatch("[^;]+") do
+    local file = tmpl:gsub("%?", "openssl")
+    if exists(file) then
+      local loader = loadlib(file, "luaopen_openssl")
+      if loader then
+        local okc, m = pcall(loader)
+        if okc and is_lua_openssl(m) then
+          return m
+        end
+      end
+    end
+  end
+
+  error("wifihaven(#1949): lua-openssl (monolithic require\"openssl\" exposing " ..
+    ".cipher/.hmac) not resolvable — luaossl shadows the 'openssl' module name " ..
+    "and no lua-openssl openssl.so was found on package.cpath. sni-tail needs " ..
+    "lua-openssl for QUIC Initial decryption.")
 end
 
 -- ---------------------------------------------------------------------------

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -35,10 +35,15 @@
 -- quic.parse_initial. Dispatch is on the IPv4 protocol byte.
 
 local uci     = require("uci")
-local openssl = require("openssl")
 local sni     = require("wifihaven.sni")
 local reasm   = require("wifihaven.sni_reassembly")
 local quic    = require("wifihaven.quic")
+-- #1949: resolve lua-openssl explicitly (NOT a bare require"openssl"). When the
+-- ws sidecar's luaossl is also installed it ships its own openssl.lua, which the
+-- Lua-file searcher finds before lua-openssl's openssl.so and returns a table
+-- with no `.cipher`/`.hmac` — crashing openssl_crypto in a procd respawn loop.
+-- resolve_openssl force-loads lua-openssl's C module past that shadow.
+local openssl = quic.resolve_openssl()
 local log     = require("wifihaven.log")
 local paths   = require("wifihaven.paths")
 local dns_log = require("wifihaven.dns_log")

--- a/openwrt/test/quic_openssl_resolve_spec.sh
+++ b/openwrt/test/quic_openssl_resolve_spec.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# #1949 on-target guard: quic.resolve_openssl() must return lua-openssl (the
+# monolithic zhaozg module whose table carries .cipher/.hmac) and cipher.get
+# for the AES-128 ciphers the QUIC Initial path needs must be CALLABLE — even
+# when luaossl is also installed and shadows the bare `openssl` module name.
+#
+# This is the end-to-end complement to the busted resolve_openssl tests in
+# quic_spec.lua (which exercise the selection logic with injected fakes,
+# deterministic in CI). Here we hit the REAL native modules: a regression that
+# drops lua-openssl from the image DEPENDS, or one where luaossl shadows it and
+# resolve_openssl fails to recover, fails this guard in seconds instead of 35
+# minutes into the Gate-2 KVM e2e (the sni-tail procd respawn loop, #1949).
+#
+# Runs only where lua-openssl is actually installed (the router, plex.lan via
+# `ssh api.lan`). SKIPs in unit CI, which installs lua-luaossl but NOT
+# lua-openssl — mirroring lua_compile_spec.sh's skip without luac5.1. The macOS
+# dev host has neither, so it skips there too.
+#
+# Detecting "lua-openssl present" must NOT rely on a bare require"openssl": that
+# is exactly what luaossl shadows (#1949), so under the shadow it would yield
+# luaossl and we'd wrongly skip the one scenario this guard exists for. We
+# instead look for lua-openssl's openssl.so on package.cpath. Exit codes from
+# the probe: 0 = present and resolver OK, 1 = present but resolver BROKEN (hard
+# fail), 2 = lua-openssl absent (skip this interpreter).
+set -e
+cd "$(dirname "$0")/.."
+
+run_probe() {
+  LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;;" \
+    "$1" - <<'LUA_EOF'
+-- Is lua-openssl installed? Either a bare require already yields it (no luaossl
+-- shadow) OR its openssl.so sits on package.cpath (shadowed-but-present).
+local function lua_openssl_installed()
+  local ok, o = pcall(require, "openssl")
+  if ok and type(o) == "table" and o.cipher and o.hmac then return true end
+  for tmpl in package.cpath:gmatch("[^;]+") do
+    local file = tmpl:gsub("%?", "openssl")
+    local fh = io.open(file, "rb")
+    if fh then
+      fh:close()
+      local loader = package.loadlib(file, "luaopen_openssl")
+      if loader then
+        local okc, m = pcall(loader)
+        if okc and type(m) == "table" and m.cipher and m.hmac then return true end
+      end
+    end
+  end
+  return false
+end
+
+if not lua_openssl_installed() then os.exit(2) end -- absent → caller skips
+
+local ok, err = pcall(function()
+  local quic = require("quic")
+  assert(type(quic.resolve_openssl) == "function",
+    "quic.resolve_openssl is missing (#1949)")
+  local o = quic.resolve_openssl()
+  assert(type(o) == "table", "resolve_openssl did not return a table")
+  assert(o.cipher and o.cipher.get, "resolved module has no .cipher.get (not lua-openssl)")
+  assert(o.hmac and o.hmac.hmac, "resolved module has no .hmac.hmac (not lua-openssl)")
+  -- The exact ciphers quic.lua:openssl_crypto looks up. cipher.get returning
+  -- nil here is precisely the #1949 crash one frame earlier.
+  assert(o.cipher.get("aes-128-gcm"), "cipher.get('aes-128-gcm') returned nil")
+  assert(o.cipher.get("aes-128-ecb"), "cipher.get('aes-128-ecb') returned nil")
+  -- Wire it through the real crypto contract sni-tail builds at startup.
+  local crypto = quic.openssl_crypto(o)
+  assert(crypto.hkdf_extract and crypto.hkdf_expand_label
+    and crypto.aes128_ecb and crypto.aes128_gcm_decrypt,
+    "openssl_crypto contract incomplete")
+end)
+if not ok then
+  io.stderr:write("FAIL quic_openssl_resolve_spec: " .. tostring(err) .. "\n")
+  os.exit(1)
+end
+io.write("ok quic_openssl_resolve_spec: resolve_openssl -> lua-openssl, "
+  .. "cipher.get('aes-128-gcm'/'aes-128-ecb') callable, openssl_crypto wired\n")
+os.exit(0)
+LUA_EOF
+}
+
+for c in lua5.1 lua luajit; do
+  command -v "$c" >/dev/null 2>&1 || continue
+  rc=0; run_probe "$c" || rc=$?
+  case "$rc" in
+    0) exit 0 ;;          # validated
+    1) exit 1 ;;          # lua-openssl present but resolver broken → hard fail
+    2) continue ;;        # lua-openssl absent on this interpreter → try next
+    *) exit "$rc" ;;
+  esac
+done
+
+printf "SKIP quic_openssl_resolve_spec: no Lua with lua-openssl installed.\n"
+printf "      (CI installs lua-luaossl only; validate on the router or\n"
+printf "       plex.lan via 'ssh api.lan' — #1949.)\n"
+exit 0

--- a/openwrt/test/quic_spec.lua
+++ b/openwrt/test/quic_spec.lua
@@ -410,3 +410,103 @@ describe("quic", function()
     end)
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- resolve_openssl — lua-openssl vs luaossl module-name collision (#1949).
+--
+-- Both feed packages claim the `openssl` Lua module name: lua-openssl (zhaozg)
+-- ships openssl.so (C, found on package.cpath) and luaossl ships openssl.lua
+-- (Lua, found on package.path). Lua's Lua-file searcher runs BEFORE the C
+-- searcher, so on any router that also has luaossl installed (the ws sidecar's
+-- dep, and the Gate-2 e2e image), a bare require"openssl" returns luaossl —
+-- whose top table has no `.cipher`/`.hmac` field — and quic.openssl_crypto
+-- crashed sni-tail in a procd respawn loop. resolve_openssl force-loads
+-- lua-openssl's openssl.so by path when that happens. Selection logic is
+-- exercised here with injected fakes (no native libs), deterministic in CI;
+-- the real-lib end-to-end assertion lives in quic_openssl_resolve_spec.sh.
+-- ---------------------------------------------------------------------------
+describe("quic.resolve_openssl (#1949 lua-openssl vs luaossl)", function()
+  -- lua-openssl (zhaozg): monolithic table carrying .cipher / .hmac directly.
+  local function lua_openssl()
+    return {
+      cipher = { get = function() return {} end },
+      hmac   = { hmac = function() end },
+    }
+  end
+  -- luaossl top module: `return require"_openssl"` → a table with neither
+  -- .cipher nor .hmac (those are separate require"openssl.cipher" submodules).
+  local function luaossl()
+    return { _VERSION = "luaossl 20220711" }
+  end
+
+  it("returns the bare require result when it is already lua-openssl (ws-off router)", function()
+    local lo = lua_openssl()
+    local scanned = false
+    local m = quic.resolve_openssl({
+      require = function(n)
+        assert.are.equal("openssl", n)
+        return lo
+      end,
+      loadlib = function() scanned = true end,
+      cpath = "/nope/?.so;;",
+      exists = function() return true end,
+    })
+    assert.are.equal(lo, m)
+    assert.is_false(scanned) -- fast path: never scanned cpath
+  end)
+
+  it("force-loads lua-openssl's openssl.so when luaossl shadows require\"openssl\"", function()
+    local lo = lua_openssl()
+    local loaded_from, loaded_fn
+    local m = quic.resolve_openssl({
+      require = function() return luaossl() end, -- shadow: no .cipher/.hmac
+      cpath = "/a/?.so;/usr/lib/lua/?.so;;",
+      exists = function(p) return p == "/usr/lib/lua/openssl.so" end,
+      loadlib = function(file, fn)
+        loaded_from, loaded_fn = file, fn
+        return function() return lo end
+      end,
+    })
+    assert.are.equal(lo, m)
+    assert.are.equal("/usr/lib/lua/openssl.so", loaded_from)
+    assert.are.equal("luaopen_openssl", loaded_fn)
+  end)
+
+  it("skips a cpath entry whose loaded module is not lua-openssl-shaped", function()
+    local lo = lua_openssl()
+    local m = quic.resolve_openssl({
+      require = function() return luaossl() end,
+      cpath = "/x/?.so;/y/?.so;;",
+      exists = function() return true end,
+      loadlib = function(file)
+        if file == "/x/openssl.so" then
+          return function() return luaossl() end -- wrong shape; must be skipped
+        end
+        return function() return lo end
+      end,
+    })
+    assert.are.equal(lo, m)
+  end)
+
+  it("tolerates a require\"openssl\" that errors (treats it as shadowed/absent)", function()
+    local lo = lua_openssl()
+    local m = quic.resolve_openssl({
+      require = function() error("module 'openssl' not found") end,
+      cpath = "/usr/lib/lua/?.so;;",
+      exists = function(p) return p == "/usr/lib/lua/openssl.so" end,
+      loadlib = function() return function() return lo end end,
+    })
+    assert.are.equal(lo, m)
+  end)
+
+  it("errors loudly when no lua-openssl is resolvable on cpath", function()
+    assert.has_error(function()
+      quic.resolve_openssl({
+        require = function() return luaossl() end,
+        cpath = "/x/?.so;;",
+        exists = function() return false end,
+        loadlib = function() return nil end,
+      })
+    end)
+  end)
+end)


### PR DESCRIPTION
## P0 — the last Gate-2 blocker before the openwrt release ships past v0.3.13

### Root cause
After #1944 (egress) and #1948 (v6 flake) merged, Gate-2 surfaced a **new** crash:

```
daemon.err wifihaven-sni-tail: /usr/bin/lua: /usr/lib/lua/wifihaven/quic.lua:602: attempt to index field 'cipher' (a nil value)
procd: Instance wifihaven::sni-tail is in a crash loop, 6 crashes
```

`quic.lua:602` is `openssl.cipher.get("aes-128-ecb")` — the **lua-openssl** (zhaozg) monolithic API, where `openssl.cipher` is a field on one table.

**#1946** added **luaossl** to the Gate-2 router image for the ws sidecar (#1848/#1845). luaossl and lua-openssl both claim the `openssl` Lua **module name**:
- lua-openssl ships `/usr/lib/lua/openssl.so` (C → `package.cpath`)
- luaossl ships `/usr/lib/lua/openssl.lua` (Lua → `package.path`), a 25-byte `return require"_openssl"`

Lua's **Lua-file searcher runs before the C searcher**, so a bare `require"openssl"` now resolves to luaossl's top table — which has **no `.cipher`/`.hmac` field** → `openssl.cipher` is nil → sni-tail crash-loops on the first QUIC packet → SNI attribution dies (`test_sni_only_hostname_attribution`), and `test_eb_direct_requery_blocked` fails as collateral of the degraded agent.

This is the **second** time a bare `require"openssl"` killed sni-tail (first was #1717: lua-openssl missing from `.ipk` DEPENDS).

### Fix — Option 1 (keep both libs, resolve past the shadow)
`quic.resolve_openssl()` returns the lua-openssl module even when luaossl shadows the bare name: fast-path `require"openssl"` when unshadowed (default ws-off router), else force-load lua-openssl's `openssl.so` directly off `package.cpath`. sni-tail calls it instead of `require("openssl")`.

luaossl is left **fully intact** — its submodules (`require"openssl.cipher"/.rand/.ssl.context`, used by the ws sidecar's TLS) resolve independently of the bare `openssl` name, and the ws sidecar runs in a separate process anyway (it selects `ws_crypto.luaossl()`, never the monolithic backend).

**Why not Option 2 (port quic to luaossl):** luaossl is deliberately *not* a base DEPENDS — `openwrt/Makefile` keeps default (ws-off) installs lean and the operator installs luaossl out-of-band only when enabling ws. Porting quic to `require"openssl.cipher"` would crash sni-tail on every default prod router, which has only lua-openssl. quic stays on lua-openssl (always in DEPENDS, guarded by `build_depends_sync_spec` since #1717).

### Prod-image parity
The fix is in the **wifihaven package** (`quic.lua` + `wifihaven-sni-tail`), shipped identically to the Gate-2 image and to prod routers — **no `build-router-image.sh` change**. That is strictly better than an image-only change, which would fix the e2e VM but miss prod routers that install luaossl when an operator opts into ws.

### Guards (mirror the #1930 luac compile-guard: fail in seconds in unit CI, not 35 min into Gate 2)
- `quic_spec.lua`: busted `resolve_openssl` selection tests with injected fakes — deterministic in CI (CI installs `lua-luaossl`, the shadowing lib).
- `quic_openssl_resolve_spec.sh`: on-target end-to-end guard. Detects lua-openssl via `openssl.so` on cpath (**not** a bare require, which the shadow defeats — so it doesn't wrongly skip the exact scenario it guards), asserts `cipher.get("aes-128-gcm"/"aes-128-ecb")` is callable through `openssl_crypto`. Skips where lua-openssl is absent (unit CI, macOS); runs on the router / plex.lan.

### On-target validation (real Lua 5.1.5 on `openwrt.lan`, luaossl installed to reproduce the shadow)
- **Reproduced**: bare `require"openssl".cipher == nil` once luaossl present.
- **Fixed**: `resolve_openssl()` recovers lua-openssl; `cipher.get(gcm/ecb)` OK; `openssl_crypto` wired; **AES-128-ECB (FIPS-197) + HMAC-SHA256 (RFC 4231) known-answer vectors match**.
- **ws intact**: `openssl.cipher` / `openssl.rand` / `openssl.ssl.context` all still load.
- Test router restored to baseline (luaossl/cqueues removed) after validation.
- Full `openwrt/test/run_tests.sh` green locally.

Fixes #1949. Relates to #1946 / #1939 and #1848 / #1845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)