### PR TITLE
fix(#1958): ws_send.py reassembles fragmented ws frames (large policy push)

### DIFF
--- a/scripts/e2e/lib/test_ws_send.py
+++ b/scripts/e2e/lib/test_ws_send.py
@@ -32,8 +32,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 from ws_send import send_frames  # noqa: E402
 
 _WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_OPCODE_CONTINUATION = 0x0
 _OPCODE_TEXT = 0x1
 _OPCODE_CLOSE = 0x8
+_OPCODE_PING = 0x9
 
 
 def _accept_key(client_key: str) -> str:
@@ -55,6 +57,46 @@ def _server_send_text(conn: socket.socket, text: str) -> None:
         header.append(127)
         header += struct.pack(">Q", n)
     conn.sendall(bytes(header) + payload)
+
+
+def _server_send_frame(conn: socket.socket, fin: bool, opcode: int, payload: bytes) -> None:
+    # Server→client frames are NOT masked (RFC 6455 §5.1). `fin`/`opcode` are
+    # explicit so a caller can emit a fragmented message: a leading data frame
+    # (FIN=0, opcode TEXT/BINARY) + continuation frames (opcode 0x0), the last
+    # with FIN=1.
+    n = len(payload)
+    b0 = (0x80 if fin else 0x00) | opcode
+    header = bytearray([b0])
+    if n < 126:
+        header.append(n)
+    elif n < 65536:
+        header.append(126)
+        header += struct.pack(">H", n)
+    else:
+        header.append(127)
+        header += struct.pack(">Q", n)
+    conn.sendall(bytes(header) + payload)
+
+
+def _server_send_fragmented_text(
+    conn: socket.socket, text: str, fragment_size: int, ping_after: int = -1
+) -> None:
+    """Send `text` as a fragmented TEXT message (RFC 6455 §5.4).
+
+    The payload is split into `fragment_size`-byte chunks: the first goes out as
+    a TEXT frame with FIN=0, the rest as CONTINUATION (0x0) frames, and only the
+    final frame carries FIN=1. If `ping_after >= 0`, an unfragmented control PING
+    is interleaved right after that fragment index — a control frame may appear
+    between fragments and must NOT be treated as continuation data.
+    """
+    payload = text.encode("utf-8")
+    chunks = [payload[i:i + fragment_size] for i in range(0, len(payload), fragment_size)]
+    last = len(chunks) - 1
+    for i, chunk in enumerate(chunks):
+        opcode = _OPCODE_TEXT if i == 0 else _OPCODE_CONTINUATION
+        _server_send_frame(conn, fin=(i == last), opcode=opcode, payload=chunk)
+        if i == ping_after:
+            _server_send_frame(conn, fin=True, opcode=_OPCODE_PING, payload=b"hb")
 
 
 def _server_recv_frame(conn: socket.socket, buf: bytearray) -> tuple[int, str]:
@@ -209,6 +251,80 @@ def test_no_extra_acks_beyond_sent_frames() -> None:
     replies = _run_with_push_at(0)
     acks = [r for r in replies if r.get("op") == "ack"]
     assert len(acks) == len(_FRAMES)
+
+
+@contextmanager
+def fake_ws_server_fragmented(policy_text: str, fragment_size: int, ping_after: int):
+    """A one-shot ws server that pushes a FRAGMENTED `policy` message, then acks.
+
+    Reproduces #1958: the server (or an edge proxy) splits the large #1849 policy
+    push into a leading TEXT fragment (FIN=0) + CONTINUATION frames, optionally
+    with a control PING interleaved. The client must reassemble per RFC 6455 §5.4
+    before json-parsing — reading only the first fragment truncates the JSON.
+    """
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+
+    def serve() -> None:
+        conn, _ = srv.accept()
+        with conn:
+            buf = _handshake(conn)
+            _server_send_fragmented_text(conn, policy_text, fragment_size, ping_after)
+            while True:
+                try:
+                    opcode, text = _server_recv_frame(conn, buf)
+                except RuntimeError:
+                    break
+                if opcode == _OPCODE_CLOSE:
+                    break
+                frame = json.loads(text)
+                _server_send_text(
+                    conn,
+                    json.dumps(
+                        {
+                            "op": "ack",
+                            "payload": {"op": frame["op"], "seq": frame["seq"], "status": "ok"},
+                        }
+                    ),
+                )
+
+    t = threading.Thread(target=serve, daemon=True)
+    t.start()
+    try:
+        yield f"ws://127.0.0.1:{port}/api/router/ws"
+    finally:
+        srv.close()
+
+
+def _big_policy_text() -> str:
+    # A policy snapshot comfortably larger than the 4096-byte recv/fragment
+    # boundary that truncated the push in #1958 (many profiles → ~12 KB here).
+    profiles = {
+        f"profile-{i}": {"blocked": False, "extraAllowed": [f"host-{i}-{j}.example.com" for j in range(8)]}
+        for i in range(40)
+    }
+    return json.dumps({"op": "policy", "payload": {"profiles": profiles, "devices": []}})
+
+
+def test_fragmented_policy_push_is_reassembled() -> None:
+    # #1958: a >4096-byte policy push split into a TEXT fragment + continuation
+    # frames must be reassembled into one parseable message — NOT truncated at
+    # the first fragment. Exercise both a clean split and one with an interleaved
+    # control PING between fragments.
+    policy_text = _big_policy_text()
+    assert len(policy_text) > 4096, "fixture must exceed the 4096B truncation boundary"
+    expected = json.loads(policy_text)
+    for ping_after in (-1, 1):
+        with fake_ws_server_fragmented(policy_text, fragment_size=4096, ping_after=ping_after) as url:
+            replies = send_frames(url, token="t", frames=_FRAMES, timeout=10.0)
+        pushes = [r for r in replies if isinstance(r, dict) and r.get("op") == "policy"]
+        assert len(pushes) == 1, f"expected one reassembled policy push (ping_after={ping_after}): {pushes}"
+        assert pushes[0] == expected, "reassembled policy push must match the full original message"
+        acks = _acks_by_seq(replies)
+        assert set(acks) == {1, 2, 3}, f"acks dropped with fragmented push (ping_after={ping_after}): {acks}"
 
 
 if __name__ == "__main__":

--- a/scripts/e2e/lib/ws_send.py
+++ b/scripts/e2e/lib/ws_send.py
@@ -33,7 +33,6 @@ from urllib.parse import urlparse
 
 _OPCODE_CONTINUATION = 0x0
 _OPCODE_TEXT = 0x1
-_OPCODE_BINARY = 0x2
 _OPCODE_CLOSE = 0x8
 _OPCODE_PING = 0x9
 _OPCODE_PONG = 0xA

--- a/scripts/e2e/lib/ws_send.py
+++ b/scripts/e2e/lib/ws_send.py
@@ -31,10 +31,14 @@ import struct
 import sys
 from urllib.parse import urlparse
 
+_OPCODE_CONTINUATION = 0x0
 _OPCODE_TEXT = 0x1
+_OPCODE_BINARY = 0x2
 _OPCODE_CLOSE = 0x8
 _OPCODE_PING = 0x9
 _OPCODE_PONG = 0xA
+
+_CONTROL_OPCODES = frozenset({_OPCODE_CLOSE, _OPCODE_PING, _OPCODE_PONG})
 
 # Ops the server sends UNSOLICITED — not a reply to any frame we sent. #1849
 # pushes `{op:"policy"}` on connect (first-policy-on-connect) and on every
@@ -121,7 +125,13 @@ def _send_text(sock: socket.socket, text: str) -> None:
     sock.sendall(bytes(header) + masked)
 
 
-def _recv_frame(sock: socket.socket, buf: bytearray) -> tuple[int, bytes]:
+def _recv_frame(sock: socket.socket, buf: bytearray) -> tuple[bool, int, bytes]:
+    """Read ONE WebSocket frame; return (fin, opcode, payload).
+
+    `fin` is the FIN bit — False marks a non-final fragment of a fragmented
+    message (RFC 6455 §5.4). Reassembly across fragments is the job of
+    `_recv_message`; this only decodes a single frame off the wire.
+    """
     def need(total: int) -> None:
         # buf.extend (in-place) not `buf += chunk`: an augmented assignment would
         # rebind `buf` as a local of this nested function → UnboundLocalError.
@@ -133,6 +143,7 @@ def _recv_frame(sock: socket.socket, buf: bytearray) -> tuple[int, bytes]:
 
     need(2)
     b0, b1 = buf[0], buf[1]
+    fin = bool(b0 & 0x80)
     opcode = b0 & 0x0F
     masked = b1 & 0x80
     length = b1 & 0x7F
@@ -155,7 +166,42 @@ def _recv_frame(sock: socket.socket, buf: bytearray) -> tuple[int, bytes]:
     if masked:
         data = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
     del buf[:idx + length]
-    return opcode, data
+    return fin, opcode, data
+
+
+def _recv_message(sock: socket.socket, buf: bytearray) -> tuple[int, bytes]:
+    """Read one complete WebSocket message, reassembling fragments (RFC 6455 §5.4).
+
+    Returns (opcode, payload). For a data message the server may split across a
+    leading TEXT/BINARY frame (FIN=0) + CONTINUATION (0x0) frames, the last with
+    FIN=1 — we concatenate their payloads and return the initial data opcode.
+    Without this, a >max-frame-size `policy` push (#1849) read as just its first
+    fragment truncates mid-JSON at the fragment boundary (#1958).
+
+    Control frames (ping/pong/close) are never fragmented (RFC 6455 §5.5) and
+    are returned as-is when they are not interleaved inside a fragmented message.
+    A control frame that arrives BETWEEN data fragments is handled inline (ping/
+    pong skipped, close → error) so it does not corrupt the reassembly — its FIN
+    bit must NOT be mistaken for the data message's FIN.
+    """
+    fin, opcode, data = _recv_frame(sock, buf)
+    if opcode in _CONTROL_OPCODES:
+        return opcode, data
+    msg_opcode = opcode
+    chunks = [data]
+    while not fin:
+        frag_fin, frag_opcode, frag_data = _recv_frame(sock, buf)
+        if frag_opcode in _CONTROL_OPCODES:
+            if frag_opcode == _OPCODE_CLOSE:
+                raise RuntimeError("server closed the socket mid-message")
+            continue  # interleaved ping/pong — skip WITHOUT advancing `fin`
+        if frag_opcode != _OPCODE_CONTINUATION:
+            raise RuntimeError(
+                f"expected continuation frame (0x0), got opcode {frag_opcode:#x} mid-message"
+            )
+        chunks.append(frag_data)
+        fin = frag_fin
+    return msg_opcode, b"".join(chunks)
 
 
 def _close(sock: socket.socket) -> None:
@@ -190,7 +236,7 @@ def send_frames(url: str, token: str | None, frames: list[dict], timeout: float)
         for frame in frames:
             _send_text(sock, json.dumps(frame))
         while solicited_seen < solicited_expected:
-            opcode, data = _recv_frame(sock, buf)
+            opcode, data = _recv_message(sock, buf)
             if opcode == _OPCODE_TEXT:
                 msg = json.loads(data.decode("utf-8"))
                 replies.append(msg)
@@ -203,7 +249,7 @@ def send_frames(url: str, token: str | None, frames: list[dict], timeout: float)
                 continue  # benign; server-initiated control ping
             if opcode == _OPCODE_CLOSE:
                 raise RuntimeError("server closed the socket before replying")
-            # ignore pong / continuation control frames
+            # ignore pong (continuation frames are reassembled inside _recv_message)
     finally:
         _close(sock)
     return replies


### PR DESCRIPTION
## Problem
With #1956 merged, Master API/UI CD **Gate 1** got past the stale-snapshot failure but hit a new ws-harness failure:

```
✗ ws frames not all acked ok: ws_send error:
   {"error": "Expecting property name enclosed in double quotes: line 1 column 4097 (char 4096)"}
```

## Root cause
`scripts/e2e/lib/ws_send.py` `_recv_frame()` read exactly **one** WebSocket frame and **ignored the FIN bit (`b0 & 0x80`) and the continuation opcode (`0x0`)**. The large #1849 `policy` push (staging snapshot >4 KiB: many profiles) is split into a leading TEXT fragment (FIN=0, ~4096 B) + CONTINUATION frames. `_recv_frame` returned only the first fragment, so `json.loads` truncated mid-string at char 4096. (Same `ws_send.py` lineage as #1951/#1953 — #1953 made it drain the push, which is what exposed the fragmentation gap once the push got large.)

## Fix (harness)
- `_recv_frame` now returns the FIN bit: `(fin, opcode, payload)`.
- New `_recv_message` reassembles per **RFC 6455 §5.4**: concatenate the leading TEXT/BINARY frame + CONTINUATION (`0x0`) frames until a frame with FIN=1, returning the initial data opcode + joined payload. Interleaved **control frames** (ping/pong/close) between fragments are handled inline (ping/pong skipped, close → error) and their FIN bit is **not** mistaken for the data message's FIN.
- `send_frames` reads complete messages via `_recv_message`.
- **TDD**: `test_fragmented_policy_push_is_reassembled` (committed failing first) sends a ~12 KB policy push fragmented at the 4096 B boundary — both a clean split and one with an interleaved control PING — and asserts the reassembled message equals the original and that all three frame acks still land. The red commit reproduced the exact char-4096 truncation. All 4 ws tests (27 in `scripts/e2e/lib/`) green.

## Product-side investigation (per the issue)

**(a) Who fragments, and at what size?** The API server sends the snapshot as a **single, unfragmented** `TextWebSocketFrame` — `RouterWsRegistry.policyFrameText` → `WebSocketFrame.text(...)` (`api/src/routes/RouterWsRegistry.scala:66,122`). There is **no `maxFrameSize` / `WebSocketConfig` override** anywhere in `api/src` (Netty's ~64 KiB default applies; the only `Server.Config` tweak is the HTTP `disableRequestStreaming(4 MiB)` body cap, unrelated to ws). The failure is observed against **staging** (`wss://api-staging.wifihaven.net`, behind Render's edge), and the boundary is **~4096 B**, not 64 KiB — so the **edge/proxy re-fragments** large outbound ws frames at ~4 KiB. Net: fragmentation happens on the wire in prod regardless of the server writing a single frame, so any ws client MUST reassemble.

**(b) Does the real #1848 Lua agent reassemble?** **No — same bug.** `openwrt/files/usr/lib/lua/wifihaven/ws_client.lua` `M:recv` (~L157) returns `frame.opcode, frame.payload` directly for `text/binary/continuation` and **never inspects `frame.fin`** — even though the framing layer `ws_frame.lua` `decode` correctly parses FIN and knows `OP_CONTINUATION = 0x0`. A large `policy` push would be truncated to its first fragment and dropped as unparseable — a real product bug once apply-on-push (#1945) lands. Filed separately (kept out of this PR to keep it scoped to the harness): **#1959** under #1023. It needs the same RFC 6455 §5.4 reassembly, validated on a real Lua-5.1/cqueues target per the #1845 spike.

## Acceptance
- [x] `ws_send.py` reassembles fragmented messages; the >4 KiB policy push parses.
- [x] Unit test covers multi-fragment >4096 B message + interleaved control frame.
- [x] Clear answer on the real agent (does **not** reassemble) + follow-up filed (#1959).
- [ ] Gate 1 ws-parity passes / Master API/UI CD green (verified post-merge).

Fixes #1958
Relates to #1849, #1953, #1848, #1023, #1959
