### PR TITLE
feat(#1983): warn on Apps page + app selector when an app's hosts are on a blocklist

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -470,7 +470,7 @@ object Main extends ZIOAppDefault {
             notifier,
             clock,
           ) ++
-          AppRoutes.routes(auth, appRepo, profileRepo, upRepo, templates) ++
+          AppRoutes.routes(auth, appRepo, profileRepo, upRepo, blRepo, templates) ++
           AdminDebugRoutes.routes(auth, policy) ++
           DebugRoutes.routes(
             cfg.debugEnabled,

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -340,6 +340,14 @@ trait BlocklistRepo {
   def loadCategory(cat: BlocklistId): Task[Set[Hostname]]
   def loadAll: Task[Map[BlocklistId, Set[Hostname]]]
 
+  // #1983: for each of the given EXACT domains, which category blocklists
+  // contain it. The caller passes the bounded set of app-host apex candidates
+  // (each host + its parent suffixes), so this is O(candidates) index probes on
+  // `idx_blocklist_domain` — NOT an O(apps × hosts × domains) scan of the large
+  // blocklist_domains table. Returns only domains that matched at least one
+  // category; absent keys mean "in no blocklist".
+  def categoriesForDomains(domains: List[String]): Task[Map[String, List[BlocklistId]]]
+
   // #958: metadata-table operations backing the SPA management page and
   // the bundled-list startup seeder. `summaries` joins blocklists with
   // a count from blocklist_domains so the SPA renders host counts
@@ -1361,6 +1369,18 @@ class BlocklistRepoLive(xa: Transactor[Task]) extends BlocklistRepo {
     .to[List]
     .transact(xa)
     .map(_.groupBy(_._1).map((k, vs) => k -> vs.map(_._2).toSet))
+
+  def categoriesForDomains(domains: List[String]) =
+    if domains.isEmpty then ZIO.succeed(Map.empty)
+    else
+      DbMetrics.timed("blocklist.categoriesForDomains") {
+        val arr = domains.distinct.toArray
+        sql"SELECT domain, category FROM blocklist_domains WHERE domain = ANY($arr)"
+          .query[(String, BlocklistId)]
+          .to[List]
+          .transact(xa)
+          .map(_.groupBy(_._1).map((d, vs) => d -> vs.map(_._2).distinct.sorted))
+      }
 
   def upsertMeta(
       id: BlocklistId,

--- a/api/src/policy/AppBlocklistOverlap.scala
+++ b/api/src/policy/AppBlocklistOverlap.scala
@@ -22,18 +22,6 @@ import zio.*
  */
 object AppBlocklistOverlap {
 
-  /** Mirror of [[HostMatch.hasApexMatch]]'s walk: the host plus each apex parent it would test. */
-  def apexCandidates(host: String, maxHops: Int = 5): List[String] = {
-    @annotation.tailrec
-    def loop(h: String, hops: Int, acc: List[String]): List[String] = {
-      val acc2 = h :: acc
-      val dot  = h.indexOf('.')
-      if (dot < 0 || hops <= 0) acc2
-      else loop(h.substring(dot + 1), hops - 1, acc2)
-    }
-    loop(host, maxHops, Nil)
-  }
-
   /**
    * For each app id, the subset of its hosts that overlap a category blocklist, with the matching
    * blocklist ids (sorted). Apps with no overlap are absent from the result map.
@@ -43,11 +31,12 @@ object AppBlocklistOverlap {
       hostsByApp: Map[AppId, List[Hostname]],
   ): Task[Map[AppId, List[AppBlocklistedHost]]] = {
     val allCandidates =
-      hostsByApp.values.flatten.flatMap(h => apexCandidates(h.value)).toList.distinct
+      hostsByApp.values.flatten.flatMap(h => HostMatch.apexTails(h.value)).toList.distinct
     blocklistRepo.categoriesForDomains(allCandidates).map { catsByDomain =>
       hostsByApp.flatMap { (appId, hosts) =>
         val flagged = hosts.flatMap { host =>
-          val cats = apexCandidates(host.value)
+          val cats = HostMatch
+            .apexTails(host.value)
             .flatMap(c => catsByDomain.getOrElse(c, Nil))
             .distinct
             .sorted

--- a/api/src/policy/AppBlocklistOverlap.scala
+++ b/api/src/policy/AppBlocklistOverlap.scala
@@ -1,0 +1,68 @@
+package wifihaven.api.policy
+
+import wifihaven.api.db.BlocklistRepo
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.*
+
+/**
+ * #1983: compute, per app, which of its hosts overlap a shipped category blocklist (and which
+ * blocklist(s) each overlapping host is on). This is the data the SPA's Apps page + app selector
+ * render as a "this app contains blocklisted hosts" warning.
+ *
+ * Matching mirrors enforcement ([[wifihaven.shared.types.HostMatch.hasApexMatch]]): a host is on a
+ * blocklist if the host itself OR one of its apex parents (up to `maxHops` deep) is a member
+ * domain. We therefore expand each host into its apex-candidate set, query the (indexed)
+ * blocklist_domains table once for the whole bounded candidate set, then map each candidate's
+ * categories back onto the hosts that produced it. No full-table scan, no re-fetch of the in-memory
+ * category map.
+ *
+ * Membership is GLOBAL (host ∈ ANY shipped blocklist), not scoped to a profile's enabled lists —
+ * the warning describes the app definition, which is profile-independent (see #1983).
+ */
+object AppBlocklistOverlap {
+
+  /** Mirror of [[HostMatch.hasApexMatch]]'s walk: the host plus each apex parent it would test. */
+  def apexCandidates(host: String, maxHops: Int = 5): List[String] = {
+    @annotation.tailrec
+    def loop(h: String, hops: Int, acc: List[String]): List[String] = {
+      val acc2 = h :: acc
+      val dot  = h.indexOf('.')
+      if (dot < 0 || hops <= 0) acc2
+      else loop(h.substring(dot + 1), hops - 1, acc2)
+    }
+    loop(host, maxHops, Nil)
+  }
+
+  /**
+   * For each app id, the subset of its hosts that overlap a category blocklist, with the matching
+   * blocklist ids (sorted). Apps with no overlap are absent from the result map.
+   */
+  def forApps(
+      blocklistRepo: BlocklistRepo,
+      hostsByApp: Map[AppId, List[Hostname]],
+  ): Task[Map[AppId, List[AppBlocklistedHost]]] = {
+    val allCandidates =
+      hostsByApp.values.flatten.flatMap(h => apexCandidates(h.value)).toList.distinct
+    blocklistRepo.categoriesForDomains(allCandidates).map { catsByDomain =>
+      hostsByApp.flatMap { (appId, hosts) =>
+        val flagged = hosts.flatMap { host =>
+          val cats = apexCandidates(host.value)
+            .flatMap(c => catsByDomain.getOrElse(c, Nil))
+            .distinct
+            .sorted
+          if (cats.isEmpty) None else Some(AppBlocklistedHost(host, cats))
+        }
+        if (flagged.isEmpty) None else Some(appId -> flagged)
+      }
+    }
+  }
+
+  /** Single-app convenience for the detail endpoint. */
+  def forHosts(
+      blocklistRepo: BlocklistRepo,
+      appId: AppId,
+      hosts: List[Hostname],
+  ): Task[List[AppBlocklistedHost]] =
+    forApps(blocklistRepo, Map(appId -> hosts)).map(_.getOrElse(appId, Nil))
+}

--- a/api/src/routes/AppRoutes.scala
+++ b/api/src/routes/AppRoutes.scala
@@ -5,6 +5,7 @@ import wifihaven.api.AppTemplate
 import wifihaven.api.AppTemplates
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
+import wifihaven.api.policy.AppBlocklistOverlap
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import zio.*
@@ -44,28 +45,45 @@ object AppRoutes {
       }
   }
 
-  private def detail(appRepo: AppRepo, a: App): Task[AppDetail] =
+  private def detail(appRepo: AppRepo, blocklistRepo: BlocklistRepo, a: App): Task[AppDetail] =
     for {
-      hosts <- appRepo.getHosts(a.id)
-      asgn  <- appRepo.listAssignmentsForApp(a.id)
-    } yield AppDetail(a, hosts, asgn)
+      hosts       <- appRepo.getHosts(a.id)
+      asgn        <- appRepo.listAssignmentsForApp(a.id)
+      // #1983: per-host category-blocklist overlap so the SPA can warn.
+      blocklisted <- AppBlocklistOverlap.forHosts(blocklistRepo, a.id, hosts)
+    } yield AppDetail(a, hosts, asgn, blocklisted)
 
   def routes(
       auth: AuthService,
       appRepo: AppRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
+      blocklistRepo: BlocklistRepo,
       templates: Map[AppTemplateId, AppTemplate] = Map.empty,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "apps"                                                ->
         handler { (req: Request) =>
           val handle: ZIO[Any, ApiError, Response] = for {
-            _        <- requireAuth(req, auth)
-            apps     <- appRepo.listAll.mapError(ApiError.Db(_))
-            detailed <- ZIO
-              .foreach(apps)(detail(appRepo, _))
+            _       <- requireAuth(req, auth)
+            apps    <- appRepo.listAll.mapError(ApiError.Db(_))
+            // Fetch hosts + assignments per app, then compute the blocklist
+            // overlap for ALL apps in a single batched query (#1983) rather
+            // than one categoriesForDomains round-trip per app.
+            base    <- ZIO
+              .foreach(apps) { a =>
+                for {
+                  hosts <- appRepo.getHosts(a.id)
+                  asgn  <- appRepo.listAssignmentsForApp(a.id)
+                } yield (a, hosts, asgn)
+              }
               .mapError(ApiError.Db(_))
+            overlap <- AppBlocklistOverlap
+              .forApps(blocklistRepo, base.map((a, hosts, _) => a.id -> hosts).toMap)
+              .mapError(ApiError.Db(_))
+            detailed = base.map { (a, hosts, asgn) =>
+              AppDetail(a, hosts, asgn, overlap.getOrElse(a.id, Nil))
+            }
           } yield Response.json(detailed.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -78,7 +96,7 @@ object AppRoutes {
               .findById(aid)
               .mapError(ApiError.Db(_))
               .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
-            d <- detail(appRepo, a).mapError(ApiError.Db(_))
+            d <- detail(appRepo, blocklistRepo, a).mapError(ApiError.Db(_))
           } yield Response.json(d.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -204,7 +222,7 @@ object AppRoutes {
                 ),
               )
             _    <- appRepo.setHosts(aid, tmpl.hosts).mapError(ApiError.Db(_))
-            d    <- detail(appRepo, app).mapError(ApiError.Db(_))
+            d    <- detail(appRepo, blocklistRepo, app).mapError(ApiError.Db(_))
           } yield Response.json(d.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },

--- a/api/test/src/feature/AppApiSpec.scala
+++ b/api/test/src/feature/AppApiSpec.scala
@@ -38,8 +38,9 @@ object AppApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
       appRepo     <- ZIO.service[AppRepo]
       profileRepo <- ZIO.service[ProfileRepo]
       upRepo      <- ZIO.service[UserProfileRepo]
+      blRepo      <- ZIO.service[BlocklistRepo]
       auth        <- makeAuth
-    } yield AppRoutes.routes(auth, appRepo, profileRepo, upRepo)
+    } yield AppRoutes.routes(auth, appRepo, profileRepo, upRepo, blRepo)
 
   private def adminToken =
     for {
@@ -160,6 +161,74 @@ object AppApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         assertTrue(
           detail.hosts.toSet == Set(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")),
         )
+    },
+    // #1983: an app whose host (or an apex parent of it) is a member of a
+    // shipped category blocklist is flagged in `AppDetail.blocklisted`, naming
+    // every blocklist that host appears on. Membership is global (host ∈ ANY
+    // shipped list). Hosts on no list never appear.
+    test("GET list+detail flags app hosts that overlap category blocklists") {
+      for {
+        _       <- cleanDb
+        token   <- adminToken
+        rs      <- makeRoutes
+        appRepo <- ZIO.service[AppRepo]
+        blRepo  <- ZIO.service[BlocklistRepo]
+        // games + social blocklists; gimkit.com is on games (the #1980 case),
+        // a parent apex (example.com) is on social, fine.com is on nothing.
+        _       <- blRepo.insertBatch(
+          List(
+            "gimkit.com"  -> "games",
+            "roblox.com"  -> "games",
+            "example.com" -> "social",
+          ),
+        )
+        id      <- appRepo.create("Gimkit", "gimkit", None, None)
+        _       <- appRepo.setHosts(
+          id,
+          List(
+            Hostname.unsafe("gimkit.com"),
+            Hostname.unsafe("play.example.com"), // apex parent example.com is on social
+            Hostname.unsafe("fine.com"),         // on no list
+          ),
+        )
+        one     <- rs.runZIO(
+          Request
+            .get(url(s"/api/apps/${id.value}"))
+            .addHeader(Header.Authorization.Bearer(token)),
+        )
+        oneBody <- one.body.asString
+        d       <- ZIO.fromEither(oneBody.fromJson[AppDetail])
+        byHost = d.blocklisted.map(b => b.host -> b.blocklists).toMap
+      } yield assertTrue(one.status == Status.Ok) &&
+        assertTrue(
+          byHost.get(Hostname.unsafe("gimkit.com")).contains(List(BlocklistId.unsafe("games"))),
+        ) &&
+        assertTrue(
+          byHost
+            .get(Hostname.unsafe("play.example.com"))
+            .contains(List(BlocklistId.unsafe("social"))),
+        ) &&
+        assertTrue(!byHost.contains(Hostname.unsafe("fine.com"))) &&
+        assertTrue(d.blocklisted.size == 2)
+    },
+    test("GET list returns empty blocklisted when no hosts overlap") {
+      for {
+        _       <- cleanDb
+        token   <- adminToken
+        rs      <- makeRoutes
+        appRepo <- ZIO.service[AppRepo]
+        blRepo  <- ZIO.service[BlocklistRepo]
+        _       <- blRepo.insertBatch(List("gambling-site.example" -> "gambling"))
+        id      <- appRepo.create("Clean", "clean", None, None)
+        _       <- appRepo.setHosts(id, List(Hostname.unsafe("clean.com")))
+        list    <- rs.runZIO(
+          Request.get(url("/api/apps")).addHeader(Header.Authorization.Bearer(token)),
+        )
+        body    <- list.body.asString
+        details <- ZIO.fromEither(body.fromJson[List[AppDetail]])
+      } yield assertTrue(list.status == Status.Ok) &&
+        assertTrue(details.length == 1) &&
+        assertTrue(details.head.blocklisted.isEmpty)
     },
     test("GET /api/apps without token returns 401") {
       for {

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -73,8 +73,9 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       appRepo     <- ZIO.service[AppRepo]
       profileRepo <- ZIO.service[ProfileRepo]
       upRepo      <- ZIO.service[UserProfileRepo]
+      blRepo      <- ZIO.service[BlocklistRepo]
       auth        <- makeAuth
-    } yield AppRoutes.routes(auth, appRepo, profileRepo, upRepo, templates)
+    } yield AppRoutes.routes(auth, appRepo, profileRepo, upRepo, blRepo, templates)
 
   private def createUser(
       userRepo: UserRepo,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -449,10 +449,24 @@ case class UpsertAppAssignmentRequest(
     allowedDuringScheduleBlock: Option[Boolean] = None,
 ) derives JsonCodec
 
+// #1983: one app host that is a member of one or more shipped category
+// blocklists, plus the blocklist(s) it appears on. Surfaced so the SPA can warn
+// — on the Apps page and the app selector — that allowing this app overlaps a
+// category that would otherwise drop the host (see #1980 for the policy-layer
+// precedence). Membership is GLOBAL: a host is flagged if it (or an apex parent)
+// is in ANY blocklist we ship, not scoped to the blocklists enabled for a given
+// profile — the simplest correct shape per #1983 (the warning is about the app
+// definition, which is profile-independent).
+case class AppBlocklistedHost(host: Hostname, blocklists: List[BlocklistId]) derives JsonCodec
+
 case class AppDetail(
     app: App,
     hosts: List[Hostname],
     assignments: List[AppPolicyAssignment],
+    // #1983: additive — hosts of this app that overlap a category blocklist.
+    // Existing clients omit it; it decodes to `Nil`, so the wire stays
+    // back-compatible.
+    blocklisted: List[AppBlocklistedHost] = Nil,
 ) derives JsonCodec
 
 // #766: recently-visited-hosts picker for the apps create/edit flow. The

--- a/shared/src/types/HostMatch.scala
+++ b/shared/src/types/HostMatch.scala
@@ -32,6 +32,26 @@ object HostMatch {
   }
 
   /**
+   * The dot-separated tails of `host` that the apex predicates test, in order from the full host
+   * down to its shallowest parent: `host :: parent :: grandparent :: …`, bounded by `maxHops`
+   * (FQDNs deeper than ~5 labels are rare). This is the single source of the host→apex walk —
+   * [[hasApexMatch]], [[lookupApex]], and the #1983 app↔blocklist overlap all consume it so the
+   * walk (and its `maxHops`) cannot drift between enforcement and the surfaces that describe it.
+   *
+   * `host` is expected to be a bare FQDN (no `*.`).
+   */
+  def apexTails(host: String, maxHops: Int = 5): List[String] = {
+    @annotation.tailrec
+    def loop(h: String, hops: Int, acc: List[String]): List[String] = {
+      val acc2 = h :: acc
+      val dot  = h.indexOf('.')
+      if (dot < 0 || hops <= 0) acc2.reverse
+      else loop(h.substring(dot + 1), hops - 1, acc2)
+    }
+    loop(host, maxHops, Nil)
+  }
+
+  /**
    * Walk the dot-separated tails of `host` and return the first one present in `apexes` (or its
    * full-host exact match). Bounded by `maxHops` since FQDNs deeper than ~5 labels are rare and
    * each step is a hash lookup. Returns None for hosts that match no apex (caller decides whether
@@ -40,18 +60,8 @@ object HostMatch {
    * `host` is expected to be a bare FQDN (no `*.`). IP-literal callers should filter before calling
    * — `192.168.1.1` will walk tails harmlessly but the result is never useful.
    */
-  def lookupApex[T](host: String, apexes: Map[String, T], maxHops: Int = 5): Option[T] = {
-    @annotation.tailrec
-    def loop(h: String, hops: Int): Option[T] =
-      apexes.get(h) match {
-        case some @ Some(_) => some
-        case None           =>
-          val dot = h.indexOf('.')
-          if (dot < 0 || hops <= 0) None
-          else loop(h.substring(dot + 1), hops - 1)
-      }
-    loop(host, maxHops)
-  }
+  def lookupApex[T](host: String, apexes: Map[String, T], maxHops: Int = 5): Option[T] =
+    apexTails(host, maxHops).iterator.flatMap(apexes.get).nextOption()
 
   /**
    * #1560: `host` matches at least one pattern in `patterns` under [[matchesPattern]] semantics.
@@ -69,15 +79,6 @@ object HostMatch {
     )
 
   /** Boolean variant of [[lookupApex]] over a set of apexes. */
-  def hasApexMatch(host: String, apexes: Set[String], maxHops: Int = 5): Boolean = {
-    @annotation.tailrec
-    def loop(h: String, hops: Int): Boolean =
-      if (apexes.contains(h)) true
-      else {
-        val dot = h.indexOf('.')
-        if (dot < 0 || hops <= 0) false
-        else loop(h.substring(dot + 1), hops - 1)
-      }
-    loop(host, maxHops)
-  }
+  def hasApexMatch(host: String, apexes: Set[String], maxHops: Int = 5): Boolean =
+    apexTails(host, maxHops).exists(apexes.contains)
 }

--- a/web/src/components/AppBlocklistWarning.tsx
+++ b/web/src/components/AppBlocklistWarning.tsx
@@ -1,0 +1,75 @@
+import type { AppBlocklistedHost } from '@/types/api'
+
+// #1983 — warns that an app contains hosts that also belong to one or more
+// category blocklists (e.g. gimkit.com on the "games" list while Gimkit is an
+// allowed app — see #1980). Two variants:
+//   - `badge`: compact "⚠ N blocklisted" pill with a native-title tooltip, for
+//     the per-profile app selector / picker where space is tight.
+//   - `detail`: an expanded list of each offending host + the blocklist(s) it's
+//     on, for the Apps page row expansion.
+// `nameById` maps a blocklist id (category slug) to its display name; absent
+// entries fall back to the id, so the warning still renders before the
+// blocklist metadata loads.
+
+function blocklistLabel(id: string, nameById?: Map<string, string>): string {
+  return nameById?.get(id) ?? id
+}
+
+function tooltip(blocklisted: AppBlocklistedHost[], nameById?: Map<string, string>): string {
+  return blocklisted
+    .map(b => `${b.host}: ${b.blocklists.map(id => blocklistLabel(id, nameById)).join(', ')}`)
+    .join('\n')
+}
+
+export function AppBlocklistWarningBadge({ blocklisted, nameById, className = '' }: {
+  blocklisted?: AppBlocklistedHost[]
+  nameById?: Map<string, string>
+  className?: string
+}) {
+  if (!blocklisted || blocklisted.length === 0) return null
+  const n = blocklisted.length
+  return (
+    <span
+      data-testid="app-blocklist-badge"
+      title={tooltip(blocklisted, nameById)}
+      className={`inline-flex items-center gap-1 bg-amber-500/15 text-amber-800 border border-amber-500/40 text-[11px] font-medium px-1.5 py-0.5 rounded-md ${className}`}
+    >
+      <span aria-hidden="true">⚠</span>
+      {n} blocklisted host{n === 1 ? '' : 's'}
+    </span>
+  )
+}
+
+export function AppBlocklistWarningDetail({ blocklisted, nameById }: {
+  blocklisted?: AppBlocklistedHost[]
+  nameById?: Map<string, string>
+}) {
+  if (!blocklisted || blocklisted.length === 0) return null
+  return (
+    <div data-testid="app-blocklist-detail">
+      <span className="block text-xs font-semibold text-amber-800 uppercase tracking-wider mb-2">
+        ⚠ On a blocklist
+      </span>
+      <p className="text-xs text-brand-text-muted mb-2">
+        These hosts are also in a category blocklist. Allowing this app overrides
+        the blocklist for them (the app-allow wins).
+      </p>
+      <ul className="space-y-1">
+        {blocklisted.map(b => (
+          <li key={b.host} className="text-xs flex flex-wrap items-center gap-1.5">
+            <span className="font-mono text-brand-ink">{b.host}</span>
+            <span className="text-brand-text-muted">on</span>
+            {b.blocklists.map(id => (
+              <span
+                key={id}
+                className="inline-flex items-center bg-amber-500/15 text-amber-800 border border-amber-500/30 px-1.5 py-0.5 rounded text-[11px]"
+              >
+                {blocklistLabel(id, nameById)}
+              </span>
+            ))}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -18,6 +18,9 @@ vi.mock('@/api/client', () => ({
     devices: {
       list: vi.fn(),
     },
+    blocklists: {
+      list: vi.fn(),
+    },
   },
 }))
 
@@ -72,10 +75,21 @@ const reddit: AppDetail = {
   assignments: [],
 }
 
+// #1983 — Gimkit's host is also on the "games" blocklist (the #1980 case).
+const gimkit: AppDetail = {
+  ...makeApp({ id: 12, name: 'Gimkit', slug: 'gimkit' }),
+  hosts: ['gimkit.com', 'fine.com'],
+  assignments: [],
+  blocklisted: [{ host: 'gimkit.com', blocklists: ['games'] }],
+}
+
 beforeEach(() => {
   vi.resetAllMocks()
   ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube, reddit])
   ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([kidsProfile, adultsProfile])
+  ;(api.blocklists.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+    { id: 'games', name: 'Games', bundled: true, hostCount: 1 },
+  ])
   ;(api.devices.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
     { id: 1, mac: 'aa:bb:cc:dd:ee:01', name: 'iPad', profileId: 1, profileName: 'Kids',
       lastSeenIp: '192.168.1.10', lastSeenAt: '2026-05-24T18:00:00Z' },
@@ -93,6 +107,23 @@ describe('AppsPage — read-only list', () => {
     const rdRow = screen.getByRole('button', { name: /reddit/i })
     expect(within(rdRow).getByText(/1 host/i)).toBeInTheDocument()
     expect(within(rdRow).getByText(/no profiles/i)).toBeInTheDocument()
+  })
+
+  it('warns on apps whose hosts are on a blocklist and names the list when expanded', async () => {
+    const user = userEvent.setup()
+    ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([gimkit, reddit])
+    render(withQuery(<AppsPage />))
+    const gkRow = await screen.findByRole('button', { name: /gimkit/i })
+    // Row carries a warning badge…
+    expect(within(gkRow).getByTestId('app-blocklist-badge')).toBeInTheDocument()
+    // …and Reddit (no overlap) does not.
+    const rdRow = screen.getByRole('button', { name: /reddit/i })
+    expect(within(rdRow).queryByTestId('app-blocklist-badge')).not.toBeInTheDocument()
+    // Expanding lists the offending host + the named blocklist.
+    await user.click(gkRow)
+    const detail = await screen.findByTestId('app-blocklist-detail')
+    expect(within(detail).getByText('gimkit.com')).toBeInTheDocument()
+    expect(within(detail).getByText('Games')).toBeInTheDocument()
   })
 
   it('shows an empty-state when there are no apps', async () => {

--- a/web/src/pages/AppsPage.tsx
+++ b/web/src/pages/AppsPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
-import { useProfiles } from '@/api/queries'
+import { useBlocklists, useProfiles } from '@/api/queries'
 import type { AppDetail } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { AppIcon } from '@/components/AppIcon'
 import { EmptyState } from '@/components/EmptyState'
+import { AppBlocklistWarningBadge, AppBlocklistWarningDetail } from '@/components/AppBlocklistWarning'
 
 // #1798 — app *definitions* (name, slug, icon, host-set) are authored only via
 // the built-in `AppTemplates` in code (which seed/reconcile server-side); the
@@ -17,12 +18,20 @@ export function AppsPage() {
   const [expandedId, setExpandedId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const { data: profiles = [] } = useProfiles()
+  // #1983 — map blocklist id (category slug) → display name for the warnings.
+  const { data: blocklists = [] } = useBlocklists()
 
   const profileNameById = useMemo(() => {
     const m = new Map<number, string>()
     for (const p of profiles) m.set(p.profile.id, p.profile.name)
     return m
   }, [profiles])
+
+  const blocklistNameById = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const b of blocklists) m.set(b.id, b.name)
+    return m
+  }, [blocklists])
 
   useEffect(() => {
     api.apps
@@ -70,7 +79,10 @@ export function AppsPage() {
                         <AppIcon icon={a.app.icon} iconType={a.app.iconType} size="lg" />
                       </span>
                       <div className="flex-1 min-w-0">
-                        <p className="font-medium text-brand-ink truncate">{a.app.name}</p>
+                        <p className="font-medium text-brand-ink truncate flex items-center gap-2">
+                          {a.app.name}
+                          <AppBlocklistWarningBadge blocklisted={a.blocklisted} nameById={blocklistNameById} />
+                        </p>
                         <p className="text-xs text-brand-text-muted mt-0.5 font-mono">{a.app.slug}</p>
                       </div>
                       <div className="text-right text-xs text-brand-text shrink-0">
@@ -84,7 +96,11 @@ export function AppsPage() {
                     </div>
                   </button>
                   {expanded && (
-                    <AppDetailView detail={a} profileNameById={profileNameById} />
+                    <AppDetailView
+                      detail={a}
+                      profileNameById={profileNameById}
+                      blocklistNameById={blocklistNameById}
+                    />
                   )}
                 </div>
               )
@@ -97,9 +113,10 @@ export function AppsPage() {
 
 // #1798 — read-only detail for an expanded app row: its host set and the
 // profiles it's assigned to. No editing controls.
-function AppDetailView({ detail, profileNameById }: {
+function AppDetailView({ detail, profileNameById, blocklistNameById }: {
   detail: AppDetail
   profileNameById: Map<number, string>
+  blocklistNameById: Map<string, string>
 }) {
   const assignedProfiles = useMemo(() => {
     const ids = new Set(detail.assignments.map(a => a.profileId))
@@ -122,6 +139,8 @@ function AppDetailView({ detail, profileNameById }: {
               ))}
         </div>
       </div>
+
+      <AppBlocklistWarningDetail blocklisted={detail.blocklisted} nameById={blocklistNameById} />
 
       <p className="text-xs text-brand-text-muted">
         Used by {assignedProfiles.length === 0

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -14,6 +14,7 @@ import type {
   UpsertAppAssignmentRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { AppIcon } from '@/components/AppIcon'
+import { AppBlocklistWarningBadge } from '@/components/AppBlocklistWarning'
 import { ProfileTimelineChart } from '@/components/usage/ProfileTimelineChart'
 import { ProfileUsageBreakdown } from '@/components/usage/ProfileUsageBreakdown'
 import { EmptyState } from '@/components/EmptyState'
@@ -1649,6 +1650,13 @@ function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-s
   // Unassigned apps stay manageable via the "+ Add app" picker below.
   const [pickerOpen, setPickerOpen] = useState(false)
   const [pickerFilter, setPickerFilter] = useState('')
+  // #1983 — blocklist id → display name for the per-app overlap warning badges.
+  const { data: blocklists = [] } = useBlocklists()
+  const blocklistNameById = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const b of blocklists) m.set(b.id, b.name)
+    return m
+  }, [blocklists])
   const assigned = useMemo(
     () => (profileId == null ? [] : apps.filter(a => findAssignment(a, profileId) != null)),
     [apps, profileId],
@@ -1746,6 +1754,7 @@ function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-s
               profileId={profileId}
               onChanged={onChanged}
               usedMins={usedMinsByAppId?.get(a.app.id)}
+              blocklistNameById={blocklistNameById}
             />
           ))}
           {pickerOpen && (
@@ -1780,6 +1789,7 @@ function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-s
                     >
                       <AppIcon icon={a.app.icon} iconType={a.app.iconType} size="sm" className="w-5 text-center" />
                       <span className="text-sm text-brand-ink flex-1 truncate">{a.app.name}</span>
+                      <AppBlocklistWarningBadge blocklisted={a.blocklisted} nameById={blocklistNameById} />
                       <span className="text-xs text-brand-text-muted">{a.hosts.length} host{a.hosts.length === 1 ? '' : 's'}</span>
                     </button>
                   ))}
@@ -1793,7 +1803,7 @@ function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-s
   )
 }
 
-function AppRow({ app, profileId, onChanged, usedMins }: {
+function AppRow({ app, profileId, onChanged, usedMins, blocklistNameById }: {
   app: AppDetail
   profileId: number
   onChanged: () => void | Promise<void>
@@ -1801,6 +1811,8 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
   // profile. Undefined → not loaded yet (e.g. subsection just opened); the
   // bar simply doesn't render until the value arrives.
   usedMins?: number
+  // #1983 — blocklist id → display name for the overlap-warning badge.
+  blocklistNameById?: Map<string, string>
 }) {
   // #1086 — app-policy edits (mode switch, exemptFromDaily toggle, removal)
   // feed the server-side daily-cap math, so a successful write must invalidate
@@ -1989,7 +2001,10 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
           <AppIcon icon={app.app.icon} iconType={app.app.iconType} size="md" />
         </span>
         <div className="flex-1 min-w-0">
-          <p className="text-sm text-brand-ink font-medium truncate">{app.app.name}</p>
+          <p className="text-sm text-brand-ink font-medium truncate flex items-center gap-2">
+            {app.app.name}
+            <AppBlocklistWarningBadge blocklisted={app.blocklisted} nameById={blocklistNameById} />
+          </p>
           <p className="text-xs text-brand-text-muted font-mono truncate">{app.hosts.length} host{app.hosts.length === 1 ? '' : 's'}</p>
         </div>
         {mode != null && (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -897,10 +897,20 @@ export interface AppPolicyAssignment {
   allowedDuringScheduleBlock?: boolean
 }
 
+// #1983 — one app host that is a member of one or more shipped category
+// blocklists, with the blocklist id(s) it appears on. Drives the "this app
+// contains blocklisted hosts" warning on the Apps page + app selector.
+export interface AppBlocklistedHost {
+  host: string
+  blocklists: string[]
+}
+
 export interface AppDetail {
   app: App
   hosts: string[]
   assignments: AppPolicyAssignment[]
+  // #1983 — additive; omitted by older APIs → treat as empty.
+  blocklisted?: AppBlocklistedHost[]
 }
 
 // #1798 — app *definitions* (name/slug/icon/host-set/create) are authored only


### PR DESCRIPTION
## What & why

Closes #1983. On the **Apps page** and the **app selector**, warn when any of an app's hosts are members of a category **blocklist**, and list which blocklist(s) each overlapping host is on. This is the UX surface of the #1980 overlap (gimkit.com is on the `games` list while Gimkit is an allowed app) — it gives the parent visibility into the conflict and which list is responsible.

## Membership shape (decision)

**Global**: a host is flagged if it (or an apex parent of it) is a member of **ANY shipped blocklist**, not scoped to the lists enabled for a particular profile. Rationale: the warning describes the *app definition*, which is profile-independent — the same app shows the same overlap everywhere it's offered. This is the simplest correct shape per the issue; per-profile scoping can be layered later if needed.

Matching mirrors enforcement (`HostMatch.hasApexMatch`): `play.example.com` is flagged if `example.com` is on a list, exactly as the router would drop it.

## Backend

- `AppDetail` gains an **additive** `blocklisted: List[AppBlocklistedHost]` (defaults `Nil`; both sides ignore the field if absent — wire stays back-compatible).
- `BlocklistRepo.categoriesForDomains(domains)` does **one** indexed lookup over the bounded app-host apex-candidate set. `AppBlocklistOverlap` expands each host into its apex candidates, queries once, and maps categories back per host — `O(candidates)` index probes, **never** an `O(apps×hosts×domains)` scan. The `GET /api/apps` list route batches every app into a single query.
- New DB call is metered via `DbMetrics.timed("blocklist.categoriesForDomains")` (bounded label).

## Query performance (prod-shaped)

Ran against the dev API DB (`api.lan`), `blocklist_domains` = **163,321 rows / 162,118 distinct domains / 10 categories** (READ-ONLY `EXPLAIN`):

```
EXPLAIN (ANALYZE, BUFFERS)
SELECT domain, category FROM blocklist_domains WHERE domain = ANY(ARRAY[... 20 candidates ...]::text[]);

 Index Only Scan using blocklist_domains_domain_category_key on blocklist_domains
   (cost=0.42..88.75 rows=20) (actual time=0.079..1.219 rows=18 loops=1)
   Index Cond: (domain = ANY (...))
   Heap Fetches: 0
   Buffers: shared hit=64
 Planning Time: 1.444 ms
 Execution Time: 1.249 ms
```

Index-Only Scan on the **existing** `UNIQUE(domain, category)` index, `Heap Fetches: 0`, ~1.25 ms. **No new index needed.**

## Frontend

- `AppBlocklistWarning` component: a compact `⚠ N blocklisted hosts` badge (with a `title` tooltip) and an expanded per-host detail list naming each blocklist.
- **Apps page**: badge on overlapping rows; expanding a row lists each offending host + the blocklist(s).
- **App selector** (Profiles page): badge on assigned app rows and in the add-app picker, so the conflict is visible at assignment time.
- Blocklist ids → display names via `useBlocklists` (falls back to the id before metadata loads).

## Tests

- **API feature test** (`AppApiSpec`, through the full route stack on embedded Postgres, no mocks): host-on-list and apex-parent-on-list are flagged with the right categories; a host on no list is absent; a clean app has empty `blocklisted`.
- **Web test** (`AppsPage.test`): badge renders on overlapping apps (not on clean ones); expansion names the host + blocklist.

TDD: failing tests committed first (`test(#1983): …`), then the implementation.

Relates to #1980, #1888, #1148.
