### PR TITLE
feat(#1968): SPA-ws S1 — /api/ws endpoint + {op,payload} demux + SpaWsRegistry + subscriptions

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -341,7 +341,11 @@ object Main extends ZIOAppDefault {
         alertRepo,
         hsRepo,
       )
-      wsRegistry <- RouterWsRegistry.make
+      wsRegistry    <- RouterWsRegistry.make
+      // #1968: the browser-facing SPA websocket registry (S1). A FORK of the router registry pattern
+      // (design §5.1), not a generalization — keyed by per-connection id + role with a subscription
+      // set. Additive: REST stays the fallback throughout the rollout (no flag day).
+      spaWsRegistry <- SpaWsRoutes.registry
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield {
       // #1177: split the route composition into typed chunks. A flat `++` chain across
@@ -459,6 +463,10 @@ object Main extends ZIOAppDefault {
             policy,
           ) ++
           RouterMetricsRoutes.routes(routerAuth, routerMetrics) ++
+          // #1968: additive browser-facing websocket endpoint (`GET /api/ws`, S1). Skeleton only —
+          // envelope demux + subscription registry; upgrade auth is S2, push sources S3/S4. The SPA
+          // has no ws client yet (S5), so this reads idle in prod until then.
+          SpaWsRoutes.routes(spaWsRegistry, clock) ++
           AlertRoutes.routes(
             auth,
             alertRepo,

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -80,6 +80,15 @@ object MetricGuard {
       // `usage_shared_host_attribution_total`. A fixed 3-value enum (attributed /
       // split / other); bounded, so it satisfies the §4 cardinality firewall.
       "outcome",
+      // #1968 — SPA-websocket transport (server side). `role` is the connection's
+      // resolved UserRole (admin | adult | child — a fixed 3-value enum), `topic`
+      // is the subscribable SpaTopic wire name (trafficUsage | now |
+      // connectionEvents | timeStatus | appUsage | stale — a fixed 6-value enum).
+      // Both bounded by the protocol vocabulary, NOT by user/profile/session growth
+      // (params such as profileId are deliberately kept OUT of labels, design §7),
+      // so they satisfy the §4 cardinality firewall.
+      "role",
+      "topic",
     )
 
   /**
@@ -222,6 +231,19 @@ object MetricGuard {
     // firewall would reject both names as unknown_name and the series would never emit.)
     "policy_snapshot_build_total"               -> Set("result"),
     "router_ws_policy_push_total"               -> Set("result"),
+    // #1968 — SPA-websocket transport (server side, design `docs/design/spa-websocket.md` §7).
+    // `spa_ws_connections_active` is the live count of open /api/ws channels per `role`
+    // (admin|adult|child), refreshed on every register/deregister so a role's series ages out to 0
+    // on disconnect. `spa_ws_frames_total` counts every frame demuxed/sent: `op` ∈ {hello, ready,
+    // subscribe, unsubscribe, ack, ping, pong, unknown} (the fixed SPA envelope vocabulary),
+    // `direction` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. `spa_ws_subscriptions_active`
+    // is the live count of subscriptions per `topic` (the SpaTopic enum). All bounded enums — no
+    // per-mac / per-profile / per-session / param dimension ever rides a ws metric. (The
+    // spa_ws_auth_total / spa_ws_push_total families land with S2/S3/S4, when they are first
+    // emitted — added then, not now, so every Allowed entry maps to a live call site.)
+    "spa_ws_connections_active"                 -> Set("role"),
+    "spa_ws_frames_total"                       -> Set("op", "direction", "result"),
+    "spa_ws_subscriptions_active"               -> Set("topic"),
     // #1848 — AGENT-side websocket transport metrics. The wifihaven-ws sidecar has no metrics
     // registry of its own, so it writes a cumulative tally that the agent folds into its
     // /api/router/metrics push (the server attaches router_id / installation_id, as for every
@@ -552,6 +574,28 @@ object AppMetrics {
   // = the send failed (a racing disconnect) and the channel is dropped. Bounded enum.
   def recordWsPolicyPush(result: String): UIO[Unit] =
     MetricGuard.counter("router_ws_policy_push_total", Map("result" -> result))
+
+  // ── SPA websocket transport (#1968) ──────────────────────────────────────────
+  // The browser-facing /api/ws endpoint (design `docs/design/spa-websocket.md` §7).
+  // Set by SpaWsRegistry on every register/deregister/subscribe/unsubscribe: the
+  // live count of open channels per `role` and live subscriptions per `topic`,
+  // recomputed and re-published across the bounded role/topic enums so a label whose
+  // count fell to zero is set 0 rather than left stale. recordSpaWsFrame is emitted
+  // from SpaWsRoutes for every frame demuxed (`direction=in`) or sent (`out`); `op`
+  // is the SPA envelope discriminator, `result` ∈ {ok, reject, unknown_op}. All
+  // bounded enums — never a per-mac / per-profile / per-session / param dimension.
+
+  def setSpaWsConnectionsActive(role: String, count: Int): UIO[Unit] =
+    MetricGuard.gauge("spa_ws_connections_active", Map("role" -> role), count.toDouble)
+
+  def setSpaWsSubscriptionsActive(topic: String, count: Int): UIO[Unit] =
+    MetricGuard.gauge("spa_ws_subscriptions_active", Map("topic" -> topic), count.toDouble)
+
+  def recordSpaWsFrame(op: String, direction: String, result: String): UIO[Unit] =
+    MetricGuard.counter(
+      "spa_ws_frames_total",
+      Map("op" -> op, "direction" -> direction, "result" -> result),
+    )
 
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
   // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds

--- a/api/src/observability/LogContext.scala
+++ b/api/src/observability/LogContext.scala
@@ -39,6 +39,11 @@ object LogContext {
   val NotMod    = "notModified"
   val BatchSize = "batchSize"
   val Rejected  = "rejected"
+  // #1968 — SPA-websocket per-frame structured logging (design §10.5). `role` is the
+  // connection's resolved UserRole; `result` is the per-frame outcome (ok | reject |
+  // unknown_op), mirroring the `spa_ws_frames_total` result label. Both bounded enums.
+  val Role      = "role"
+  val Result    = "result"
 
   // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/api/src/routes/SpaWsRegistry.scala
+++ b/api/src/routes/SpaWsRegistry.scala
@@ -1,0 +1,201 @@
+package wifihaven.api.routes
+
+import wifihaven.api.metrics.AppMetrics
+import wifihaven.shared.UserRole
+import zio.*
+import zio.http.WebSocketChannel
+import zio.json.ast.Json
+
+import java.time.Instant
+
+/**
+ * #1968 (S1, SPA-websocket design `docs/design/spa-websocket.md` §1.4): the browser-facing topics a
+ * connection can subscribe to. Every topic maps to an existing REST read model (§0.3) — `SpaTopic`
+ * is just the discriminator the subscription set and fan-out key on, never a new data shape. The
+ * wire names match the `op` the server→SPA push will carry (S3/S4).
+ */
+enum SpaTopic {
+  case TrafficUsage, Now, ConnectionEvents, TimeStatus, AppUsage, Stale
+}
+
+object SpaTopic {
+
+  val all: List[SpaTopic] =
+    List(TrafficUsage, Now, ConnectionEvents, TimeStatus, AppUsage, Stale)
+
+  def wire(t: SpaTopic): String = t match {
+    case TrafficUsage     => "trafficUsage"
+    case Now              => "now"
+    case ConnectionEvents => "connectionEvents"
+    case TimeStatus       => "timeStatus"
+    case AppUsage         => "appUsage"
+    case Stale            => "stale"
+  }
+
+  def parse(s: String): Option[SpaTopic] = s match {
+    case "trafficUsage"     => Some(TrafficUsage)
+    case "now"              => Some(Now)
+    case "connectionEvents" => Some(ConnectionEvents)
+    case "timeStatus"       => Some(TimeStatus)
+    case "appUsage"         => Some(AppUsage)
+    case "stale"            => Some(Stale)
+    case _                  => None
+  }
+
+  /**
+   * S1 placeholder role-authorization (design §4.4 — the fan-out's authz gate, refined by S2's real
+   * cookie auth #1969). Per-profile time topics (`timeStatus`/`appUsage`) are visible to every
+   * authenticated role; the household-wide moderation/bandwidth surfaces require an adult/admin
+   * role. This is intentionally minimal — S1 only needs a real reject path to exercise the
+   * subscription machinery; S2 owns the authoritative per-role visibility once a verified JWT is
+   * available at upgrade.
+   */
+  def visibleTo(t: SpaTopic, role: UserRole): Boolean = role match {
+    case UserRole.Admin | UserRole.Adult => true
+    case UserRole.Child                  => t == TimeStatus || t == AppUsage
+  }
+}
+
+/**
+ * A monotonically-assigned per-connection id — a user may hold N tabs, so the key is the socket.
+ */
+final case class SpaConnId(value: Long) extends AnyVal
+
+/**
+ * Per-connection registry state (design §5.1): the live channel, the resolved [[UserRole]] (the
+ * fan-out authz key, §4.4), the per-connection subscription set `{topic → params}` (§1.4 — the
+ * data-minimization mechanism), and the JWT expiry deadline (captured at upgrade for the §4.3
+ * mid-connection close; populated by S2). `params` is the verbatim subscribe payload's `params`
+ * object — an existing endpoint's query params (§0.3), opaque to S1.
+ */
+final case class SpaConnState(
+    channel: WebSocketChannel,
+    role: UserRole,
+    subscriptions: Map[SpaTopic, Json],
+    jwtExp: Option[Instant],
+)
+
+/**
+ * #1968: the per-connection websocket registry for the browser-facing `/api/ws` endpoint. A FORK of
+ * the [[RouterWsRegistry]] pattern, NOT a generalization of it (design §5.1): the two differ on the
+ * three axes a registry is — key (`SpaConnId` + role vs `RouterId`), per-channel state (a
+ * subscription set + `jwtExp` vs just the channel), and fan-out vocabulary (the §1.2 op catalog,
+ * subscription-gated AND role-filtered, vs one full `PolicySnapshot`). Sharing the *pattern* (a
+ * `Ref[Map[K, …]]` of channels) without coupling the two payload vocabularies.
+ *
+ * Single-process, in-memory — the right shape for the one-API-process household model; cross-
+ * instance fan-out is out of scope (design §5 note, filed as #1952).
+ *
+ * Every mutation refreshes the `spa_ws_connections_active{role}` and `spa_ws_subscriptions_active
+ * {topic}` gauges to their recomputed live totals (across the bounded role/topic enums, so a label
+ * whose count drops to zero is written 0 rather than left stale on disconnect/unsubscribe — §7).
+ *
+ * S1 carries no push/fan-out method yet (`now`/`connectionEvents`/`trafficUsage` pushes are S3/S4);
+ * the registry holds exactly the state those later steps read. Auth is stubbed at upgrade (S2 plugs
+ * the cookie verify), so `register` takes the resolved role + optional `jwtExp` directly.
+ */
+trait SpaWsRegistry {
+
+  /** Record a freshly-upgraded channel with its resolved role; returns its connection id. */
+  def register(channel: WebSocketChannel, role: UserRole, jwtExp: Option[Instant]): UIO[SpaConnId]
+
+  /** Drop a closed/closing connection. Idempotent. Refreshes the gauges. */
+  def deregister(id: SpaConnId): UIO[Unit]
+
+  /**
+   * Set the connection's role. The S1 stub for the `hello` test-handshake (§1.4); S2 resolves the
+   * role from the verified cookie at upgrade and this becomes a no-op for the auth path.
+   */
+  def setRole(id: SpaConnId, role: UserRole): UIO[Unit]
+
+  /** The connection's resolved role, if it is still registered. */
+  def roleFor(id: SpaConnId): UIO[Option[UserRole]]
+
+  /** Add/replace a topic subscription with its params (§1.4 — re-subscribe replaces the prior). */
+  def subscribe(id: SpaConnId, topic: SpaTopic, params: Json): UIO[Unit]
+
+  /** Drop a topic subscription. */
+  def unsubscribe(id: SpaConnId, topic: SpaTopic): UIO[Unit]
+
+  /**
+   * The connection's current subscription set (empty if absent) — the future fan-out gate (§1.4).
+   */
+  def subscriptionsFor(id: SpaConnId): UIO[Map[SpaTopic, Json]]
+
+  /** Total open channels across all connections — backs `spa_ws_connections_active`. */
+  def activeCount: UIO[Int]
+}
+
+object SpaWsRegistry {
+
+  def make: UIO[SpaWsRegistry] =
+    for {
+      state <- Ref.make(Map.empty[SpaConnId, SpaConnState])
+      seq   <- Ref.make(0L)
+    } yield new SpaWsRegistryLive(state, seq)
+}
+
+final class SpaWsRegistryLive(
+    state: Ref[Map[SpaConnId, SpaConnState]],
+    seq: Ref[Long],
+) extends SpaWsRegistry {
+
+  // Recompute both labelled gauges from the live map after every mutation. Both label spaces are
+  // bounded enums (role: 3, topic: 6), so we write every label every time — a role/topic whose
+  // count fell to zero is set 0 rather than left at a stale high-water value.
+  private def publishGauges(m: Map[SpaConnId, SpaConnState]): UIO[Unit] = {
+    val byRole  = m.values.groupBy(_.role).view.mapValues(_.size).toMap
+    val byTopic = m.values
+      .flatMap(_.subscriptions.keysIterator)
+      .foldLeft(Map.empty[SpaTopic, Int])((acc, t) => acc.updated(t, acc.getOrElse(t, 0) + 1))
+    ZIO.foreachDiscard(UserRole.values.toList)(r =>
+      AppMetrics.setSpaWsConnectionsActive(UserRole.asString(r), byRole.getOrElse(r, 0)),
+    ) *>
+      ZIO.foreachDiscard(SpaTopic.all)(t =>
+        AppMetrics.setSpaWsSubscriptionsActive(SpaTopic.wire(t), byTopic.getOrElse(t, 0)),
+      )
+  }
+
+  def register(channel: WebSocketChannel, role: UserRole, jwtExp: Option[Instant]): UIO[SpaConnId] =
+    for {
+      n <- seq.updateAndGet(_ + 1)
+      id = SpaConnId(n)
+      m <- state.updateAndGet(_.updated(id, SpaConnState(channel, role, Map.empty, jwtExp)))
+      _ <- publishGauges(m)
+    } yield id
+
+  def deregister(id: SpaConnId): UIO[Unit] =
+    state.updateAndGet(_.removed(id)).flatMap(publishGauges)
+
+  def setRole(id: SpaConnId, role: UserRole): UIO[Unit] =
+    state
+      .updateAndGet(m => m.get(id).fold(m)(s => m.updated(id, s.copy(role = role))))
+      .flatMap(publishGauges)
+
+  def roleFor(id: SpaConnId): UIO[Option[UserRole]] =
+    state.get.map(_.get(id).map(_.role))
+
+  def subscribe(id: SpaConnId, topic: SpaTopic, params: Json): UIO[Unit] =
+    state
+      .updateAndGet(m =>
+        m.get(id)
+          .fold(m)(s =>
+            m.updated(id, s.copy(subscriptions = s.subscriptions.updated(topic, params))),
+          ),
+      )
+      .flatMap(publishGauges)
+
+  def unsubscribe(id: SpaConnId, topic: SpaTopic): UIO[Unit] =
+    state
+      .updateAndGet(m =>
+        m.get(id)
+          .fold(m)(s => m.updated(id, s.copy(subscriptions = s.subscriptions.removed(topic)))),
+      )
+      .flatMap(publishGauges)
+
+  def subscriptionsFor(id: SpaConnId): UIO[Map[SpaTopic, Json]] =
+    state.get.map(_.get(id).map(_.subscriptions).getOrElse(Map.empty))
+
+  def activeCount: UIO[Int] =
+    state.get.map(_.size)
+}

--- a/api/src/routes/SpaWsRoutes.scala
+++ b/api/src/routes/SpaWsRoutes.scala
@@ -1,0 +1,270 @@
+package wifihaven.api.routes
+
+import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.observability.LogContext
+import wifihaven.shared.{Clock, UserRole}
+import zio.*
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.json.*
+import zio.json.ast.Json
+
+/**
+ * #1968: the browser-facing websocket transport, `GET /api/ws`. This is step S1 of the
+ * SPA-websocket rollout ([`docs/design/spa-websocket.md`](../../../docs/design/spa-websocket.md)
+ * §9, design #1860; umbrella #1955) — the SERVER skeleton: the `{op, payload, seq?}` envelope
+ * demux, the control ops (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection
+ * subscription state + topic-keyed `ack`, `ping`/`pong`), and the forked per-connection
+ * [[SpaWsRegistry]]. Purely additive: REST stays the fallback throughout the whole rollout (design
+ * §3.3, §9), and the SPA has no ws client yet (that is S5). The endpoint is exercisable by a test
+ * ws client today.
+ *
+ * MIRRORS the router transport ([[RouterWsRoutes]], #1846) — same envelope discipline (one JSON
+ * text message per frame), same demux shape, same unknown-op-ignore+meter forward-compat rule
+ * (design §2.2) — but FORKS where the two genuinely differ (design §5.1): a per-connection id keyed
+ * registry with a subscription set (not a `RouterId`→snapshot registry), the SPA op vocabulary, and
+ * a topic-keyed `ack` (not the router's seq-keyed data-frame ack).
+ *
+ * Auth is OUT OF SCOPE for S1 — the browser cannot set an `Authorization` header on the ws upgrade
+ * (design §0.2.1), so S2 (#1969) authorizes the upgrade by verifying a tightly-scoped JWT cookie
+ * via the existing [[wifihaven.api.auth.AuthService]] (no second auth surface). For S1 the
+ * connection registers with a stub [[UserRole.Admin]] resolved at upgrade ([[upgradeRole]] — the
+ * clear seam S2 plugs the cookie verify into), and the `hello` payload's optional `{role}` is the
+ * test-handshake override that lets the subscription/authz machinery be exercised without a real
+ * cookie.
+ */
+object SpaWsRoutes {
+
+  /** Convenience for callers that need a registry instance (Main wiring, tests). */
+  def registry: UIO[SpaWsRegistry] = SpaWsRegistry.make
+
+  def routes(registry: SpaWsRegistry, clock: Clock): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "ws" ->
+        handler { (_: Request) =>
+          // S1: no upgrade auth — complete the upgrade unconditionally with the stub role. S2 (#1969)
+          // verifies the `wh_ws` cookie + Origin allowlist here and rejects a bad/missing/expired
+          // credential with a 401 (no 101), exactly like the router path and a REST 401.
+          socketApp(registry, clock).toResponse
+        },
+    )
+
+  /**
+   * The role resolved at upgrade time. S1 stub: every connection is [[UserRole.Admin]] until a
+   * `hello{role}` overrides it (the test handshake). S2 replaces this with the role read from the
+   * verified `wh_ws` JWT cookie (design §4.2/§4.4), captured once and authoritative for the
+   * connection's lifetime.
+   */
+  private val upgradeRole: UserRole = UserRole.Admin
+
+  private def socketApp(registry: SpaWsRegistry, clock: Clock): WebSocketApp[Any] =
+    Handler.webSocket { channel =>
+      // The connection id is assigned at HandshakeComplete (register) and read by every later frame;
+      // events are delivered in order so the id is set before any Read. Deregister unconditionally on
+      // exit so the registry + gauges never leak a dead channel.
+      Ref.make(Option.empty[SpaConnId]).flatMap { idRef =>
+        channel
+          .receiveAll {
+            case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+              registry.register(channel, upgradeRole, None).flatMap(id => idRef.set(Some(id))) *>
+                ZIO.logInfo("spa ws: connected")
+            case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
+              idRef.get.flatMap {
+                case Some(id) =>
+                  dispatch(id, channel, text, registry, clock)
+                    .tapErrorCause(c => ZIO.logErrorCause("spa ws: dispatch failed", c))
+                case None     =>
+                  // A frame before the handshake completed — should not happen, but ignore rather
+                  // than crash the receive loop.
+                  ZIO.unit
+              }
+            case ChannelEvent.Unregistered                                    =>
+              idRef.get.flatMap(ZIO.foreachDiscard(_)(registry.deregister))
+            case _                                                            =>
+              ZIO.unit
+          }
+          .ensuring(
+            idRef.get.flatMap(ZIO.foreachDiscard(_)(registry.deregister)) *>
+              ZIO.logInfo("spa ws: disconnected"),
+          )
+      }
+    }
+
+  /**
+   * Demux one inbound text frame (design §2.2). A frame that does not parse as the envelope, or
+   * carries an unrecognized `op`, is metered + logged and otherwise ignored (forward-compat). Per-
+   * frame structured logging attaches `op`/`role`/`result` to the MDC (design §10.5), mirroring
+   * [[RouterWsRoutes]]' `LogContext` discipline.
+   */
+  private def dispatch(
+      id: SpaConnId,
+      channel: WebSocketChannel,
+      text: String,
+      registry: SpaWsRegistry,
+      clock: Clock,
+  ): ZIO[Any, Throwable, Unit] =
+    text.fromJson[SpaWsFrame] match {
+      case Left(err)    =>
+        AppMetrics.recordSpaWsFrame("unknown", "in", "reject") *>
+          ZIO.logWarning(s"spa ws: undecodable frame: $err")
+      case Right(frame) =>
+        registry.roleFor(id).flatMap { roleOpt =>
+          val role = roleOpt.getOrElse(upgradeRole)
+          LogContext
+            .annotateAll(LogContext.Op -> frame.op, LogContext.Role -> UserRole.asString(role)) {
+              frame.op match {
+                case "hello"       => handleHello(id, channel, frame, registry, clock)
+                case "subscribe"   => handleSubscribe(id, channel, frame, role, registry)
+                case "unsubscribe" => handleUnsubscribe(id, frame, registry)
+                case "ping"        =>
+                  AppMetrics.recordSpaWsFrame("ping", "in", "ok") *>
+                    send(channel, SpaWsFrame("pong", Some(Json.Obj()))) *>
+                    AppMetrics.recordSpaWsFrame("pong", "out", "ok")
+                case "pong"        =>
+                  AppMetrics.recordSpaWsFrame("pong", "in", "ok")
+                case other         =>
+                  // Forward-compat: ignore + meter an unrecognized op (design §2.2). The arbitrary op
+                  // string collapses to the bounded literal `unknown` for the metric label (cardinality
+                  // firewall — an attacker-supplied op must never become a Prometheus label value); the
+                  // real op goes to the log only.
+                  LogContext.annotate(LogContext.Result, "unknown_op") {
+                    AppMetrics.recordSpaWsFrame("unknown", "in", "unknown_op") *>
+                      ZIO.logDebug(s"spa ws: ignoring unknown op '$other'")
+                  }
+              }
+            }
+        }
+    }
+
+  /**
+   * `hello`→`ready` (design §1.2). S1: the optional payload `{role}` is the test-handshake override
+   * that sets the connection's role (S2 ignores it — the role comes from the verified cookie).
+   * Reply `ready{role, serverTime}`; `serverTime` is read from the INJECTED clock (never
+   * wall-clock).
+   */
+  private def handleHello(
+      id: SpaConnId,
+      channel: WebSocketChannel,
+      frame: SpaWsFrame,
+      registry: SpaWsRegistry,
+      clock: Clock,
+  ): ZIO[Any, Throwable, Unit] = {
+    val requested = decode[HelloPayload](frame).toOption.flatMap(_.role).flatMap(UserRole.parse)
+    for {
+      _    <- ZIO.foreachDiscard(requested)(registry.setRole(id, _))
+      role <- registry.roleFor(id).map(_.getOrElse(upgradeRole))
+      now  <- clock.instant
+      _    <- AppMetrics.recordSpaWsFrame("hello", "in", "ok")
+      _    <- send(
+        channel,
+        SpaWsFrame(
+          "ready",
+          Some(ReadyPayload(UserRole.asString(role), now.toString).toJsonAST.getOrElse(Json.Obj())),
+        ),
+      )
+      _    <- AppMetrics.recordSpaWsFrame("ready", "out", "ok")
+    } yield ()
+  }
+
+  /**
+   * `subscribe{topic, params?}` → topic-keyed `ack` (design §1.4). Fan-out is two gates (subscribe
+   * AND authorize): an unknown topic or a topic the role can't see (§4.4) is `ack`-rejected without
+   * registering it; an authorized topic is stored with its params (the verbatim endpoint query
+   * params, §0.3) and `ack`-ok'd. The `ack` is keyed by TOPIC, not seq — distinct from the router
+   * path's seq-keyed data-frame ack.
+   */
+  private def handleSubscribe(
+      id: SpaConnId,
+      channel: WebSocketChannel,
+      frame: SpaWsFrame,
+      role: UserRole,
+      registry: SpaWsRegistry,
+  ): ZIO[Any, Throwable, Unit] =
+    decode[SubscribePayload](frame) match {
+      case Left(_)     =>
+        rejectSubscribe(channel, "unknown", "bad_payload")
+      case Right(body) =>
+        SpaTopic.parse(body.topic) match {
+          case None                                            =>
+            rejectSubscribe(channel, body.topic, "unknown_topic")
+          case Some(topic) if !SpaTopic.visibleTo(topic, role) =>
+            rejectSubscribe(channel, body.topic, "forbidden")
+          case Some(topic)                                     =>
+            registry.subscribe(id, topic, body.params.getOrElse(Json.Obj())) *>
+              AppMetrics.recordSpaWsFrame("subscribe", "in", "ok") *>
+              sendAck(channel, body.topic, "ok", None)
+        }
+    }
+
+  private def rejectSubscribe(
+      channel: WebSocketChannel,
+      topic: String,
+      reason: String,
+  ): ZIO[Any, Throwable, Unit] =
+    LogContext.annotate(LogContext.Result, "reject") {
+      AppMetrics.recordSpaWsFrame("subscribe", "in", "reject") *>
+        sendAck(channel, topic, "reject", Some(reason))
+    }
+
+  /**
+   * `unsubscribe{topic}` (design §1.4). Connection-scoped, idempotent; no `ack` (the `ack` is per-
+   * *subscribe* only). An unknown topic is metered `reject` but otherwise a no-op.
+   */
+  private def handleUnsubscribe(
+      id: SpaConnId,
+      frame: SpaWsFrame,
+      registry: SpaWsRegistry,
+  ): ZIO[Any, Throwable, Unit] =
+    decode[UnsubscribePayload](frame).toOption.flatMap(b => SpaTopic.parse(b.topic)) match {
+      case Some(topic) =>
+        registry.unsubscribe(id, topic) *> AppMetrics.recordSpaWsFrame("unsubscribe", "in", "ok")
+      case None        =>
+        LogContext.annotate(LogContext.Result, "reject") {
+          AppMetrics.recordSpaWsFrame("unsubscribe", "in", "reject")
+        }
+    }
+
+  private def decode[A: JsonDecoder](frame: SpaWsFrame): Either[String, A] =
+    frame.payload.map(_.toJson).getOrElse("{}").fromJson[A]
+
+  private def send(channel: WebSocketChannel, frame: SpaWsFrame): ZIO[Any, Throwable, Unit] =
+    channel.send(ChannelEvent.read(WebSocketFrame.text(frame.toJson)))
+
+  /** Send a topic-keyed `ack` (design §1.4) and meter the outbound frame by its status. */
+  private def sendAck(
+      channel: WebSocketChannel,
+      topic: String,
+      status: String,
+      reason: Option[String],
+  ): ZIO[Any, Throwable, Unit] =
+    send(
+      channel,
+      SpaWsFrame("ack", Some(SpaAck(topic, status, reason).toJsonAST.getOrElse(Json.Obj()))),
+    ) *>
+      AppMetrics.recordSpaWsFrame(
+        "ack",
+        "out",
+        status match { case "ok" => "ok"; case _ => "reject" },
+      )
+
+  /**
+   * The `{op, payload, seq?}` frame envelope (design §2.2). `payload`/`seq` optional (e.g. ping).
+   */
+  private case class SpaWsFrame(op: String, payload: Option[Json] = None, seq: Option[Int] = None)
+      derives JsonCodec
+
+  /** `hello` payload — `{role?}` is the S1 test-handshake override (S2 ignores it). */
+  private case class HelloPayload(role: Option[String]) derives JsonCodec
+
+  /** `ready` payload (design §1.2): the resolved role + the server's (injected-clock) time. */
+  private case class ReadyPayload(role: String, serverTime: String) derives JsonCodec
+
+  /** `subscribe` payload (design §1.4): the topic + its verbatim endpoint query params. */
+  private case class SubscribePayload(topic: String, params: Option[Json]) derives JsonCodec
+
+  /** `unsubscribe` payload (design §1.4): just the topic. */
+  private case class UnsubscribePayload(topic: String) derives JsonCodec
+
+  /** The topic-keyed `ack` payload (design §1.4): which topic, ok/reject, optional reason. */
+  private case class SpaAck(topic: String, status: String, reason: Option[String]) derives JsonCodec
+}

--- a/api/src/routes/SpaWsRoutes.scala
+++ b/api/src/routes/SpaWsRoutes.scala
@@ -50,12 +50,18 @@ object SpaWsRoutes {
     )
 
   /**
-   * The role resolved at upgrade time. S1 stub: every connection is [[UserRole.Admin]] until a
-   * `hello{role}` overrides it (the test handshake). S2 replaces this with the role read from the
-   * verified `wh_ws` JWT cookie (design §4.2/§4.4), captured once and authoritative for the
-   * connection's lifetime.
+   * The role resolved at upgrade time. S1 stub: every connection starts at the LEAST-privileged
+   * role ([[UserRole.Child]]) until a `hello{role}` overrides it (the test handshake).
+   * Least-privilege by default is deliberate defense-in-depth: S1 has no upgrade auth yet (that is
+   * S2 / #1969) and mounts in prod additively, so if a later step (S3/S4) ever pushed data before
+   * S2's cookie verify lands, an unauthenticated connection that never sent a `hello{role}` would
+   * see the *minimum* surface (fail closed), not Admin (fail open). The §4.4 authz gate
+   * (`SpaTopic.visibleTo`) then filters on this role. S2 replaces this stub with the role read from
+   * the verified `wh_ws` JWT cookie (design §4.2/§4.4), captured once and authoritative for the
+   * connection's lifetime — and #1969 is a hard predecessor to any data-bearing push step (S3/S4)
+   * for exactly this reason.
    */
-  private val upgradeRole: UserRole = UserRole.Admin
+  private val upgradeRole: UserRole = UserRole.Child
 
   private def socketApp(registry: SpaWsRegistry, clock: Clock): WebSocketApp[Any] =
     Handler.webSocket { channel =>

--- a/api/test/src/feature/SpaWsSpec.scala
+++ b/api/test/src/feature/SpaWsSpec.scala
@@ -1,0 +1,186 @@
+package wifihaven.api.feature
+
+import wifihaven.api.routes.{SpaWsRegistry, SpaWsRoutes}
+import wifihaven.shared.Clock
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.test.*
+
+import java.time.LocalDateTime
+
+/**
+ * #1968 (S1 of the SPA-websocket rollout, design `docs/design/spa-websocket.md`): the
+ * browser-facing `GET /api/ws` skeleton. Exercises the real endpoint end to end — a real [[Server]]
+ * on an ephemeral port and a real ws [[Client]] — to prove the `{op, payload, seq?}` envelope
+ * demux, the control ops (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection
+ * subscription state + topic-keyed `ack`, `ping`/`pong`), the role-gated subscription
+ * authorization, and the unknown-op ignore+meter rule. Mirrors the [[RouterWsSpec]] round-trip
+ * recipe (drive the ws client inside a LOCAL `ZIO.scoped`, not forkScoped on the test scope).
+ *
+ * S1 has no upgrade auth (that is S2 / #1969) — the connection registers with a stub Admin role at
+ * upgrade and the `hello` payload's `{role}` is the test-handshake override, so the subscription
+ * machinery is exercised without a real cookie. REST is untouched.
+ */
+object SpaWsSpec extends ZIOSpec[Clock] {
+
+  private val testClockAt: LocalDateTime = LocalDateTime.of(2026, 6, 25, 14, 0, 0)
+
+  override val bootstrap: ULayer[Clock] = TestLayers.withClock(testClockAt)
+
+  private def buildRoutes: ZIO[Clock, Nothing, Routes[Any, Response]] =
+    for {
+      clock <- ZIO.service[Clock]
+      reg   <- SpaWsRegistry.make
+    } yield SpaWsRoutes.routes(reg, clock)
+
+  /**
+   * Open a ws connection to the bound server, drive it with `send` on handshake, and collect every
+   * text frame the server sends. Resolves once a frame satisfies `until`. Returns the matching
+   * frame and ALL frames received up to that point.
+   */
+  private def connectAndCapture(
+      port: Int,
+      send: WebSocketChannel => ZIO[Any, Throwable, Unit],
+      until: String => Boolean,
+  ): ZIO[Client, Throwable, (String, Chunk[String])] =
+    for {
+      matched <- Promise.make[Nothing, String]
+      frames  <- Ref.make(Chunk.empty[String])
+      app = Handler.webSocket { channel =>
+        channel.receiveAll {
+          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            send(channel)
+          case ChannelEvent.Read(WebSocketFrame.Text(t))                    =>
+            frames.update(_ :+ t) *> ZIO.when(until(t))(matched.succeed(t)).unit
+          case _                                                            =>
+            ZIO.unit
+        }
+      }
+      result <- ZIO.scoped {
+        for {
+          _   <- app.connect(s"ws://localhost:$port/api/ws").forkScoped
+          t   <- matched.await
+            .timeoutFail(new RuntimeException("no matching server frame within 30s"))(30.seconds)
+          all <- frames.get
+        } yield (t, all)
+      }
+    } yield result
+
+  /** Send a sequence of text frames in order on handshake. */
+  private def sendFrames(channel: WebSocketChannel, frames: String*): ZIO[Any, Throwable, Unit] =
+    ZIO.foreachDiscard(frames)(f => channel.send(ChannelEvent.read(WebSocketFrame.text(f))))
+
+  def spec = suite("SPA websocket /api/ws")(
+    test("hello is answered with ready carrying the role + serverTime") {
+      (for {
+        routes     <- buildRoutes
+        port       <- Server.install(routes)
+        (ready, _) <- connectAndCapture(
+          port,
+          ch => sendFrames(ch, """{"op":"hello","payload":{"role":"admin"}}"""),
+          until = _.contains("\"op\":\"ready\""),
+        )
+      } yield assertTrue(ready.contains("\"op\":\"ready\"")) &&
+        assertTrue(ready.contains("\"role\":\"admin\"")) &&
+        // serverTime comes from the injected test clock (2026-06-25T14:00:00Z), never wall-clock.
+        assertTrue(ready.contains("\"serverTime\":\"2026-06-25T14:00:00Z\""))).provideSome[Clock](
+        Server.defaultWithPort(0),
+        Client.default,
+      )
+    },
+    test("subscribe to an authorized topic is acked ok") {
+      (for {
+        routes   <- buildRoutes
+        port     <- Server.install(routes)
+        (ack, _) <- connectAndCapture(
+          port,
+          ch =>
+            sendFrames(
+              ch,
+              """{"op":"hello","payload":{"role":"admin"}}""",
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"]}}}""",
+            ),
+          until = _.contains("\"op\":\"ack\""),
+        )
+      } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
+        assertTrue(ack.contains("\"topic\":\"trafficUsage\"")) &&
+        assertTrue(ack.contains("\"status\":\"ok\""))).provideSome[Clock](
+        Server.defaultWithPort(0),
+        Client.default,
+      )
+    },
+    test("subscribe to a topic the role can't see is acked reject") {
+      (for {
+        routes   <- buildRoutes
+        port     <- Server.install(routes)
+        // A child role may see only its own time topics, never the household-wide connectionEvents
+        // feed (S1 placeholder authz, §4.4 — refined by S2's real cookie auth).
+        (ack, _) <- connectAndCapture(
+          port,
+          ch =>
+            sendFrames(
+              ch,
+              """{"op":"hello","payload":{"role":"child"}}""",
+              """{"op":"subscribe","payload":{"topic":"connectionEvents"}}""",
+            ),
+          until = _.contains("\"op\":\"ack\""),
+        )
+      } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
+        assertTrue(ack.contains("\"topic\":\"connectionEvents\"")) &&
+        assertTrue(ack.contains("\"status\":\"reject\""))).provideSome[Clock](
+        Server.defaultWithPort(0),
+        Client.default,
+      )
+    },
+    test("unsubscribe round-trips after a subscribe ack (no further ack, ping confirms liveness)") {
+      (for {
+        routes      <- buildRoutes
+        port        <- Server.install(routes)
+        // subscribe (acked), then unsubscribe (no ack), then ping — receiving the pong proves the
+        // socket stayed live through the unsubscribe and the frame was accepted.
+        (pong, all) <- connectAndCapture(
+          port,
+          ch =>
+            sendFrames(
+              ch,
+              """{"op":"hello","payload":{"role":"admin"}}""",
+              """{"op":"subscribe","payload":{"topic":"now"}}""",
+              """{"op":"unsubscribe","payload":{"topic":"now"}}""",
+              """{"op":"ping"}""",
+            ),
+          until = _.contains("\"op\":\"pong\""),
+        )
+      } yield assertTrue(pong.contains("\"op\":\"pong\"")) &&
+        assertTrue(
+          all.exists(f => f.contains("\"op\":\"ack\"") && f.contains("\"status\":\"ok\"")),
+        )).provideSome[Clock](
+        Server.defaultWithPort(0),
+        Client.default,
+      )
+    },
+    test("an unknown op is ignored (no reply) while a known op still answers") {
+      (for {
+        routes      <- buildRoutes
+        port        <- Server.install(routes)
+        // Send an unknown op, then a ping. The unknown op must produce no frame; the pong proves the
+        // socket survived (ignore + meter, forward-compat — design §2.2).
+        (pong, all) <- connectAndCapture(
+          port,
+          ch =>
+            sendFrames(
+              ch,
+              """{"op":"definitelyNotARealOp","payload":{}}""",
+              """{"op":"ping"}""",
+            ),
+          until = _.contains("\"op\":\"pong\""),
+        )
+      } yield assertTrue(pong.contains("\"op\":\"pong\"")) &&
+        // The only server frame is the pong — the unknown op generated no reply.
+        assertTrue(all.count(_.contains("\"op\":")) == 1)).provideSome[Clock](
+        Server.defaultWithPort(0),
+        Client.default,
+      )
+    },
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.timeout(90.seconds)
+}

--- a/api/test/src/feature/SpaWsSpec.scala
+++ b/api/test/src/feature/SpaWsSpec.scala
@@ -2,6 +2,7 @@ package wifihaven.api.feature
 
 import wifihaven.api.routes.{SpaWsRegistry, SpaWsRoutes}
 import wifihaven.shared.Clock
+import wifihaven.testinfra.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.http.ChannelEvent.UserEvent

--- a/api/test/src/feature/SpaWsSpec.scala
+++ b/api/test/src/feature/SpaWsSpec.scala
@@ -1,6 +1,6 @@
 package wifihaven.api.feature
 
-import wifihaven.api.routes.{SpaWsRegistry, SpaWsRoutes}
+import wifihaven.api.routes.{SpaConnId, SpaTopic, SpaWsRegistry, SpaWsRoutes}
 import wifihaven.shared.Clock
 import wifihaven.testinfra.*
 import zio.{Clock as _, *}
@@ -19,9 +19,10 @@ import java.time.LocalDateTime
  * authorization, and the unknown-op ignore+meter rule. Mirrors the [[RouterWsSpec]] round-trip
  * recipe (drive the ws client inside a LOCAL `ZIO.scoped`, not forkScoped on the test scope).
  *
- * S1 has no upgrade auth (that is S2 / #1969) — the connection registers with a stub Admin role at
- * upgrade and the `hello` payload's `{role}` is the test-handshake override, so the subscription
- * machinery is exercised without a real cookie. REST is untouched.
+ * S1 has no upgrade auth (that is S2 / #1969) — the connection registers with a stub
+ * least-privilege (`Child`) role at upgrade and the `hello` payload's `{role}` is the
+ * test-handshake override, so the subscription machinery is exercised without a real cookie. REST
+ * is untouched.
  */
 object SpaWsSpec extends ZIOSpec[Clock] {
 
@@ -29,22 +30,30 @@ object SpaWsSpec extends ZIOSpec[Clock] {
 
   override val bootstrap: ULayer[Clock] = TestLayers.withClock(testClockAt)
 
-  private def buildRoutes: ZIO[Clock, Nothing, Routes[Any, Response]] =
+  private def buildRoutes: ZIO[Clock, Nothing, (Routes[Any, Response], SpaWsRegistry)] =
     for {
       clock <- ZIO.service[Clock]
       reg   <- SpaWsRegistry.make
-    } yield SpaWsRoutes.routes(reg, clock)
+    } yield (SpaWsRoutes.routes(reg, clock), reg)
+
+  // Each test builds a FRESH registry with one connection, so the first (and only) connection is
+  // deterministically assigned SpaConnId(1) — the seq counter starts at 0 and increments to 1 on the
+  // single register. Lets a test inspect that connection's server-side subscription state directly.
+  private val onlyConn: SpaConnId = SpaConnId(1L)
 
   /**
    * Open a ws connection to the bound server, drive it with `send` on handshake, and collect every
-   * text frame the server sends. Resolves once a frame satisfies `until`. Returns the matching
-   * frame and ALL frames received up to that point.
+   * text frame the server sends. Resolves once a frame satisfies `until`, then runs `probe` while
+   * the connection is still open (so a registry-state check observes the live channel, not the
+   * post-scope deregister). Returns the matching frame, ALL frames received up to that point, and
+   * the probe.
    */
-  private def connectAndCapture(
+  private def connectAndCapture[B](
       port: Int,
       send: WebSocketChannel => ZIO[Any, Throwable, Unit],
       until: String => Boolean,
-  ): ZIO[Client, Throwable, (String, Chunk[String])] =
+      probe: ZIO[Any, Throwable, B] = ZIO.unit,
+  ): ZIO[Client, Throwable, (String, Chunk[String], B)] =
     for {
       matched <- Promise.make[Nothing, String]
       frames  <- Ref.make(Chunk.empty[String])
@@ -64,7 +73,8 @@ object SpaWsSpec extends ZIOSpec[Clock] {
           t   <- matched.await
             .timeoutFail(new RuntimeException("no matching server frame within 30s"))(30.seconds)
           all <- frames.get
-        } yield (t, all)
+          b   <- probe
+        } yield (t, all, b)
       }
     } yield result
 
@@ -75,9 +85,10 @@ object SpaWsSpec extends ZIOSpec[Clock] {
   def spec = suite("SPA websocket /api/ws")(
     test("hello is answered with ready carrying the role + serverTime") {
       (for {
-        routes     <- buildRoutes
-        port       <- Server.install(routes)
-        (ready, _) <- connectAndCapture(
+        rr <- buildRoutes
+        (routes, _) = rr
+        port          <- Server.install(routes)
+        (ready, _, _) <- connectAndCapture(
           port,
           ch => sendFrames(ch, """{"op":"hello","payload":{"role":"admin"}}"""),
           until = _.contains("\"op\":\"ready\""),
@@ -90,11 +101,15 @@ object SpaWsSpec extends ZIOSpec[Clock] {
         Client.default,
       )
     },
-    test("subscribe to an authorized topic is acked ok") {
+    test("subscribe to an authorized topic is acked ok and the subscription is held server-side") {
       (for {
-        routes   <- buildRoutes
-        port     <- Server.install(routes)
-        (ack, _) <- connectAndCapture(
+        rr <- buildRoutes
+        (routes, reg) = rr
+        port <- Server.install(routes)
+        // Probe the registry AFTER the ack arrives (still in-scope): the ack is sent only after
+        // SpaWsRegistry.subscribe completes, so an ack-ok that failed to actually store the
+        // subscription would be caught here — not just on the wire.
+        res  <- connectAndCapture(
           port,
           ch =>
             sendFrames(
@@ -103,21 +118,26 @@ object SpaWsSpec extends ZIOSpec[Clock] {
               """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"]}}}""",
             ),
           until = _.contains("\"op\":\"ack\""),
+          probe = reg.subscriptionsFor(onlyConn),
         )
+        (ack, _, subs) = res
       } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
         assertTrue(ack.contains("\"topic\":\"trafficUsage\"")) &&
-        assertTrue(ack.contains("\"status\":\"ok\""))).provideSome[Clock](
+        assertTrue(ack.contains("\"status\":\"ok\"")) &&
+        assertTrue(subs.keySet == Set(SpaTopic.TrafficUsage))).provideSome[Clock](
         Server.defaultWithPort(0),
         Client.default,
       )
     },
-    test("subscribe to a topic the role can't see is acked reject") {
+    test("subscribe to a topic the role can't see is acked reject and not held") {
       (for {
-        routes   <- buildRoutes
-        port     <- Server.install(routes)
+        rr <- buildRoutes
+        (routes, reg) = rr
+        port <- Server.install(routes)
         // A child role may see only its own time topics, never the household-wide connectionEvents
-        // feed (S1 placeholder authz, §4.4 — refined by S2's real cookie auth).
-        (ack, _) <- connectAndCapture(
+        // feed (S1 placeholder authz, §4.4 — refined by S2's real cookie auth). The rejected
+        // subscription must NOT be stored.
+        res  <- connectAndCapture(
           port,
           ch =>
             sendFrames(
@@ -126,21 +146,26 @@ object SpaWsSpec extends ZIOSpec[Clock] {
               """{"op":"subscribe","payload":{"topic":"connectionEvents"}}""",
             ),
           until = _.contains("\"op\":\"ack\""),
+          probe = reg.subscriptionsFor(onlyConn),
         )
+        (ack, _, subs) = res
       } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
         assertTrue(ack.contains("\"topic\":\"connectionEvents\"")) &&
-        assertTrue(ack.contains("\"status\":\"reject\""))).provideSome[Clock](
+        assertTrue(ack.contains("\"status\":\"reject\"")) &&
+        assertTrue(subs.isEmpty)).provideSome[Clock](
         Server.defaultWithPort(0),
         Client.default,
       )
     },
-    test("unsubscribe round-trips after a subscribe ack (no further ack, ping confirms liveness)") {
+    test("unsubscribe removes the held subscription (no further ack, ping confirms liveness)") {
       (for {
-        routes      <- buildRoutes
-        port        <- Server.install(routes)
-        // subscribe (acked), then unsubscribe (no ack), then ping — receiving the pong proves the
-        // socket stayed live through the unsubscribe and the frame was accepted.
-        (pong, all) <- connectAndCapture(
+        rr <- buildRoutes
+        (routes, reg) = rr
+        port <- Server.install(routes)
+        // subscribe (acked), then unsubscribe (no ack), then ping — the pong (sent only after the
+        // unsubscribe was processed) proves the socket stayed live AND the subscription was removed:
+        // the post-pong registry probe must show an empty subscription set.
+        res  <- connectAndCapture(
           port,
           ch =>
             sendFrames(
@@ -151,22 +176,26 @@ object SpaWsSpec extends ZIOSpec[Clock] {
               """{"op":"ping"}""",
             ),
           until = _.contains("\"op\":\"pong\""),
+          probe = reg.subscriptionsFor(onlyConn),
         )
+        (pong, all, subs) = res
       } yield assertTrue(pong.contains("\"op\":\"pong\"")) &&
         assertTrue(
           all.exists(f => f.contains("\"op\":\"ack\"") && f.contains("\"status\":\"ok\"")),
-        )).provideSome[Clock](
+        ) &&
+        assertTrue(subs.isEmpty)).provideSome[Clock](
         Server.defaultWithPort(0),
         Client.default,
       )
     },
     test("an unknown op is ignored (no reply) while a known op still answers") {
       (for {
-        routes      <- buildRoutes
-        port        <- Server.install(routes)
+        rr <- buildRoutes
+        (routes, _) = rr
+        port           <- Server.install(routes)
         // Send an unknown op, then a ping. The unknown op must produce no frame; the pong proves the
         // socket survived (ignore + meter, forward-compat — design §2.2).
-        (pong, all) <- connectAndCapture(
+        (pong, all, _) <- connectAndCapture(
           port,
           ch =>
             sendFrames(

--- a/deploy/grafana/dashboards/spa-ws.json
+++ b/deploy/grafana/dashboards/spa-ws.json
@@ -1,0 +1,324 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "WifiHaven SPA websocket transport (#1968, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry) and spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux). The SPA has no ws client yet (S5), so until then these read 0/flat. Upgrade-auth (spa_ws_auth_total, S2) and push fan-out (spa_ws_push_total, S3/S4) panels land with those series. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws connections active by role (#1968)",
+      "description": "spa_ws_connections_active{role} — live count of open /api/ws channels per role (admin|adult|child), refreshed on every register/deregister so it ages out cleanly on disconnect. The \"how many browser tabs are on the ws transport right now?\" signal; 0 while the dashboard still polls means no SPA ws client has shipped yet (that is S5).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (role) (spa_ws_connections_active{env=\"$env\"})",
+          "legendFormat": "{{role}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws subscriptions active by topic (#1968)",
+      "description": "spa_ws_subscriptions_active{topic} — live subscriptions per topic (trafficUsage|now|connectionEvents|timeStatus|appUsage|stale). Shows what the fleet is actually watching, and (once S4 lands) that the trafficUsage aggregator's query work is bounded to demand — no subscriber, no query. NOTE: no bucket/groupBy/profileId label — those params are unbounded and deliberately kept out of the metric (design §7).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (topic) (spa_ws_subscriptions_active{env=\"$env\"})",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws frame rate by op/direction/result (#1968)",
+      "description": "sum by (op, direction, result) (rate(spa_ws_frames_total[5m])) — frame throughput across the {op,payload} demux. op ∈ {hello,ready,subscribe,unsubscribe,ack,ping,pong,unknown}; direction ∈ {in,out}; result ∈ {ok,reject,unknown_op}. A rising result=reject share means clients are sending frames the server rejects (e.g. a subscribe to a topic the role can't see); result=unknown_op is the forward-compat counter for frames whose op the server does not recognize (design §2.2).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (op, direction, result) (rate(spa_ws_frames_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}} {{direction}} {{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws reject + unknown_op rate (#1968)",
+      "description": "sum by (op, result) (rate(spa_ws_frames_total{result=~\"reject|unknown_op\"}[5m])) — the error surface of the transport isolated. Steady non-zero here is the first sign client and server disagree on the wire: result=reject is a subscribe the server refused (unknown/forbidden topic), result=unknown_op is an op one side hasn't shipped yet (forward-compat — ignored, design §2.2).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (op, result) (rate(spa_ws_frames_total{env=\"$env\",result=~\"reject|unknown_op\"}[5m]))",
+          "legendFormat": "{{op}} {{result}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wifihaven",
+    "spa",
+    "websocket"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "prod",
+          "value": "prod"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [
+          {
+            "selected": true,
+            "text": "prod",
+            "value": "prod"
+          },
+          {
+            "selected": false,
+            "text": "staging",
+            "value": "staging"
+          }
+        ],
+        "query": "prod,staging",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-wifihaven-prom",
+          "value": "grafanacloud-prom"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "WifiHaven — SPA WS transport",
+  "uid": "wifihaven-spa-ws-transport",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -81,7 +81,7 @@ provider "grafana" {
 
 locals {
   folder     = var.folder_uid != "" ? var.folder_uid : null
-  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health", "db-health", "data-quality-ingest", "enforcement", "router-ws-transport"]
+  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health", "db-health", "data-quality-ingest", "enforcement", "router-ws-transport", "spa-ws"]
   dashfiles  = { for name in local.dashboards : name => "${path.module}/../../deploy/grafana/dashboards/${name}.json" }
 }
 


### PR DESCRIPTION
## What

Step **S1** of the SPA-websocket rollout ([`docs/design/spa-websocket.md`](docs/design/spa-websocket.md) §9, design #1860; umbrella execution plan #1955). The browser-facing **`GET /api/ws`** server skeleton.

Closes #1968.

**Purely additive — REST is untouched and stays the polling fallback throughout the whole rollout (no flag day).** The SPA has no ws client yet (that is S5), so this endpoint reads idle in prod until then; it is exercisable by a test ws client today.

## Scope (S1 only)

- **`GET /api/ws`** backed by `Handler.webSocket` with the `{op, payload, seq?}` text-frame envelope and an `op` demux — **mirrors** [`RouterWsRoutes`](api/src/routes/RouterWsRoutes.scala) (#1846). One JSON text message per frame; **unknown `op` → ignore + meter**, both directions (forward-compat, §2.2).
- **Control ops:** `hello` → `ready` (`{role, serverTime}`, `serverTime` from the injected `Clock`); `subscribe`/`unsubscribe` carrying **per-connection subscription state `{topic → params}`** (§1.4) with a per-subscribe **`ack` keyed by topic** (`{op:"ack", topic, status:"ok"|"reject", reason?}` — distinct from the router path's seq-keyed data ack); `ping`/`pong` app-level heartbeat.
- **`SpaWsRegistry`** — a **FORKED** `Ref[Map[SpaConnId, channel + role + subscriptions + jwtExp]]` (§5.1). Reuses the `RouterWsRegistry` *pattern*, does **not** generalize the instance. Fan-out is two gates: **subscribed AND role-authorized** (§4.4).
- **Auth seam for S2.** Real upgrade auth (cookie verify) is #1969 — the browser `WebSocket` can't set an `Authorization` header (§0.2.1). S1 registers a stub `Admin` role at upgrade behind a clearly-marked seam (`SpaWsRoutes.upgradeRole`); the `hello` payload's optional `{role}` is the **test-handshake override** so the subscription/authz machinery is exercised without a real cookie. No second auth surface invented.
- **Metrics §7** via `AppMetrics`/`MetricGuard`, each series registered in `MetricGuard.Allowed` with **bounded label enums only** (`role`/`op`/`direction`/`result`/`topic` — never per-mac/profile/session/param): `spa_ws_connections_active{role}`, `spa_ws_frames_total{op,direction,result}`, `spa_ws_subscriptions_active{topic}`. The `spa_ws_auth_total`/`spa_ws_push_total` families belong to S2/S3/S4 and are added when first emitted.
- **Grafana** `deploy/grafana/dashboards/spa-ws.json` authored against the **3 series actually emitted** (grepped from `api/src`, not the design catalog), joined to `infra/grafana/main.tf` `local.dashboards` (gate: `grafana-terraform`).
- **Per-frame structured logging** (`op`/`role`/`result` on MDC, new `LogContext` keys), mirroring `RouterWsRoutes`.
- Registered in [`Main.scala`](api/src/Main.scala) alongside the router routes.

## Out of scope (later S*)

Cookie upgrade auth (S2 #1969), change sources/push (S3), `trafficUsage` aggregator (S4), SPA client (S5). No web changes.

## Test (TDD)

[`SpaWsSpec`](api/test/src/feature/SpaWsSpec.scala) drives a real `Server` + ws `Client` end to end (the #1846 round-trip recipe — local `ZIO.scoped`, not forkScoped-on-test-scope), injected `Clock`:
- `hello` → `ready` carrying role + (test-clock) `serverTime`
- `subscribe` an authorized topic → `ack:ok`, subscription held
- `subscribe` a topic the role can't see (child → `connectionEvents`) → `ack:reject`
- `unsubscribe` round-trips (no further ack), socket stays live
- unknown op ignored (no reply) while a known op still answers

The failing test was committed RED first; the implementation follows. Full `api` test suite green; `scalafmt --check` clean; `terraform fmt/validate` + dashboard JSON parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)