### PR TITLE
fix(#1954): snapshot cache returns fresh on read-after-write (all mutation paths invalidate)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -155,8 +155,9 @@ class PolicyServiceLive(
   // single-household model there is exactly one global snapshot, so one slot suffices (design §6.2
   // ticker note). Populated on first build, refreshed by `reevaluate`.
   //
-  // #1954: each entry is STAMPED with the `mutationVersion` observed at the START of its build
-  // (`builtAtVersion`, below). A reader trusts a cached entry only when its stamp is still the
+  // #1954: each entry is STAMPED with the `mutationVersion` observed at the START of its build (the
+  // leading `Long` of the tuple — the `gen` captured in `buildVersioned`/`reevaluate`). A reader
+  // trusts a cached entry only when its stamp is still the
   // current version; a stamp older than the current version means a mutation landed since the build
   // began, so the entry may predate that mutation and is treated as a miss (rebuild). This is what
   // closes the stale-read race that the old "clear-on-invalidate" alone could not: a `buildSnapshot`

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -11,7 +11,7 @@ import zio.json.*
 
 import java.security.MessageDigest
 import java.time.{DayOfWeek, Instant, LocalDate}
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 
 trait PolicyService {
 
@@ -143,15 +143,37 @@ class PolicyServiceLive(
     // active; when false (test default) every `snapshot` rebuilds and `invalidate`/`reevaluate` are
     // no-ops. See the trait docs.
     cacheEnabled: Boolean = false,
+    // #1954: test-only barrier run at the END of every `buildSnapshot` (after the DB read, before the
+    // result is returned to the caller that installs it in the cache). Defaults to a no-op for
+    // production and the ~40 existing specs; PolicySnapshotCacheSpec wires a gate here to suspend an
+    // in-flight build deterministically and prove a stale build cannot clobber a fresher cache entry.
+    buildBarrier: UIO[Unit] = ZIO.unit,
 ) extends PolicyService {
 
-  // #1849: the single cached `(etag, snapshot)`. Process-local `AtomicReference` (matching the
-  // existing `lastSnapshotEtag` style in this class) so the `apply` factory stays a pure
-  // constructor. For the single-household model there is exactly one global snapshot, so one slot
-  // suffices (design §6.2 ticker note). Populated on first build, refreshed by `reevaluate`, cleared
-  // by `invalidate`.
-  private val snapshotCache: AtomicReference[Option[(ETag, PolicySnapshot)]] =
-    new AtomicReference(Option.empty[(ETag, PolicySnapshot)])
+  // #1849: the single cached snapshot. Process-local `AtomicReference` (matching the existing
+  // `lastSnapshotEtag` style in this class) so the `apply` factory stays a pure constructor. For the
+  // single-household model there is exactly one global snapshot, so one slot suffices (design §6.2
+  // ticker note). Populated on first build, refreshed by `reevaluate`.
+  //
+  // #1954: each entry is STAMPED with the `mutationVersion` observed at the START of its build
+  // (`builtAtVersion`, below). A reader trusts a cached entry only when its stamp is still the
+  // current version; a stamp older than the current version means a mutation landed since the build
+  // began, so the entry may predate that mutation and is treated as a miss (rebuild). This is what
+  // closes the stale-read race that the old "clear-on-invalidate" alone could not: a `buildSnapshot`
+  // that began reading the DB BEFORE a mutation could complete AFTER `invalidate` cleared the slot
+  // and repopulate it with pre-mutation bytes, so the very next read got a cache HIT on stale data
+  // (Gate-1: a just-created profile missing from `/api/router/policy`). With the version stamp, that
+  // late write lands tagged with the old version and every reader rejects it — the next read rebuilds
+  // synchronously and serves fresh bytes. See #1954.
+  private val snapshotCache: AtomicReference[Option[(Long, ETag, PolicySnapshot)]] =
+    new AtomicReference(Option.empty[(Long, ETag, PolicySnapshot)])
+
+  // #1954: monotonic counter bumped once per policy mutation (every `invalidate`). A build stamps the
+  // value it reads here BEFORE it touches the DB; a reader compares a cached stamp against the
+  // current value. Because the bump happens-after the mutation's DB commit (routes call `invalidate`
+  // after the write), any cached entry whose stamp equals the current version is guaranteed to
+  // reflect every committed mutation.
+  private val mutationVersion: AtomicLong = new AtomicLong(0L)
 
   // #1849: the push sink, installed at startup via `setPublisher`. Defaults to noop so a snapshot
   // rebuilt before the registry exists (or in a test) is simply not pushed.
@@ -200,47 +222,75 @@ class PolicyServiceLive(
       )
 
   // #1849: cache-aware entry point. On a hit, return the cached snapshot and meter `cache_hit` — no
-  // rebuild, which is the #1512 win for both ws and (un-migrated) REST poll agents. On a cold or
-  // invalidated cache, rebuild once, store, and serve it. With the cache disabled, always rebuild.
+  // rebuild, which is the #1512 win for both ws and (un-migrated) REST poll agents. On a cold,
+  // invalidated, or STALE-stamped cache, rebuild once, store, and serve it. With the cache disabled,
+  // always rebuild.
+  //
+  // #1954: a cached entry is a hit only when its stamp is still the current `mutationVersion` — an
+  // older stamp means a mutation landed after the build began, so the entry may be stale and we
+  // rebuild. `buildVersioned` captures the version BEFORE reading the DB and stores the entry under
+  // that stamp, so a build racing a concurrent mutation can never install bytes the next reader will
+  // trust as current.
   def snapshot: Task[PolicySnapshot] =
     if (!cacheEnabled) buildSnapshot
     else
       ZIO.succeed(snapshotCache.get).flatMap {
-        case Some((_, snap)) => AppMetrics.recordSnapshotBuild("cache_hit").as(snap)
-        case None            =>
-          buildSnapshot.tap(snap => ZIO.succeed(snapshotCache.set(Some((snap.etag, snap)))))
+        case Some((_, _, snap)) => // BUG(red): trusts any present entry, ignoring its version stamp
+          AppMetrics.recordSnapshotBuild("cache_hit").as(snap)
+        case _                  => buildVersioned
       }
 
   def invalidate: UIO[Unit] =
     if (!cacheEnabled) ZIO.unit
     else
-      // Clear so the next REST poll rebuilds immediately (fresh bytes), and reconcile in the
-      // background so any connected ws router is pushed the change without blocking the mutating
-      // request on a ~500ms rebuild. Clearing is safe w.r.t. the push: `reevaluate` keys its push
-      // decision off `lastPublishedEtag`, NOT off the (now-cleared, possibly poll-repopulated) cache
-      // slot — so the push still fires exactly once even if a REST poll races in. The reconcile
-      // ticker is a backstop on the same bound.
-      ZIO.succeed(snapshotCache.set(None)) *> reevaluate.forkDaemon.unit
+      // Bump the version so every cache entry built before this mutation is now stale-stamped and the
+      // next REST poll rebuilds immediately (fresh bytes), then reconcile in the background so any
+      // connected ws router is pushed the change without blocking the mutating request on a ~500ms
+      // rebuild. Bumping (rather than clearing) is what makes this race-safe: an in-flight build that
+      // began before this call and completes after it lands stamped with the OLD version, so readers
+      // reject it instead of getting a cache HIT on stale bytes (#1954). The push still fires exactly
+      // once — `reevaluate` keys its push decision off `lastPublishedEtag`, not the cache slot. The
+      // reconcile ticker is a backstop on the same bound.
+      // BUG(red): clear-on-invalidate (main's behavior) — does NOT protect against an in-flight build
+      // that began before this call repopulating the slot with pre-mutation bytes afterwards.
+      ZIO.succeed(mutationVersion.incrementAndGet()) *>
+        ZIO.succeed(snapshotCache.set(None)) *> reevaluate.forkDaemon.unit
+
+  // #1954: rebuild and install under the version observed BEFORE the DB read. The install is a CAS
+  // loop that only replaces an entry whose stamp is <= ours, so a slower build (older stamp) can
+  // never overwrite a fresher one (newer stamp) — last-writer-wins is replaced by newest-version-
+  // wins. Returns the freshly built snapshot to the caller regardless (it reflects every mutation
+  // committed before our DB read began).
+  private def buildVersioned: Task[PolicySnapshot] =
+    ZIO.succeed(mutationVersion.get).flatMap { gen =>
+      buildSnapshot.tap(snap => ZIO.succeed(installSnapshot(gen, snap)))
+    }
+
+  private def installSnapshot(gen: Long, snap: PolicySnapshot): Unit =
+    // BUG(red): unconditional last-writer-wins — a stale build can clobber a fresher entry.
+    snapshotCache.set(Some((gen, snap.etag, snap)))
 
   def reevaluate: UIO[Unit] =
     if (!cacheEnabled) ZIO.unit
     else
-      buildSnapshot.foldZIO(
-        err =>
-          // Keep the last good cache on a transient build failure (e.g. a DB blip) so the REST poll
-          // keeps serving the previous snapshot rather than a cold rebuild storm; the next tick
-          // retries.
-          ZIO.logWarning(s"policy reevaluate: snapshot rebuild failed, keeping cache: $err"),
-        snap => {
-          snapshotCache.set(Some((snap.etag, snap)))
-          // Push only when the ETag actually moved since the last PUSH — the same "change is exactly
-          // an ETag move" semantics the REST 200-vs-304 path uses (design §6.2), so we never fan out
-          // a frame the routers would treat as unchanged. Keyed off `lastPublishedEtag` (not the
-          // cache slot) so a racing REST poll repopulating the cache can't suppress the push.
-          val prevPublished = lastPublishedEtag.getAndSet(Some(snap.etag))
-          ZIO.when(!prevPublished.contains(snap.etag))(publisher.get.publish(snap)).unit
-        },
-      )
+      ZIO.succeed(mutationVersion.get).flatMap { gen =>
+        buildSnapshot.foldZIO(
+          err =>
+            // Keep the last good cache on a transient build failure (e.g. a DB blip) so the REST poll
+            // keeps serving the previous snapshot rather than a cold rebuild storm; the next tick
+            // retries.
+            ZIO.logWarning(s"policy reevaluate: snapshot rebuild failed, keeping cache: $err"),
+          snap => {
+            installSnapshot(gen, snap)
+            // Push only when the ETag actually moved since the last PUSH — the same "change is exactly
+            // an ETag move" semantics the REST 200-vs-304 path uses (design §6.2), so we never fan out
+            // a frame the routers would treat as unchanged. Keyed off `lastPublishedEtag` (not the
+            // cache slot) so a racing REST poll repopulating the cache can't suppress the push.
+            val prevPublished = lastPublishedEtag.getAndSet(Some(snap.etag))
+            ZIO.when(!prevPublished.contains(snap.etag))(publisher.get.publish(snap)).unit
+          },
+        )
+      }
 
   def setPublisher(p: PolicySnapshotPublisher): UIO[Unit] =
     ZIO.succeed(publisher.set(p))
@@ -459,6 +509,8 @@ class PolicyServiceLive(
         .setGlobalPolicy(snap.global.extraAllowed.size, defaultDenyProfiles)
         .zipRight(logSnapshotChanged(snap))
         .zipRight(AppMetrics.recordSnapshotBuild("computed"))
+        // #1954: test-only suspension point (no-op in production); see `buildBarrier`.
+        .zipLeft(buildBarrier)
         .as(snap)
     }
 

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -235,9 +235,9 @@ class PolicyServiceLive(
     if (!cacheEnabled) buildSnapshot
     else
       ZIO.succeed(snapshotCache.get).flatMap {
-        case Some((_, _, snap)) => // BUG(red): trusts any present entry, ignoring its version stamp
+        case Some((builtAt, _, snap)) if builtAt == mutationVersion.get =>
           AppMetrics.recordSnapshotBuild("cache_hit").as(snap)
-        case _                  => buildVersioned
+        case _                                                          => buildVersioned
       }
 
   def invalidate: UIO[Unit] =
@@ -251,10 +251,7 @@ class PolicyServiceLive(
       // reject it instead of getting a cache HIT on stale bytes (#1954). The push still fires exactly
       // once — `reevaluate` keys its push decision off `lastPublishedEtag`, not the cache slot. The
       // reconcile ticker is a backstop on the same bound.
-      // BUG(red): clear-on-invalidate (main's behavior) — does NOT protect against an in-flight build
-      // that began before this call repopulating the slot with pre-mutation bytes afterwards.
-      ZIO.succeed(mutationVersion.incrementAndGet()) *>
-        ZIO.succeed(snapshotCache.set(None)) *> reevaluate.forkDaemon.unit
+      ZIO.succeed(mutationVersion.incrementAndGet()) *> reevaluate.forkDaemon.unit
 
   // #1954: rebuild and install under the version observed BEFORE the DB read. The install is a CAS
   // loop that only replaces an entry whose stamp is <= ours, so a slower build (older stamp) can
@@ -266,9 +263,18 @@ class PolicyServiceLive(
       buildSnapshot.tap(snap => ZIO.succeed(installSnapshot(gen, snap)))
     }
 
-  private def installSnapshot(gen: Long, snap: PolicySnapshot): Unit =
-    // BUG(red): unconditional last-writer-wins — a stale build can clobber a fresher entry.
-    snapshotCache.set(Some((gen, snap.etag, snap)))
+  private def installSnapshot(gen: Long, snap: PolicySnapshot): Unit = {
+    var swapped = false
+    while (!swapped) {
+      val cur = snapshotCache.get
+      cur match {
+        case Some((builtAt, _, _)) if builtAt > gen =>
+          swapped = true // a newer-version entry is already present — don't clobber it
+        case _                                      =>
+          swapped = snapshotCache.compareAndSet(cur, Some((gen, snap.etag, snap)))
+      }
+    }
+  }
 
   def reevaluate: UIO[Unit] =
     if (!cacheEnabled) ZIO.unit

--- a/api/test/src/feature/PolicySnapshotCacheSpec.scala
+++ b/api/test/src/feature/PolicySnapshotCacheSpec.scala
@@ -48,7 +48,7 @@ object PolicySnapshotCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
    * cross a schedule boundary), with a probe publisher attached. Returns the service, the clock
    * ref, and the probe's record.
    */
-  private def makeCachedSvc(startAt: LocalDateTime) =
+  private def makeCachedSvc(startAt: LocalDateTime, buildBarrier: UIO[Unit] = ZIO.unit) =
     for {
       pr     <- ZIO.service[ProfileRepo]
       nsr    <- ZIO.service[NamedScheduleRepo]
@@ -77,6 +77,7 @@ object PolicySnapshotCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
         clk,
         namedScheduleRepo = nsr,
         cacheEnabled = true,
+        buildBarrier = buildBarrier,
       )
       pushed <- Ref.make(List.empty[PolicySnapshot])
       _      <- svc.setPublisher(new ProbePublisher(pushed))
@@ -188,6 +189,86 @@ object PolicySnapshotCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
         assertTrue(blockedMacs(snapFresh) == List("aa:bb:cc:11:22:33")) &&
         assertTrue(pushes.size == 1) &&               // pushed once, on the transition
         assertTrue(blockedMacs(pushes.head) == List("aa:bb:cc:11:22:33"))
+    },
+    // #1954: the create-then-read invariant Gate 1 checks — a profile created + invalidated is in the
+    // VERY NEXT read. (Passes pre-#1954 too; pinned so the wiring can't silently regress.)
+    test("a newly created + invalidated profile is in the very next snapshot read") {
+      for {
+        _      <- cleanDb
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
+        (svc, _, _) = triple
+        _    <- svc.snapshot // warm the cache (no profiles yet)
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        pid  <- pr.create("e2e-router", Nil)
+        _    <- TestLayers.seedDevice(dr, "e2:e2:e2:8e:79:5b", "e2e-dev", pid)
+        _    <- svc.invalidate
+        snap <- svc.snapshot
+      } yield assertTrue(snap.profiles.contains(pid)) &&
+        assertTrue(
+          snap.devices
+            .get(MacAddress.unsafe("e2:e2:e2:8e:79:5b"))
+            .flatMap(_.profileId)
+            .contains(pid),
+        )
+    },
+    // #1954: deletion is equally read-after-write — a deleted profile/device is gone on the next read.
+    test("a deleted + invalidated profile disappears from the very next snapshot read") {
+      for {
+        _      <- cleanDb
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon)
+        (svc, _, _) = triple
+        pr      <- ZIO.service[ProfileRepo]
+        pid     <- pr.create("temp", Nil)
+        _       <- svc.invalidate
+        present <- svc.snapshot
+        _       <- pr.delete(pid)
+        _       <- svc.invalidate
+        gone    <- svc.snapshot
+      } yield assertTrue(present.profiles.contains(pid)) &&
+        assertTrue(!gone.profiles.contains(pid))
+    },
+    // #1954 REGRESSION PIN: the Gate-1 failure. A `buildSnapshot` that started reading the DB BEFORE a
+    // mutation must NOT be able to finish AFTER the mutation's `invalidate` and clobber the cache with
+    // pre-mutation bytes — which would make the next read a cache HIT on stale data (a just-created
+    // profile missing from the snapshot). We suspend an in-flight build with `buildBarrier`, land a
+    // create + invalidate + fresh rebuild while it is parked, then release it so its (stale) result
+    // tries to install LAST. The next read must still be fresh.
+    test(
+      "a stale in-flight build cannot clobber a fresher cache entry (read-after-write stays fresh)",
+    ) {
+      for {
+        _       <- cleanDb
+        pr      <- ZIO.service[ProfileRepo]
+        pidA    <- pr.create("A", Nil)
+        pidB    <- pr.create("B", Nil)
+        entered <- Promise.make[Nothing, Unit]
+        release <- Promise.make[Nothing, Unit]
+        armed   <- Ref.make(true)
+        // Gate the FIRST build only: it signals `entered` (with {A,B} already read) and parks on
+        // `release`; once disarmed, every later build passes straight through.
+        barrier     = armed.get.flatMap {
+          case true  => entered.succeed(()) *> release.await
+          case false => ZIO.unit
+        }
+        triple <- makeCachedSvc(TestClock.schoolDayAfternoon, buildBarrier = barrier)
+        (svc, _, _) = triple
+        // The stale in-flight build: reads {A,B} (C not yet created), then parks in the barrier.
+        staleFib <- svc.reevaluate.fork
+        _        <- entered.await
+        _        <- armed.set(false) // disarm so the fresh rebuild below is not gated
+        // A mutation lands while the stale build is parked: create C + invalidate (version bump) +
+        // a fresh rebuild that installs {A,B,C}.
+        pidC     <- pr.create("C", Nil)
+        _        <- svc.invalidate
+        _        <- svc.reevaluate   // fresh build installs {A,B,C} under the new version
+        // Now release the stale build so its pre-mutation {A,B} result tries to install LAST.
+        _        <- release.succeed(())
+        _        <- staleFib.join
+        snap     <- svc.snapshot
+      } yield assertTrue(snap.profiles.contains(pidA)) &&
+        assertTrue(snap.profiles.contains(pidB)) &&
+        assertTrue(snap.profiles.contains(pidC)) // the stale build did NOT clobber C away
     },
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
## What

Fixes the **#1849 computed-snapshot cache** serving a **stale** snapshot after a policy mutation. Master API/UI CD **Gate 1** (`Router API smoke against staging`) failed: after creating a profile + assigning a device, the very next `GET /api/router/policy` snapshot **omitted the just-created profile** (`profile 306 missing from snapshot.profiles: …`). Staging is `numInstances: 1`, so this is single-instance staleness, not cache coherence.

## Root cause — an in-flight build clobbers the cleared cache

Every mutation route *does* call `invalidate` (audited: profile create/update/patch/delete, device upsert/patch/delete, schedule attach/edit, household settings incl. `blockEncryptedDns`, pause/unpause, manual block/allow, time-extension — all wired). So the missing-invalidation theory was **not** the bug.

The bug is the **async-rebuild race**. #1849's `invalidate` *cleared* the cache slot (`set(None)`) and let the next read rebuild, and `reevaluate`/the read path *unconditionally stored* whatever they built. That is correct for a quiescent create-then-read, but a `buildSnapshot` that began reading the DB **before** a mutation can finish **after** `invalidate` cleared the slot and repopulate it with **pre-mutation bytes**:

1. reconcile ticker's `reevaluate` reads the DB (profile 306 not yet created) — build is slow (~500 ms)
2. `POST /api/profiles` commits 306 → `invalidate` clears the slot
3. the in-flight build from (1) finishes and **stores its stale bytes** (no 306)
4. `GET /api/router/policy` → cache **HIT** on the stale entry → 306 missing ← Gate-1 failure

A stale snapshot served to a router is also real **enforcement lag**, not just a CD red.

## Fix — version-stamp the cache (choke-point, race-safe)

- A single monotonic `mutationVersion` is bumped once per mutation. `invalidate` now **bumps** the version instead of clearing.
- Every cache entry is **stamped** with the version observed *before* its DB read (`buildVersioned` / `reevaluate`). Because the bump happens-after the mutation's commit (routes call `invalidate` after the write), a stamp equal to the current version is guaranteed to reflect every committed mutation.
- The read path serves a `cache_hit` **only** when `builtAt == mutationVersion`; otherwise it rebuilds **synchronously**. `installSnapshot` refuses to overwrite a newer-version entry (CAS).
- A late stale build therefore lands tagged with the **old** version and is rejected at **both** install and read — read-after-write is fresh again. No reliance on the reconcile ticker for correctness (it remains only for time-dependent transitions: schedule boundaries, daily-limit exhaustion).

Single-source-of-truth preserved: `reevaluate` is still the sole rebuild-and-publish point; same snapshot bytes for a given state; no second snapshot computation.

### #1849 perf win preserved
Unchanged version ⇒ `cache_hit` with no rebuild (the #1512 win); 304 semantics unchanged; push-on-change still keys off `lastPublishedEtag` so a racing REST poll can't suppress a push.

## Tests (TDD: red commit, then green)

`PolicySnapshotCacheSpec` (embedded Postgres, injected `Clock.TestClock`):
- **Regression pin** — a `buildBarrier` test seam suspends an in-flight build; a create + `invalidate` + fresh rebuild land while it's parked; the stale build is released to install **last**; the next read must still include the new profile. Faithful-red commit (main's clear-on-invalidate behavior) fails **only** this test; green passes.
- create-then-read invariant: a newly created + invalidated profile (and its assigned device) is in the **very next** read — the exact Gate-1 sequence.
- delete-then-read: a deleted + invalidated profile disappears on the next read.
- existing cache_hit / invalidate / push-on-change / schedule-boundary specs still green.

Full `mill api.test` suite green (1109 tests).

Fixes #1954. Relates to #1849 / #1934 (computed-snapshot cache), #1023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
