### PR TITLE
fix(#1984): bound full JVM memory envelope so staging API fits 512Mi under smoke

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -38,8 +38,9 @@ services:
     # regression #1268 originally fixed (free → starter). starter (~$7/mo) is
     # the minimum non-spin-down JVM-capable tier; any future staging cost trim
     # must come from a different lever (e.g. suspend staging when not
-    # deploying), NOT from dropping to free. Bump to `standard` if OOM appears
-    # in the logs (RAM is 512 MB on both free and starter; -Xmx384m heap).
+    # deploying), NOT from dropping to free. RAM is 512 MB on starter; the
+    # JVM envelope is fully bounded to fit it (see JVM_HEAP_OPTS below, #1984).
+    # Bump to `standard` only if a bounded OOM reappears after that tuning.
     plan: starter
     region: oregon
     numInstances: 1
@@ -82,13 +83,31 @@ services:
       # ample and stays well clear of Render's reserved connections.
       - key: WIFIHAVEN_DB_POOL_SIZE
         value: "8"
-      # #590 / #1268 / #1389: free tier is 512 MB. Leave headroom for OS +
-      # JIT + native heap; this -Xmx384m envelope started clean on free
-      # before #1268 and stays unchanged across the free → starter → free
-      # round-trip. Raise the heap (and move to `plan: standard`, 2 GB) only
-      # if OOM appears in logs.
+      # #1984: starter is a HARD 512 MB cgroup cap and the JVM was only
+      # bounding HEAP (-Xmx384m). Everything else off-heap was on JVM defaults:
+      # crucially -XX:MaxDirectMemorySize defaults to ~= -Xmx, so Netty's
+      # direct/pooled buffers could grow another ~384 MB on top of heap. Under
+      # the (grown) CD smoke burst that pushed RSS well past 512 MB and Render
+      # OOM-killed the container ~2 min after each deploy (server_failed /
+      # oomKilled events), reddening Gate 1 / 3a / 3b. Cold-start was already
+      # handled by #1967's /api/health gate — this is the distinct second
+      # failure. The fix is to bound EVERY region so total RSS fits 512 MB with
+      # headroom, not just the heap:
+      #   heap      -Xmx288m              (smoke is light; 288 MB is ample)
+      #   metaspace -XX:MaxMetaspaceSize=128m   (Scala 3 / ZIO load many classes)
+      #   code      -XX:ReservedCodeCacheSize=64m
+      #   direct    -XX:MaxDirectMemorySize=64m + -Dio.netty.maxDirectMemory
+      #             (belt-and-suspenders: cap both the JVM ceiling AND Netty's
+      #              own arena accounting at 64 MB = 67108864 bytes)
+      #   GC        -XX:+UseSerialGC      (lowest-footprint GC; starter is 0.5
+      #             CPU so the JVM picks Serial anyway — make it deterministic
+      #             regardless of container CPU detection)
+      # Budget: 288 + 128 + 64 + 64 + ~25 (stacks) + ~30 (native) caps; these
+      # maxima don't co-commit, so realistic RSS lands ~420-470 MB. Raise the
+      # heap and/or move to `plan: standard` (2 GB) only if a *bounded* OOM
+      # (heap / metaspace / direct exhaustion in logs) reappears after this.
       - key: JVM_HEAP_OPTS
-        value: "-Xms256m -Xmx384m"
+        value: "-Xms192m -Xmx288m -XX:MaxMetaspaceSize=128m -XX:ReservedCodeCacheSize=64m -XX:MaxDirectMemorySize=64m -Dio.netty.maxDirectMemory=67108864 -XX:+UseSerialGC"
       # Staging runs DEBUG so issues are visible in the Render log stream.
       - key: WIFIHAVEN_LOG_LEVEL
         value: DEBUG


### PR DESCRIPTION
Closes #1984.

## Problem
`wifihaven-api-staging` (Render `srv-d8549fgjo89c73buvkf0`, plan **`starter` = 512Mi** hard cgroup cap) is **OOM-killed ~2 min after each deploy**, exactly when the (recently grown) CD smoke bursts load. Render `server_failed` events carry `"oomKilled": {"memoryLimit": "512Mi"}`. Each OOM = ~90-100s of 502s that no curl-retry window survives → recurring red on **Master API/UI CD (Gate 1, Gate 3b)** and **Master Router CD (Gate 3a)**.

This is the *second, distinct* failure after #1967's `/api/health` cold-start gate — that gate genuinely moved the smoke past where it used to die; the mid-run OOM is what remains.

## Root cause: only the heap was bounded
The staging container set `JVM_HEAP_OPTS=-Xms256m -Xmx384m` — heap capped, **everything else off-heap on JVM defaults**. Critically, `-XX:MaxDirectMemorySize` **defaults to ≈ `-Xmx`**, so Netty's pooled direct/off-heap buffers could grow *another ~384Mi on top of heap*. Metaspace and code cache were likewise unbounded.

```
worst-case heap (384) + Netty direct (~384) ≈ 768Mi  →  on a 512Mi container = guaranteed OOM under burst
```

## Fix — bound every region (staging only)
`render.yaml` `JVM_HEAP_OPTS` for `wifihaven-api-staging`:

| region | before | after |
|---|---|---|
| heap | `-Xmx384m` | `-Xms192m -Xmx288m` |
| metaspace | *(unbounded)* | `-XX:MaxMetaspaceSize=128m` |
| code cache | *(unbounded)* | `-XX:ReservedCodeCacheSize=64m` |
| **direct/Netty** | **≈ Xmx (~384m)** | `-XX:MaxDirectMemorySize=64m` + `-Dio.netty.maxDirectMemory=67108864` |
| GC | *(default)* | `-XX:+UseSerialGC` |

Direct memory is capped on **both** the JVM ceiling and Netty's own arena accounting (belt-and-suspenders). SerialGC is the lowest-footprint collector and is what the JVM picks anyway on starter's 0.5 CPU — set explicitly so it's deterministic regardless of container CPU detection.

### Memory math (512Mi budget)
```
heap      288
metaspace 128   (cap; Scala 3 / ZIO realistic ~90)
code       64   (cap; realistic ~40)
direct     64   (cap; realistic ~20)
stacks    ~25
native    ~30
```
These maxima **don't co-commit** — the caps exist to stop runaway *direct memory* (the OOM driver), not to reserve their sum. Realistic steady RSS lands **~420-470Mi**, ~50-90Mi under the 512Mi cap. The smoke is light (API contract checks), so 288Mi heap is ample.

## Scope
- **Staging only.** Prod (`wifihaven-api-prod`, `plan: standard` / 2GB, `-Xmx1400m`) is **not** OOMing and is left **unchanged** per the operator decision.
- **No plan bump.** The pre-authorized `standard` fallback was **not** needed — honest tuning fits 512Mi. (Bump to `standard` only if a *bounded* OOM — heap/metaspace/direct exhaustion in logs — reappears after this.)
- render.yaml-only; no Scala touched. Render Blueprint Lint (`ruby -ryaml`) passes locally.

## Proof
Render Blueprint Lint passes. Post-deploy I will run the staging smoke and confirm via the Render events API that **no** `server_failed`/`oomKilled` fires during the smoke window, and that **Master API/UI CD** + **Master Router CD** go green on the staging gates. Evidence to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)