### PR TITLE
feat(#1966): wire shared_hosts — MathAcademy d3js.org/jsdelivr + Feeling Great elevenlabs/launchdarkly

### DIFF
--- a/api/resources/app_templates/_index.yml
+++ b/api/resources/app_templates/_index.yml
@@ -37,8 +37,8 @@ slugs:
   - x
   # #1815: traffic-driven catalog pass (see evidence/classification-1815.md)
   - lego
-  # #1889: Feeling Great CBT app (distinctive host only; shared
-  # elevenlabs/launchdarkly deferred to #1888)
+  # #1889: Feeling Great CBT app (distinctive app.feelinggreat.com +
+  # shared elevenlabs/launchdarkly wired in by #1966)
   - feeling-great
   # #1922: traffic-driven catalog pass (see evidence/classification-1922.md)
   - math-playground

--- a/api/resources/app_templates/feeling-great.yml
+++ b/api/resources/app_templates/feeling-great.yml
@@ -13,16 +13,22 @@ icon_type: url
 # `nftset=/<host>/` suffix-matches `app.feelinggreat.com` and its subtree but
 # not `www.feelinggreat.com` (same deliberate sub-experience scoping as lego.yml).
 #
-# SHARED HOSTS — deferred to #1888 (do NOT add as distinctive hosts here):
-#   * elevenlabs.io   — TTS API powering the AI chat voice
+# SHARED HOSTS — wired in by #1966 (the #1888 mechanism shipped: S1b parse/seed,
+# S2 engaged-min exclusion, S3 reporting allocation, S4 most-permissive
+# enforcement). Listed under `shared_hosts:` below, NOT `hosts:`, so they are:
+#   * elevenlabs.io    — TTS API powering the AI chat voice
 #   * launchdarkly.com — feature flags
 # Both are backends shared by MANY apps. The prod evidence proves it:
-# launchdarkly.com shows meaningful traffic on devices that hit feelinggreat
-# ZERO bytes (every device in the 90d sample), so listing it here would
-# mis-attribute its bytes to Feeling Great. They are the motivating case for the
-# shared-host attribution mechanism (#1888) — once that lands they'll be added
-# here marked `shared` (credited to Feeling Great only when app.feelinggreat.com
-# is also active for the same device/window). TODO(#1888): add elevenlabs.io and
-# launchdarkly.com as `shared` hosts once the mechanism ships.
+# launchdarkly.com shows meaningful traffic on devices that hit feelinggreat ZERO
+# bytes (re-confirmed 2026-06-25: Sameer Desk 431 hits, Skylight Calendar 39,
+# Rachel iPhone 10, none of which run Feeling Great), so listing it as a
+# distinctive host would mis-attribute its bytes to Feeling Great. As `shared`
+# they are credited to Feeling Great only while app.feelinggreat.com is also
+# active for the same device/window (co-presence rule, #1888), and — per S4
+# most-permissive enforcement — carve into `extraAllowed` whenever Feeling Great
+# resolves to Allowed but are NEVER added to a drop set when it is blocked.
 hosts:
   - app.feelinggreat.com
+shared_hosts:
+  - elevenlabs.io     # TTS API for the AI chat voice (apex covers api.elevenlabs.io)
+  - launchdarkly.com  # feature flags (apex covers app./events./sdk.launchdarkly.com)

--- a/api/resources/app_templates/feeling-great.yml
+++ b/api/resources/app_templates/feeling-great.yml
@@ -27,6 +27,11 @@ icon_type: url
 # active for the same device/window (co-presence rule, #1888), and — per S4
 # most-permissive enforcement — carve into `extraAllowed` whenever Feeling Great
 # resolves to Allowed but are NEVER added to a drop set when it is blocked.
+# (`events.launchdarkly.com` also sits on the GLOBAL allow+suppress list
+# `InfraHosts.canonical` (#1503); the overlap is intentional and harmless — that
+# list handles the fleet-wide never-block + presence-suppression for the
+# analytics-events subdomain, while this `shared_hosts:` tag adds per-app
+# co-presence attribution for the rest of the launchdarkly.com surface.)
 hosts:
   - app.feelinggreat.com
 shared_hosts:

--- a/api/resources/app_templates/math-academy.yml
+++ b/api/resources/app_templates/math-academy.yml
@@ -3,5 +3,32 @@ name: Math Academy
 # Emoji fallback: 🧮
 icon: "https://icons.duckduckgo.com/ip3/mathacademy.com.ico"
 icon_type: url
+#
+# SHARED HOSTS (#1966 / #1888). MathAcademy's lesson pages pull two generic
+# multi-tenant library CDNs that are NOT MathAcademy's own bytes — listing them
+# under `hosts:` would mis-credit every other site's use of the same CDN to
+# MathAcademy and (pre-S4) drag them into MathAcademy's drop sets. Prod evidence
+# (2026-06, Prima iPad 04:72:ef:d6:e4:5a + Kid Mac ca:ef:a1:72:6a:a3):
+#   * d3js.org      — the D3.js data-viz library CDN MathAcademy renders graphs
+#                     with. 40 hits on Prima, ALL blocked; 14 during the active
+#                     2026-06-16 14:00–14:45 session WHILE mathacademy.com was
+#                     allow-carved (the operator's motivating observation).
+#   * jsdelivr.net  — generic npm/GitHub package CDN, referenced directly in
+#                     www.mathacademy.com's page HTML (4 `cdn.jsdelivr.net` refs)
+#                     and hit 33× on Prima (blocked schedule/timeLimit).
+# WHY SHARED, NOT GLOBAL-ALLOW: the observed drops were the whole-MAC TimeLimit
+# block (Prima's daily limit exhausted) collateral-dropping these CDNs while
+# MathAcademy — an Allowed/exempt educational app — stayed carved. Tagging them
+# `shared` here makes S4's most-permissive rule carve them into `extraAllowed`
+# exactly when MathAcademy resolves to Allowed (the same disposition that already
+# carves mathacademy.com), so they track mathacademy.com's reachability precisely.
+# They are deliberately NOT added to the global infra allowlist
+# (`InfraHosts.canonical`, #1307/#1308): that list is device-level infra only and
+# explicitly excludes per-app library CDNs, and never-blocking a generic JS-host
+# would punch a hole even when MathAcademy itself is meant to be blocked. Apex
+# form covers all subdomains via HostMatch (per `_README.yml`).
 hosts:
   - mathacademy.com
+shared_hosts:
+  - d3js.org
+  - jsdelivr.net

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -202,6 +202,30 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       val b = tmpl("b", List("b.com"), List("elevenlabs.io"))
       assertTrue(AppTemplates.sharedHostViolations(List(a, b)).isEmpty)
     },
+    test("#1966 Feeling Great + Math Academy wire the known shared backends") {
+      // Pins the #1888 rollout: the four shared backends are listed under
+      // `shared_hosts:` (not distinctive `hosts:`) so S2 excludes them from
+      // engaged-minutes, S3 routes them through co-presence, and S4 keeps them
+      // out of every drop set while carving them when the app is Allowed.
+      for {
+        templates <- AppTemplates.loadAll()
+        bySlug = templates.map(t => t.slug.value -> t).toMap
+        fg     = bySlug("feeling-great")
+        ma     = bySlug("math-academy")
+      } yield assertTrue(
+        // distinctive host-sets stay branded / app-specific
+        fg.hosts == List(Hostname.unsafe("app.feelinggreat.com")),
+        ma.hosts == List(Hostname.unsafe("mathacademy.com")),
+        // shared backends are tagged shared, never distinctive
+        fg.sharedHosts.toSet ==
+          Set(Hostname.unsafe("elevenlabs.io"), Hostname.unsafe("launchdarkly.com")),
+        ma.sharedHosts.toSet ==
+          Set(Hostname.unsafe("d3js.org"), Hostname.unsafe("jsdelivr.net")),
+        // the whole catalog still satisfies the global shared/distinctive
+        // consistency invariant after wiring these in
+        AppTemplates.sharedHostViolations(templates).isEmpty,
+      )
+    },
     test("#1896 seeder persists the shared flag per host") {
       for {
         _       <- cleanDb


### PR DESCRIPTION
## Summary
Completes the **#1888 shared-host rollout**. The mechanism (S1a→S4) is fully merged, but no app template used `shared_hosts:` yet, so the feature shipped doing nothing. This wires in the known shared backends and fixes the operator's prod observation (Prima's iPad: d3js.org blocked alongside MathAcademy).

## Hosts added (under `shared_hosts:`, never `hosts:`)
| Template | shared_hosts | Why shared |
|---|---|---|
| `feeling-great.yml` | `elevenlabs.io`, `launchdarkly.com` | Multi-tenant vendor backends (TTS, feature flags). Resolves the in-file `TODO(#1888)`. |
| `math-academy.yml` | `d3js.org`, `jsdelivr.net` | Generic multi-tenant library CDNs MathAcademy's lesson pages pull. |

Distinctive host-sets unchanged: `app.feelinggreat.com`, `mathacademy.com`.

## Traffic evidence (prod, `api.wifihaven.net`, read-only)
MathAcademy is used by **Kid Mac** (`ca:ef:a1:72:6a:a3`, 267 hits/30d) and **Prima iPad** (`04:72:ef:d6:e4:5a`, 211).

- **d3js.org** — 40 hits on Prima, **all blocked**; 14 during the active **2026-06-16 14:00–14:45** session. The D3.js data-viz library CDN MathAcademy renders graphs with.
- **jsdelivr.net** — referenced directly **4× in `www.mathacademy.com`'s page HTML** (`cdn.jsdelivr.net`), and hit 33× on Prima (blocked schedule/timeLimit). Generic npm/GitHub package CDN.
- **launchdarkly.com** (Feeling Great) — re-confirmed multi-tenant: hit by Sameer Desk (431), Skylight Calendar (39), Rachel iPhone (10) — none of which run Feeling Great. Listing it distinctive would mis-attribute its bytes.

Other common library CDNs (unpkg, cdnjs, jquery, mathjax, katex, polyfill, bootstrapcdn) showed **zero** traffic on the MathAcademy devices — deliberately **not** added (no whack-a-mole, no over-guessing). `fonts.gstatic.com` is hit but is device-wide font infra, not a MathAcademy-distinctive dep, so it's left out.

## Enforcement decision — shared, NOT global-allow (the issue's "IMPORTANT" section)
The observed drops are **not** a bug in the carve — they're the **whole-MAC `TimeLimit` block** (Prima's daily limit exhausted) collateral-dropping d3js.org. The decisive evidence, same MAC/same window on 06-16 14:09–14:39:

```
mathacademy.com  blocked=false  reason=allow      ← MathAcademy carved
d3js.org         blocked=true   reason=timeLimit  ← NOT carved (not listed)
```

So MathAcademy is an **Allowed/exempt educational app** whose hosts carve into `extraAllowed` even under the whole-MAC `TimeLimit` block; `mathacademy.com` carves, `d3js.org` doesn't. Verified in code (`ProfileAppDispositions.enforcement`, `PolicyService.scala`): the **allow** path uses the full host-set (`allowed ++= hosts`), the **block** path only `distinctive`. Tagging d3js.org/jsdelivr `shared` on MathAcademy makes S4's most-permissive rule carve them into `extraAllowed` **exactly when MathAcademy resolves to Allowed** — the same disposition that already carves `mathacademy.com`. They now track `mathacademy.com`'s reachability precisely. **This fixes the operator's observation.**

**Why not the global infra allowlist (`InfraHosts.canonical`, #1307/#1308):**
1. The list is **device-level infra only** and its boundary doc explicitly excludes per-app library/asset CDNs ("must ATTRIBUTE to the app and COUNT, not be suppressed").
2. It's **unnecessary** — the shared carve already covers the observed case.
3. It would be **wrong** — never-blocking a generic JS-hosting CDN punches a hole even when MathAcademy is genuinely meant to be blocked (Schedule/Paused/Manual). With shared-tagging the CDNs are reachable **iff** MathAcademy is, which is the correct, strictly-tighter behavior.

Note: when Prima's **whole MAC** is time-blocked and MathAcademy is Allowed/exempt, these CDNs now carve and render. If MathAcademy were ever set to a non-exempt mode that the daily limit blocks, the CDNs would (correctly) drop with it.

## Consistency audit
Grepped the full catalog for any template listing a now-shared host (`d3js.org`, `jsdelivr`, `elevenlabs.io`, `launchdarkly.com`) under plain `hosts:`. **None** — the global shared/distinctive consistency invariant holds. (`InfraHosts.canonical` lists `events.launchdarkly.com` for the *global never-block* path; that's a separate mechanism from per-app `shared_hosts:` and not a violation.)

## Tests
- New `AppTemplatesSpec` test `#1966 Feeling Great + Math Academy wire the known shared backends` pins the four shared entries, the distinctive host-sets, and re-asserts `sharedHostViolations(catalog).isEmpty`.
- `mill api.test` green (all suites, 0 failures); `scalafmt --check` clean.

Fixes #1966
Relates to #1888, #1899, #1889, #1307, #1308