### PR TITLE
ci(#1989): resolve base SHA on workflow_dispatch so CD gates can be triggered manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,12 +304,20 @@ jobs:
 
       - name: Resolve base SHA
         id: base
-        # pull_request → PR base; merge_group → merge-base; push → before-SHA.
+        # pull_request → PR base; merge_group → merge-base; push → before-SHA;
+        # workflow_dispatch → parent of the dispatched commit (HEAD~1), the
+        # same "what did this commit change" base as push. Without this arm
+        # `sha` is empty on a manual dispatch and check-migrations.sh aborts
+        # with a usage error, reddening CD runs kicked off via
+        # `gh workflow run` (e.g. to validate a render.yaml-only deploy that
+        # the path filters otherwise skip). fetch-depth:0 above makes HEAD~1
+        # resolvable.
         run: |
           case "${{ github.event_name }}" in
-            pull_request) echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT" ;;
-            merge_group)  echo "sha=${{ github.event.merge_group.base_sha }}"  >> "$GITHUB_OUTPUT" ;;
-            push)         echo "sha=${{ github.event.before }}"                >> "$GITHUB_OUTPUT" ;;
+            pull_request)     echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT" ;;
+            merge_group)      echo "sha=${{ github.event.merge_group.base_sha }}"  >> "$GITHUB_OUTPUT" ;;
+            push)             echo "sha=${{ github.event.before }}"                >> "$GITHUB_OUTPUT" ;;
+            workflow_dispatch) echo "sha=$(git rev-parse HEAD~1)"                  >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Reject changes to existing migration files


### PR DESCRIPTION
Part of #1989 (follows #1984/#1988).

## Why
#1988 bounded the staging JVM envelope in `render.yaml` to stop the 512Mi OOM, but render.yaml-only changes aren't on the CD path filters, so **the gates never re-ran** and the fix is unvalidated. The natural way to force a gate run is `gh workflow run master-api-ui.yml --ref main` (both Master pipelines expose `workflow_dispatch`). I tried that — both runs **failed in CI** at `Migrations Immutability Check`, before any build/deploy/gate job:

```
.github/scripts/check-migrations.sh: line 12: 1: usage: check-migrations.sh <base-ref>
BASE_SHA:
##[error]Process completed with exit code 1.
```

## Root cause
`ci.yml`'s `migrations-immutable` job resolves a base SHA with a `case` over `github.event_name` covering only `pull_request` / `merge_group` / `push`. On `workflow_dispatch` the case falls through, `steps.base.outputs.sha` is empty, and `check-migrations.sh "$BASE_SHA"` aborts on its `${1:?usage}` guard.

This is self-inflicted: the `changes` job *already* forces every path output to `true` on `workflow_dispatch` (so all path-gated jobs, including this one, run) — the clear intent being that a manual dispatch exercises the full CD chain. That intent is defeated because the very job it enables can't resolve a base.

(The sibling `migration-isolation` job has the same `case` but is `if`-gated to `pull_request || merge_group`, so it correctly skips on dispatch and is unaffected. No change needed there.)

## Fix
Add a `workflow_dispatch` arm that uses `HEAD~1` — the parent of the dispatched commit, the same "what did this commit change" base as `push`. `fetch-depth: 0` on the job's checkout makes `HEAD~1` resolvable. On main, `HEAD~1...HEAD` over the migration dir is empty (no mutations ever land on main), so the check passes as intended.

## Validation path
`.github/workflows/ci.yml` is on **both** master-api-ui and master-router push-path filters, so **merging this PR triggers both CD pipelines via a real `push` event** (with a proper `github.event.before` → migrations check passes the normal way) — which runs Gate 1 / Gate 3a / Gate 3b against the redeployed staging API and validates the #1988 OOM fix end-to-end. Render staging (`srv-d8549fgjo89c73buvkf0`) has shown **no `oomKilled` since the 02:18 redeploy** (the one 02:21 spike was a startup transient with no smoke load); this merge runs the smoke against it for real.

Render Blueprint is untouched; `ruby -ryaml` parse + `actionlint` pass locally.

### Follow-up (not in this PR)
The deeper gap — a deploy-affecting `render.yaml` change doesn't run the deploy gates at all (render.yaml isn't on the CD path filters) — remains. Noting it here per #1989 item 4; worth a small follow-up to add `render.yaml` to the master-*.yml path filters so blueprint changes self-validate.