### PR TITLE
fix(#1951): ws-parity e2e tolerates #1849 policy push (match acks to sent frames)

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -364,10 +364,14 @@ WS_REPLIES=$(printf '%s' "$PARITY" \
 WS_PARITY=$(printf '%s\n%s' "$PARITY" "$WS_REPLIES" | _py "
 import json, sys
 sent = json.loads(sys.stdin.readline()).get('ws_frames', [])
-replies = json.loads(sys.stdin.readline())
+raw = sys.stdin.readline()
+if not raw.strip():
+    print('bad: ws_send produced no output (helper crashed before any reply)'); sys.exit()
+replies = json.loads(raw)
 if not isinstance(replies, list):
     print('bad: ws_send error: ' + json.dumps(replies)); sys.exit()
 # Server→client pushes are expected #1849 traffic — partition them from the acks.
+# NB: the push-op set here must mirror ws_send.py's _PUSH_OPS (only 'policy' today).
 pushes = [r for r in replies if isinstance(r, dict) and r.get('op') == 'policy']
 acks   = [r for r in replies if isinstance(r, dict) and r.get('op') == 'ack']
 def acked_ok(op, seq):

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -348,22 +348,45 @@ for kind in events usage metrics; do
 done
 pass "REST usage/events/metrics accepted (200)"
 
-# ws leg — send all three frames over one connection; every reply must be ack ok.
+# ws leg — send all three frames over one connection; each SENT frame must get
+# a matching `ack ok` (matched by op+seq). The server ALSO pushes unsolicited
+# `{op:policy}` frames (#1849 first-policy-on-connect / push-on-change), and an
+# earlier policy mutation in this script makes one land among the replies; those
+# are expected push-on-change traffic, NOT a parity violation, so we partition
+# them out before the ack check rather than asserting "every reply is an ack"
+# (the pre-#1849 assumption that broke in #1951).
 # `|| true` so a ws_send.py failure doesn't abort under `set -e` before we can
 # surface it: on error the helper prints `{"error":…}` to stdout, which the
-# ACKS_OK parse below reports verbatim in the fail message.
+# WS_PARITY parse below reports verbatim in the fail message.
 WS_REPLIES=$(printf '%s' "$PARITY" \
   | _py "import json,sys; print(json.dumps(json.load(sys.stdin)['ws_frames']))" \
   | python3 "$WS_SEND" --url "$WS_URL" --token "$RTOK" || true)
-ACKS_OK=$(printf '%s' "$WS_REPLIES" | _py "
+WS_PARITY=$(printf '%s\n%s' "$PARITY" "$WS_REPLIES" | _py "
 import json, sys
-replies = json.load(sys.stdin)
-ok = (isinstance(replies, list) and len(replies) == 3
-      and all(r.get('op') == 'ack' and (r.get('payload') or {}).get('status') == 'ok' for r in replies))
-print('ok' if ok else 'bad: ' + json.dumps(replies))
+sent = json.loads(sys.stdin.readline()).get('ws_frames', [])
+replies = json.loads(sys.stdin.readline())
+if not isinstance(replies, list):
+    print('bad: ws_send error: ' + json.dumps(replies)); sys.exit()
+# Server→client pushes are expected #1849 traffic — partition them from the acks.
+pushes = [r for r in replies if isinstance(r, dict) and r.get('op') == 'policy']
+acks   = [r for r in replies if isinstance(r, dict) and r.get('op') == 'ack']
+def acked_ok(op, seq):
+    return any((a.get('payload') or {}).get('op') == op
+               and (a.get('payload') or {}).get('seq') == seq
+               and (a.get('payload') or {}).get('status') == 'ok'
+               for a in acks)
+missing = ['%s#%s' % (f['op'], f['seq']) for f in sent if not acked_ok(f['op'], f['seq'])]
+if missing:
+    print('bad: unacked ' + ','.join(missing) + ' in ' + json.dumps(replies))
+else:
+    # ok[:push-count] — surface whether the #1849 push was observed (coverage,
+    # not a gate: its arrival races frame dispatch so it may land after the acks).
+    print('ok:%d' % len(pushes))
 ")
-[ "$ACKS_OK" = ok ] || fail "ws frames not all acked ok: $ACKS_OK"
-pass "ws usage/events/metrics frames each acked ok"
+case "$WS_PARITY" in
+  ok:*) pass "ws usage/events/metrics frames each acked ok (op+seq); #1849 policy pushes observed: ${WS_PARITY#ok:}, ignored" ;;
+  *)    fail "ws frames not all acked ok: $WS_PARITY" ;;
+esac
 
 # (c) Deep parity — the connection events land identically whether posted over
 # REST or ws. Read both MACs via the public /api/logs and compare the

--- a/scripts/e2e/lib/test_ws_send.py
+++ b/scripts/e2e/lib/test_ws_send.py
@@ -1,0 +1,215 @@
+"""Unit cover for the #1846 ws e2e client's tolerance of #1849 push frames (#1951).
+
+`ws_send.py` drives the API's `/api/router/ws` endpoint for the e2e parity check:
+it sends N `{op,payload,seq}` frames and collects the server's `ack` replies. After
+#1849 the server PUSHES an unsolicited `{op:"policy",...}` frame on connect (and on
+snapshot change). The old client read exactly one reply per sent frame, so an
+interleaved push displaced the 1:1 mapping and dropped the last frame's ack — the
+symptom in #1951.
+
+This pins the fixed behavior: regardless of WHERE the server interleaves the
+push, `send_frames` keeps reading until every sent frame has an `ack`, and surfaces
+the push frame(s) in the returned list so the caller can ignore (and optionally
+assert on) them.
+
+Run standalone:
+
+    python3 -m pytest scripts/e2e/lib/test_ws_send.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import socket
+import struct
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from ws_send import send_frames  # noqa: E402
+
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_OPCODE_TEXT = 0x1
+_OPCODE_CLOSE = 0x8
+
+
+def _accept_key(client_key: str) -> str:
+    digest = hashlib.sha1((client_key + _WS_GUID).encode("ascii")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _server_send_text(conn: socket.socket, text: str) -> None:
+    # Server→client frames are NOT masked (RFC 6455 §5.1).
+    payload = text.encode("utf-8")
+    n = len(payload)
+    header = bytearray([0x80 | _OPCODE_TEXT])
+    if n < 126:
+        header.append(n)
+    elif n < 65536:
+        header.append(126)
+        header += struct.pack(">H", n)
+    else:
+        header.append(127)
+        header += struct.pack(">Q", n)
+    conn.sendall(bytes(header) + payload)
+
+
+def _server_recv_frame(conn: socket.socket, buf: bytearray) -> tuple[int, str]:
+    def need(total: int) -> None:
+        while len(buf) < total:
+            chunk = conn.recv(4096)
+            if not chunk:
+                raise RuntimeError("client closed mid-frame")
+            buf.extend(chunk)
+
+    need(2)
+    opcode = buf[0] & 0x0F
+    b1 = buf[1]
+    masked = b1 & 0x80
+    length = b1 & 0x7F
+    idx = 2
+    if length == 126:
+        need(4)
+        length = struct.unpack(">H", bytes(buf[2:4]))[0]
+        idx = 4
+    elif length == 127:
+        need(10)
+        length = struct.unpack(">Q", bytes(buf[2:10]))[0]
+        idx = 10
+    mask = b""
+    if masked:
+        need(idx + 4)
+        mask = bytes(buf[idx:idx + 4])
+        idx += 4
+    need(idx + length)
+    data = bytearray(buf[idx:idx + length])
+    if masked:
+        data = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+    del buf[:idx + length]
+    text = "" if opcode == _OPCODE_CLOSE else bytes(data).decode("utf-8")
+    return opcode, text
+
+
+def _handshake(conn: socket.socket) -> bytearray:
+    buf = bytearray()
+    while b"\r\n\r\n" not in buf:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise RuntimeError("client closed during handshake")
+        buf += chunk
+    head, _, rest = bytes(buf).partition(b"\r\n\r\n")
+    key = ""
+    for line in head.split(b"\r\n"):
+        if line.lower().startswith(b"sec-websocket-key:"):
+            key = line.split(b":", 1)[1].strip().decode("ascii")
+    resp = (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Accept: {_accept_key(key)}\r\n\r\n"
+    )
+    conn.sendall(resp.encode("ascii"))
+    return bytearray(rest)
+
+
+@contextmanager
+def fake_ws_server(push_position: int):
+    """A one-shot ws server that acks every frame and injects one `policy` push.
+
+    `push_position` controls when the unsolicited push is sent relative to the
+    acks: 0 → before any ack (the #1951 reproduction), N → after the Nth ack,
+    so the test exercises the push landing first, in the middle, and last.
+    """
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+
+    def serve() -> None:
+        conn, _ = srv.accept()
+        with conn:
+            buf = _handshake(conn)
+            policy = json.dumps({"op": "policy", "payload": {"profiles": {}, "devices": []}})
+            if push_position == 0:
+                _server_send_text(conn, policy)
+            acked = 0
+            while True:
+                try:
+                    opcode, text = _server_recv_frame(conn, buf)
+                except RuntimeError:
+                    break
+                if opcode == _OPCODE_CLOSE:
+                    break
+                frame = json.loads(text)
+                _server_send_text(
+                    conn,
+                    json.dumps(
+                        {
+                            "op": "ack",
+                            "payload": {"op": frame["op"], "seq": frame["seq"], "status": "ok"},
+                        }
+                    ),
+                )
+                acked += 1
+                if acked == push_position:
+                    _server_send_text(conn, policy)
+
+    t = threading.Thread(target=serve, daemon=True)
+    t.start()
+    try:
+        yield f"ws://127.0.0.1:{port}/api/router/ws"
+    finally:
+        srv.close()
+
+
+_FRAMES = [
+    {"op": "events", "seq": 1, "payload": {}},
+    {"op": "usage", "seq": 2, "payload": {}},
+    {"op": "metrics", "seq": 3, "payload": {}},
+]
+
+
+def _acks_by_seq(replies: list[dict]) -> dict[int, dict]:
+    out = {}
+    for r in replies:
+        if r.get("op") == "ack":
+            out[(r.get("payload") or {}).get("seq")] = r["payload"]
+    return out
+
+
+def _run_with_push_at(position: int) -> list[dict]:
+    with fake_ws_server(push_position=position) as url:
+        return send_frames(url, token="t", frames=_FRAMES, timeout=10.0)
+
+
+def test_every_sent_frame_is_acked_regardless_of_push_position() -> None:
+    # The push landing first (0 == the #1951 repro), middle, or last must never
+    # drop an ack: all three seqs are present and ok in every interleaving.
+    for position in (0, 1, 2, 3):
+        replies = _run_with_push_at(position)
+        acks = _acks_by_seq(replies)
+        assert set(acks) == {1, 2, 3}, f"missing acks at push_position={position}: {acks}"
+        assert all(a["status"] == "ok" for a in acks.values())
+
+
+def test_policy_push_is_surfaced_not_swallowed() -> None:
+    # The push frame is returned to the caller (so the e2e script can ignore it
+    # for the ack check and optionally assert it WAS observed).
+    replies = _run_with_push_at(0)
+    pushes = [r for r in replies if r.get("op") == "policy"]
+    assert len(pushes) == 1, f"expected exactly one policy push, got {pushes}"
+
+
+def test_no_extra_acks_beyond_sent_frames() -> None:
+    # Tolerating pushes must not weaken parity: exactly one ack per sent frame.
+    replies = _run_with_push_at(0)
+    acks = [r for r in replies if r.get("op") == "ack"]
+    assert len(acks) == len(_FRAMES)
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/scripts/e2e/lib/ws_send.py
+++ b/scripts/e2e/lib/ws_send.py
@@ -41,7 +41,8 @@ _OPCODE_PONG = 0xA
 # snapshot change, so it can arrive interleaved with the acks for our frames.
 # These are collected and returned to the caller, but they do NOT count toward
 # the one-reply-per-sent-frame accounting below (the #1951 fix). Extend this set
-# if the transport gains further server→client push ops.
+# if the transport gains further server→client push ops — and mirror it in the
+# matching push-op filter in scripts/e2e-router.sh's ws-parity check.
 _PUSH_OPS = frozenset({"policy"})
 
 

--- a/scripts/e2e/lib/ws_send.py
+++ b/scripts/e2e/lib/ws_send.py
@@ -36,6 +36,14 @@ _OPCODE_CLOSE = 0x8
 _OPCODE_PING = 0x9
 _OPCODE_PONG = 0xA
 
+# Ops the server sends UNSOLICITED — not a reply to any frame we sent. #1849
+# pushes `{op:"policy"}` on connect (first-policy-on-connect) and on every
+# snapshot change, so it can arrive interleaved with the acks for our frames.
+# These are collected and returned to the caller, but they do NOT count toward
+# the one-reply-per-sent-frame accounting below (the #1951 fix). Extend this set
+# if the transport gains further server→client push ops.
+_PUSH_OPS = frozenset({"policy"})
+
 
 class UpgradeRejected(Exception):
     def __init__(self, status: int, detail: str = ""):
@@ -160,23 +168,41 @@ def _close(sock: socket.socket) -> None:
 
 
 def send_frames(url: str, token: str | None, frames: list[dict], timeout: float) -> list[dict]:
+    """Send every frame, then read replies until each sent frame has a reply.
+
+    Returns the server's TEXT frames in receive order — the solicited reply
+    (`ack`/`pong`) for each sent frame PLUS any unsolicited server pushes
+    (`_PUSH_OPS`, e.g. #1849's `{op:policy}`) that landed in between. The caller
+    matches replies to its sent frames (by op+seq) and ignores the pushes; the
+    pushes do NOT gate completion, so an interleaved push can no longer displace
+    a frame's reply or leave the last ack unread (#1951).
+    """
     sock, buf = _open(url, token, timeout)
     sock.settimeout(timeout)
+    # Send all frames up front, then drain replies. Reading is decoupled from
+    # sending so a push that arrives before/among the acks is simply collected
+    # rather than mistaken for a specific frame's reply.
     replies: list[dict] = []
+    solicited_expected = len(frames)
+    solicited_seen = 0
     try:
         for frame in frames:
             _send_text(sock, json.dumps(frame))
-            # Read the next data (text) frame, answering any control frames.
-            while True:
-                opcode, data = _recv_frame(sock, buf)
-                if opcode == _OPCODE_TEXT:
-                    replies.append(json.loads(data.decode("utf-8")))
-                    break
-                if opcode == _OPCODE_PING:
-                    continue  # benign; server-initiated control ping
-                if opcode == _OPCODE_CLOSE:
-                    raise RuntimeError("server closed the socket before replying")
-                # ignore pong / continuation
+        while solicited_seen < solicited_expected:
+            opcode, data = _recv_frame(sock, buf)
+            if opcode == _OPCODE_TEXT:
+                msg = json.loads(data.decode("utf-8"))
+                replies.append(msg)
+                op = msg.get("op") if isinstance(msg, dict) else None
+                if op not in _PUSH_OPS:
+                    # A reply to one of our frames (ack / pong) — counts toward done.
+                    solicited_seen += 1
+                continue
+            if opcode == _OPCODE_PING:
+                continue  # benign; server-initiated control ping
+            if opcode == _OPCODE_CLOSE:
+                raise RuntimeError("server closed the socket before replying")
+            # ignore pong / continuation control frames
     finally:
         _close(sock)
     return replies


### PR DESCRIPTION
## Problem

Master **API/UI CD** has been red since the #1849 merge wave. The `Live e2e against staging stack` job runs `scripts/e2e-router.sh`, which passes its main checks and then fails the **#1846 ws demux-parity** section:

```
✗ ws frames not all acked ok: bad:
    [{"op":"policy","payload":{…snapshot…}},
     {"op":"ack","payload":{"op":"events","seq":1,"status":"ok"}},
     {"op":"ack","payload":{"op":"usage","seq":2,"status":"ok"}}]
```

## Root cause — test assumption broken by #1849, NOT a product bug

The #1846 parity check sent `events`/`usage`/`metrics` frames over one ws connection and asserted **every reply is an `ack ok`**. After #1849 the server pushes an unsolicited `{op:"policy"}` frame on connect (first-policy-on-connect, `RouterWsRoutes` `HandshakeComplete`) and on every snapshot change. An earlier policy mutation in the script makes a `policy` push land among the replies, so the check saw a non-`ack` and failed.

Worse, `ws_send.py` read **exactly one reply per sent frame**, so the interleaved push displaced the 1:1 mapping and the **third frame's ack was never read** — that's why the failing array shows only 2 acks.

The transport is correct: 3 acks + 1 server-initiated `policy` push. The assertion just predates #1849.

## Fix (test/harness only — match acks to sent frames)

- **`scripts/e2e/lib/ws_send.py`** — send all frames, then read until every **sent** frame has a *solicited* reply (`ack`/`pong`), collecting interleaved server pushes (`_PUSH_OPS = {"policy"}`) without counting them toward completion. The push can no longer displace a frame's reply or leave the last ack unread.
- **`scripts/e2e-router.sh`** — assert each **sent** frame got a matching `ack ok` (matched by `op`+`seq`) and **partition out** `op==policy` pushes before the check, instead of "every reply is an ack". Genuine parity is preserved: a missing or `reject` ack still fails. The policy push is surfaced as coverage (`ok:<count>`), **not** a gate — its arrival races frame dispatch, so it may land after the acks and the check must not depend on its timing.

**ws transport / server behavior is unchanged** — #1849's policy push is correct.

## Tests

New `scripts/e2e/lib/test_ws_send.py` drives `send_frames` against a minimal stdlib ws server that injects a `policy` push **before / between / after** the acks. It pins:
- every sent frame is acked regardless of where the push lands (the previously-dropped-ack case),
- the push is surfaced (not swallowed),
- no extra acks beyond the sent frames (parity not weakened).

Red→green committed separately. Verified the `e2e-router.sh` ack-matching branch across: push-first (the repro), no-push, missing ack, rejected ack, and ws_send error — only genuine breaks fail.

Fixes #1951. Relates to #1849 (push-on-change), #1846 / #1023 (ws transport), #1939 (ws push→apply e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)