### PR TITLE
fix(#1959): agent ws client reassembles fragmented frames (large policy push)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/ws_client.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/ws_client.lua
@@ -155,20 +155,35 @@ end
 -- the whole loop. Validated on a real Lua-5.1 + packaged-cqueues (epoll) target:
 -- without the clearerr the connection dies after a few idle heartbeat cycles.
 function M:recv(timeout)
+  -- Reassemble fragmented messages (RFC 6455 §5.4): a large server push (e.g. a
+  -- #1849 `policy` snapshot, which Render's edge re-fragments at ~4 KiB) arrives
+  -- as TEXT(FIN=0) + CONTINUATION frames. Returning the first frame raw (the
+  -- pre-#1959 behaviour) truncates the snapshot to unparseable JSON. The pure
+  -- reassembler (ws_frame) accumulates fragments and passes interleaved control
+  -- frames back for us to answer; it persists across recv() calls so a message
+  -- split over multiple socket reads still completes.
+  self.reasm = self.reasm or ws_frame.reassembler()
   while true do
     local frame, consumed = ws_frame.decode(self.rxbuf)
     if frame then
       self.rxbuf = self.rxbuf:sub(consumed + 1)
-      if frame.opcode == ws_frame.OP_PING then
-        self:send_pong(frame.payload)            -- heartbeat: keepalive
-      elseif frame.opcode == ws_frame.OP_PONG then
-        -- liveness ack; caller may track it. Loop for the next real frame.
-      elseif frame.opcode == ws_frame.OP_CLOSE then
+      local status, a, b = self.reasm:push(frame)
+      if status == "control" then
+        local opcode, payload = a, b
+        if opcode == ws_frame.OP_PING then
+          self:send_pong(payload)                -- heartbeat: keepalive
+        elseif opcode == ws_frame.OP_CLOSE then
+          self.closed = true
+          return nil, "closed"
+        end
+        -- OP_PONG: liveness ack; loop for the next frame.
+      elseif status == "message" then
+        return a, b                              -- (opcode, reassembled payload)
+      elseif status == "error" then
         self.closed = true
-        return nil, "closed"
-      else
-        return frame.opcode, frame.payload       -- text/binary/continuation
+        return nil, "protocol: " .. tostring(a)
       end
+      -- "more": a fragment was buffered; keep reading for the rest.
     elseif frame == false then
       self.closed = true
       return nil, "protocol: " .. tostring(consumed)

--- a/openwrt/files/usr/lib/lua/wifihaven/ws_frame.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/ws_frame.lua
@@ -174,4 +174,75 @@ function M.new_client_key(rand16_fn, base64_fn)
   return base64_fn(rand16_fn(16))
 end
 
+-- ── message reassembly (RFC 6455 §5.4) ───────────────────────────────────────
+--
+-- decode() returns ONE frame at a time; a single application message may be
+-- split across a leading data frame (TEXT/BINARY, FIN=0) plus CONTINUATION
+-- (0x0) frames, with control frames (ping/pong/close) optionally interleaved.
+-- The server (and intermediaries — Render's edge re-fragments large outbound
+-- frames at ~4 KiB, #1959) can split a large `policy` push this way, so the
+-- agent MUST reassemble or it truncates the snapshot to garbage.
+--
+-- This is the part of the cqueues client's recv loop that has no I/O, so it
+-- lives here (PURE, no cqueues) where it is unit-tested on the dev host AND
+-- runs identically under OpenWrt Lua 5.1 — the same split the rest of this
+-- module uses. The cqueues client (ws_client:recv) feeds each decoded frame to
+-- push() and acts on the verdict.
+--
+-- reassembler() → object with push(frame) → (status, a, b):
+--   "message", opcode, payload  — a complete application message (the START
+--                                 data opcode + concatenated payload). Returned
+--                                 for an unfragmented data frame, or the final
+--                                 CONTINUATION of a fragmented one.
+--   "control", opcode, payload  — a control frame (ping/pong/close); the caller
+--                                 handles it (pong/close) and keeps reading.
+--                                 Reassembly state is untouched (§5.4 allows
+--                                 control frames between message fragments).
+--   "more"                      — fragment accepted; need more frames.
+--   "error",  reason            — a protocol violation; the caller must drop the
+--                                 connection. reason ∈ { unexpected_continuation,
+--                                 interleaved_data, fragmented_control }.
+local Reassembler = {}
+Reassembler.__index = Reassembler
+
+function M.reassembler()
+  return setmetatable({ op = nil, parts = nil }, Reassembler)
+end
+
+function Reassembler:push(frame)
+  local opcode = frame.opcode
+
+  -- Control frames (0x8..0xF) are never part of a data message and MUST NOT be
+  -- fragmented (§5.5). They pass straight through; an in-progress fragmented
+  -- data message is unaffected.
+  if opcode >= 0x8 then
+    if not frame.fin then return "error", "fragmented_control" end
+    return "control", opcode, frame.payload
+  end
+
+  if opcode == M.OP_CONTINUATION then
+    if not self.op then return "error", "unexpected_continuation" end
+    self.parts[#self.parts + 1] = frame.payload
+    if not frame.fin then return "more" end
+    local payload = table.concat(self.parts)
+    local start_op = self.op
+    self.op, self.parts = nil, nil          -- reset for the next message
+    return "message", start_op, payload
+  end
+
+  -- A data frame (TEXT/BINARY). A NEW data frame while a message is still being
+  -- assembled is illegal — only continuations and control frames may follow a
+  -- FIN=0 data frame (§5.4).
+  if self.op then return "error", "interleaved_data" end
+
+  if frame.fin then                          -- the common unfragmented case
+    return "message", opcode, frame.payload
+  end
+
+  -- Start of a fragmented message: remember the opcode, buffer the first chunk.
+  self.op = opcode
+  self.parts = { frame.payload }
+  return "more"
+end
+
 return M

--- a/openwrt/files/usr/lib/lua/wifihaven/ws_frame.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/ws_frame.lua
@@ -201,32 +201,46 @@ end
 --   "more"                      — fragment accepted; need more frames.
 --   "error",  reason            — a protocol violation; the caller must drop the
 --                                 connection. reason ∈ { unexpected_continuation,
---                                 interleaved_data, fragmented_control }.
+--                                 interleaved_data, fragmented_control,
+--                                 oversized_control, message_too_large }.
+--
+-- reassembler(max_bytes) — cap the TOTAL assembled message size (default 1 MiB).
+-- decode()'s 64-bit-length guard bounds a SINGLE frame; this bounds the sum
+-- across continuation frames so a buggy/hostile peer streaming endless
+-- continuations cannot grow self.parts unbounded and OOM the RAM-constrained
+-- router. A real `policy` snapshot is far under this.
 local Reassembler = {}
 Reassembler.__index = Reassembler
 
-function M.reassembler()
-  return setmetatable({ op = nil, parts = nil }, Reassembler)
+local DEFAULT_MAX_BYTES = 1024 * 1024
+
+function M.reassembler(max_bytes)
+  return setmetatable(
+    { op = nil, parts = nil, size = 0, max_bytes = max_bytes or DEFAULT_MAX_BYTES },
+    Reassembler)
 end
 
 function Reassembler:push(frame)
   local opcode = frame.opcode
 
   -- Control frames (0x8..0xF) are never part of a data message and MUST NOT be
-  -- fragmented (§5.5). They pass straight through; an in-progress fragmented
-  -- data message is unaffected.
+  -- fragmented (§5.5) and MUST carry ≤125 payload bytes. They pass straight
+  -- through; an in-progress fragmented data message is unaffected.
   if opcode >= 0x8 then
     if not frame.fin then return "error", "fragmented_control" end
+    if #frame.payload > 125 then return "error", "oversized_control" end
     return "control", opcode, frame.payload
   end
 
   if opcode == M.OP_CONTINUATION then
     if not self.op then return "error", "unexpected_continuation" end
+    self.size = self.size + #frame.payload
+    if self.size > self.max_bytes then return "error", "message_too_large" end
     self.parts[#self.parts + 1] = frame.payload
     if not frame.fin then return "more" end
     local payload = table.concat(self.parts)
     local start_op = self.op
-    self.op, self.parts = nil, nil          -- reset for the next message
+    self.op, self.parts, self.size = nil, nil, 0   -- reset for the next message
     return "message", start_op, payload
   end
 
@@ -240,8 +254,10 @@ function Reassembler:push(frame)
   end
 
   -- Start of a fragmented message: remember the opcode, buffer the first chunk.
+  if #frame.payload > self.max_bytes then return "error", "message_too_large" end
   self.op = opcode
   self.parts = { frame.payload }
+  self.size = #frame.payload
   return "more"
 end
 

--- a/openwrt/spike/ws-1845/e2e_test.sh
+++ b/openwrt/spike/ws-1845/e2e_test.sh
@@ -46,16 +46,19 @@ trap 'kill "${SRV_PID:-}" 2>/dev/null || true; rm -rf "$WORK"' EXIT
 BASE_PORT=$(( 20000 + ($$ % 20000) ))
 FAILED=0
 
-# run_case <name> <server-args> <client-uri> <client-env>
+# run_case <name> <server-args> <client-uri> <client-env> [client-cmd] [server-env]
+# client-cmd defaults to `poc_echo.lua <uri> 4`; server-env is extra env for the
+# echo server (e.g. WS_ECHO_FRAGMENT=512 to drive the #1959 reassembly case).
 run_case() {
   name="$1"; srv_args="$2"; uri="$3"; cli_env="$4"
+  cli_cmd="${5:-poc_echo.lua $uri 4}"; srv_env="${6:-}"
   log="$WORK/$name.srv.log"
   # shellcheck disable=SC2086
-  WS_ECHO_DEBUG=1 "$LUA" run_echo_server.lua $srv_args >"$log" 2>&1 &
+  env $srv_env WS_ECHO_DEBUG=1 "$LUA" run_echo_server.lua $srv_args >"$log" 2>&1 &
   SRV_PID=$!
   sleep 1
   # shellcheck disable=SC2086
-  if env $cli_env "$LUA" poc_echo.lua "$uri" 4 >"$WORK/$name.cli.log" 2>&1 \
+  if env $cli_env "$LUA" $cli_cmd >"$WORK/$name.cli.log" 2>&1 \
        && grep -q "RESULT: PASS" "$WORK/$name.cli.log"; then
     echo "PASS  $name  ($uri)"
   else
@@ -81,6 +84,22 @@ openssl req -x509 -newkey rsa:2048 -keyout "$WORK/key.pem" -out "$WORK/cert.pem"
   -days 1 -nodes -subj /CN=localhost >/dev/null 2>&1
 run_case "wss" "$WSS_PORT tls $WORK/cert.pem $WORK/key.pem" \
   "wss://localhost:$WSS_PORT" "WS_INSECURE=1"
+
+# Case 3: #1959 fragment reassembly over ws:// — the server echoes a 12 KiB
+# payload as 512-byte §5.4 fragments (TEXT FIN=0 + CONTINUATIONs) with an
+# interleaved PING; the client must reassemble it byte-for-byte. Before #1959
+# the client returned only the first fragment and poc_fragment FAILs the length
+# check. This is the real-Lua-5.1/cqueues twin of the pure ws_frame_spec case.
+FRAG_PORT=$(( BASE_PORT + 2 ))
+run_case "frag-ws" "$FRAG_PORT" "ws://127.0.0.1:$FRAG_PORT" "" \
+  "poc_fragment.lua ws://127.0.0.1:$FRAG_PORT 12288" "WS_ECHO_FRAGMENT=512"
+
+# Case 4: the same over wss:// (TLS), since the prod re-fragmentation that
+# motivates #1959 happens at the TLS edge.
+FRAG_WSS_PORT=$(( BASE_PORT + 3 ))
+run_case "frag-wss" "$FRAG_WSS_PORT tls $WORK/cert.pem $WORK/key.pem" \
+  "wss://localhost:$FRAG_WSS_PORT" "WS_INSECURE=1" \
+  "poc_fragment.lua wss://localhost:$FRAG_WSS_PORT 12288" "WS_ECHO_FRAGMENT=512"
 
 if [ "$FAILED" -eq 0 ]; then
   echo "== ws e2e: ALL PASS =="

--- a/openwrt/spike/ws-1845/echo_server.lua
+++ b/openwrt/spike/ws-1845/echo_server.lua
@@ -48,6 +48,38 @@ end
 local DEBUG = os.getenv("WS_ECHO_DEBUG")
 local function dbg(...) if DEBUG then io.write("[echo] ", table.concat({...}, " "), "\n"); io.flush() end end
 
+-- WS_ECHO_FRAGMENT=<chunk>: instead of echoing a data frame in one shot, split
+-- it into <chunk>-byte RFC 6455 §5.4 fragments — a TEXT/BINARY frame with FIN=0,
+-- then CONTINUATION (0x0) frames, the last FIN=1 — and inject a PING after the
+-- first fragment. This drives the #1959 client-side reassembly path (continuation
+-- + interleaved control) over the REAL cqueues socket on the Lua-5.1 target,
+-- which the pure busted spec can't reach. Default 0 = no fragmentation.
+local FRAGMENT = tonumber(os.getenv("WS_ECHO_FRAGMENT") or "0") or 0
+
+-- Echo `payload` (opcode = the client's data opcode) back to the socket, either
+-- as one frame or as FRAGMENT-byte fragments with an interleaved ping.
+local function echo_payload(sock, opcode, payload)
+  if FRAGMENT <= 0 or #payload <= FRAGMENT then
+    sock:write(ws_frame.encode(opcode, payload)); sock:flush()
+    return
+  end
+  local pos, first = 1, true
+  while pos <= #payload do
+    local chunk = payload:sub(pos, pos + FRAGMENT - 1)
+    local last = (pos + FRAGMENT) > #payload
+    local op = first and opcode or ws_frame.OP_CONTINUATION
+    sock:write(ws_frame.encode(op, chunk, nil, last))  -- fin=last
+    sock:flush()
+    if first then
+      -- §5.4: a control frame between message fragments. The client must pong
+      -- this WITHOUT corrupting the in-progress reassembly.
+      sock:write(ws_frame.encode(ws_frame.OP_PING, "mid")); sock:flush()
+      first = false
+    end
+    pos = pos + FRAGMENT
+  end
+end
+
 local function serve(sock, crypto)
   sock:setmode("b", "b")
   if not handshake(sock, crypto) then sock:close(); return end
@@ -65,10 +97,8 @@ local function serve(sock, crypto)
       elseif frame.opcode == ws_frame.OP_PONG then
         -- ignore
       else
-        local out = ws_frame.encode(frame.opcode, frame.payload)
-        local ok, werr = sock:write(out)
-        sock:flush()
-        dbg("echoed", #out, "bytes, write ok=", tostring(ok), "err=", tostring(werr))
+        dbg("echoing", #frame.payload, "byte payload, fragment=", tostring(FRAGMENT))
+        echo_payload(sock, frame.opcode, frame.payload)
       end
     elseif frame == false then
       break

--- a/openwrt/spike/ws-1845/poc_fragment.lua
+++ b/openwrt/spike/ws-1845/poc_fragment.lua
@@ -1,0 +1,77 @@
+#!/usr/bin/env lua
+-- poc_fragment.lua — on-target proof for the #1959 ws frame reassembly fix.
+-- TARGET/Linux only (needs cqueues + openssl), same as poc_echo.lua.
+--
+-- Sends a LARGE (default 12 KiB) text payload to a fragmenting echo server
+-- (run_echo_server.lua with WS_ECHO_FRAGMENT set). The server echoes it back
+-- as a TEXT(FIN=0) + CONTINUATION(0x0) sequence with a PING interleaved between
+-- fragments. The REAL ws_client:recv must reassemble those fragments — and pong
+-- the interleaved ping without corrupting the message — into the exact bytes we
+-- sent. A byte-for-byte match proves the §5.4 reassembly works on the real
+-- Lua-5.1 + cqueues stack, which the pure busted spec (ws_frame_spec.lua) can't
+-- exercise. Before #1959 the client returned only the first ~chunk and this
+-- FAILS the length/equality check.
+--
+--   lua poc_fragment.lua <uri> [payload_bytes]
+-- Exit 0 = reassembled payload == sent payload. Non-zero = mismatch/failure.
+
+local SCRIPT_DIR = (arg and arg[0] and arg[0]:match("^(.*/)") or "./")
+package.path = SCRIPT_DIR .. "?.lua;"
+  .. SCRIPT_DIR .. "../../files/usr/lib/lua/?.lua;" .. package.path
+
+local cqueues = require("cqueues")
+local ws_client = require("wifihaven.ws_client")
+
+local uri = arg[1] or "ws://127.0.0.1:8800"
+local N = tonumber(arg[2] or "12288")        -- 12 KiB > the ~4 KiB edge boundary
+
+local function log(...) io.write("[frag] ", table.concat({ ... }, " "), "\n"); io.flush() end
+
+-- A non-uniform payload so a wrong offset/truncation can't accidentally match:
+-- a repeating 0..9 ramp, distinct per position modulo 10.
+local function make_payload(n)
+  local t = {}
+  for i = 1, n do t[i] = string.char(48 + ((i - 1) % 10)) end
+  return table.concat(t)
+end
+
+local loop = cqueues.new()
+local ok_overall = false
+
+loop:wrap(function()
+  local c, err = ws_client.connect(uri,
+    { connect_timeout = 10, insecure = (os.getenv("WS_INSECURE") ~= nil) })
+  if not c then log("connect failed:", tostring(err)); return end
+  log("connected + handshake OK")
+
+  local sent = make_payload(N)
+  assert(c:send_text(sent))
+  log("sent", tostring(#sent), "byte payload")
+
+  -- recv() must internally reassemble the fragmented echo + answer the
+  -- interleaved ping. A single recv() returns the WHOLE reassembled message.
+  local op, payload = c:recv(15)
+  if not op then
+    log("recv failed:", tostring(payload))
+  elseif #payload ~= #sent then
+    log("LENGTH MISMATCH: got", tostring(#payload), "want", tostring(#sent),
+      "(truncated — reassembly broken)")
+  elseif payload ~= sent then
+    log("CONTENT MISMATCH: same length but bytes differ")
+  else
+    log("reassembled", tostring(#payload), "bytes, exact match")
+    ok_overall = true
+  end
+  c:close()
+end)
+
+local ok, lerr = loop:loop()
+if not ok then log("event loop error:", tostring(lerr)) end
+
+if ok_overall then
+  log("RESULT: PASS — fragmented message reassembled intact (#1959)")
+  os.exit(0)
+else
+  log("RESULT: FAIL — see log above")
+  os.exit(1)
+end

--- a/openwrt/test/ws_frame_spec.lua
+++ b/openwrt/test/ws_frame_spec.lua
@@ -270,6 +270,39 @@ describe("ws_frame", function()
       assert.are.equal(expected, payload)
     end)
 
+    it("errors when the assembled size exceeds the cap (no unbounded growth)", function()
+      -- A tiny cap so the test stays fast; the start frame is under it, the
+      -- continuation pushes the running total over.
+      local r = frame.reassembler(10)
+      assert.are.equal("more", (r:push(fr(frame.OP_TEXT, "12345", false))))   -- 5 ≤ 10
+      local status, err = r:push(fr(frame.OP_CONTINUATION, "678901", false))  -- 11 > 10
+      assert.are.equal("error", status)
+      assert.are.equal("message_too_large", err)
+    end)
+
+    it("errors when the FIRST frame already exceeds the cap", function()
+      local r = frame.reassembler(4)
+      local status, err = r:push(fr(frame.OP_TEXT, "toolong", false))
+      assert.are.equal("error", status)
+      assert.are.equal("message_too_large", err)
+    end)
+
+    it("resets the size counter so a second large-but-ok message still passes", function()
+      local r = frame.reassembler(10)
+      r:push(fr(frame.OP_TEXT, "12345", false))
+      assert.are.equal("message", (r:push(fr(frame.OP_CONTINUATION, "67", true))))  -- 7 ≤ 10
+      -- counter reset to 0; another 7-byte message is fine, not 14 cumulative.
+      r:push(fr(frame.OP_TEXT, "abcde", false))
+      assert.are.equal("message", (r:push(fr(frame.OP_CONTINUATION, "fg", true))))
+    end)
+
+    it("errors on a control frame with a >125-byte payload (§5.5)", function()
+      local r = frame.reassembler()
+      local status, err = r:push(fr(frame.OP_PING, string.rep("x", 126)))
+      assert.are.equal("error", status)
+      assert.are.equal("oversized_control", err)
+    end)
+
     it("can reassemble a second message after the first completes", function()
       local r = frame.reassembler()
       r:push(fr(frame.OP_TEXT, "one", false))

--- a/openwrt/test/ws_frame_spec.lua
+++ b/openwrt/test/ws_frame_spec.lua
@@ -158,4 +158,127 @@ describe("ws_frame", function()
       assert.are.equal(data, frame.apply_mask(masked, key))
     end)
   end)
+
+  -- reassembler() — the #1959 fix. A pure, stateful accumulator that turns a
+  -- stream of decoded frames (the output of decode()) into complete application
+  -- messages, reassembling RFC 6455 §5.4 fragmentation (a data frame with
+  -- FIN=0 followed by CONTINUATION frames) and passing interleaved control
+  -- frames straight through. It is the part of M:recv that the cqueues client
+  -- couldn't unit-test on macOS, lifted out so it runs identically here and on
+  -- the real Lua-5.1 target. Vectors mirror the RFC §5.4 / §5.7 fragmentation
+  -- examples.
+  describe("reassembler (RFC 6455 §5.4 fragmentation)", function()
+    -- helper: a decoded-frame table as decode() would return.
+    local function fr(opcode, payload, fin)
+      if fin == nil then fin = true end
+      return { fin = fin, opcode = opcode, payload = payload or "" }
+    end
+
+    it("passes an unfragmented text frame straight through as a message", function()
+      local r = frame.reassembler()
+      local status, opcode, payload = r:push(fr(frame.OP_TEXT, "Hello"))
+      assert.are.equal("message", status)
+      assert.are.equal(frame.OP_TEXT, opcode)
+      assert.are.equal("Hello", payload)
+    end)
+
+    it("preserves the binary opcode for an unfragmented binary frame", function()
+      local r = frame.reassembler()
+      local status, opcode = r:push(fr(frame.OP_BINARY, "\1\2\3"))
+      assert.are.equal("message", status)
+      assert.are.equal(frame.OP_BINARY, opcode)
+    end)
+
+    it("reassembles TEXT(fin=0) + CONTINUATION(fin=1) into one message", function()
+      local r = frame.reassembler()
+      assert.are.equal("more", (r:push(fr(frame.OP_TEXT, "Hel", false))))
+      local status, opcode, payload =
+        r:push(fr(frame.OP_CONTINUATION, "lo", true))
+      assert.are.equal("message", status)
+      assert.are.equal(frame.OP_TEXT, opcode)        -- the START opcode, not 0x0
+      assert.are.equal("Hello", payload)
+    end)
+
+    it("reassembles a three-fragment message in order", function()
+      local r = frame.reassembler()
+      assert.are.equal("more", (r:push(fr(frame.OP_TEXT, "abc", false))))
+      assert.are.equal("more", (r:push(fr(frame.OP_CONTINUATION, "def", false))))
+      local status, _, payload = r:push(fr(frame.OP_CONTINUATION, "ghi", true))
+      assert.are.equal("message", status)
+      assert.are.equal("abcdefghi", payload)
+    end)
+
+    it("surfaces a control frame interleaved between fragments, then completes", function()
+      local r = frame.reassembler()
+      assert.are.equal("more", (r:push(fr(frame.OP_TEXT, "Hel", false))))
+      -- §5.4: a control frame MAY appear in the middle of a fragmented message.
+      local cstatus, copcode, cpayload = r:push(fr(frame.OP_PING, "hb"))
+      assert.are.equal("control", cstatus)
+      assert.are.equal(frame.OP_PING, copcode)
+      assert.are.equal("hb", cpayload)
+      -- the fragmented data message is unaffected and still completes.
+      local status, opcode, payload =
+        r:push(fr(frame.OP_CONTINUATION, "lo", true))
+      assert.are.equal("message", status)
+      assert.are.equal(frame.OP_TEXT, opcode)
+      assert.are.equal("Hello", payload)
+    end)
+
+    it("passes a standalone control frame through as control", function()
+      local r = frame.reassembler()
+      local status, opcode = r:push(fr(frame.OP_CLOSE, ""))
+      assert.are.equal("control", status)
+      assert.are.equal(frame.OP_CLOSE, opcode)
+    end)
+
+    it("errors on a CONTINUATION with no message in progress", function()
+      local r = frame.reassembler()
+      local status, err = r:push(fr(frame.OP_CONTINUATION, "x", true))
+      assert.are.equal("error", status)
+      assert.are.equal("unexpected_continuation", err)
+    end)
+
+    it("errors on a new data frame while a message is in progress", function()
+      local r = frame.reassembler()
+      assert.are.equal("more", (r:push(fr(frame.OP_TEXT, "Hel", false))))
+      local status, err = r:push(fr(frame.OP_TEXT, "new", false))
+      assert.are.equal("error", status)
+      assert.are.equal("interleaved_data", err)
+    end)
+
+    it("errors on a fragmented (fin=0) control frame", function()
+      local r = frame.reassembler()
+      local status, err = r:push(fr(frame.OP_PING, "x", false))
+      assert.are.equal("error", status)
+      assert.are.equal("fragmented_control", err)
+    end)
+
+    it("handles a >4 KiB payload split across many continuation frames", function()
+      local r = frame.reassembler()
+      local chunk = string.rep("z", 1000)
+      local expected = ""
+      -- 1 TEXT start + 9 continuations = ~10 KiB, well past the ~4 KiB edge
+      -- re-fragmentation boundary the #1959 issue calls out.
+      r:push(fr(frame.OP_TEXT, chunk, false)); expected = expected .. chunk
+      for _ = 1, 8 do
+        r:push(fr(frame.OP_CONTINUATION, chunk, false)); expected = expected .. chunk
+      end
+      local status, _, payload = r:push(fr(frame.OP_CONTINUATION, chunk, true))
+      expected = expected .. chunk
+      assert.are.equal("message", status)
+      assert.are.equal(10000, #payload)
+      assert.are.equal(expected, payload)
+    end)
+
+    it("can reassemble a second message after the first completes", function()
+      local r = frame.reassembler()
+      r:push(fr(frame.OP_TEXT, "one", false))
+      assert.are.equal("message", (r:push(fr(frame.OP_CONTINUATION, "1", true))))
+      -- state is reset; a fresh fragmented message reassembles cleanly.
+      r:push(fr(frame.OP_TEXT, "two", false))
+      local status, _, payload = r:push(fr(frame.OP_CONTINUATION, "2", true))
+      assert.are.equal("message", status)
+      assert.are.equal("two2", payload)
+    end)
+  end)
 end)


### PR DESCRIPTION
## What

The OpenWRT agent's hand-rolled RFC 6455 ws client (`ws_client:recv`, #1848) did **not reassemble fragmented WebSocket messages** — it returned the *first* frame raw, never inspecting `frame.fin` or accumulating `CONTINUATION` frames. A large #1849 `policy` push that the edge re-fragments at ~4 KiB (observed against staging behind Render) therefore truncated to unparseable JSON, and `ws_loop.handle_inbound` dropped it as `"unknown"`. Once apply-on-push (#1945) lands, a large snapshot would silently fail to apply.

Fixes #1959.

## How

- **`ws_frame.reassembler()`** — a new **pure**, stateful accumulator (RFC 6455 §5.4): buffers a `TEXT`/`BINARY`(FIN=0) start frame + its `CONTINUATION` (0x0) frames into one message, returning the **start** opcode + concatenated payload; passes interleaved control frames (ping/pong/close) straight through (§5.4 permits them mid-message); and rejects the protocol violations (`unexpected_continuation`, `interleaved_data`, `fragmented_control`).
- **`ws_client:recv`** now drives the reassembler and answers control frames exactly as before. The reassembler persists across `recv()` calls, so a message split over multiple socket reads still completes.

Keeping the logic pure means it unit-tests on the dev host **and** runs identically under OpenWrt Lua 5.1 — the same split the rest of `ws_frame` uses. No new decision logic on the router; this is framing only.

## Tests (TDD — red commit `c3566e53`, green `4f48263b`)

- **Unit (`ws_frame_spec.lua`):** 11 new cases — continuation reassembly, three-fragment ordering, interleaved control, standalone control, >4 KiB many-fragment payload, second-message reset, and the three §5.4 protocol errors. Runs on macOS busted + PUC Lua 5.1.
- **On-target e2e (`spike/ws-1845`):** the echo server gained a `WS_ECHO_FRAGMENT` mode (splits its echo into §5.4 fragments with an interleaved ping); `poc_fragment.lua` asserts a 12 KiB payload round-trips byte-for-byte; `e2e_test.sh` runs it over `ws://` **and** `wss://`.

### Real-hardware validation (Lua 5.1 + packaged cqueues/luaossl, plex.lan)
```
== ws e2e (LUA=.../lua5.1) ==
PASS  ws       (ws://127.0.0.1:22288)
PASS  wss      (wss://localhost:22289)
PASS  frag-ws  (ws://127.0.0.1:22290)
PASS  frag-wss (wss://localhost:22291)
== ws e2e: ALL PASS ==
```
Pre-fix the client returns only the first 512 B fragment and the length check fails. Full openwrt suite: 947 busted + 44 shell, 0 failures.

## Wire contract

No wire change — purely the client's frame-decode path. Additive (`ws_frame.reassembler()`); both sides already ignore unknown fields.

Relates to #1023, #1848, #1849, #1945, #1958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)