### PR TITLE
ci(#1963): add one-time /api/health cold-start gate to the staging smoke

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -53,6 +53,11 @@ E2E_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/e2e/lib" && pwd)"
 # shellcheck source=scripts/e2e/lib/curl-retry.sh
 source "$E2E_LIB/curl-retry.sh"
 
+# One-time cold-start gate (#1963): absorb a post-deploy JVM cold-start (where
+# /api/health is 503 status=starting) once up front, so the request burst below
+# isn't fighting it per-assertion. Best-effort — per-request retry is the backstop.
+wh_wait_for_health "$BASE"
+
 # ── Admin login ────────────────────────────────────────────────────────────
 # #1790: shared self-healing helper. On a fresh staging DB reset, rotates
 # the seeded 'changeme' password back to $ADMIN_PASS before returning a JWT;

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -36,16 +36,12 @@ _py() { python3 -c "$1"; }
 # shellcheck source=scripts/e2e/lib/curl-retry.sh
 source "$(dirname "${BASH_SOURCE[0]}")/e2e/lib/curl-retry.sh"
 
-# Quick wait for the API to come up (compose healthcheck should already gate, but be safe).
-step "Waiting for API at $BASE"
-for i in $(seq 1 60); do
-  code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
-    -H 'content-type: application/json' -d '{}' \
-    "$BASE/api/auth/login" 2>/dev/null || true)
-  if [ "$code" = 400 ] || [ "$code" = 401 ]; then pass "API responding ($code)"; break; fi
-  if [ "$i" = 60 ]; then fail "API never came up (last code: $code)"; fi
-  sleep 1
-done
+# One-time cold-start gate (#1963): poll /api/health until 200 before running
+# the assertion burst, so a post-deploy JVM cold-start (503 status=starting) is
+# absorbed once up front rather than fought per-request. Best-effort — the
+# per-request curl retry is the backstop. Replaces the old bespoke login-wait
+# loop; /api/health 200 means readiness has flipped and gated routes serve.
+wh_wait_for_health "$BASE"
 
 step "Login as admin"
 # #1790: shared self-healing helper. On a fresh staging DB reset, rotates

--- a/scripts/e2e/lib/curl-retry.sh
+++ b/scripts/e2e/lib/curl-retry.sh
@@ -117,3 +117,34 @@ curl() {
     attempt=$((attempt + 1))
   done
 }
+
+# wh_wait_for_health <base-url> — one-time readiness gate run at the START of a
+# staging smoke (#1963). Complements the per-request retry budget above: it
+# polls <base>/api/health until 200 so a single post-deploy JVM cold-start
+# (where /api/health returns 503 status=starting, the same gate as the prod
+# compose healthcheck) is absorbed ONCE up front, instead of every assertion in
+# the burst fighting the cold-start with its own ~39s retry round. Uses the REAL
+# curl binary (not the override) so the 503-while-starting poll is this loop,
+# not a nested per-call retry budget.
+#
+# Best-effort: on timeout it warns and returns 0 so the smoke still runs — the
+# per-request curl retry above is the backstop, and a genuinely-down API will
+# fail the assertions anyway. ~60s budget (30 × 2s) mirrors the cold-start window.
+WH_HEALTH_MAX_ATTEMPTS="${WH_HEALTH_MAX_ATTEMPTS:-30}"
+WH_HEALTH_INTERVAL_SECS="${WH_HEALTH_INTERVAL_SECS:-2}"
+wh_wait_for_health() {
+  local base="$1" i code
+  echo "▶ Waiting for $base/api/health (cold-start gate)" >&2
+  for ((i = 1; i <= WH_HEALTH_MAX_ATTEMPTS; i++)); do
+    code=$(command "$WH_CURL_BIN" -s -o /dev/null -w '%{http_code}' \
+      "$base/api/health" 2>/dev/null || true)
+    if [ "$code" = 200 ]; then
+      echo "  ✓ API healthy ($code) after $i poll(s)" >&2
+      return 0
+    fi
+    [ "$i" -lt "$WH_HEALTH_MAX_ATTEMPTS" ] && sleep "$WH_HEALTH_INTERVAL_SECS"
+  done
+  echo "  ! API health gate timed out (last code: ${code:-n/a}); proceeding" \
+    "— per-request retry is the backstop" >&2
+  return 0
+}

--- a/scripts/e2e/lib/curl-retry.test.sh
+++ b/scripts/e2e/lib/curl-retry.test.sh
@@ -98,5 +98,24 @@ WH_CURL_BACKOFF_SECS=1 WH_CURL_BACKOFF_MAX=8 WH_CURL_MAX_ATTEMPTS=6 \
 SCHEDULE=$(tr '\n' ' ' <"$SLEEP_LOG" | sed 's/ $//')
 check "escalating backoff capped at 8s" "$SCHEDULE" "1 2 4 8 8"
 
+echo "▶ wh_wait_for_health (#1963)"
+hrun() { # $1=mock seq → sets HRC and HEALTH_POLLS
+  WH_MOCK_CTR="$WORK/ctr-health"; : >"$WH_MOCK_CTR"; export WH_MOCK_CTR
+  export WH_MOCK_SEQ="$1"
+  WH_HEALTH_INTERVAL_SECS=0 WH_HEALTH_MAX_ATTEMPTS=5 \
+    wh_wait_for_health http://x >/dev/null 2>&1 && HRC=0 || HRC=$?
+  HEALTH_POLLS=$(cat "$WH_MOCK_CTR")
+}
+
+# 503 (still starting) then 200 → gate clears on the second poll.
+hrun "0:503:;0:200:"
+check "health gate clears on 200 (rc)" "$HRC" "0"
+check "health gate stops polling once healthy" "$HEALTH_POLLS" "2"
+
+# Persistent 503 → gate times out but returns 0 (best-effort) after the budget.
+hrun "0:503:"
+check "health gate times out best-effort (rc)" "$HRC" "0"
+check "health gate exhausts its poll budget" "$HEALTH_POLLS" "5"
+
 echo
 if [ "$FAILED" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi


### PR DESCRIPTION
## Summary
Follow-up to #1961/#1962. Issue #1963 calls for two complementary fixes to stop Gate 1 (Master API/UI CD) flaking against the starter-tier staging API's **5–30s+ 502 windows**:
1. **Extend the per-request retry budget** — ✅ **already shipped by #1964/#1965** (escalating backoff, ~39s budget). This PR keeps that as-is.
2. **A one-time health-gate at the START of the smoke** — this PR.

So this PR is now scoped to the **health-gate** only (the still-unaddressed half of #1963), layered on top of #1965.

## What this adds
`wh_wait_for_health <base>` in `scripts/e2e/lib/curl-retry.sh`, called at the start of both staging smokes:
- Polls `<base>/api/health` until `200` (best-effort, ~60s = 30 × 2s) **using the real curl binary** — not the retrying override, so the 503-while-starting poll is this single loop, not a nested per-call retry budget.
- Absorbs a post-deploy JVM cold-start (`/api/health` returns `503 status=starting`, the same gate as the prod compose healthcheck at `deploy/docker-compose.prod.yml:64`) **once up front**, instead of every assertion in the burst fighting the cold-start with its own ~39s retry round.
- Best-effort: on timeout it warns and proceeds (returns 0) — the per-request retry (#1965) is the backstop, and a genuinely-down API fails the assertions anyway.

Wired into `e2e-router.sh` and `e2e-tests.sh`; in `e2e-tests.sh` it replaces the old bespoke login-wait loop (`/api/health` 200 means readiness flipped and gated routes serve).

## Why both halves
#1965's budget rides out a 502 **burst that hits mid-smoke**. The health-gate handles the **cold-start at the very start** — without it, the first wave of assertions each burn a full ~39s retry round against a still-starting API. Gating once is cheaper and clearer.

## Discipline preserved
No change to the retry classifier: only transient 5xx (502/503/504) and connection-layer rc (7/28/35/52/56) retry; **expected-4xx assertions still fail-fast**.

## Validation
- `scripts/e2e/lib/curl-retry.test.sh` passes (network-free mock): #1965's escalating-backoff schedule test is untouched; new coverage for `wh_wait_for_health` (clears on 200; best-effort timeout on persistent 503).
- `shellcheck` clean on all four touched files (only pre-existing SC1091 info for `admin-auth.sh` sourcing).
- Real proof is Master API/UI CD **Gate 1 staying green across a deploy** (cold-start) — watching post-merge.

Fixes #1963. Builds on #1965; relates to #1961/#1962/#1964/#1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)