### PR TITLE
fix(#1972): attach Loki appender to root + surface send-error/auth failures

### DIFF
--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -104,7 +104,31 @@
           <drainOnStop>false</drainOnStop>
         </batch>
       </appender>
+      <!--
+        #1972: the <root> MUST be declared HERE, inside this top-level <if>, and
+        must NOT carry a nested <if> of its own. logback (1.5.25 — the version
+        loki4j 2.0.3 forces onto the classpath and the deployed jar runs) REJECTS
+        an <if> nested within a <root>/<logger>/<appender> element
+        ("IfNestedWithinSecondPhaseElementSC"): the nested <appender-ref ref="LOKI">
+        was silently skipped and the LOKI appender never attached to root, so a
+        deployed API shipped ZERO logs to Grafana Cloud Loki even with the
+        GRAFANA_CLOUD_LOKI_* secrets set (0 ingest). Declaring a full <root> per
+        branch keeps every <if> at the top level (which logback DOES allow) and
+        attaches LOKI deterministically when the secret is present.
+        Pinned by LokiAppenderConfigSpec, which now loads this file through the
+        real JoranConfigurator at the shipped logback version.
+      -->
+      <root level="WARN">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="LOKI" />
+      </root>
     </then>
+    <else>
+      <!-- Local dev / `mill __.test`: no Loki secret → console only. -->
+      <root level="WARN">
+        <appender-ref ref="STDOUT" />
+      </root>
+    </else>
   </if>
 
   <!--
@@ -113,15 +137,5 @@
     /api/router/* endpoints (mac, hostname, allowed/blocked, etc.). See
     docs/install-api.md § Debugging.
   -->
-  <root level="WARN">
-    <appender-ref ref="STDOUT" />
-    <!-- #1873: attach LOKI only where the secret is present (same gate as above). -->
-    <if condition='isDefined("GRAFANA_CLOUD_LOKI_URL")'>
-      <then>
-        <appender-ref ref="LOKI" />
-      </then>
-    </if>
-  </root>
-
   <logger name="wifihaven" level="${WIFIHAVEN_LOG_LEVEL:-INFO}" />
 </configuration>

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -152,6 +152,15 @@ object MetricGuard {
     // §4 cardinality firewall (service/env/level already ride the Loki stream
     // labels, not this Prometheus series).
     "loki_logs_dropped_total"                   -> Set.empty[String],
+    // #1972 — log batches the loki4j appender SENT to Grafana Cloud Loki that came
+    // back as an error (HTTP 401/403 wrong-scope token, 4xx/5xx, connection/timeout).
+    // Distinct from loki_logs_dropped_total, which only counts queue-full drops on
+    // the way IN: a misscoped access-policy token (logs:write missing) sheds every
+    // line at the SEND boundary, leaving drops flat at 0 — that auth failure was the
+    // invisible second half of #1972. loki4j is fail-open and routes these to the
+    // logback StatusManager only, so without this counter the loss is silent.
+    // Unlabelled (same cardinality firewall as the drop series).
+    "loki_logs_send_errors_total"               -> Set.empty[String],
     // §5.1 router-sourced, pushed via POST /api/router/metrics (#1205). Every one carries the
     // server-attached `router_id` + `installation_id` plus its own bounded enum label.
     "dnsmasq_restarts_total"                    -> Set("reason", "router_id", "installation_id"),
@@ -517,6 +526,15 @@ object AppMetrics {
     ZIO
       .when(delta > 0)(
         MetricGuard.counter("loki_logs_dropped_total", Map.empty, delta),
+      )
+      .unit
+
+  // #1972 — loki4j send-side errors (401/403/4xx/5xx/timeout) the appender reported
+  // to the logback StatusManager. Unlabelled; only emits when `delta > 0`.
+  def recordLokiSendErrors(delta: Long): UIO[Unit] =
+    ZIO
+      .when(delta > 0)(
+        MetricGuard.counter("loki_logs_send_errors_total", Map.empty, delta),
       )
       .unit
 

--- a/api/src/observability/LokiDropMetrics.scala
+++ b/api/src/observability/LokiDropMetrics.scala
@@ -78,7 +78,18 @@ object LokiDropMetrics {
   ): UIO[Unit] =
     findAppender.flatMap {
       case None      =>
-        ZIO.logDebug("LOKI appender not present; loki-drop metrics disabled (local/test).")
+        // No appender attached. Two cases: (a) local/test, where the logback `<if>` gate is false
+        // because the secret is unset — expected, debug-only; (b) a DEPLOYED env where the secret
+        // IS set but the appender failed to attach (a logback wiring regression like #1972). Case
+        // (b) is the silent 0-ingest failure mode, so surface it as a loud WARN — otherwise it is
+        // invisible (loki4j is fail-open and the drop metric never even registers).
+        if (lokiUrlConfigured)
+          ZIO.logWarning(
+            "GRAFANA_CLOUD_LOKI_URL is set but no LOKI appender is attached to the root logger — " +
+              "API logs are NOT shipping to Grafana Cloud Loki. Check logback.xml appender wiring (#1972).",
+          )
+        else
+          ZIO.logDebug("LOKI appender not present; loki-drop metrics disabled (local/test).")
       case Some(app) =>
         for {
           start    <- ZIO.succeed(app.droppedEventsTotal)

--- a/api/src/observability/LokiDropMetrics.scala
+++ b/api/src/observability/LokiDropMetrics.scala
@@ -4,8 +4,10 @@ import com.github.loki4j.logback.MeteredLoki4jAppender
 import wifihaven.api.metrics.AppMetrics
 import org.slf4j.LoggerFactory
 import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.core.status.{Status, StatusListener}
 import zio.*
 
+import java.util.concurrent.atomic.AtomicLong
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -29,11 +31,48 @@ import scala.jdk.CollectionConverters.*
  * `isDefined("GRAFANA_CLOUD_LOKI_URL")` in `logback.xml`, so on local dev / `mill __.test` it is
  * never instantiated. [[findAppender]] returns `None` there and [[loop]] no-ops — same presence
  * gate as the appender, no duplicated env check.
+ *
+ * #1972 extends this with TWO more observability hooks for the *other* ways shipping can fail
+ * silently — both invisible to the drop counter, which only sees queue-full backpressure:
+ *   - When the secret IS set but the appender never attached (a logback wiring regression like the
+ *     `<if>`-nested-in-`<root>` bug #1972 fixed), [[loop]] logs a loud WARN instead of a silent
+ *     debug, so the 0-ingest cause is named in the API's own logs.
+ *   - A [[SendErrorCountingListener]] on the logback StatusManager counts loki4j SEND errors
+ *     (401/403 wrong-scope token, 4xx/5xx, timeouts) into `loki_logs_send_errors_total`. loki4j is
+ *     fail-open and reports these only to the StatusManager, so a misscoped access-policy token
+ *     would otherwise reject every line with no metric moving at all.
  */
 object LokiDropMetrics {
 
   /** Poll cadence. Drops accrue slowly relative to scrape interval; 30s keeps the series cheap. */
   val DefaultInterval: Duration = 30.seconds
+
+  /**
+   * #1972: classify a logback status as a loki4j send-side error. loki4j routes its HTTP failures
+   * (401/403 wrong-scope token, 4xx/5xx, connection/timeout) to the logback StatusManager via
+   * `InternalLogger.error(...)`, with the originating loki4j object as the status origin. We count
+   * ERROR-level statuses whose origin class lives under `com.github.loki4j` — capturing the silent
+   * auth failure that left `loki_logs_dropped_total` flat at 0 while every line was rejected at the
+   * send boundary. Pure (takes the origin's class name) so it is unit-testable without loki4j.
+   */
+  def isLokiSendError(level: Int, originClassName: Option[String]): Boolean =
+    level == Status.ERROR && originClassName.exists(_.startsWith("com.github.loki4j"))
+
+  /**
+   * Logback [[StatusListener]] holding a monotonic count of loki4j send errors (see
+   * [[isLokiSendError]]). Reset-resistant so it survives a logback reconfigure. The poll loop reads
+   * [[errorsTotal]] and diffs it into `loki_logs_send_errors_total`, exactly as the drop counter is
+   * polled — keeping the zio-metrics bridge on the ZIO side, off the logback callback thread.
+   */
+  final class SendErrorCountingListener extends StatusListener {
+    private val errors                                = new AtomicLong(0L)
+    override def isResetResistant: Boolean            = true
+    override def addStatusEvent(status: Status): Unit =
+      if (isLokiSendError(status.getLevel, Option(status.getOrigin).map(_.getClass.getName))) {
+        val _ = errors.incrementAndGet()
+      }
+    def errorsTotal: Long                             = errors.get()
+  }
 
   /**
    * Locate the [[MeteredLoki4jAppender]] attached to the logback root logger, if any. `None` when
@@ -67,6 +106,31 @@ object LokiDropMetrics {
       _    <- AppMetrics.recordLokiDropped(cur - prev)
     } yield ()
 
+  /** Same monotonic-delta shape as [[emitDelta]], for the send-error counter (#1972). */
+  def emitSendErrorDelta(read: UIO[Long], lastSeen: Ref[Long]): UIO[Unit] =
+    for {
+      cur  <- read
+      prev <- lastSeen.getAndSet(cur)
+      _    <- AppMetrics.recordLokiSendErrors(cur - prev)
+    } yield ()
+
+  /**
+   * Register a [[SendErrorCountingListener]] on the logback root context's StatusManager so loki4j
+   * send errors are counted, returning it for polling. `None` when logback isn't a
+   * [[LoggerContext]] (defensive). Installed only when the LOKI appender is present (the caller
+   * gates on that).
+   */
+  def installSendErrorListener: UIO[Option[SendErrorCountingListener]] =
+    ZIO.succeed {
+      LoggerFactory.getILoggerFactory match {
+        case ctx: LoggerContext =>
+          val listener = new SendErrorCountingListener
+          ctx.getStatusManager.add(listener)
+          Some(listener)
+        case _                  => None
+      }
+    }
+
   /**
    * Fiber loop: if the LOKI appender is present, poll its drop count every `interval` and emit the
    * delta; otherwise log once and return (local/test). `lastSeen` is seeded with the count at start
@@ -92,10 +156,16 @@ object LokiDropMetrics {
           ZIO.logDebug("LOKI appender not present; loki-drop metrics disabled (local/test).")
       case Some(app) =>
         for {
-          start    <- ZIO.succeed(app.droppedEventsTotal)
-          lastSeen <- Ref.make(start)
-          _        <- ZIO.logInfo("loki-drop metrics fiber polling MeteredLoki4jAppender")
-          _        <- emitDelta(ZIO.succeed(app.droppedEventsTotal), lastSeen)
+          start        <- ZIO.succeed(app.droppedEventsTotal)
+          lastSeen     <- Ref.make(start)
+          // #1972: also poll loki4j send errors (401/4xx/5xx) so an auth/scope failure that sheds
+          // every line at the send boundary is visible — it never touches the queue-full drop count.
+          sendListener <- installSendErrorListener
+          errStart = sendListener.fold(0L)(_.errorsTotal)
+          lastErrSeen <- Ref.make(errStart)
+          _           <- ZIO.logInfo("loki-drop metrics fiber polling MeteredLoki4jAppender")
+          _           <- (emitDelta(ZIO.succeed(app.droppedEventsTotal), lastSeen) *>
+            emitSendErrorDelta(ZIO.succeed(sendListener.fold(0L)(_.errorsTotal)), lastErrSeen))
             .repeat(Schedule.fixed(interval))
             .unit
         } yield ()

--- a/api/src/observability/LokiDropMetrics.scala
+++ b/api/src/observability/LokiDropMetrics.scala
@@ -72,7 +72,10 @@ object LokiDropMetrics {
    * delta; otherwise log once and return (local/test). `lastSeen` is seeded with the count at start
    * so a pre-existing total isn't replayed as one large spike. Never fails; fork as a daemon.
    */
-  def loop(interval: Duration = DefaultInterval): UIO[Unit] =
+  def loop(
+      interval: Duration = DefaultInterval,
+      lokiUrlConfigured: => Boolean = sys.env.contains("GRAFANA_CLOUD_LOKI_URL"),
+  ): UIO[Unit] =
     findAppender.flatMap {
       case None      =>
         ZIO.logDebug("LOKI appender not present; loki-drop metrics disabled (local/test).")

--- a/api/test/src/feature/LokiDropMetricsSpec.scala
+++ b/api/test/src/feature/LokiDropMetricsSpec.scala
@@ -87,7 +87,9 @@ object LokiDropMetricsSpec extends ZIOSpec[PrometheusPublisher] {
         _    <- LokiDropMetrics.loop(lokiUrlConfigured = true)
         logs <- ZTestLogger.logOutput
       } yield assertTrue(
-        logs.exists(e => e.logLevel == LogLevel.Warning && e.message().contains("not shipping")),
+        logs.exists(e =>
+          e.logLevel == LogLevel.Warning && e.message().contains("shipping to Grafana Cloud Loki"),
+        ),
       )).provide(ZTestLogger.default)
     },
   )

--- a/api/test/src/feature/LokiDropMetricsSpec.scala
+++ b/api/test/src/feature/LokiDropMetricsSpec.scala
@@ -78,5 +78,17 @@ object LokiDropMetricsSpec extends ZIOSpec[PrometheusPublisher] {
         value    <- awaitValue(25.0)
       } yield assertTrue(value == 25.0)
     } @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds),
+    test("warns loudly when the Loki URL is set but no appender is attached (#1972)") {
+      // findAppender returns None in-test (no LOKI appender on the test logger), so this exercises
+      // the misconfiguration branch: a deployed env that has GRAFANA_CLOUD_LOKI_URL but, due to a
+      // logback wiring regression, never attached the appender — the silent 0-ingest mode #1972
+      // hit. The branch must surface a WARN so the next recurrence is diagnosable, not invisible.
+      (for {
+        _    <- LokiDropMetrics.loop(lokiUrlConfigured = true)
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(
+        logs.exists(e => e.logLevel == LogLevel.Warning && e.message().contains("not shipping")),
+      )).provide(ZTestLogger.default)
+    },
   )
 }

--- a/api/test/src/feature/LokiDropMetricsSpec.scala
+++ b/api/test/src/feature/LokiDropMetricsSpec.scala
@@ -8,6 +8,7 @@ import zio.*
 import zio.http.*
 import zio.metrics.connectors.prometheus.PrometheusPublisher
 import zio.test.*
+import ch.qos.logback.core.status.{ErrorStatus, Status}
 
 /**
  * #1885: the poller side of the loki-drop metric. [[LokiDropMetrics.emitDelta]] reads the
@@ -91,6 +92,37 @@ object LokiDropMetricsSpec extends ZIOSpec[PrometheusPublisher] {
           e.logLevel == LogLevel.Warning && e.message().contains("shipping to Grafana Cloud Loki"),
         ),
       )).provide(ZTestLogger.default)
+    },
+    test("send-error classifier counts loki4j ERROR statuses, ignores others (#1972)") {
+      // The 401 'invalid scope requested' that a misscoped token returns arrives as an ERROR-level
+      // logback status whose origin is a com.github.loki4j.* object. Anything else must NOT count.
+      assertTrue(
+        LokiDropMetrics
+          .isLokiSendError(Status.ERROR, Some("com.github.loki4j.logback.MeteredLoki4jAppender")),
+        LokiDropMetrics.isLokiSendError(
+          Status.ERROR,
+          Some("com.github.loki4j.client.pipeline.AsyncBufferPipeline"),
+        ),
+        !LokiDropMetrics
+          .isLokiSendError(Status.WARN, Some("com.github.loki4j.logback.MeteredLoki4jAppender")),
+        !LokiDropMetrics.isLokiSendError(Status.ERROR, Some("ch.qos.logback.core.ConsoleAppender")),
+        !LokiDropMetrics.isLokiSendError(Status.ERROR, None),
+      )
+    },
+    test("send-error counting listener increments on a loki4j ERROR status (#1972)") {
+      val listener = new LokiDropMetrics.SendErrorCountingListener
+      // Simulate loki4j reporting a 401 to the StatusManager.
+      val origin   = new com.github.loki4j.logback.MeteredLoki4jAppender
+      listener.addStatusEvent(
+        new ErrorStatus(
+          "Loki responded with non-success status 401 ... invalid scope requested",
+          origin,
+        ),
+      )
+      listener.addStatusEvent(
+        new ErrorStatus("unrelated", new ch.qos.logback.core.ConsoleAppender[Any]),
+      )
+      assertTrue(listener.errorsTotal == 1L, listener.isResetResistant)
     },
   )
 }

--- a/api/test/src/unit/LokiAppenderConfigSpec.scala
+++ b/api/test/src/unit/LokiAppenderConfigSpec.scala
@@ -6,6 +6,11 @@ import java.nio.file.{Files, Paths}
 import javax.xml.parsers.DocumentBuilderFactory
 import org.w3c.dom.{Element, Node}
 
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.joran.JoranConfigurator
+import ch.qos.logback.core.status.Status
+import scala.jdk.CollectionConverters.*
+
 /**
  * #1873 (epic #1831): pins the structural contract of the Grafana Cloud Loki appender in
  * `api/resources/logback.xml`. Logback `<if>` conditions resolve against the JVM environment, which
@@ -78,6 +83,62 @@ object LokiAppenderConfigSpec extends ZIOSpecDefault {
       .find(_.getAttribute("name") == "LOKI")
       .getOrElse(throw new AssertionError("no <appender name=\"LOKI\"> in logback.xml"))
 
+  /**
+   * The shipped logback.xml URL. Prefer the checked-in source file (so a local edit is exercised
+   * without a rebuild); fall back to the classpath copy — which is what `mill __.test` and the
+   * deployed jar actually load. Either way JoranConfigurator runs the REAL config, not a copy.
+   */
+  private val logbackUrl: java.net.URL = {
+    val srcFile = Paths.get("api/resources/logback.xml")
+    if (Files.exists(srcFile)) srcFile.toUri.toURL
+    else
+      Option(getClass.getClassLoader.getResource("logback.xml"))
+        .getOrElse(throw new IllegalStateException("logback.xml not found on classpath"))
+  }
+
+  /**
+   * #1972: drive logback's real [[JoranConfigurator]] over the shipped `logback.xml` with the
+   * GRAFANA_CLOUD_LOKI_* secrets present (via system properties — logback's `isDefined`/`${...}`
+   * resolve those), into a private [[LoggerContext]] (never the global one). Returns the recorded
+   * Joran status list plus whether a "LOKI" appender ended up attached to the ROOT logger.
+   *
+   * This is the gap the DOM-shape assertions above could not cover: the original config nested the
+   * root's `<appender-ref ref="LOKI">` inside an `<if>`, which logback (1.5.25, the version loki4j
+   * 2.0.3 forces and prod runs) forbids INSIDE `<root>`/`<logger>`/`<appender>` — so the appender
+   * silently never attached (0 Loki ingest) even though every shape assertion passed. Only running
+   * Joran at the shipped logback version surfaces that.
+   */
+  private def loadConfig(): (List[Status], Boolean) = {
+    val keys  = List(
+      "GRAFANA_CLOUD_LOKI_URL"      -> "http://localhost:3100/loki/api/v1/push",
+      "GRAFANA_CLOUD_LOKI_USER"     -> "12345",
+      "GRAFANA_CLOUD_LOKI_PASSWORD" -> "test-token",
+      "WIFIHAVEN_ENV"               -> "test",
+    )
+    val saved = keys.map { case (k, _) => k -> Option(System.getProperty(k)) }
+    keys.foreach { case (k, v) => System.setProperty(k, v) }
+    val ctx   = new LoggerContext()
+    try {
+      val configurator = new JoranConfigurator()
+      configurator.setContext(ctx)
+      configurator.doConfigure(logbackUrl)
+      val statuses     = ctx.getStatusManager.getCopyOfStatusList.asScala.toList
+      val attached     = ctx
+        .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
+        .iteratorForAppenders()
+        .asScala
+        .exists(_.getName == "LOKI")
+      (statuses, attached)
+    } finally {
+      // drainOnStop=false keeps this quick; releases loki4j's background sender threads.
+      ctx.stop()
+      saved.foreach {
+        case (k, Some(v)) => System.setProperty(k, v)
+        case (k, None)    => System.clearProperty(k)
+      }
+    }
+  }
+
   def spec = suite("LokiAppenderConfigSpec")(
     test("the LOKI appender is gated on the GRAFANA_CLOUD_LOKI_URL secret (deployed envs only)") {
       assertTrue(gatedByLokiSecret(lokiAppender))
@@ -104,6 +165,22 @@ object LokiAppenderConfigSpec extends ZIOSpecDefault {
       val smEl = elements(lokiAppender, "structuredMetadata").head
       // `* = %%mdc` expands every MDC entry into structured metadata, not labels.
       assertTrue(smEl.getTextContent.replaceAll("\\s", "").contains("*=%%mdc"))
+    },
+    test("logback actually loads the config and ATTACHES the LOKI appender to root (#1972)") {
+      val (statuses, attached) = loadConfig()
+      val errors               = statuses.filter(_.getEffectiveLevel == Status.ERROR)
+      // logback rejects `<if>` nested in <root>/<logger>/<appender> with this WARN, then fails to
+      // find the appender the broken ref pointed at — the exact #1972 failure signature.
+      val nestedIfRejected     =
+        statuses.exists(s => Option(s.getMessage).exists(_.contains("cannot be nested")))
+      val failedToFindLoki     =
+        statuses.exists(s =>
+          Option(s.getMessage).exists(_.contains("Failed to find appender named [LOKI]")),
+        )
+      assertTrue(attached) &&
+      assertTrue(!nestedIfRejected) &&
+      assertTrue(!failedToFindLoki) &&
+      assertTrue(errors.isEmpty)
     },
     test("fail-open: bounded send queue (drop-on-backpressure) and no drain-on-stop") {
       val batchEl     = elements(lokiAppender, "batch").head

--- a/build.mill
+++ b/build.mill
@@ -44,7 +44,15 @@ val flywayVersion      = "10.17.3"
 val jwtVersion         = "10.0.1"
 val bcryptVersion      = "0.10.2"
 val postgresVersion    = "42.7.4"
-val logbackVersion     = "1.5.8"
+// #1972: pin to the version loki4j 2.0.3 transitively forces (1.5.25). The old
+// 1.5.8 pin was silently bumped to 1.5.25 by coursier conflict resolution, so the
+// declared number did not match what actually resolved/shipped (`showMvnDepsTree`
+// printed `1.5.8 -> 1.5.25`). Aligning the declaration removes that confusion and
+// the "Found logback version ?" / "versions are different" noise. NB the two
+// versions differ on a config nuance that bit us here: 1.5.25 REJECTS an `<if>`
+// nested inside `<root>` ("IfNestedWithinSecondPhaseElementSC") where 1.5.8
+// tolerated it — see logback.xml and LokiAppenderConfigSpec.
+val logbackVersion     = "1.5.25"
 // #1873: loki4j ships API app logs straight to Grafana Cloud Loki via a
 // logback appender (deployed envs only). 2.0.x requires logback 1.5.x — matches
 // `logbackVersion` above. janino backs the `<if>` conditional in logback.xml that

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -617,6 +617,36 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Loki log shipping send errors (#1972)",
+      "description": "sum(rate(loki_logs_send_errors_total[5m])) — log batches the loki4j appender SENT to Grafana Cloud Loki that came back as an error (HTTP 401/403 wrong-scope access-policy token, other 4xx/5xx, connection/timeout). Counted by a logback StatusListener (LokiDropMetrics.SendErrorCountingListener) since loki4j routes these only to the StatusManager and is fail-open. DISTINCT from the drops panel: drops are queue-full on the way IN; this is rejection at the SEND boundary, which leaves drops flat at 0. A sustained rate with 0 ingest means the GRAFANA_CLOUD_LOKI_PASSWORD token lacks logs:write scope (the #1972 failure) — re-issue the access policy token. Should be flat zero in steady state.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 48 },
+      "id": 19,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0.001 }] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(loki_logs_send_errors_total{env=\"$env\"}[5m]))",
+          "legendFormat": "send errors/s",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary

Fixes #1972 — Grafana Cloud Loki showed **0 ingest** from the API even after the
operator set the `GRAFANA_CLOUD_LOKI_*` secrets on the Render web services.
Observability-first investigation found **two independent root causes**, both
of which were silent (loki4j is fail-open by construction):

### Root cause A — the LOKI appender never attached (logback config bug)
`logback.xml` declared the root's `<appender-ref ref="LOKI">` inside an `<if>`
**nested within `<root>`**. logback **1.5.25** — the version loki4j 2.0.3
transitively forces onto the classpath, and what the deployed jar runs —
**rejects** an `<if>` nested in `<root>`/`<logger>`/`<appender>`
(`IfNestedWithinSecondPhaseElementSC`). The deploy logs show it exactly:

```
WARN  IfNestedWithinSecondPhaseElementSC - <if> elements cannot be nested within an <appender>, <logger> or <root> element
WARN  AppenderModelHandler - Appender named [LOKI] not referenced. Skipping further processing.
ERROR AppenderRefModelHandler - Failed to find appender named [LOKI]
```

So the appender was never attached and the API shipped **zero** logs to Loki.

**Fix:** declare a full `<root>` inside each branch of the **top-level** `<if>`
(LOKI+STDOUT when the secret is present, STDOUT-only otherwise). Every `<if>`
now sits at the top level, which logback allows on all versions, and LOKI
attaches deterministically. Verified end-to-end against logback 1.5.25 via the
real `JoranConfigurator`.

Also pinned `logbackVersion` to `1.5.25` (the version that already resolved/
shipped) so the declaration matches reality, removing the silent `1.5.8 -> 1.5.25`
bump and the "Found logback version ? / versions are different" startup noise.
The mismatch is also why the test classpath behaviour matched prod.

### Root cause B — the access-policy token lacks `logs:write` scope (operator action)
A live push from the **real staging creds** is rejected at the send boundary:

```
ERROR ... Loki responded with non-success status 401 ... {"error":"authentication error: invalid scope requested"}
```

The `GRAFANA_CLOUD_LOKI_PASSWORD` Grafana Cloud access-policy token does not have
`logs:write` for the logs instance. loki4j's `droppedEventsCount` only counts
**queue-full** drops on the way *in*, so a send-boundary 401 leaves
`loki_logs_dropped_total` flat at 0 — the invisible failure mode the issue's
suspect #5 named.

> **⚠️ Operator action required:** re-issue the access-policy token used for
> `GRAFANA_CLOUD_LOKI_PASSWORD` with **`logs:write`** scope on the logs instance,
> then redeploy `wifihaven-api-{staging,prod}`. The logback fix is necessary but
> not sufficient on its own — Loki will keep showing 0 ingest until the token is
> re-scoped.

## Observability (so neither failure mode is silent again)
- **WARN on misconfig:** when `GRAFANA_CLOUD_LOKI_URL` is set but no appender is
  attached, `LokiDropMetrics.loop` now logs a loud WARN instead of a silent debug
  (catches root cause A on any future regression).
- **`loki_logs_send_errors_total`:** a reset-resistant logback `StatusListener`
  counts loki4j send errors (401/403/4xx/5xx/timeout, which loki4j routes only to
  the StatusManager), polled by the existing `LokiDropMetrics` fiber. Catches root
  cause B. Ships with a consuming Grafana panel on `api-self-metrics.json`
  (new-metric-ships-with-its-dashboard rule); registered unlabelled in the
  cardinality firewall.

## Tests (TDD — red commit first)
- `LokiAppenderConfigSpec` now drives the **real `JoranConfigurator`** over the
  shipped `logback.xml` (loaded from the classpath, the same artifact the jar
  runs) with the secrets set via system properties, asserting the LOKI appender
  actually **attaches to root**. The prior DOM-shape assertions could not see the
  nesting bug. Red before the fix (`Failed to find appender named [LOKI]`), green
  after.
- `LokiDropMetricsSpec` pins the misconfig WARN, the `isLokiSendError` classifier,
  and the `SendErrorCountingListener`.

## Verification
- Full `mill api.test` green (one pre-existing unrelated flake, `MetricsExportSpec`,
  passes in isolation).
- Live push with real staging creds confirmed the 401 (root cause B) and that the
  restructured config no longer trips the nested-`<if>` rejection (root cause A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
