### PR TITLE
fix(#1980): allowed (TimeLimited, within-budget) app host beats category blocklist

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -710,6 +710,25 @@ class PolicyServiceLive(
                       else
                         timeLimitBlockFromState(h, now, settings, dayState) match {
                           case Some(r) => ZIO.succeed(r)
+                          // #1980: a TimeLimited app host still within its own budget beats a
+                          // category-blocklist drop. Checked AFTER pause / schedule / blocked-app /
+                          // time_limit (so it stays subordinate to every whole-MAC and per-app cap
+                          // block — the ordering is the /decision analogue of the snapshot's
+                          // `!state.blocked` gate) but BEFORE `categoryBlock`, mirroring the
+                          // snapshot's `extraAllowed`-beats-`bl_` precedence. Shares the single
+                          // `timeLimitedUnderCapHosts` definition with the snapshot (#1532).
+                          case None
+                              if matchesAny(
+                                h,
+                                PolicyService.timeLimitedUnderCapHosts(dayState),
+                              ) =>
+                            ZIO.succeed(
+                              RouterDecisionResponse(
+                                ConnectionDecision.Allow,
+                                BlockReason.asWire(BlockReason.ExtraAllowed),
+                                None,
+                              ),
+                            )
                           case None    =>
                             categoryBlock(p.blockedCategories, h).map {
                               case Some(cat) =>
@@ -1017,9 +1036,20 @@ object PolicyService {
     // `global.extraAllowed`, the top of the router's precedence ladder (#1319) —
     // so a hard pause remains a true off-switch for every per-profile carve-out,
     // sparing only the fleet-wide always-reachable set.
+    // #1980: a TimeLimited app still within its own per-app budget carves its FULL host-set (main +
+    // shared) into extraAllowed so it beats category-blocklist membership at the router (#421). Gated
+    // on the profile NOT being whole-MAC blocked: unlike the exempt carve above (which beats
+    // pause/schedule/daily-limit), this allow only outranks the per-host blocklist drop and stays
+    // subordinate to the whole-MAC block paths — the time budget governs *when* the host is
+    // reachable, the blocklist never *whether*. When the app's own cap exhausts it drops out of
+    // `timeLimitedUnderCapHosts` and `appLimitExtraBlocked` takes over (the redundant blocklist drop
+    // is fine).
+    val timeLimitedUnderCap =
+      if (state.blocked) Nil else timeLimitedUnderCapHosts(state)
+
     val profileExtraAllowed =
       if (isHardPause) Nil
-      else (appExtraAllowed ++ appExemptAllowedHosts).distinct
+      else (appExtraAllowed ++ appExemptAllowedHosts ++ timeLimitedUnderCap).distinct
 
     if (profile.defaultDeny)
       // #1318: default-deny baseline. Block-all with only the profile/device
@@ -1097,6 +1127,31 @@ object PolicyService {
       // two cannot disagree on what "exhausted" means (AGENTS.md §single-
       // source-of-truth).
       case sd if sd.exemptFromDaily && sd.dailyLimitMinutes.forall(sd.usedMinutes < _) =>
+        sd.hosts.map(Hostname.unsafe)
+    }.flatten
+
+  /**
+   * #1980: the full host-set (main + shared) of every TimeLimited app still UNDER its own per-app
+   * cap — the allow-side complement of [[appCapExhaustedHosts]] across the same `state.perApp` (the
+   * TimeLimited-only subset; see [[TimeStatusService.appDayStates]]). Carved into `extraAllowed` so
+   * a within-budget app host beats category-blocklist membership (`bl_`) at the router (#421,
+   * `feedback_extraallowed_beats_blocked`), which is the #1980 fix: a TimeLimited app contributes
+   * nothing to `extraAllowed` on its own, so without this an app host that is also a blocklist
+   * member (e.g. `gimkit.com` in the `games` list) is dropped during the app's allowed window.
+   *
+   * Unlike [[exemptUnderCapHosts]] (which carves UNCONDITIONALLY so an exempt app beats whole-MAC
+   * blocks), this carve is gated by the caller on the profile NOT being whole-MAC blocked
+   * (`!state.blocked` in [[computeBlockRules]]; the precedence ordering in `decide`). So it beats
+   * the per-host blocklist drop but stays subordinate to paused / schedule / profile-daily-limit
+   * blocks — the time budget governs *when* the host is reachable, the blocklist never *whether*
+   * (the app assignment is an explicit, authoritative allow). The full host-set is used (not just
+   * distinctive) because a shared backend belonging to an allowed app must stay reachable too, and
+   * over-allowing a shared host is safe — `extraAllowed` beats every drop. Shared by the snapshot
+   * and the /decision fallback so the two cannot diverge (#1532).
+   */
+  private[policy] def timeLimitedUnderCapHosts(state: ProfileDayState): List[Hostname] =
+    state.perApp.collect {
+      case sd if sd.dailyLimitMinutes.forall(lim => sd.usedMinutes < lim) =>
         sd.hosts.map(Hostname.unsafe)
     }.flatten
 

--- a/api/test/src/feature/PolicySnapshotAppBlocklistPrecedenceSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppBlocklistPrecedenceSpec.scala
@@ -1,0 +1,218 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+
+/**
+ * #1980: a host that belongs to an allowed (TimeLimited, within-budget) app's host-set — whether
+ * the app's MAIN or SHARED hosts — must take precedence over category-blocklist membership for the
+ * profile. The app assignment is an explicit, authoritative allow; a category blocklist is a broad
+ * catch. App-allow wins while the app is within its daily budget.
+ *
+ * Concrete repro: `gimkit.com` is a member of the `games` blocklist AND a host of the Gimkit app,
+ * assigned TimeLimited (10 min/day) to a kids profile. While within budget the host must be carved
+ * into `extraAllowed` (which the router applies above the `bl_` blocklist drop — #421,
+ * `feedback_extraallowed_beats_blocked`). Once the per-app cap exhausts, the cap path moves the
+ * distinctive hosts to `extraBlocked` and the blocklist drop becoming redundant is fine.
+ *
+ * Pre-#1980 a TimeLimited app contributed NOTHING to `extraAllowed` while within budget (the
+ * per-app cap path only emits the exhausted → `extraBlocked` direction), so a TimeLimited app host
+ * that is also a blocklist member was dropped by the blocklist during its allowed window.
+ */
+object PolicySnapshotAppBlocklistPrecedenceSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
+      ref    <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(
+      pr,
+      hsr,
+      tlr,
+      atlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      clk,
+      namedScheduleRepo = nsr,
+    ): PolicyService
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-seed", Sha256Hex.unsafe("b" * 64)))
+
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val today0  = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = today0.plusSeconds(i * 300L)
+        val end   = start.plusSeconds(300)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          end,
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  /**
+   * Gimkit: `gimkit.com` distinctive (main) + `gameshared.example` shared; both also in `games`.
+   */
+  private def seedGimkit(ar: AppRepo, kid: ProfileId, cap: Option[Int]): Task[Unit] =
+    for {
+      appId <- ar.create("Gimkit", "gimkit", None, None)
+      _     <- ar.setHostEntries(
+        appId,
+        List(
+          AppHostEntry(Hostname.unsafe("gimkit.com"), shared = false),
+          AppHostEntry(Hostname.unsafe("gameshared.example"), shared = true),
+        ),
+      )
+      _     <- ar.upsertAssignment(appId, kid, AppMode.TimeLimited, cap, exemptFromDaily = false)
+    } yield ()
+
+  /** A `games` category blocklist that contains BOTH Gimkit hosts. */
+  private def seedGamesBlocklist(blr: BlocklistRepo): Task[Unit] =
+    blr.insertBatch(List(("gimkit.com", "games"), ("gameshared.example", "games"))).unit
+
+  def spec = suite("PolicySnapshot — allowed-app host beats category blocklist (#1980)")(
+    test(
+      "within budget: main + shared app hosts carve into extraAllowed (beat the games blocklist)",
+    ) {
+      val mac = "aa:bb:cc:dd:ee:80"
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        kid  <- TestLayers.seedKidsProfile(pr)
+        _    <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("games")))
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _    <- seedGamesBlocklist(blr)
+        _    <- seedGimkit(ar, kid, Some(10))
+        svc  <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+        bl    = rules.blocklistIds.map(_.value).toSet
+      } yield
+      // The games blocklist is actually applied to this profile…
+      assertTrue(bl.contains("games")) &&
+        // …yet both the main and shared app hosts are carved into extraAllowed, so the router's
+        // extraAllowed-beats-blocklist precedence (#421) keeps them reachable within budget.
+        assertTrue(ea.contains("gimkit.com")) &&
+        assertTrue(ea.contains("gameshared.example")) &&
+        // Within budget nothing is dropped at the per-app cap layer.
+        assertTrue(!eb.contains("gimkit.com")) &&
+        assertTrue(!rules.blocked)
+    },
+    test("budget exhausted: distinctive host falls to extraBlocked and out of extraAllowed") {
+      val mac = "aa:bb:cc:dd:ee:81"
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        kid  <- TestLayers.seedKidsProfile(pr)
+        _    <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("games")))
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        rid  <- seedRouterRow
+        _    <- seedGamesBlocklist(blr)
+        _    <- seedGimkit(ar, kid, Some(10))
+        // 10 min on the distinctive host → aggregate hits the 10-min cap.
+        _    <- seedTraffic(rid, mac, "gimkit.com", LocalDate.of(2025, 1, 6), 10)
+        svc  <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+      } yield
+      // Cap exhausted: the app's own cap path moves the distinctive host to the blocked lane and it
+      // is no longer carved into extraAllowed (the blocklist drop becoming redundant is fine).
+      assertTrue(eb.contains("gimkit.com")) &&
+        assertTrue(!ea.contains("gimkit.com"))
+    },
+    test("/decision agrees: within budget the app host is allowed despite blocklist membership") {
+      val mac = "aa:bb:cc:dd:ee:82"
+      for {
+        _      <- cleanDb
+        pr     <- ZIO.service[ProfileRepo]
+        dr     <- ZIO.service[DeviceRepo]
+        ar     <- ZIO.service[AppRepo]
+        blr    <- ZIO.service[BlocklistRepo]
+        kid    <- TestLayers.seedKidsProfile(pr)
+        _      <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("games")))
+        _      <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _      <- seedGamesBlocklist(blr)
+        _      <- seedGimkit(ar, kid, Some(10))
+        ps     <- makePsAt(TestClock.schoolDayAfternoon)
+        main   <- ps.decide(mac, "gimkit.com")
+        shared <- ps.decide(mac, "gameshared.example")
+      } yield assertTrue(main.decision == ConnectionDecision.Allow) &&
+        assertTrue(shared.decision == ConnectionDecision.Allow)
+    },
+    test("/decision agrees: budget exhausted → the distinctive app host is blocked") {
+      val mac = "aa:bb:cc:dd:ee:83"
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        kid  <- TestLayers.seedKidsProfile(pr)
+        _    <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("games")))
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        rid  <- seedRouterRow
+        _    <- seedGamesBlocklist(blr)
+        _    <- seedGimkit(ar, kid, Some(10))
+        _    <- seedTraffic(rid, mac, "gimkit.com", LocalDate.of(2025, 1, 6), 10)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        main <- ps.decide(mac, "gimkit.com")
+      } yield assertTrue(main.decision == ConnectionDecision.Block)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/PolicySnapshotAppBlocklistPrecedenceSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppBlocklistPrecedenceSpec.scala
@@ -195,6 +195,34 @@ object PolicySnapshotAppBlocklistPrecedenceSpec
       } yield assertTrue(main.decision == ConnectionDecision.Allow) &&
         assertTrue(shared.decision == ConnectionDecision.Allow)
     },
+    test("default-deny profile: within-budget app host still carves into extraAllowed") {
+      // The carve flows into the default-deny branch too: a TimeLimited app within budget is an
+      // explicit allow, so it must survive the block-all baseline (consistent with how Allowed-mode
+      // / exempt apps carve under default-deny). state.blocked stays false for a pure default-deny
+      // profile (no pause/schedule/daily-limit), so the #1980 gate lets the carve through.
+      val mac = "aa:bb:cc:dd:ee:84"
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        blr  <- ZIO.service[BlocklistRepo]
+        kid  <- TestLayers.seedKidsProfile(pr)
+        p    <- pr.findById(kid).map(_.get)
+        _    <- pr.update(p.copy(defaultDeny = true))
+        _    <- pr.setBlockedCategories(kid, List(BlocklistId.unsafe("games")))
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _    <- seedGamesBlocklist(blr)
+        _    <- seedGimkit(ar, kid, Some(10))
+        svc  <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.DefaultDeny)) &&
+        assertTrue(ea.contains("gimkit.com")) &&
+        assertTrue(ea.contains("gameshared.example"))
+    },
     test("/decision agrees: budget exhausted → the distinctive app host is blocked") {
       val mac = "aa:bb:cc:dd:ee:83"
       for {

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -802,12 +802,19 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(ea.contains("mathacademy.com"))
     },
     test("#1105: same app assigned to two profiles with different exempt flags → independent") {
+      // The exempt flag only differentiates behaviour under a whole-MAC block: an exempt app under
+      // cap carves around it (`exemptUnderCapHosts`, unconditional), a non-exempt one does NOT (its
+      // within-budget carve is gated on `!state.blocked`; #1980). Pause both profiles so the
+      // distinction is visible — within budget and unblocked, BOTH would now carry the host in
+      // extraAllowed (#1980), so the host-set alone no longer distinguishes the exempt flag.
       for {
         _     <- cleanDb
         pr    <- ZIO.service[ProfileRepo]
         ar    <- ZIO.service[AppRepo]
         kid   <- TestLayers.seedKidsProfile(pr)
         adult <- TestLayers.seedAdultsProfile(pr)
+        _     <- pr.setPaused(kid, true)
+        _     <- pr.setPaused(adult, true)
         appId <- ar.create("Khan", "khan", None, None)
         _     <- ar.setHosts(appId, List(Hostname.unsafe("khanacademy.org")))
         _     <- ar.upsertAssignment(appId, kid, AppMode.TimeLimited, Some(60), true)
@@ -816,7 +823,10 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         snap  <- svc.snapshot
         kidEa   = snap.profiles(kid).rules.extraAllowed.map(_.value).toSet
         adultEa = snap.profiles(adult).rules.extraAllowed.map(_.value).toSet
-      } yield assertTrue(kidEa.contains("khanacademy.org")) &&
+      } yield assertTrue(snap.profiles(kid).rules.blocked) &&
+        assertTrue(snap.profiles(adult).rules.blocked) &&
+        // exempt app beats the pause; non-exempt app does not (its #1980 carve is gated off here).
+        assertTrue(kidEa.contains("khanacademy.org")) &&
         assertTrue(!adultEa.contains("khanacademy.org"))
     },
     // ── #1899 (shared-hosts S4): most-permissive enforcement for shared hosts ──


### PR DESCRIPTION
Fixes #1980.

## Root cause
A **TimeLimited** app (e.g. Gimkit, 10 min/day) contributed **nothing** to `extraAllowed` while within its budget. In `ProfileAppDispositions.enforcement` the fold is literally `case AppMode.TimeLimited => ()`, and the per-app cap path (`PolicyService.appCapExhaustedHosts`) only emits the **exhausted → `extraBlocked`** direction. There was no *within-budget → allow* direction at all.

So an app host that is **also** a category-blocklist member — `gimkit.com` is in the `games` list — was dropped by the blocklist (`blocklistIds`, the `bl_` nftables set) during the app's allowed window. The kid hit the block page even though Gimkit was an allowed, within-budget app.

This affected **both main and shared hosts**, because neither landed in `extraAllowed` for a TimeLimited app. (Allowed-mode apps were unaffected — `enforcement` carves their full host-set unconditionally, so `extraAllowed` already beat `bl_` per #421 / `feedback_extraallowed_beats_blocked`.) The broken path was the **TimeLimited mode**, for main *and* shared hosts alike.

## Fix (server-side only — no wire/router change)
- New shared helper `PolicyService.timeLimitedUnderCapHosts(state)`: the **full** host-set (main + shared) of every TimeLimited app still under its own per-app cap — the allow-side complement of `appCapExhaustedHosts` (both read the TimeLimited-only `state.perApp`).
- `computeBlockRules` carves it into `extraAllowed`, **gated on `!state.blocked`**. So it beats the per-host `bl_` blocklist drop but stays **subordinate** to whole-MAC blocks (paused / schedule / profile-daily-limit). The time budget governs *when* the host is reachable; the blocklist never governs *whether* — the app assignment is an explicit, authoritative allow. (Unlike the exempt carve, which beats whole-MAC blocks, this carve does not.)
- The `/decision` fallback gains the same carve check, ordered **after** pause / schedule / blocked-app / time_limit but **before** `categoryBlock` — the per-host analogue of the snapshot's `!state.blocked` gate. It reads the **same** helper, so the snapshot and `/decision` cannot diverge (#1532).
- Once the app's own cap exhausts, the host drops out of `timeLimitedUnderCapHosts` and `appCapExhaustedHosts` moves the distinctive hosts to `extraBlocked` (the redundant blocklist drop is fine — the host is blocked either way).

Expressed entirely via the existing `extraAllowed` functional field; the router stays a dumb applier (AGENTS.md architectural model).

## Tests (TDD — failing test committed first)
`PolicySnapshotAppBlocklistPrecedenceSpec` (feature, embedded Postgres, `Clock.TestClock`):
- within budget: **main + shared** Gimkit hosts carve into `extraAllowed` while `games` is in `blocklistIds` (so the carve is meaningful), nothing dropped;
- budget exhausted: distinctive host falls to `extraBlocked` and out of `extraAllowed`;
- `/decision` agrees both within budget (Allow) and exhausted (Block).

Also updated `PolicySnapshotAppsSpec` "#1105 different exempt flags → independent" to pause both profiles, where the exempt flag is the actual differentiator now that a within-budget non-exempt TimeLimited host correctly carves into `extraAllowed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)