### PR TITLE
ci(#1964): widen staging smoke retry budget (escalating backoff ~39s)

### DIFF
--- a/scripts/e2e/lib/curl-retry.sh
+++ b/scripts/e2e/lib/curl-retry.sh
@@ -21,8 +21,17 @@
 #   2. status capture:      CODE=$(curl -s -o /dev/null -w '%{http_code}' ...)
 
 # Tunables (env-overridable; tests set backoff to 0 for speed).
-WH_CURL_MAX_ATTEMPTS="${WH_CURL_MAX_ATTEMPTS:-5}"
-WH_CURL_BACKOFF_SECS="${WH_CURL_BACKOFF_SECS:-1}"
+#
+# Budget sizing (#1964): a single retry round of 5 × 1s (~4s) was too short —
+# the starter-tier staging API throws transient 502 *bursts* under the smoke's
+# request load that outlast 4s, so Gate 1 still flaked after #1962. Backoff now
+# escalates (capped exponential: base, 2·base, 4·base … capped at BACKOFF_MAX),
+# and the default 8-attempt budget waits 1+2+4+8+8+8+8 ≈ 39s total before
+# giving up — enough to ride out a transient burst without masking a genuine
+# outage (a persistent 5xx still fails the gate, just ~39s later).
+WH_CURL_MAX_ATTEMPTS="${WH_CURL_MAX_ATTEMPTS:-8}"
+WH_CURL_BACKOFF_SECS="${WH_CURL_BACKOFF_SECS:-1}"   # base; doubles each retry
+WH_CURL_BACKOFF_MAX="${WH_CURL_BACKOFF_MAX:-8}"     # per-sleep cap (seconds)
 # Indirection so the unit test can point this at a deterministic mock.
 WH_CURL_BIN="${WH_CURL_BIN:-curl}"
 
@@ -98,8 +107,13 @@ curl() {
       printf '%s\n' "${err:-}" >&2
       return "$rc"
     fi
-    echo "[curl-retry] transient failure (attempt $attempt/$WH_CURL_MAX_ATTEMPTS, rc=$rc code=${code:-n/a}); retrying in ${WH_CURL_BACKOFF_SECS}s" >&2
-    sleep "$WH_CURL_BACKOFF_SECS"
+    # Capped exponential backoff: base · 2^(attempt-1), clamped to BACKOFF_MAX.
+    # With base 0 (tests) every sleep is 0, so the attempt-count assertions stay
+    # deterministic and fast.
+    local backoff=$((WH_CURL_BACKOFF_SECS * (1 << (attempt - 1))))
+    [ "$backoff" -gt "$WH_CURL_BACKOFF_MAX" ] && backoff="$WH_CURL_BACKOFF_MAX"
+    echo "[curl-retry] transient failure (attempt $attempt/$WH_CURL_MAX_ATTEMPTS, rc=$rc code=${code:-n/a}); retrying in ${backoff}s" >&2
+    sleep "$backoff"
     attempt=$((attempt + 1))
   done
 }

--- a/scripts/e2e/lib/curl-retry.test.sh
+++ b/scripts/e2e/lib/curl-retry.test.sh
@@ -33,6 +33,12 @@ export WH_CURL_MAX_ATTEMPTS=5
 # shellcheck source=scripts/e2e/lib/curl-retry.sh
 source "$HERE/curl-retry.sh"
 
+# Override sleep so the backoff schedule can be asserted without real waiting.
+# Records each requested duration to $SLEEP_LOG; default tests use base 0 so
+# this just records 0s harmlessly.
+SLEEP_LOG="$WORK/sleeps"; : >"$SLEEP_LOG"
+sleep() { printf '%s\n' "$1" >>"$SLEEP_LOG"; }
+
 FAILED=0
 check() { if [ "$2" = "$3" ]; then echo "  ✓ $1"; else echo "  ✗ $1: expected '$3', got '$2'" >&2; FAILED=1; fi; }
 
@@ -82,6 +88,15 @@ check "conn-reset rc 52 retries (attempts)" "$ATTEMPTS" "2"
 # Non-transient hard failure (rc 6 couldn't resolve host) → fail-fast.
 run "6::curl: (6) Could not resolve host" -fsS http://x
 check "non-transient rc 6 fails fast (attempts)" "$ATTEMPTS" "1"
+
+echo "▶ backoff schedule (#1964 — capped exponential)"
+# base=1, cap=8, 6 attempts, persistent 5xx → 5 retries with sleeps
+# 1,2,4,8,8 (the 5th is 16 capped to 8); the 6th attempt gives up, no sleep.
+: >"$SLEEP_LOG"
+WH_CURL_BACKOFF_SECS=1 WH_CURL_BACKOFF_MAX=8 WH_CURL_MAX_ATTEMPTS=6 \
+  run "0:503:" -s -o /dev/null -w '%{http_code}' http://x
+SCHEDULE=$(tr '\n' ' ' <"$SLEEP_LOG" | sed 's/ $//')
+check "escalating backoff capped at 8s" "$SCHEDULE" "1 2 4 8 8"
 
 echo
 if [ "$FAILED" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi


### PR DESCRIPTION
## Follow-up to #1961 / #1962 — the retry budget was too short

#1962 added the `curl` retry wrapper so the Gate 1 staging smoke retries transient 502/503/504. The **mechanism worked exactly as designed** — but its budget (5 attempts × constant 1s ≈ **4s**) was too short to ride out a transient 502 *burst* on the starter-tier staging API, so Gate 1 still flaked on the post-merge run.

### Evidence — Master API/UI CD run 28198643966 (post-#1962 merge)
```
[curl-retry] transient failure (attempt 1/5, rc=22 code=n/a); retrying in 1s
[curl-retry] transient failure (attempt 2/5, ...); retrying in 1s
... (5 attempts, ~4s total) ...
[curl-retry] giving up after 5 attempts (rc=22 code=n/a)
curl: (22) The requested URL returned error: 502
##[error]Process completed with exit code 22.
```
The admin smoke had already passed moments earlier, and Gate 1 `needs: [deploy-staging]` (whose post-deploy step health-checks `/api/devices` for 401/200/403 before completing) — so the deploy was confirmed healthy. This is a transient burst 502 mid-router-smoke that simply outlasted the 4s window.

## Fix — escalating backoff, ~39s budget
- Backoff is now **capped exponential**: `base · 2^(attempt-1)`, clamped to `WH_CURL_BACKOFF_MAX` (default 8s).
- Default attempts raised 5 → **8**, giving a total retry window of `1+2+4+8+8+8+8 ≈ 39s` before giving up.
- This absorbs a transient burst while a **genuine persistent 5xx still fails the gate** — just ~39s later, not masked.
- **Critical constraint unchanged**: only 5xx + connection-layer curl failures (rc 7/28/35/52/56) retry; expected-4xx assertions still fail-fast.

## Validation
- `curl-retry.test.sh` adds a `sleep` override that records backoff durations and **pins the escalating schedule** (`1 2 4 8 8` for base=1/cap=8/6 attempts). All prior cases (retry-on-5xx, fail-fast-on-4xx, conn-reset, non-transient) still pass. `shellcheck -x` clean; **ALL PASS**.
- Real proof: Master API/UI CD Gate 1 staying green across the cold-start/burst window.

Fixes #1964
Relates to #1961, #1962, #1454 (starter-tier floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)