### PR TITLE
feat(#1969): SPA-ws S2 — cookie upgrade auth (AuthService.verify + Origin allowlist + jwtExp 4401 close)

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -13,6 +13,7 @@ case class AppConfig(
     cors: CorsConfig,
     policy: PolicyConfig = PolicyConfig(),
     metrics: MetricsConfig = MetricsConfig(),
+    ws: WsConfig = WsConfig(),
 ) {
   // WIFIHAVEN_DEBUG env var: when set to a non-empty, non-"0"/"false"/"no"
   // value, mounts the read-only /api/debug/* endpoints (loopback only).
@@ -143,6 +144,55 @@ case class PolicyConfig(
           )
       }
       .toList
+}
+
+// #1969 — SPA-websocket upgrade auth for the browser-facing `GET /api/ws` (design
+// docs/design/spa-websocket.md §4/§8). The cookie/JWT verify reuses the existing
+// AuthService (no second auth surface); the only ws-specific server config here is
+// the `Origin` allowlist — "the one server-side ws config that differs by hosting
+// mode" (§8).
+//
+// `allowedOrigins` is a comma-separated list of allowed Origin HOSTS (scheme/port
+// ignored — the design's allowlist is host-based: app.wifihaven.net, staging.*,
+// localhost). Matched case-insensitively, with two wildcard forms: a leading
+// `*.suffix` matches any subdomain of `suffix` (and `suffix` itself), and a
+// trailing `prefix.*` matches `prefix` and any host starting `prefix.`. EMPTY
+// disables the cross-origin check entirely — the self-hosted same-origin default,
+// where SameSite=Strict on the wh_ws cookie (§4.2) is the CSWSH guard; cloud/
+// staging set the allowlist so a cross-site upgrade is rejected pre-101 (§8).
+case class WsConfig(
+    allowedOrigins: String = "",
+    // §4.3 — cadence at which each open connection re-checks `now ≥ jwtExp` and, once
+    // crossed, closes with `4401 token-expired`. Bounds mid-connection stale-authz
+    // carry-over to one tick (mirrors the design's ~30s app-level heartbeat). Clamped
+    // to a 1s floor so a misconfigured 0/negative can't become a no-delay tight loop.
+    expiryCheckSeconds: Int = 30,
+) {
+  val allowedOriginHosts: List[String] =
+    allowedOrigins.split(",").iterator.map(_.trim.toLowerCase).filter(_.nonEmpty).toList
+
+  val expiryCheckInterval: zio.Duration =
+    zio.Duration.fromSeconds(math.max(1, expiryCheckSeconds).toLong)
+
+  /**
+   * Whether `host` (the Origin header's host, lower-cased) is permitted. An empty allowlist returns
+   * `true` for every host — the self-hosted same-origin mode where the cross-origin check is off.
+   * When the allowlist is non-empty the check is enforced (an absent Origin is handled by the
+   * caller, which has no host to pass here).
+   */
+  def originAllowed(host: String): Boolean =
+    allowedOriginHosts.isEmpty || {
+      val h = host.toLowerCase
+      allowedOriginHosts.exists { pat =>
+        if pat.startsWith("*.") then { val s = pat.drop(2); h == s || h.endsWith("." + s) }
+        else if pat.endsWith(".*") then {
+          val p = pat.dropRight(2); h == p || h.startsWith(p + ".")
+        } else h == pat
+      }
+    }
+
+  /** Origin enforcement is on only when an allowlist is configured (cloud/staging). */
+  val enforceOrigin: Boolean = allowedOriginHosts.nonEmpty
 }
 
 object AppConfig {

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -463,10 +463,11 @@ object Main extends ZIOAppDefault {
             policy,
           ) ++
           RouterMetricsRoutes.routes(routerAuth, routerMetrics) ++
-          // #1968: additive browser-facing websocket endpoint (`GET /api/ws`, S1). Skeleton only —
-          // envelope demux + subscription registry; upgrade auth is S2, push sources S3/S4. The SPA
-          // has no ws client yet (S5), so this reads idle in prod until then.
-          SpaWsRoutes.routes(spaWsRegistry, clock) ++
+          // #1968/#1969: additive browser-facing websocket endpoint (`GET /api/ws`). S2 (#1969)
+          // authorizes the upgrade via the `wh_ws` cookie (existing AuthService.verify) + the §8
+          // Origin allowlist (cfg.ws); push sources are S3/S4. The SPA has no ws client yet (S5), so
+          // this reads idle in prod until then.
+          SpaWsRoutes.routes(auth, spaWsRegistry, clock, cfg.ws) ++
           AlertRoutes.routes(
             auth,
             alertRepo,

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -239,11 +239,16 @@ object MetricGuard {
     // `direction` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. `spa_ws_subscriptions_active`
     // is the live count of subscriptions per `topic` (the SpaTopic enum). All bounded enums — no
     // per-mac / per-profile / per-session / param dimension ever rides a ws metric. (The
-    // spa_ws_auth_total / spa_ws_push_total families land with S2/S3/S4, when they are first
-    // emitted — added then, not now, so every Allowed entry maps to a live call site.)
+    // spa_ws_push_total lands with S3/S4, when first emitted.)
     "spa_ws_connections_active"                 -> Set("role"),
     "spa_ws_frames_total"                       -> Set("op", "direction", "result"),
     "spa_ws_subscriptions_active"               -> Set("topic"),
+    // #1969 (S2) — upgrade-auth outcomes for `GET /api/ws` (design §4/§7). `result` ∈
+    // {ok, no_cookie, invalid_jwt, expired_jwt, bad_origin, jwt_expired_midconn} — the
+    // cookie-verify + Origin-allowlist outcomes plus the mid-connection expiry close. A
+    // fixed 6-value enum; bounded, no per-user/session dimension. A spike in
+    // bad_origin/invalid_jwt is the CSWSH/forgery-probe tripwire (alert in spa-ws.json).
+    "spa_ws_auth_total"                         -> Set("result"),
     // #1848 — AGENT-side websocket transport metrics. The wifihaven-ws sidecar has no metrics
     // registry of its own, so it writes a cumulative tally that the agent folds into its
     // /api/router/metrics push (the server attaches router_id / installation_id, as for every
@@ -596,6 +601,13 @@ object AppMetrics {
       "spa_ws_frames_total",
       Map("op" -> op, "direction" -> direction, "result" -> result),
     )
+
+  // #1969 (S2) — emitted from SpaWsRoutes at upgrade time (cookie verify + Origin check)
+  // and from the per-connection expiry watcher. `result` ∈ {ok, no_cookie, invalid_jwt,
+  // expired_jwt, bad_origin, jwt_expired_midconn} — a fixed bounded enum, never a per-user
+  // dimension. The verify itself reuses AuthService (SSOT); this only labels the outcome.
+  def recordSpaWsAuth(result: String): UIO[Unit] =
+    MetricGuard.counter("spa_ws_auth_total", Map("result" -> result))
 
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
   // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -235,7 +235,8 @@ object MetricGuard {
     // `spa_ws_connections_active` is the live count of open /api/ws channels per `role`
     // (admin|adult|child), refreshed on every register/deregister so a role's series ages out to 0
     // on disconnect. `spa_ws_frames_total` counts every frame demuxed/sent: `op` ∈ {hello, ready,
-    // subscribe, unsubscribe, ack, ping, pong, unknown} (the fixed SPA envelope vocabulary),
+    // subscribe, unsubscribe, ack, ping, pong, reauth, unknown} (the fixed SPA envelope vocabulary;
+    // `reauth` added by #1969 — the forward-compat reject seam),
     // `direction` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. `spa_ws_subscriptions_active`
     // is the live count of subscriptions per `topic` (the SpaTopic enum). All bounded enums — no
     // per-mac / per-profile / per-session / param dimension ever rides a ws metric. (The

--- a/api/src/routes/SpaWsRoutes.scala
+++ b/api/src/routes/SpaWsRoutes.scala
@@ -1,5 +1,7 @@
 package wifihaven.api.routes
 
+import wifihaven.api.WsConfig
+import wifihaven.api.auth.{AuthError, AuthService}
 import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.observability.LogContext
 import wifihaven.shared.{Clock, UserRole}
@@ -9,71 +11,177 @@ import zio.http.ChannelEvent.UserEvent
 import zio.json.*
 import zio.json.ast.Json
 
+import java.time.Instant
+
 /**
- * #1968: the browser-facing websocket transport, `GET /api/ws`. This is step S1 of the
- * SPA-websocket rollout ([`docs/design/spa-websocket.md`](../../../docs/design/spa-websocket.md)
- * §9, design #1860; umbrella #1955) — the SERVER skeleton: the `{op, payload, seq?}` envelope
- * demux, the control ops (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection
- * subscription state + topic-keyed `ack`, `ping`/`pong`), and the forked per-connection
- * [[SpaWsRegistry]]. Purely additive: REST stays the fallback throughout the whole rollout (design
- * §3.3, §9), and the SPA has no ws client yet (that is S5). The endpoint is exercisable by a test
- * ws client today.
+ * #1968 / #1969: the browser-facing websocket transport, `GET /api/ws`. S1 (#1968) shipped the
+ * SERVER skeleton — the `{op, payload, seq?}` envelope demux, the control ops (`hello`→`ready`,
+ * `subscribe`/`unsubscribe` with per-connection subscription state + topic-keyed `ack`,
+ * `ping`/`pong`, unknown-op ignore+meter), and the forked per-connection [[SpaWsRegistry]]. S2
+ * (#1969) plugs in UPGRADE AUTH (design
+ * [`docs/design/spa-websocket.md`](../../../docs/design/spa-websocket.md) §4/§8): the connection is
+ * authorized BEFORE the 101, exactly like the router path.
  *
- * MIRRORS the router transport ([[RouterWsRoutes]], #1846) — same envelope discipline (one JSON
- * text message per frame), same demux shape, same unknown-op-ignore+meter forward-compat rule
- * (design §2.2) — but FORKS where the two genuinely differ (design §5.1): a per-connection id keyed
- * registry with a subscription set (not a `RouterId`→snapshot registry), the SPA op vocabulary, and
- * a topic-keyed `ack` (not the router's seq-keyed data-frame ack).
+ * Auth (design §4.2): the browser `WebSocket` constructor can't set an `Authorization` header
+ * (§0.2.1), so the operator JWT rides a tightly-scoped `wh_ws` cookie set just before connect. On
+ * the upgrade we (a) check the `Origin` against the configured allowlist (§8 — the one server-side
+ * ws config that differs by hosting mode), then (b) read the `wh_ws` cookie and verify it with the
+ * EXISTING [[AuthService.verify]] (no second auth surface — `AGENTS.md#single-source-of-truth`). A
+ * bad/missing/expired cookie or disallowed Origin → reject with a plain 401/403 (no 101), identical
+ * to a REST 401 and the router path. The resolved [[UserRole]] is captured at upgrade and is the
+ * fan-out authz key (§4.4); the JWT's `exp` is captured as the connection's authz deadline (§4.3) —
+ * a per-connection watcher closes the channel with `4401 token-expired` on the tick where `now ≥
+ * jwtExp`. Every upgrade outcome is metered `spa_ws_auth_total{result}` (§7).
  *
- * Auth is OUT OF SCOPE for S1 — the browser cannot set an `Authorization` header on the ws upgrade
- * (design §0.2.1), so S2 (#1969) authorizes the upgrade by verifying a tightly-scoped JWT cookie
- * via the existing [[wifihaven.api.auth.AuthService]] (no second auth surface). For S1 the
- * connection registers with a stub [[UserRole.Admin]] resolved at upgrade ([[upgradeRole]] — the
- * clear seam S2 plugs the cookie verify into), and the `hello` payload's optional `{role}` is the
- * test-handshake override that lets the subscription/authz machinery be exercised without a real
- * cookie.
+ * `reauth` is a forward-compat seam (§4.3): v1 has no silent token refresh, so the op is `ack`
+ * rejected — the SPA falls back to polling + `/login` on `4401`.
+ *
+ * MIRRORS the router transport ([[RouterWsRoutes]], #1846) — same envelope discipline, same
+ * pre-upgrade auth shape — but FORKS where the two genuinely differ (design §5.1): a cookie (not a
+ * bearer header) carries the credential, a per-connection id keyed registry with a subscription
+ * set, the SPA op vocabulary, and a topic-keyed `ack`.
  */
 object SpaWsRoutes {
 
   /** Convenience for callers that need a registry instance (Main wiring, tests). */
   def registry: UIO[SpaWsRegistry] = SpaWsRegistry.make
 
-  def routes(registry: SpaWsRegistry, clock: Clock): Routes[Any, Response] =
+  def routes(
+      auth: AuthService,
+      registry: SpaWsRegistry,
+      clock: Clock,
+      cfg: WsConfig,
+  ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "ws" ->
-        handler { (_: Request) =>
-          // S1: no upgrade auth — complete the upgrade unconditionally with the stub role. S2 (#1969)
-          // verifies the `wh_ws` cookie + Origin allowlist here and rejects a bad/missing/expired
-          // credential with a 401 (no 101), exactly like the router path and a REST 401.
-          socketApp(registry, clock).toResponse
+        handler { (req: Request) =>
+          // Authorize the upgrade BEFORE completing it (design §4.2). On any rejection, meter the
+          // outcome and return the plain 401/403 Response (no 101) — the SPA treats a ws reject like
+          // a REST 401. On success, register with the resolved role + jwtExp and complete the upgrade.
+          authorizeUpgrade(req, auth, cfg).foldZIO(
+            reject =>
+              LogContext.annotate(LogContext.Result, reject.metric) {
+                AppMetrics.recordSpaWsAuth(reject.metric) *>
+                  ZIO.logWarning(s"spa ws: upgrade rejected (${reject.metric})") *>
+                  ZIO.succeed(reject.response)
+              },
+            authd =>
+              AppMetrics.recordSpaWsAuth("ok") *>
+                socketApp(registry, clock, authd, cfg).toResponse,
+          )
         },
     )
 
   /**
-   * The role resolved at upgrade time. S1 stub: every connection starts at the LEAST-privileged
-   * role ([[UserRole.Child]]) until a `hello{role}` overrides it (the test handshake).
-   * Least-privilege by default is deliberate defense-in-depth: S1 has no upgrade auth yet (that is
-   * S2 / #1969) and mounts in prod additively, so if a later step (S3/S4) ever pushed data before
-   * S2's cookie verify lands, an unauthenticated connection that never sent a `hello{role}` would
-   * see the *minimum* surface (fail closed), not Admin (fail open). The §4.4 authz gate
-   * (`SpaTopic.visibleTo`) then filters on this role. S2 replaces this stub with the role read from
-   * the verified `wh_ws` JWT cookie (design §4.2/§4.4), captured once and authoritative for the
-   * connection's lifetime — and #1969 is a hard predecessor to any data-bearing push step (S3/S4)
-   * for exactly this reason.
+   * The least-privileged role ([[UserRole.Child]]). S2 resolves the real role from the verified
+   * cookie at upgrade, so this is only a defensive fallback for the (impossible-post-auth) case
+   * where `roleFor` finds no registration for an active connection — fail closed, not open.
    */
-  private val upgradeRole: UserRole = UserRole.Child
+  private val fallbackRole: UserRole = UserRole.Child
 
-  private def socketApp(registry: SpaWsRegistry, clock: Clock): WebSocketApp[Any] =
+  /**
+   * The resolved upgrade identity captured once and authoritative for the connection's lifetime.
+   */
+  private final case class Authorized(role: UserRole, jwtExp: Instant)
+
+  /**
+   * Why an upgrade was refused. Each case carries its `spa_ws_auth_total{result}` label and the
+   * plain HTTP `Response` returned in place of the 101 — cookie failures map to 401 (mirroring a
+   * REST 401 / the router bearer path), a disallowed Origin to 403.
+   */
+  private enum UpgradeReject(val metric: String) {
+    case NoCookie   extends UpgradeReject("no_cookie")
+    case InvalidJwt extends UpgradeReject("invalid_jwt")
+    case ExpiredJwt extends UpgradeReject("expired_jwt")
+    case BadOrigin  extends UpgradeReject("bad_origin")
+
+    def response: Response = this match {
+      case NoCookie   => Response.unauthorized("missing wh_ws cookie")
+      case InvalidJwt => Response.unauthorized("invalid token")
+      case ExpiredJwt => Response.unauthorized("token expired")
+      case BadOrigin  => Response.forbidden("origin not allowed")
+    }
+  }
+
+  /**
+   * Resolve the upgrade to an [[Authorized]] identity, or fail with the reason it was refused.
+   * Origin first (cheap, no crypto), then the cookie verify (design §4.2). The verify is delegated
+   * to [[AuthService.verify]] — the SAME implementation REST uses — so the ws path adds no second
+   * JWT-validation surface.
+   */
+  private def authorizeUpgrade(
+      req: Request,
+      auth: AuthService,
+      cfg: WsConfig,
+  ): IO[UpgradeReject, Authorized] =
+    checkOrigin(req, cfg) *> verifyCookie(req, auth)
+
+  private def checkOrigin(req: Request, cfg: WsConfig): IO[UpgradeReject, Unit] =
+    if !cfg.enforceOrigin then ZIO.unit // self-hosted same-origin: cross-origin check off (§8)
+    else
+      originHost(req) match {
+        case Some(host) if cfg.originAllowed(host) => ZIO.unit
+        case _                                     => ZIO.fail(UpgradeReject.BadOrigin)
+      }
+
+  /** The Origin header's host (lower-cased), if the header is present and parseable. */
+  private def originHost(req: Request): Option[String] =
+    req
+      .rawHeader("Origin")
+      .flatMap(o => URL.decode(o).toOption)
+      .flatMap(_.host)
+      .map(_.toLowerCase)
+
+  private def verifyCookie(
+      req: Request,
+      auth: AuthService,
+  ): IO[UpgradeReject, Authorized] =
+    req.cookie("wh_ws").map(_.content) match {
+      case None        => ZIO.fail(UpgradeReject.NoCookie)
+      case Some(token) =>
+        auth
+          .verify(token)
+          .mapError {
+            case AuthError.TokenExpired => UpgradeReject.ExpiredJwt
+            case _                      => UpgradeReject.InvalidJwt
+          }
+          .map { claims =>
+            Authorized(
+              role = UserRole.parse(claims.role).getOrElse(fallbackRole),
+              jwtExp = Instant.ofEpochSecond(claims.exp),
+            )
+          }
+    }
+
+  private def socketApp(
+      registry: SpaWsRegistry,
+      clock: Clock,
+      authd: Authorized,
+      cfg: WsConfig,
+  ): WebSocketApp[Any] =
     Handler.webSocket { channel =>
       // The connection id is assigned at HandshakeComplete (register) and read by every later frame;
-      // events are delivered in order so the id is set before any Read. Deregister unconditionally on
-      // exit so the registry + gauges never leak a dead channel.
-      Ref.make(Option.empty[SpaConnId]).flatMap { idRef =>
-        channel
+      // events are delivered in order so the id is set before any Read. A per-connection expiry
+      // watcher is forked at register and interrupted on exit. Deregister unconditionally on exit so
+      // the registry + gauges never leak a dead channel.
+      for {
+        idRef    <- Ref.make(Option.empty[SpaConnId])
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        _        <- channel
           .receiveAll {
             case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
-              registry.register(channel, upgradeRole, None).flatMap(id => idRef.set(Some(id))) *>
-                ZIO.logInfo("spa ws: connected")
+              registry.register(channel, authd.role, Some(authd.jwtExp)).flatMap { id =>
+                idRef.set(Some(id)) *>
+                  watchExpiry(
+                    channel,
+                    id,
+                    authd.jwtExp,
+                    registry,
+                    clock,
+                    cfg.expiryCheckInterval,
+                  ).forkDaemon
+                    .flatMap(f => fiberRef.set(Some(f)))
+              } *> ZIO.logInfo("spa ws: connected")
             case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
               idRef.get.flatMap {
                 case Some(id) =>
@@ -90,11 +198,48 @@ object SpaWsRoutes {
               ZIO.unit
           }
           .ensuring(
-            idRef.get.flatMap(ZIO.foreachDiscard(_)(registry.deregister)) *>
+            fiberRef.get.flatMap(ZIO.foreachDiscard(_)(_.interrupt)) *>
+              idRef.get.flatMap(ZIO.foreachDiscard(_)(registry.deregister)) *>
               ZIO.logInfo("spa ws: disconnected"),
           )
-      }
+      } yield ()
     }
+
+  /**
+   * The per-connection authz-deadline watcher (design §4.3). On each tick it reads the INJECTED
+   * clock; once `now ≥ jwtExp` it closes the channel with `4401 token-expired`, deregisters, and
+   * meters `jwt_expired_midconn`, then stops. Until then it sleeps one `interval` and re-checks, so
+   * stale-authz carry-over is bounded by one tick. Never fails; interrupted on connection close.
+   */
+  private def watchExpiry(
+      channel: WebSocketChannel,
+      id: SpaConnId,
+      jwtExp: Instant,
+      registry: SpaWsRegistry,
+      clock: Clock,
+      interval: Duration,
+  ): UIO[Unit] = {
+    def loop: UIO[Unit] =
+      clock.instant.flatMap { now =>
+        if !now.isBefore(jwtExp) then closeExpired(channel, id, registry)
+        else loop.delay(interval)
+      }
+    loop
+  }
+
+  private def closeExpired(
+      channel: WebSocketChannel,
+      id: SpaConnId,
+      registry: SpaWsRegistry,
+  ): UIO[Unit] =
+    AppMetrics.recordSpaWsAuth("jwt_expired_midconn") *>
+      ZIO.logInfo("spa ws: closing expired connection (4401 token-expired)") *>
+      registry.deregister(id) *>
+      // Send the close frame and let the handshake drive teardown (the peer echoes Close, then the
+      // server's receive loop ends and `.ensuring` runs). Do NOT `channel.shutdown` here — aborting
+      // the transport immediately after the send can truncate the Close frame before it flushes, so
+      // the client would see an abnormal 1006 instead of the `4401 token-expired` code (§4.3).
+      channel.send(ChannelEvent.read(WebSocketFrame.close(4401, Some("token-expired")))).ignore
 
   /**
    * Demux one inbound text frame (design §2.2). A frame that does not parse as the envelope, or
@@ -115,13 +260,21 @@ object SpaWsRoutes {
           ZIO.logWarning(s"spa ws: undecodable frame: $err")
       case Right(frame) =>
         registry.roleFor(id).flatMap { roleOpt =>
-          val role = roleOpt.getOrElse(upgradeRole)
+          val role = roleOpt.getOrElse(fallbackRole)
           LogContext
             .annotateAll(LogContext.Op -> frame.op, LogContext.Role -> UserRole.asString(role)) {
               frame.op match {
-                case "hello"       => handleHello(id, channel, frame, registry, clock)
+                case "hello"       => handleHello(id, channel, registry, clock)
                 case "subscribe"   => handleSubscribe(id, channel, frame, role, registry)
                 case "unsubscribe" => handleUnsubscribe(id, frame, registry)
+                case "reauth"      =>
+                  // Forward-compat seam (design §4.3): v1 has NO silent refresh, so reject. The SPA
+                  // falls back to polling + /login on `4401`; when refresh lands, the server will
+                  // advance jwtExp here instead.
+                  LogContext.annotate(LogContext.Result, "reject") {
+                    AppMetrics.recordSpaWsFrame("reauth", "in", "reject") *>
+                      sendAck(channel, "reauth", "reject", Some("reauth_unsupported"))
+                  }
                 case "ping"        =>
                   AppMetrics.recordSpaWsFrame("ping", "in", "ok") *>
                     send(channel, SpaWsFrame("pong", Some(Json.Obj()))) *>
@@ -143,22 +296,18 @@ object SpaWsRoutes {
     }
 
   /**
-   * `hello`→`ready` (design §1.2). S1: the optional payload `{role}` is the test-handshake override
-   * that sets the connection's role (S2 ignores it — the role comes from the verified cookie).
-   * Reply `ready{role, serverTime}`; `serverTime` is read from the INJECTED clock (never
-   * wall-clock).
+   * `hello`→`ready` (design §1.2). The connection's role was fixed at upgrade from the verified
+   * cookie (§4.2), so `hello` carries no role override — it just elicits `ready{role, serverTime}`.
+   * `serverTime` is read from the INJECTED clock (never wall-clock).
    */
   private def handleHello(
       id: SpaConnId,
       channel: WebSocketChannel,
-      frame: SpaWsFrame,
       registry: SpaWsRegistry,
       clock: Clock,
-  ): ZIO[Any, Throwable, Unit] = {
-    val requested = decode[HelloPayload](frame).toOption.flatMap(_.role).flatMap(UserRole.parse)
+  ): ZIO[Any, Throwable, Unit] =
     for {
-      _    <- ZIO.foreachDiscard(requested)(registry.setRole(id, _))
-      role <- registry.roleFor(id).map(_.getOrElse(upgradeRole))
+      role <- registry.roleFor(id).map(_.getOrElse(fallbackRole))
       now  <- clock.instant
       _    <- AppMetrics.recordSpaWsFrame("hello", "in", "ok")
       _    <- send(
@@ -170,7 +319,6 @@ object SpaWsRoutes {
       )
       _    <- AppMetrics.recordSpaWsFrame("ready", "out", "ok")
     } yield ()
-  }
 
   /**
    * `subscribe{topic, params?}` → topic-keyed `ack` (design §1.4). Fan-out is two gates (subscribe
@@ -258,9 +406,6 @@ object SpaWsRoutes {
    */
   private case class SpaWsFrame(op: String, payload: Option[Json] = None, seq: Option[Int] = None)
       derives JsonCodec
-
-  /** `hello` payload — `{role?}` is the S1 test-handshake override (S2 ignores it). */
-  private case class HelloPayload(role: Option[String]) derives JsonCodec
 
   /** `ready` payload (design §1.2): the resolved role + the server's (injected-clock) time. */
   private case class ReadyPayload(role: String, serverTime: String) derives JsonCodec

--- a/api/test/src/feature/SpaWsSpec.scala
+++ b/api/test/src/feature/SpaWsSpec.scala
@@ -1,55 +1,102 @@
 package wifihaven.api.feature
 
+import wifihaven.api.JwtConfig
+import wifihaven.api.WsConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
 import wifihaven.api.routes.{SpaConnId, SpaTopic, SpaWsRegistry, SpaWsRoutes}
 import wifihaven.shared.Clock
+import wifihaven.shared.Clock.TestClock
 import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.http.ChannelEvent.UserEvent
+import zio.metrics.*
 import zio.test.*
 
 import java.time.LocalDateTime
 
 /**
- * #1968 (S1 of the SPA-websocket rollout, design `docs/design/spa-websocket.md`): the
- * browser-facing `GET /api/ws` skeleton. Exercises the real endpoint end to end — a real [[Server]]
- * on an ephemeral port and a real ws [[Client]] — to prove the `{op, payload, seq?}` envelope
- * demux, the control ops (`hello`→`ready`, `subscribe`/`unsubscribe` with per-connection
- * subscription state + topic-keyed `ack`, `ping`/`pong`), the role-gated subscription
- * authorization, and the unknown-op ignore+meter rule. Mirrors the [[RouterWsSpec]] round-trip
- * recipe (drive the ws client inside a LOCAL `ZIO.scoped`, not forkScoped on the test scope).
+ * #1969 (S2 of the SPA-websocket rollout, design `docs/design/spa-websocket.md` §4/§8): upgrade
+ * auth for the browser-facing `GET /api/ws`. Exercises the real endpoint end to end — a real
+ * [[Server]] on an ephemeral port and a real ws [[Client]] for the success paths, and
+ * `routes.runZIO` directly for the reject paths (the upgrade is refused with a plain 401/403 BEFORE
+ * the 101, so no handshake is needed to observe it).
  *
- * S1 has no upgrade auth (that is S2 / #1969) — the connection registers with a stub
- * least-privilege (`Child`) role at upgrade and the `hello` payload's `{role}` is the
- * test-handshake override, so the subscription machinery is exercised without a real cookie. REST
- * is untouched.
+ * The credential is the existing operator JWT, validated by the EXISTING [[AuthService.verify]] (no
+ * second auth surface, `AGENTS.md#single-source-of-truth`) — tests issue a REAL token via the same
+ * `AuthServiceLive` the app uses, never a mock. It rides a `wh_ws` cookie on the upgrade (the
+ * browser `WebSocket` API can't set headers, design §0.2.1); the role is resolved from the verified
+ * claims, NOT from the S1 `hello{role}` stub. The `Origin` allowlist (§8) is the one server-side ws
+ * config that differs by hosting mode. Mid-connection the connection's authz deadline is the JWT's
+ * `exp`: on the heartbeat tick where `now ≥ jwtExp` the channel is closed `4401 token-expired`
+ * (§4.3). Every outcome increments `spa_ws_auth_total{result}` (§7).
  */
-object SpaWsSpec extends ZIOSpec[Clock] {
+object SpaWsSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
 
   private val testClockAt: LocalDateTime = LocalDateTime.of(2026, 6, 25, 14, 0, 0)
 
-  override val bootstrap: ULayer[Clock] = TestLayers.withClock(testClockAt)
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(testClockAt)
 
-  private def buildRoutes: ZIO[Clock, Nothing, (Routes[Any, Response], SpaWsRegistry)] =
-    for {
-      clock <- ZIO.service[Clock]
-      reg   <- SpaWsRegistry.make
-    } yield (SpaWsRoutes.routes(reg, clock), reg)
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  // Origin enforcement ON (cloud/staging shape): `localhost` is the dev allowlist entry, so a
+  // ws upgrade whose Origin host is localhost passes and any other host is rejected. A short
+  // expiry-check interval keeps the mid-connection-expiry test fast (the 1s floor is fine under the
+  // 90s suite timeout).
+  private val enforcedCfg = WsConfig(allowedOrigins = "localhost", expiryCheckSeconds = 1)
+  // Origin enforcement OFF (self-hosted same-origin shape): an empty allowlist disables the
+  // cross-origin check — SameSite=Strict on the cookie (§4.2) is the CSWSH guard there.
+  private val openCfg     = WsConfig(allowedOrigins = "", expiryCheckSeconds = 1)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   // Each test builds a FRESH registry with one connection, so the first (and only) connection is
-  // deterministically assigned SpaConnId(1) — the seq counter starts at 0 and increments to 1 on the
-  // single register. Lets a test inspect that connection's server-side subscription state directly.
+  // deterministically SpaConnId(1) — the seq counter starts at 0 and increments to 1 on register.
   private val onlyConn: SpaConnId = SpaConnId(1L)
 
+  /** A real `AuthServiceLive` over the per-spec DB + the given clock (never a mock — SSOT). */
+  private def makeAuth(clock: Clock): URIO[UserRepo, AuthServiceLive] =
+    ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg, clock))
+
+  /** Issue a real operator JWT for a freshly-created user with the given role. */
+  private def tokenFor(
+      auth: AuthService,
+      role: String,
+      username: String,
+  ): ZIO[UserRepo, Throwable, String] =
+    for {
+      hash <- auth.hashPassword("pass")
+      _    <- ZIO.serviceWithZIO[UserRepo](_.create(username, hash, role))
+      tok  <- auth.login(username, "pass").mapError(e => new RuntimeException(s"login: $e"))
+    } yield tok.token.value
+
+  /** The seeded admin (`admin`/`changeme`, must_change_password cleared in the test template). */
+  private def adminToken(auth: AuthService): ZIO[Any, Throwable, String] =
+    auth
+      .login("admin", "changeme")
+      .mapError(e => new RuntimeException(s"login: $e"))
+      .map(_.token.value)
+
+  private def cookieAndOrigin(token: String, origin: String): Headers =
+    Headers("Cookie", s"wh_ws=$token") ++ Headers("Origin", origin)
+
+  private def authCount(result: String): UIO[Double] =
+    Metric.counter("spa_ws_auth_total").tagged("result", result).value.map(_.count)
+
   /**
-   * Open a ws connection to the bound server, drive it with `send` on handshake, and collect every
-   * text frame the server sends. Resolves once a frame satisfies `until`, then runs `probe` while
-   * the connection is still open (so a registry-state check observes the live channel, not the
-   * post-scope deregister). Returns the matching frame, ALL frames received up to that point, and
-   * the probe.
+   * Open a ws connection (with the upgrade headers) to the bound server, drive it with `send` on
+   * handshake, and collect every text frame the server sends. Resolves once a frame satisfies
+   * `until`, then runs `probe` while still open. Returns the matching frame, all frames so far, and
+   * the probe result.
    */
   private def connectAndCapture[B](
       port: Int,
+      headers: Headers,
       send: WebSocketChannel => ZIO[Any, Throwable, Unit],
       until: String => Boolean,
       probe: ZIO[Any, Throwable, B] = ZIO.unit,
@@ -69,7 +116,7 @@ object SpaWsSpec extends ZIOSpec[Clock] {
       }
       result <- ZIO.scoped {
         for {
-          _   <- app.connect(s"ws://localhost:$port/api/ws").forkScoped
+          _   <- app.connect(s"ws://localhost:$port/api/ws", headers).forkScoped
           t   <- matched.await
             .timeoutFail(new RuntimeException("no matching server frame within 30s"))(30.seconds)
           all <- frames.get
@@ -82,67 +129,74 @@ object SpaWsSpec extends ZIOSpec[Clock] {
   private def sendFrames(channel: WebSocketChannel, frames: String*): ZIO[Any, Throwable, Unit] =
     ZIO.foreachDiscard(frames)(f => channel.send(ChannelEvent.read(WebSocketFrame.text(f))))
 
-  def spec = suite("SPA websocket /api/ws")(
-    test("hello is answered with ready carrying the role + serverTime") {
+  private def get(path: String, headers: Headers): Request =
+    Request.get(URL.decode(path).toOption.get).addHeaders(headers)
+
+  def spec = suite("SPA websocket /api/ws upgrade auth (#1969)")(
+    // ── success paths (real client, 101 + ready) ────────────────────────────────
+    test("valid cookie + allowed Origin → 101 + ready carrying the JWT's role (not the stub)") {
       (for {
-        rr <- buildRoutes
-        (routes, _) = rr
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        port          <- Server.install(routes)
+        before        <- authCount("ok")
+        (ready, _, _) <- connectAndCapture(
+          port,
+          cookieAndOrigin(tok, "http://localhost"),
+          ch => sendFrames(ch, """{"op":"hello"}"""),
+          until = _.contains("\"op\":\"ready\""),
+        )
+        after         <- authCount("ok")
+      } yield assertTrue(ready.contains("\"op\":\"ready\"")) &&
+        // role is the cookie's role (admin), NOT the S1 least-privilege Child stub.
+        assertTrue(ready.contains("\"role\":\"admin\"")) &&
+        assertTrue(ready.contains("\"serverTime\":\"2026-06-25T14:00:00Z\"")) &&
+        assertTrue(after - before >= 1.0)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    test("self-hosted same-origin (empty allowlist) → ok with no Origin header") {
+      (for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, openCfg)
         port          <- Server.install(routes)
         (ready, _, _) <- connectAndCapture(
           port,
-          ch => sendFrames(ch, """{"op":"hello","payload":{"role":"admin"}}"""),
+          Headers("Cookie", s"wh_ws=$tok"), // no Origin — self-hosted same-origin
+          ch => sendFrames(ch, """{"op":"hello"}"""),
           until = _.contains("\"op\":\"ready\""),
         )
       } yield assertTrue(ready.contains("\"op\":\"ready\"")) &&
-        assertTrue(ready.contains("\"role\":\"admin\"")) &&
-        // serverTime comes from the injected test clock (2026-06-25T14:00:00Z), never wall-clock.
-        assertTrue(ready.contains("\"serverTime\":\"2026-06-25T14:00:00Z\""))).provideSome[Clock](
-        Server.defaultWithPort(0),
-        Client.default,
-      )
+        assertTrue(ready.contains("\"role\":\"admin\""))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
     },
-    test("subscribe to an authorized topic is acked ok and the subscription is held server-side") {
+    test(
+      "a child cookie's subscribe to a household topic is acked reject (role scoping per frame)",
+    ) {
       (for {
-        rr <- buildRoutes
-        (routes, reg) = rr
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- tokenFor(auth, "child", "kid")
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
         port <- Server.install(routes)
-        // Probe the registry AFTER the ack arrives (still in-scope): the ack is sent only after
-        // SpaWsRegistry.subscribe completes, so an ack-ok that failed to actually store the
-        // subscription would be caught here — not just on the wire.
         res  <- connectAndCapture(
           port,
+          cookieAndOrigin(tok, "http://localhost"),
           ch =>
             sendFrames(
               ch,
-              """{"op":"hello","payload":{"role":"admin"}}""",
-              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"]}}}""",
-            ),
-          until = _.contains("\"op\":\"ack\""),
-          probe = reg.subscriptionsFor(onlyConn),
-        )
-        (ack, _, subs) = res
-      } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
-        assertTrue(ack.contains("\"topic\":\"trafficUsage\"")) &&
-        assertTrue(ack.contains("\"status\":\"ok\"")) &&
-        assertTrue(subs.keySet == Set(SpaTopic.TrafficUsage))).provideSome[Clock](
-        Server.defaultWithPort(0),
-        Client.default,
-      )
-    },
-    test("subscribe to a topic the role can't see is acked reject and not held") {
-      (for {
-        rr <- buildRoutes
-        (routes, reg) = rr
-        port <- Server.install(routes)
-        // A child role may see only its own time topics, never the household-wide connectionEvents
-        // feed (S1 placeholder authz, §4.4 — refined by S2's real cookie auth). The rejected
-        // subscription must NOT be stored.
-        res  <- connectAndCapture(
-          port,
-          ch =>
-            sendFrames(
-              ch,
-              """{"op":"hello","payload":{"role":"child"}}""",
+              """{"op":"hello"}""",
               """{"op":"subscribe","payload":{"topic":"connectionEvents"}}""",
             ),
           until = _.contains("\"op\":\"ack\""),
@@ -152,65 +206,196 @@ object SpaWsSpec extends ZIOSpec[Clock] {
       } yield assertTrue(ack.contains("\"op\":\"ack\"")) &&
         assertTrue(ack.contains("\"topic\":\"connectionEvents\"")) &&
         assertTrue(ack.contains("\"status\":\"reject\"")) &&
-        assertTrue(subs.isEmpty)).provideSome[Clock](
-        Server.defaultWithPort(0),
-        Client.default,
-      )
+        assertTrue(subs.isEmpty)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
     },
-    test("unsubscribe removes the held subscription (no further ack, ping confirms liveness)") {
+    test("an admin cookie's subscribe to a household topic is acked ok and held server-side") {
       (for {
-        rr <- buildRoutes
-        (routes, reg) = rr
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
         port <- Server.install(routes)
-        // subscribe (acked), then unsubscribe (no ack), then ping — the pong (sent only after the
-        // unsubscribe was processed) proves the socket stayed live AND the subscription was removed:
-        // the post-pong registry probe must show an empty subscription set.
         res  <- connectAndCapture(
           port,
+          cookieAndOrigin(tok, "http://localhost"),
           ch =>
             sendFrames(
               ch,
-              """{"op":"hello","payload":{"role":"admin"}}""",
-              """{"op":"subscribe","payload":{"topic":"now"}}""",
-              """{"op":"unsubscribe","payload":{"topic":"now"}}""",
-              """{"op":"ping"}""",
+              """{"op":"hello"}""",
+              """{"op":"subscribe","payload":{"topic":"trafficUsage"}}""",
             ),
-          until = _.contains("\"op\":\"pong\""),
+          until = _.contains("\"op\":\"ack\""),
           probe = reg.subscriptionsFor(onlyConn),
         )
-        (pong, all, subs) = res
-      } yield assertTrue(pong.contains("\"op\":\"pong\"")) &&
-        assertTrue(
-          all.exists(f => f.contains("\"op\":\"ack\"") && f.contains("\"status\":\"ok\"")),
-        ) &&
-        assertTrue(subs.isEmpty)).provideSome[Clock](
-        Server.defaultWithPort(0),
-        Client.default,
-      )
+        (ack, _, subs) = res
+      } yield assertTrue(ack.contains("\"status\":\"ok\"")) &&
+        assertTrue(subs.keySet == Set(SpaTopic.TrafficUsage))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
     },
+    test("reauth is acked reject (forward-compat seam; v1 has no silent refresh)") {
+      (for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        port <- Server.install(routes)
+        res  <- connectAndCapture(
+          port,
+          cookieAndOrigin(tok, "http://localhost"),
+          ch => sendFrames(ch, """{"op":"reauth","payload":{"jwt":"whatever"}}"""),
+          until = _.contains("\"op\":\"ack\""),
+        )
+        (ack, _, _) = res
+      } yield assertTrue(ack.contains("\"topic\":\"reauth\"")) &&
+        assertTrue(ack.contains("\"status\":\"reject\""))).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    // ── reject paths (no 101) ───────────────────────────────────────────────────
+    test("missing cookie → 401, no 101, metered no_cookie") {
+      for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        before <- authCount("no_cookie")
+        resp   <- routes.runZIO(get("/api/ws", Headers("Origin", "http://localhost")))
+        after  <- authCount("no_cookie")
+      } yield assertTrue(resp.status == Status.Unauthorized) &&
+        assertTrue(after - before >= 1.0)
+    },
+    test("forged/garbage cookie → 401, no 101, metered invalid_jwt") {
+      for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        before <- authCount("invalid_jwt")
+        resp   <- routes.runZIO(
+          get("/api/ws", cookieAndOrigin("not-a-real-jwt", "http://localhost")),
+        )
+        after  <- authCount("invalid_jwt")
+      } yield assertTrue(resp.status == Status.Unauthorized) &&
+        assertTrue(after - before >= 1.0)
+    },
+    test("already-expired JWT → 401, no 101, metered expired_jwt") {
+      for {
+        _         <- cleanDb
+        (clk, tc) <- TestClock.makeWithControl(testClockAt)
+        auth      <- makeAuth(clk)
+        tok       <- adminToken(auth)
+        _         <- tc.advance(java.time.Duration.ofHours(2)) // exp was now+1h → now past it
+        reg       <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clk, enforcedCfg)
+        before <- authCount("expired_jwt")
+        resp   <- routes.runZIO(get("/api/ws", cookieAndOrigin(tok, "http://localhost")))
+        after  <- authCount("expired_jwt")
+      } yield assertTrue(resp.status == Status.Unauthorized) &&
+        assertTrue(after - before >= 1.0)
+    },
+    test("disallowed Origin (valid cookie) → reject, no 101, metered bad_origin") {
+      for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        before <- authCount("bad_origin")
+        resp   <- routes.runZIO(get("/api/ws", cookieAndOrigin(tok, "http://evil.example.com")))
+        after  <- authCount("bad_origin")
+      } yield assertTrue(resp.status != Status.SwitchingProtocols) &&
+        assertTrue(resp.status == Status.Forbidden) &&
+        assertTrue(after - before >= 1.0)
+    },
+    test("absent Origin under an enforced allowlist → reject, metered bad_origin") {
+      for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        before <- authCount("bad_origin")
+        resp   <- routes.runZIO(get("/api/ws", Headers("Cookie", s"wh_ws=$tok")))
+        after  <- authCount("bad_origin")
+      } yield assertTrue(resp.status == Status.Forbidden) &&
+        assertTrue(after - before >= 1.0)
+    },
+    // ── mid-connection expiry (§4.3) ────────────────────────────────────────────
+    test("JWT exp crossing mid-connection → 4401 close + deregister, metered jwt_expired_midconn") {
+      (for {
+        _         <- cleanDb
+        (clk, tc) <- TestClock.makeWithControl(testClockAt)
+        auth      <- makeAuth(clk)
+        tok       <- adminToken(auth)
+        reg       <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clk, enforcedCfg)
+        port   <- Server.install(routes)
+        before <- authCount("jwt_expired_midconn")
+        readyP <- Promise.make[Nothing, Unit]
+        closeP <- Promise.make[Nothing, Int]
+        app            = Handler.webSocket { channel =>
+          channel.receiveAll {
+            case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete)                =>
+              channel.send(ChannelEvent.read(WebSocketFrame.text("""{"op":"hello"}""")))
+            case ChannelEvent.Read(WebSocketFrame.Text(t)) if t.contains("\"op\":\"ready\"") =>
+              readyP.succeed(()).unit
+            case ChannelEvent.Read(WebSocketFrame.Close(code, _))                            =>
+              closeP.succeed(code).unit
+            case _                                                                           =>
+              ZIO.unit
+          }
+        }
+        result <- ZIO.scoped {
+          for {
+            _      <- app
+              .connect(s"ws://localhost:$port/api/ws", cookieAndOrigin(tok, "http://localhost"))
+              .forkScoped
+            _      <- readyP.await.timeoutFail(new RuntimeException("no ready"))(30.seconds)
+            _      <- tc.advance(java.time.Duration.ofHours(2)) // cross exp mid-connection
+            code   <- closeP.await.timeoutFail(new RuntimeException("no 4401 close"))(30.seconds)
+            active <- reg.activeCount
+          } yield (code, active)
+        }
+        (code, active) = result
+        after <- authCount("jwt_expired_midconn")
+      } yield assertTrue(code == 4401) &&
+        assertTrue(active == 0) &&
+        assertTrue(after - before >= 1.0)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
+    // ── forward-compat (unchanged from S1) ──────────────────────────────────────
     test("an unknown op is ignored (no reply) while a known op still answers") {
       (for {
-        rr <- buildRoutes
-        (routes, _) = rr
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
         port           <- Server.install(routes)
-        // Send an unknown op, then a ping. The unknown op must produce no frame; the pong proves the
-        // socket survived (ignore + meter, forward-compat — design §2.2).
         (pong, all, _) <- connectAndCapture(
           port,
+          cookieAndOrigin(tok, "http://localhost"),
           ch =>
-            sendFrames(
-              ch,
-              """{"op":"definitelyNotARealOp","payload":{}}""",
-              """{"op":"ping"}""",
-            ),
+            sendFrames(ch, """{"op":"definitelyNotARealOp","payload":{}}""", """{"op":"ping"}"""),
           until = _.contains("\"op\":\"pong\""),
         )
       } yield assertTrue(pong.contains("\"op\":\"pong\"")) &&
-        // The only server frame is the pong — the unknown op generated no reply.
-        assertTrue(all.count(_.contains("\"op\":")) == 1)).provideSome[Clock](
-        Server.defaultWithPort(0),
-        Client.default,
-      )
+        assertTrue(all.count(_.contains("\"op\":")) == 1)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
     },
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.timeout(90.seconds)
 }

--- a/api/test/src/feature/SpaWsSpec.scala
+++ b/api/test/src/feature/SpaWsSpec.scala
@@ -237,6 +237,41 @@ object SpaWsSpec
         TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
       ](Server.defaultWithPort(0), Client.default)
     },
+    test("unsubscribe removes the held subscription (no further ack; ping confirms liveness)") {
+      (for {
+        _     <- cleanDb
+        clock <- ZIO.service[Clock]
+        auth  <- makeAuth(clock)
+        tok   <- adminToken(auth)
+        reg   <- SpaWsRegistry.make
+        routes = SpaWsRoutes.routes(auth, reg, clock, enforcedCfg)
+        port <- Server.install(routes)
+        // subscribe (acked), then unsubscribe (no ack), then ping — the pong (sent only after the
+        // unsubscribe was processed) proves the socket stayed live AND the subscription was removed:
+        // the post-pong registry probe must show an empty subscription set.
+        res  <- connectAndCapture(
+          port,
+          cookieAndOrigin(tok, "http://localhost"),
+          ch =>
+            sendFrames(
+              ch,
+              """{"op":"hello"}""",
+              """{"op":"subscribe","payload":{"topic":"now"}}""",
+              """{"op":"unsubscribe","payload":{"topic":"now"}}""",
+              """{"op":"ping"}""",
+            ),
+          until = _.contains("\"op\":\"pong\""),
+          probe = reg.subscriptionsFor(onlyConn),
+        )
+        (pong, all, subs) = res
+      } yield assertTrue(pong.contains("\"op\":\"pong\"")) &&
+        assertTrue(
+          all.exists(f => f.contains("\"op\":\"ack\"") && f.contains("\"status\":\"ok\"")),
+        ) &&
+        assertTrue(subs.isEmpty)).provideSome[
+        TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task],
+      ](Server.defaultWithPort(0), Client.default)
+    },
     test("reauth is acked reject (forward-compat seam; v1 has no silent refresh)") {
       (for {
         _     <- cleanDb

--- a/api/test/src/feature/SpaWsSpec.scala
+++ b/api/test/src/feature/SpaWsSpec.scala
@@ -344,18 +344,22 @@ object SpaWsSpec
         before <- authCount("jwt_expired_midconn")
         readyP <- Promise.make[Nothing, Unit]
         closeP <- Promise.make[Nothing, Int]
-        app            = Handler.webSocket { channel =>
-          channel.receiveAll {
-            case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete)                =>
-              channel.send(ChannelEvent.read(WebSocketFrame.text("""{"op":"hello"}""")))
-            case ChannelEvent.Read(WebSocketFrame.Text(t)) if t.contains("\"op\":\"ready\"") =>
-              readyP.succeed(()).unit
-            case ChannelEvent.Read(WebSocketFrame.Close(code, _))                            =>
-              closeP.succeed(code).unit
-            case _                                                                           =>
-              ZIO.unit
+        // forwardCloseFrames so the server's `4401` Close is delivered to this handler as a Read
+        // (the default config handles close frames internally and would not surface the code).
+        app            = Handler
+          .webSocket { channel =>
+            channel.receiveAll {
+              case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete)                =>
+                channel.send(ChannelEvent.read(WebSocketFrame.text("""{"op":"hello"}""")))
+              case ChannelEvent.Read(WebSocketFrame.Text(t)) if t.contains("\"op\":\"ready\"") =>
+                readyP.succeed(()).unit
+              case ChannelEvent.Read(WebSocketFrame.Close(code, _))                            =>
+                closeP.succeed(code).unit
+              case _                                                                           =>
+                ZIO.unit
+            }
           }
-        }
+          .withConfig(WebSocketConfig.default.forwardCloseFrames(true))
         result <- ZIO.scoped {
           for {
             _      <- app

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -68,6 +68,26 @@ wifihaven {
     uiAllowedHosts = ""
   }
 
+  ws {
+    # #1969: SPA-websocket upgrade-auth Origin allowlist (design §8 — the one
+    # server-side ws config that differs by hosting mode). Comma-separated Origin
+    # HOSTS (scheme/port ignored) allowed to upgrade GET /api/ws. Wildcards: a
+    # leading "*.suffix" matches any subdomain of suffix; a trailing "prefix.*"
+    # matches prefix and prefix.<anything>. EMPTY disables the cross-origin check
+    # entirely — the self-hosted same-origin default, where SameSite=Strict on the
+    # wh_ws cookie is the CSWSH guard. Set on cloud/staging so a cross-site upgrade
+    # is rejected before the 101.
+    # Example (prod):    "app.wifihaven.net"
+    # Example (staging): "app-staging.wifihaven.net,staging.wifihaven.net"
+    # Example (dev):     "localhost"
+    allowedOrigins = ""
+
+    # #1969: cadence (seconds) at which each open ws connection re-checks the JWT's
+    # exp and closes with 4401 token-expired once crossed (design §4.3). Clamped to
+    # a 1s floor. Default 30s mirrors the app-level heartbeat.
+    # expiryCheckSeconds = 30
+  }
+
   metrics {
     # #1242: Prometheus exposition at GET /metrics (JVM + runtime + app
     # gauges/counters). enabled=false leaves the route unmounted.

--- a/deploy/grafana/dashboards/spa-ws.json
+++ b/deploy/grafana/dashboards/spa-ws.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven SPA websocket transport (#1968, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry) and spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux). The SPA has no ws client yet (S5), so until then these read 0/flat. Upgrade-auth (spa_ws_auth_total, S2) and push fan-out (spa_ws_push_total, S3/S4) panels land with those series. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
+  "description": "WifiHaven SPA websocket transport (#1968/#1969, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1+S2) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry), spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux), and spa_ws_auth_total{result} (S2 upgrade auth). The SPA has no ws client yet (S5), so until then these read 0/flat. Push fan-out (spa_ws_push_total, S3/S4) panels land with that series. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -250,6 +250,144 @@
           },
           "expr": "sum by (op, result) (rate(spa_ws_frames_total{env=\"$env\",result=~\"reject|unknown_op\"}[5m]))",
           "legendFormat": "{{op}} {{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws upgrade-auth outcomes by result (#1969)",
+      "description": "sum by (result) (rate(spa_ws_auth_total[5m])) — outcomes of the /api/ws upgrade auth (design §4): the cookie verify (existing AuthService) + the §8 Origin allowlist, plus the mid-connection expiry close. result ∈ {ok, no_cookie, invalid_jwt, expired_jwt, bad_origin, jwt_expired_midconn}. ok should dominate once the SPA ws client ships (S5); a steady stream of no_cookie/expired_jwt is benign (an unauthenticated/expired tab), while bad_origin/invalid_jwt is the security-relevant surface broken out in the next panel.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(spa_ws_auth_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws auth tripwire — bad_origin + invalid_jwt (#1969)",
+      "description": "sum (rate(spa_ws_auth_total{result=~\"bad_origin|invalid_jwt\"}[5m])) — the CSWSH/forgery-probe surface isolated (design §4/§7). bad_origin = an upgrade whose Origin failed the §8 allowlist; invalid_jwt = a wh_ws cookie that failed AuthService.verify (forged/garbage). Both are ~0 in normal operation: a sustained spike means something is hammering /api/ws with cross-site or forged upgrades and is alert-worthy. (no_cookie/expired_jwt are deliberately EXCLUDED here — those are benign unauthenticated/expired tabs, not an attack signal.) Threshold: amber > 0, red on a sustained climb.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 2,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.001
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (result) (rate(spa_ws_auth_total{env=\"$env\",result=~\"bad_origin|invalid_jwt\"}[5m]))",
+          "legendFormat": "{{result}}",
           "refId": "A"
         }
       ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 : "${WIFIHAVEN_DEBUG:=}"
 : "${WIFIHAVEN_ALLOWED_ORIGINS:=}"
 : "${WIFIHAVEN_UI_ALLOWED_HOSTS:=}"
+# #1969: SPA-websocket Origin allowlist (design §8). Comma-separated Origin HOSTS
+# allowed to upgrade GET /api/ws. Empty = cross-origin check off (self-hosted
+# same-origin). Cloud/staging set it so a cross-site upgrade is rejected pre-101.
+: "${WIFIHAVEN_WS_ALLOWED_ORIGINS:=}"
 : "${WIFIHAVEN_METRICS_ENABLED:=true}"
 : "${WIFIHAVEN_METRICS_SCRAPE_TOKEN:=}"
 
@@ -54,6 +58,9 @@ wifihaven {
   }
   policy {
     uiAllowedHosts = "${WIFIHAVEN_UI_ALLOWED_HOSTS}"
+  }
+  ws {
+    allowedOrigins = "${WIFIHAVEN_WS_ALLOWED_ORIGINS}"
   }
   metrics {
     enabled     = ${WIFIHAVEN_METRICS_ENABLED}

--- a/render.yaml
+++ b/render.yaml
@@ -107,6 +107,11 @@ services:
       # #1840: app-staging.wifihaven.net added additively (#1832 rename).
       - key: WIFIHAVEN_UI_ALLOWED_HOSTS
         value: "staging.wifihaven.net,api-staging.wifihaven.net,app-staging.wifihaven.net"
+      # #1969: SPA-websocket Origin allowlist (design §8). HOSTS only (scheme/port
+      # ignored) — the cross-site-upgrade backstop that pairs with the SameSite=Strict
+      # wh_ws cookie. Staging-only hosts; mirrors the SPA origins above.
+      - key: WIFIHAVEN_WS_ALLOWED_ORIGINS
+        value: "staging.wifihaven.net,app-staging.wifihaven.net"
       # #614: SPA is served by the wifihaven-spa-staging Static Site (CDN).
       # The JVM still bundles a copy as a self-hosted fallback, but the API
       # origin must not serve it here — non-/api/* paths return 404.
@@ -229,6 +234,11 @@ services:
       # #1840: app.wifihaven.net added additively (#1832 rename).
       - key: WIFIHAVEN_UI_ALLOWED_HOSTS
         value: "wifihaven.net,www.wifihaven.net,api.wifihaven.net,app.wifihaven.net"
+      # #1969: SPA-websocket Origin allowlist (design §8). HOSTS only (scheme/port
+      # ignored) — the cross-site-upgrade backstop that pairs with the SameSite=Strict
+      # wh_ws cookie. Mirrors the SPA origins above (where the dashboard ws client runs).
+      - key: WIFIHAVEN_WS_ALLOWED_ORIGINS
+        value: "wifihaven.net,www.wifihaven.net,app.wifihaven.net"
       # #614: SPA is served by the wifihaven-spa-prod Static Site (CDN).
       # The JVM still bundles a copy as a self-hosted fallback, but the API
       # origin must not serve it here — non-/api/* paths return 404.

--- a/web/src/api/wsAuth.test.ts
+++ b/web/src/api/wsAuth.test.ts
@@ -1,0 +1,73 @@
+// #1969 (SPA-ws S2): the wh_ws upgrade-cookie helper (design §2.1/§4.2). Asserts the
+// scoping that IS the security boundary — Path=/api/ws, SameSite=Strict, Secure, a
+// short Max-Age, and the registrable-domain vs host-only split derived from the API
+// base URL. A fake cookie jar is injected so the exact attribute string is observable
+// (jsdom silently drops Secure/cross-Domain cookies, which would hide the contract).
+import { describe, it, expect } from 'vitest'
+import {
+  setWsAuthCookie,
+  clearWsAuthCookie,
+  wsCookieDomain,
+  WS_COOKIE_MAX_AGE_SECONDS,
+} from './wsAuth'
+
+function fakeJar(): { writes: string[]; get cookie(): string; set cookie(v: string) } {
+  const writes: string[] = []
+  return {
+    writes,
+    get cookie() {
+      return ''
+    },
+    set cookie(v: string) {
+      writes.push(v)
+    },
+  }
+}
+
+describe('setWsAuthCookie (#1969 §4.2)', () => {
+  it('sets the wh_ws cookie scoped Path=/api/ws; SameSite=Strict; Secure with a short Max-Age', () => {
+    const jar = fakeJar()
+    setWsAuthCookie('jwt-token-abc', jar)
+
+    expect(jar.writes).toHaveLength(1)
+    const c = jar.writes[0]
+    expect(c).toMatch(/^wh_ws=jwt-token-abc(;|$)/)
+    expect(c).toContain('Path=/api/ws')
+    expect(c).toContain('SameSite=Strict')
+    expect(c).toContain('Secure')
+    expect(c).toContain(`Max-Age=${WS_COOKIE_MAX_AGE_SECONDS}`)
+  })
+
+  it('is a no-op when the jwt is missing (an unauthenticated SPA never opens the socket)', () => {
+    const jar = fakeJar()
+    setWsAuthCookie(null, jar)
+    setWsAuthCookie(undefined, jar)
+    setWsAuthCookie('', jar)
+    expect(jar.writes).toHaveLength(0)
+  })
+
+  it('clears the cookie with the same Path and Max-Age=0', () => {
+    const jar = fakeJar()
+    clearWsAuthCookie(jar)
+    expect(jar.writes).toHaveLength(1)
+    const c = jar.writes[0]
+    expect(c).toMatch(/^wh_ws=(;|$)/)
+    expect(c).toContain('Path=/api/ws')
+    expect(c).toContain('Max-Age=0')
+  })
+})
+
+describe('wsCookieDomain (#1969 §2.1/§8)', () => {
+  it('scopes to the registrable domain for a cloud api subdomain (reaches api. from app.)', () => {
+    expect(wsCookieDomain('https://api.wifihaven.net')).toBe('wifihaven.net')
+    expect(wsCookieDomain('https://api-staging.wifihaven.net')).toBe('wifihaven.net')
+  })
+
+  it('is host-only (empty) for the self-hosted same-origin build', () => {
+    // Empty base ⇒ same-origin self-hosted ⇒ host-only.
+    expect(wsCookieDomain('')).toBe('')
+    // localhost / IPs / single-label hosts are always host-only.
+    expect(wsCookieDomain('http://localhost:8080')).toBe('')
+    expect(wsCookieDomain('http://192.168.1.1')).toBe('')
+  })
+})

--- a/web/src/api/wsAuth.ts
+++ b/web/src/api/wsAuth.ts
@@ -1,0 +1,103 @@
+// #1969 (SPA-ws S2, design docs/design/spa-websocket.md §2.1/§4.2): the browser
+// `WebSocket` constructor can't set an `Authorization` header (§0.2.1), so the
+// operator JWT rides a tightly-scoped `wh_ws` cookie set just before connect and
+// cleared right after the socket opens. This module owns ONLY that cookie dance —
+// the full ws client (subscriptions, reconnect, cache-patching) is S5. There is no
+// second auth surface: the same JWT REST already sends as a bearer is what the
+// server verifies at upgrade via the existing AuthService (AGENTS.md SSOT).
+//
+// Cookie scoping IS the security boundary (§4.2), not secrecy:
+//   - Path=/api/ws       → sent only on the ws upgrade, never on REST calls (no
+//                          broad cookie ⇒ no CSRF surface added to the REST API).
+//   - SameSite=Strict    → the browser won't attach it to a cross-site-initiated
+//                          upgrade; with the server Origin allowlist (§8) this
+//                          closes cross-site websocket hijacking (CSWSH).
+//   - Secure             → HTTPS only (http://localhost is a secure context for dev).
+//   - Max-Age short (~60s)→ the cookie is meant to live only across the upgrade; the
+//                          SPA clears it on open, and the short Max-Age self-expires a
+//                          lingering cookie if the tab dies between set and open.
+//   - Domain=wifihaven.net in cloud (so it reaches api. from app. — same registrable
+//                          domain, first-party) — host-only for the self-hosted
+//                          same-origin build (derived from VITE_API_BASE_URL).
+
+// Same env var the REST client keys off (client.ts): empty (same-origin) for the
+// JVM-bundled self-hosted build, absolute https://api.wifihaven.net for the cloud
+// Cloudflare-Pages build.
+const VITE_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+// ~60s: long enough to cover set→connect, short enough that a lingering cookie
+// self-expires quickly if the tab is killed before the open clears it (§4.2).
+export const WS_COOKIE_MAX_AGE_SECONDS = 60
+
+/** The cookie name shared with the server's upgrade verify (SpaWsRoutes reads `wh_ws`). */
+export const WS_COOKIE_NAME = 'wh_ws'
+
+/**
+ * The registrable-domain `Domain=` attribute to scope the cookie across `app.` → `api.` in cloud,
+ * or `''` (host-only) for the self-hosted same-origin build. The distinguishing signal is exactly
+ * the one the REST client already keys off (§2.1/§8): the cloud build sets `VITE_API_BASE_URL` to an
+ * absolute cross-subdomain API URL (so the SPA on `app.wifihaven.net` needs `Domain=wifihaven.net`
+ * to reach `api.wifihaven.net`), while the self-hosted build leaves it EMPTY (same origin) — which
+ * must be a host-only cookie. So: an empty base ⇒ host-only; a non-empty base ⇒ the registrable
+ * domain of that API host (unless it's localhost / an IP / a single-label host, which stay
+ * host-only).
+ */
+export function wsCookieDomain(apiBaseUrl: string = VITE_API_BASE_URL): string {
+  // Empty/relative base ⇒ same-origin self-hosted build ⇒ host-only (no Domain attribute).
+  if (!apiBaseUrl) return ''
+  let host: string
+  try {
+    host = new URL(apiBaseUrl).hostname
+  } catch {
+    return ''
+  }
+  // localhost / IP literals / single-label hosts ⇒ host-only.
+  if (host === 'localhost' || /^[0-9.]+$/.test(host) || !host.includes('.')) return ''
+  // Scope to the registrable domain: the last two labels (e.g. api.wifihaven.net → wifihaven.net).
+  // Good enough for our *.wifihaven.net deployment; multi-part public suffixes (co.uk) aren't used.
+  return host.split('.').slice(-2).join('.')
+}
+
+interface CookieWriter {
+  get cookie(): string
+  set cookie(value: string)
+}
+
+function defaultCookieJar(): CookieWriter | null {
+  return typeof document !== 'undefined' ? (document as unknown as CookieWriter) : null
+}
+
+/**
+ * Set the tightly-scoped `wh_ws` cookie carrying `jwt`, just before opening the ws (§4.2). Pass a
+ * falsy `jwt` and it is a no-op (an unauthenticated SPA never opens the socket). `jar` is injectable
+ * for tests.
+ */
+export function setWsAuthCookie(
+  jwt: string | null | undefined,
+  jar: CookieWriter | null = defaultCookieJar(),
+): void {
+  if (!jwt || !jar) return
+  const domain = wsCookieDomain()
+  const attrs = [
+    `${WS_COOKIE_NAME}=${jwt}`,
+    'Path=/api/ws',
+    'SameSite=Strict',
+    'Secure',
+    `Max-Age=${WS_COOKIE_MAX_AGE_SECONDS}`,
+  ]
+  if (domain) attrs.push(`Domain=${domain}`)
+  jar.cookie = attrs.join('; ')
+}
+
+/**
+ * Clear the `wh_ws` cookie immediately after the socket opens (§4.2) — the credential should not sit
+ * around once the upgrade is done. Expire it with the SAME Path (+ Domain) it was set with, since a
+ * cookie is keyed by (name, Path, Domain). `jar` is injectable for tests.
+ */
+export function clearWsAuthCookie(jar: CookieWriter | null = defaultCookieJar()): void {
+  if (!jar) return
+  const domain = wsCookieDomain()
+  const attrs = [`${WS_COOKIE_NAME}=`, 'Path=/api/ws', 'SameSite=Strict', 'Secure', 'Max-Age=0']
+  if (domain) attrs.push(`Domain=${domain}`)
+  jar.cookie = attrs.join('; ')
+}


### PR DESCRIPTION
Step **S2** of the SPA-websocket rollout (umbrella #1955, design [`docs/design/spa-websocket.md`](docs/design/spa-websocket.md) §4/§8). Builds on **S1** (#1968, merged). Closes #1969.

## What

Plug real **upgrade auth** into the S1 `/api/ws` skeleton. The browser `WebSocket` constructor can't set an `Authorization` header (§0.2.1), so the operator JWT rides a tightly-scoped `wh_ws` cookie; the upgrade is authorized **before the 101** by the **existing `AuthService.verify`** — no second auth surface (`AGENTS.md#single-source-of-truth`). A bad/missing/expired cookie or a disallowed `Origin` → plain **401/403, no 101**, exactly like a REST 401 and the router bearer path.

### Server (`SpaWsRoutes`)
- `authorizeUpgrade` = **Origin allowlist** (§8 — the one server-side ws config that differs by hosting mode) **then** `wh_ws` cookie → `AuthService.verify`.
- Role is resolved from the **verified claims** (replaces the S1 least-privilege `Child` stub); `hello` no longer carries a role override.
- `jwtExp` captured at upgrade; a per-connection watcher closes the channel **`4401 token-expired`** + deregisters on the tick where `now ≥ jwtExp` (§4.3, injected `Clock`).
- `reauth` op is **ack-rejected** — the forward-compat seam (v1 has no silent refresh; SPA falls back to polling + `/login` on `4401`).

### Config (`WsConfig`)
Origin allowlist (host-based, `*.suffix`/`prefix.*` wildcards) + expiry-check cadence. **Empty allowlist = check off** (self-hosted same-origin; `SameSite=Strict` cookie is the CSWSH guard). Wired through `Main`, the docker entrypoint, `application.conf.example`, and `render.yaml` (staging/prod set the allowlist so cross-site upgrades are rejected pre-101).

### Metric + dashboard
`spa_ws_auth_total{result ∈ ok|no_cookie|invalid_jwt|expired_jwt|bad_origin|jwt_expired_midconn}` via `MetricGuard` (bounded label). `spa-ws.json` gains an **auth-outcomes** panel + a **`bad_origin`/`invalid_jwt` CSWSH/forgery tripwire** (alert-worthy). `spa-ws` is already in `infra/grafana/main.tf` `local.dashboards`, so only the JSON changed.

### SPA helper (web)
`setWsAuthCookie` / `clearWsAuthCookie` (`Path=/api/ws; SameSite=Strict; Secure; Max-Age` short; registrable-`Domain` in cloud vs host-only self-hosted, derived from `VITE_API_BASE_URL`) + vitest. **No ws client yet** — that's S5.

## Tests (TDD, red→green in history)

Full-stack on embedded Postgres with a **real JWT** (never a mock): valid cookie → `ready` carrying the JWT's role; missing/forged/expired cookie → 401; bad/absent Origin → 403; self-hosted same-origin → ok; mid-connection `exp` crossing under `Clock.TestClock` → `4401` close + deregister; child role scoping ack-reject; `reauth` seam. Each path asserts the `spa_ws_auth_total{result}` delta.

`mill api.test` green (full suite), `web` lint + type-check + 414 vitest green.

## Back-compat

Additive — REST stays the fallback throughout the rollout. The only behavioral change is that `/api/ws` now **requires** auth (it was an unauthenticated skeleton in S1, with no client shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)