### PR TITLE
ci(#1961): staging smoke retries transient 5xx (Gate 1 flake)

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -47,6 +47,12 @@ _py() { python3 -c "$1"; }
 # read-back so the typed-BlockReason wire contract has one source of truth.
 E2E_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/e2e/lib" && pwd)"
 
+# Retry transient 502/503/504 + connection failures from the starter-tier
+# staging API (#1961). Drop-in `curl` override; expected-4xx assertions still
+# fail-fast. Sourced before any curl (including admin-auth.sh's logins).
+# shellcheck source=scripts/e2e/lib/curl-retry.sh
+source "$E2E_LIB/curl-retry.sh"
+
 # ── Admin login ────────────────────────────────────────────────────────────
 # #1790: shared self-healing helper. On a fresh staging DB reset, rotates
 # the seeded 'changeme' password back to $ADMIN_PASS before returning a JWT;

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -30,6 +30,12 @@ fail() { echo "  ✗ $*" >&2; exit 1; }
 step() { echo; echo "▶ $*"; }
 _py() { python3 -c "$1"; }
 
+# Retry transient 502/503/504 + connection failures from the starter-tier
+# staging API (#1961). Drop-in `curl` override; expected-4xx assertions still
+# fail-fast. Sourced before any curl (including admin-auth.sh's logins).
+# shellcheck source=scripts/e2e/lib/curl-retry.sh
+source "$(dirname "${BASH_SOURCE[0]}")/e2e/lib/curl-retry.sh"
+
 # Quick wait for the API to come up (compose healthcheck should already gate, but be safe).
 step "Waiting for API at $BASE"
 for i in $(seq 1 60); do

--- a/scripts/e2e/lib/curl-retry-test.sh
+++ b/scripts/e2e/lib/curl-retry-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Unit test for curl-retry.sh (#1961). No network: points WH_CURL_BIN at a
+# deterministic mock that replays a per-attempt response sequence, so we can
+# assert exactly which transient cases retry and which 4xx cases fail-fast.
+#
+# Run: scripts/e2e/lib/curl-retry-test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# Mock "curl": ignores its real args, replays the WH_MOCK_SEQ tokens one per
+# invocation. Tokens are ';'-separated (err text contains spaces). A token is
+# "rc:out:err" — rc is the exit code, out goes to stdout (the http_code for the
+# -w shape), err goes to stderr (the -f shape's "curl: (22) ...returned error:
+# 50x" message). Colons in err are fine; we only split the first two fields.
+cat >"$WORK/mock-curl" <<'MOCK'
+#!/usr/bin/env bash
+ctr="$WH_MOCK_CTR"; n=$(cat "$ctr" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" >"$ctr"
+IFS=';' read -r -a seq <<<"$WH_MOCK_SEQ"
+idx=$((n - 1)); [ "$idx" -ge "${#seq[@]}" ] && idx=$((${#seq[@]} - 1))
+tok="${seq[$idx]}"; rc="${tok%%:*}"; rest="${tok#*:}"; out="${rest%%:*}"; err="${rest#*:}"
+[ -n "$out" ] && printf '%s' "$out"
+[ -n "$err" ] && printf '%s\n' "$err" >&2
+exit "$rc"
+MOCK
+chmod +x "$WORK/mock-curl"
+
+export WH_CURL_BIN="$WORK/mock-curl"
+export WH_CURL_BACKOFF_SECS=0
+export WH_CURL_MAX_ATTEMPTS=5
+# shellcheck source=scripts/e2e/lib/curl-retry.sh
+source "$HERE/curl-retry.sh"
+
+FAILED=0
+check() { if [ "$2" = "$3" ]; then echo "  ✓ $1"; else echo "  ✗ $1: expected '$3', got '$2'" >&2; FAILED=1; fi; }
+
+run() { # $1=mock seq → sets global OUT, RC, ATTEMPTS
+  WH_MOCK_CTR="$WORK/ctr"; : >"$WH_MOCK_CTR"; export WH_MOCK_CTR
+  export WH_MOCK_SEQ="$1"; shift
+  OUT=$(curl "$@" 2>/dev/null) && RC=0 || RC=$?
+  ATTEMPTS=$(cat "$WH_MOCK_CTR")
+}
+
+echo "▶ status-capture (-w) shape"
+# Transient 5xx then success → retried away, final 200 returned.
+run "0:502:;0:502:;0:200:" -s -o /dev/null -w '%{http_code}' http://x
+check "5xx then 200 retries to success (out)" "$OUT" "200"
+check "5xx then 200 retries to success (attempts)" "$ATTEMPTS" "3"
+
+# Expected 4xx → NOT retried, returned immediately on attempt 1.
+run "0:400:" -s -o /dev/null -w '%{http_code}' http://x
+check "400 is not retried (out)" "$OUT" "400"
+check "400 is not retried (attempts)" "$ATTEMPTS" "1"
+
+run "0:401:" -s -o /dev/null -w '%{http_code}' http://x
+check "401 is not retried (attempts)" "$ATTEMPTS" "1"
+
+# Persistent 5xx → exhausts attempts, surfaces the 5xx so the assertion fails.
+run "0:503:" -s -o /dev/null -w '%{http_code}' http://x
+check "persistent 503 exhausts attempts" "$ATTEMPTS" "5"
+check "persistent 503 surfaces code" "$OUT" "503"
+
+echo "▶ body/-f shape"
+# -f 5xx surfaces as rc 22 + stderr → transient, retried.
+run "22::curl: (22) The requested URL returned error: 502;22::curl: (22) The requested URL returned error: 502;0:body:" -fsS http://x
+check "-f 5xx retries to success (out)" "$OUT" "body"
+check "-f 5xx retries to success (rc)" "$RC" "0"
+check "-f 5xx retries to success (attempts)" "$ATTEMPTS" "3"
+
+# -f 4xx surfaces as rc 22 + "error: 400" → NOT transient, fail-fast.
+run "22::curl: (22) The requested URL returned error: 400" -fsS http://x
+check "-f 4xx fails fast (rc)" "$RC" "22"
+check "-f 4xx fails fast (attempts)" "$ATTEMPTS" "1"
+
+# Connection-layer rc (52 empty reply) → transient, retried.
+run "52::curl: (52) Empty reply from server;0:body:" -fsS http://x
+check "conn-reset rc 52 retries (rc)" "$RC" "0"
+check "conn-reset rc 52 retries (attempts)" "$ATTEMPTS" "2"
+
+# Non-transient hard failure (rc 6 couldn't resolve host) → fail-fast.
+run "6::curl: (6) Could not resolve host" -fsS http://x
+check "non-transient rc 6 fails fast (attempts)" "$ATTEMPTS" "1"
+
+echo
+if [ "$FAILED" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi

--- a/scripts/e2e/lib/curl-retry.sh
+++ b/scripts/e2e/lib/curl-retry.sh
@@ -1,0 +1,105 @@
+# shellcheck shell=bash
+# curl-retry.sh — sourced by the staging smoke scripts (#1961).
+#
+# Why this exists: Gate 1's staging smoke (scripts/e2e-router.sh, scripts/
+# e2e-tests.sh) bursts a large, growing number of requests at the starter-tier
+# staging API. Staging intermittently returns a transient 502/503/504 on
+# cold-start / resource pressure (render.yaml notes `starter` is the floor), so
+# a single random server 5xx anywhere in the burst failed the whole gate even
+# though every assertion is correct. This wraps `curl` so transient server-side
+# and connection-layer failures retry with short backoff before failing.
+#
+# CRITICAL: this only retries SERVER failures (5xx) and connection-layer
+# failures (couldn't-connect / timeout / empty-reply / conn-reset). It does NOT
+# retry a 4xx — those are real test outcomes (e.g. "expected 400 for unknown
+# bucket", "wrong password → 401", "missing auth → 401") and must fail-fast.
+# Retry lives at the transport layer; assertion logic is untouched.
+#
+# The override is transparent: every existing `curl ...` call in the sourcing
+# script gets retry-on-transient for free, for both call shapes the smoke uses:
+#   1. body/`-f` capture:   curl -fsS ... >file   |   curl -fsS ... | _py
+#   2. status capture:      CODE=$(curl -s -o /dev/null -w '%{http_code}' ...)
+
+# Tunables (env-overridable; tests set backoff to 0 for speed).
+WH_CURL_MAX_ATTEMPTS="${WH_CURL_MAX_ATTEMPTS:-5}"
+WH_CURL_BACKOFF_SECS="${WH_CURL_BACKOFF_SECS:-1}"
+# Indirection so the unit test can point this at a deterministic mock.
+WH_CURL_BIN="${WH_CURL_BIN:-curl}"
+
+# Connection-layer curl exit codes — no HTTP status was ever received, so the
+# request never reached the application and is always safe to retry:
+#   7  couldn't connect       28 operation timeout
+#   35 SSL connect error      52 empty reply from server
+#   56 recv failure (connection reset)
+_wh_curl_transient_rc() {
+  case "$1" in
+    7 | 28 | 35 | 52 | 56) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_wh_curl_5xx() {
+  case "$1" in
+    502 | 503 | 504) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# curl — drop-in override. `command "$WH_CURL_BIN"` reaches the real binary
+# (bypassing this function); the function name shadows it for callers.
+curl() {
+  local attempt=1 rc out code err has_w=0 a
+  for a in "$@"; do
+    case "$a" in
+      -w | --write-out)
+        has_w=1
+        break
+        ;;
+    esac
+  done
+
+  while :; do
+    if [ "$has_w" = 1 ]; then
+      # Status-capture shape: the caller reads curl's stdout (the http_code
+      # write-out; body goes to -o/dev/null). Buffer it so we can inspect the
+      # status and retry a transient 5xx, then re-emit it verbatim. `|| rc=$?`
+      # keeps `set -e` from aborting on a failed request.
+      out=$(command "$WH_CURL_BIN" "$@") && rc=0 || rc=$?
+      code=$(printf '%s' "$out" | grep -oE '[0-9]{3}' | tail -1) || true
+      if [ "$rc" -eq 0 ]; then
+        # curl itself succeeded; retry only when the status is a 5xx.
+        _wh_curl_5xx "$code" || { printf '%s' "$out"; return 0; }
+      else
+        # curl failed at the connection layer; retry only the transient set.
+        _wh_curl_transient_rc "$rc" || { printf '%s' "$out"; return "$rc"; }
+      fi
+    else
+      # Body/`-f` shape: pass curl's stdout straight through (fd 3) and capture
+      # only stderr so we can classify the failure and re-emit it on giving up.
+      { err=$(command "$WH_CURL_BIN" "$@" 2>&1 1>&3) && rc=0 || rc=$?; } 3>&1
+      if [ "$rc" -eq 0 ]; then
+        return 0
+      fi
+      # With -f a 5xx surfaces as rc 22 + "...returned error: 50x" on stderr.
+      # Retry that and the connection-layer set; fail-fast on a real 4xx.
+      if ! _wh_curl_transient_rc "$rc" &&
+        ! printf '%s' "$err" | grep -qE 'error: 50[0-9]'; then
+        printf '%s\n' "$err" >&2
+        return "$rc"
+      fi
+    fi
+
+    if [ "$attempt" -ge "$WH_CURL_MAX_ATTEMPTS" ]; then
+      echo "[curl-retry] giving up after $attempt attempts (rc=$rc code=${code:-n/a})" >&2
+      if [ "$has_w" = 1 ]; then
+        printf '%s' "$out"
+        return "$rc"
+      fi
+      printf '%s\n' "${err:-}" >&2
+      return "$rc"
+    fi
+    echo "[curl-retry] transient failure (attempt $attempt/$WH_CURL_MAX_ATTEMPTS, rc=$rc code=${code:-n/a}); retrying in ${WH_CURL_BACKOFF_SECS}s" >&2
+    sleep "$WH_CURL_BACKOFF_SECS"
+    attempt=$((attempt + 1))
+  done
+}

--- a/scripts/e2e/lib/curl-retry.test.sh
+++ b/scripts/e2e/lib/curl-retry.test.sh
@@ -3,7 +3,8 @@
 # deterministic mock that replays a per-attempt response sequence, so we can
 # assert exactly which transient cases retry and which 4xx cases fail-fast.
 #
-# Run: scripts/e2e/lib/curl-retry-test.sh
+# Run: scripts/e2e/lib/curl-retry.test.sh  (CI's Shell Tests job discovers
+# *.test.sh and runs it automatically).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Root cause — CD reliability, not a code bug

Master API/UI CD **Gate 1 — API contract smoke (staging)** is flaky. The smoke (the `Router API smoke against staging` → `scripts/e2e-router.sh`, plus the `Admin API smoke` → `scripts/e2e-tests.sh`) bursts a large, **growing** number of requests at the **starter-tier** staging API. The smoke has grown a lot recently (new checks for #1849 snapshot, #1912/#1921 blockEncryptedDns, blockReason, extraAllowed carve, ws-parity, #924/#927/#928/#929/#931/#932…), so it now hits the same starter-tier staging harder. render.yaml notes `starter` is the floor; under cold-start / resource pressure staging intermittently returns a transient **502/503/504**.

The smoke did **not** retry transient 5xx, so a single random server 502 anywhere in the burst failed the whole gate. Across 3 consecutive re-runs the 502 landed at a *different* request each time and every real assertion passed (ws-parity, snapshot read-after-write, extraAllowed carve, blockReason, #924/#927/#928/#929/#931) — the code is correct; only the harness was fragile.

```
run 1: ✗ #931: expected 400 for bucket=off on /series, got 502
run 2: curl: (22) ... error 502   (after blockReason=Paused check)
run 3: curl: (22) ... error 502   (right after wrong-password→401 check)
```

## Fix — retry transient 5xx at the transport layer

New shared `curl` override `scripts/e2e/lib/curl-retry.sh`, sourced by both smoke scripts (before any curl, so `admin-auth.sh`'s logins are covered too). It retries **502/503/504** and connection-layer curl failures (exit 7/28/35/52/56 — couldn't-connect / timeout / SSL-connect / empty-reply / conn-reset) with short backoff (default 5 attempts, 1s) before failing. It's transparent across all ~80 existing call sites for both shapes the smoke uses:

- body / `-f` capture: `curl -fsS … >file` / `curl -fsS … | _py` (5xx surfaces as rc 22 + `…returned error: 50x` on stderr)
- status capture: `CODE=$(curl -s -o /dev/null -w '%{http_code}' …)`

### Expected-4xx assertions are NOT retried
This is the critical constraint. Retry only fires for **server 5xx** and **connection failures**. A 4xx is a real test outcome and still **fails-fast** — the negative-path checks (`expected 400 for unknown bucket`, `missing auth → 401`, `bogus bearer → 401`, `bogus enrollment token → 4xx`, `wrong password → 401`) are untouched. Retry lives at the transport layer; assertion logic is unchanged.

## Validation
- `scripts/e2e/lib/curl-retry-test.sh` — network-free unit test with a deterministic mock curl. Pins: 5xx-then-200 retries to success; persistent 5xx exhausts attempts and surfaces the 5xx (assertion still fails); **400/401 not retried (1 attempt)**; `-f` 5xx retries; **`-f` 4xx fails fast**; conn-reset (rc 52) retries; non-transient rc 6 fails fast. **ALL PASS.**
- `shellcheck -x` clean on all four files.
- Real-curl passthrough sanity check against the dev API: `-f` body capture (200), `-w` code capture (401, fast), bad host fails fast (rc 6, no long retry) — confirms the override is transparent with the real binary.
- The real proof is Master API/UI CD Gate 1 going green and staying green across the cold-start window.

Fixes #1961
Relates to #1454 (staging tier floor), #1849/#1912/#1921 (recent smoke growth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)