### PR TITLE
feat(#1970): SPA-ws S3 — change sources (Publisher→broadcast + SpaEventHub → now/connectionEvents/stale)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -67,8 +67,8 @@ object Main extends ZIOAppDefault {
         templatesById = templates.map(t => t.slug -> t).toMap
         bundledById   = bundled.map(b => b.id -> b).toMap
         routesAndRegistry <- allRoutes(templatesById, bundledById, readyRef.get)
-        (routes, wsRegistry) = routesAndRegistry
-        withCors             = Cors.wrap(routes, cfg.cors)
+        (routes, wsRegistry, spaWsRegistry, spaEventBus) = routesAndRegistry
+        withCors                                         = Cors.wrap(routes, cfg.cors)
         _ <- ZIO
           .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
           .when(cfg.cors.origins.nonEmpty)
@@ -187,14 +187,29 @@ object Main extends ZIOAppDefault {
         // already loads and sleep until then, so the ~2.5s build runs at real transitions instead of
         // every tick.
         policyForPush <- ZIO.service[PolicyService]
-        _ <- policyForPush.setPublisher(new wifihaven.api.policy.PolicySnapshotPublisher {
-          def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =
-            wsRegistry.publishPolicy(snap)
-        })
-        _ <- policyForPush.reevaluate
+        // #1970 (S3): the publisher is now MULTI-subscriber (design §5.2.1). Sink 1 is the router
+        // registry (full snapshot → `policy` frame), unchanged and synchronous so the #1846/#1849
+        // router push timing is behavior-PRESERVED. Sink 2 bridges "policy changed" into the SPA
+        // change bus as a `now` recompute trigger (a reevaluate can flip who's blocked/online), so
+        // the SPA `now` push stays fresh on schedule edges / cap exhaustion / unpause without a poll.
+        _             <- policyForPush.setPublisher(
+          wifihaven.api.policy.PolicySnapshotPublisher.broadcast(
+            List(
+              new wifihaven.api.policy.PolicySnapshotPublisher {
+                def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =
+                  wsRegistry.publishPolicy(snap)
+              },
+              new wifihaven.api.policy.PolicySnapshotPublisher {
+                def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =
+                  spaEventBus.publish(SpaEvent.NowChanged)
+              },
+            ),
+          ),
+        )
+        _             <- policyForPush.reevaluate
           .repeat(Schedule.fixed(cfg.policy.snapshotCacheRefreshInterval))
           .forkScoped
-        _ <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
+        _             <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
         _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkScoped
         // #1265: connection-event rollup tier — same cadence/lookback as the
         // traffic rollups, re-rolling the trailing windows into
@@ -237,6 +252,23 @@ object Main extends ZIOAppDefault {
         _                 <- ZIO.logInfo(
           "rollup fibers forked (hourly + daily + time_used_daily + conn_events_hourly + conn_events_daily)",
         )
+        // #1970 (S3): fork the SPA-websocket change-source consumer. It drains the SpaEventBus and
+        // fans out subscription-gated, role-filtered `now`/`connectionEvents`/`stale` frames over
+        // `/api/ws` (design §5.2). forkScoped (inside `run`) so it is interrupted before the Hikari
+        // pool closes on shutdown, like the rollup loops. `now` rebuilds via the shared
+        // DashboardNowRoutes.computeNow builder (SSOT). No SPA ws client ships until S5, so this
+        // reads idle in prod until then; it is additive and never blocks ingest.
+        _                 <- SpaPush.run(
+          spaEventBus,
+          spaWsRegistry,
+          trafficRepoForJ,
+          connRepoForJobs,
+          deviceRepoForJ,
+          profileRepoForJ,
+          stlRepoForJ,
+          clockForJobs,
+        )
+        _                 <- ZIO.logInfo("spa-ws push consumer fiber forked")
         // #1243: poll the HikariCP MXBean into the Prometheus pool gauges. forkDaemon so it lives
         // for the process and never blocks startup.
         dbPool            <- ZIO.service[Database.DbPool]
@@ -330,8 +362,13 @@ object Main extends ZIOAppDefault {
       promPublisher  <- ZIO.service[PrometheusPublisher]
       routerAuth = new RouterAuthLive(routerRepo)
       routerMetrics <- RouterMetricsService.make
+      // #1970 (S3): the SPA-websocket change-source bus (design §5.2.2). The write sites publish
+      // change events here; the SpaPush consumer (forked in the run scope) drains it and fans out
+      // role-filtered, subscription-gated `now`/`connectionEvents`/`stale` frames.
+      spaEventBus   <- SpaEventBus.make
       // #1846: the transport-agnostic ingest service shared by the REST ingest routes and the new
-      // websocket transport, plus the per-router ws connection registry.
+      // websocket transport, plus the per-router ws connection registry. #1970: it also publishes
+      // SPA change events (new connection-events head + `now` trigger + `stale{alerts}`) to the bus.
       routerIngest = new RouterIngestService(
         routerRepo,
         trafficRepo,
@@ -340,6 +377,7 @@ object Main extends ZIOAppDefault {
         connRepo,
         alertRepo,
         hsRepo,
+        spaEventBus,
       )
       wsRegistry    <- RouterWsRegistry.make
       // #1968: the browser-facing SPA websocket registry (S1). A FORK of the router registry pattern
@@ -385,11 +423,24 @@ object Main extends ZIOAppDefault {
             // per-profile time-status entry instead of leaving a stale "paused for schedule".
             timeCache,
             // #1849: bust the computed-snapshot cache on a profile/schedule mutation.
-            policy.invalidate,
+            // #1970 (S3): also nudge `stale{profiles}` so an open SPA re-fetches the class-(3)
+            // profiles resource (design §3.2) — composed onto the existing invalidate callback, so
+            // every profile mutation publishes without touching the route's signature.
+            policy.invalidate <* spaEventBus.publish(SpaEvent.Stale(StaleTopic.Profiles)),
           ) ++
-          ScheduleRoutes.routes(auth, namedSchedRepo, policy.invalidate) ++
+          ScheduleRoutes.routes(
+            auth,
+            namedSchedRepo,
+            policy.invalidate <* spaEventBus.publish(SpaEvent.Stale(StaleTopic.Schedules)),
+          ) ++
           HouseholdSettingsRoutes.routes(auth, hsRepo, policy.invalidate) ++
-          DeviceRoutes.routes(auth, deviceRepo, upRepo, profileRepo, policy.invalidate)
+          DeviceRoutes.routes(
+            auth,
+            deviceRepo,
+            upRepo,
+            profileRepo,
+            policy.invalidate <* spaEventBus.publish(SpaEvent.Stale(StaleTopic.Devices)),
+          )
 
       val statsRoutes: Routes[Any, Response] =
         TimeRoutes.routes(
@@ -544,6 +595,8 @@ object Main extends ZIOAppDefault {
       ) ++ metricsRoutes
       // #1849: hand the ws registry back so the run scope can wire it as PolicyService's push sink
       // and fork the reconcile ticker (both need the run scope, which `allRoutes` is not).
-      (assembled, wsRegistry)
+      // #1970 (S3): also hand back the SPA registry + change-source bus so the run scope can fork the
+      // SpaPush consumer and add the SPA `now`-trigger sink to the (now multi-subscriber) publisher.
+      (assembled, wsRegistry, spaWsRegistry, spaEventBus)
     }
 }

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -248,8 +248,8 @@ object MetricGuard {
     // `reauth` added by #1969 — the forward-compat reject seam),
     // `direction` ∈ {in, out}, `result` ∈ {ok, reject, unknown_op}. `spa_ws_subscriptions_active`
     // is the live count of subscriptions per `topic` (the SpaTopic enum). All bounded enums — no
-    // per-mac / per-profile / per-session / param dimension ever rides a ws metric. (The
-    // spa_ws_push_total lands with S3/S4, when first emitted.)
+    // per-mac / per-profile / per-session / param dimension ever rides a ws metric. (#1970 added
+    // spa_ws_push_total{op,result} below for the S3 change-source fan-out.)
     "spa_ws_connections_active"                 -> Set("role"),
     "spa_ws_frames_total"                       -> Set("op", "direction", "result"),
     "spa_ws_subscriptions_active"               -> Set("topic"),
@@ -259,6 +259,12 @@ object MetricGuard {
     // fixed 6-value enum; bounded, no per-user/session dimension. A spike in
     // bad_origin/invalid_jwt is the CSWSH/forgery-probe tripwire (alert in spa-ws.json).
     "spa_ws_auth_total"                         -> Set("result"),
+    // #1970 (S3) — per-topic fan-out health for the change-source push path (design §6.3/§7).
+    // `op` ∈ {now, connectionEvents, stale} today (trafficUsage/timeStatus/appUsage land with
+    // S4/S6a as those topics start pushing); `result` ∈ {ok, coalesced, dropped, channel_closed}.
+    // Both bounded enums — no per-mac / per-profile / per-session / param dimension. A rising
+    // channel_closed/dropped is the slow-client tripwire surfaced by spa-ws.json's push-health panel.
+    "spa_ws_push_total"                         -> Set("op", "result"),
     // #1848 — AGENT-side websocket transport metrics. The wifihaven-ws sidecar has no metrics
     // registry of its own, so it writes a cumulative tally that the agent folds into its
     // /api/router/metrics push (the server attaches router_id / installation_id, as for every
@@ -627,6 +633,12 @@ object AppMetrics {
   // dimension. The verify itself reuses AuthService (SSOT); this only labels the outcome.
   def recordSpaWsAuth(result: String): UIO[Unit] =
     MetricGuard.counter("spa_ws_auth_total", Map("result" -> result))
+
+  // #1970 (S3) — emitted from SpaWsRegistry on every change-source fan-out (design §5.2/§6.3).
+  // `op` is the pushed topic (now|connectionEvents|stale today), `result` ∈
+  // {ok, coalesced, dropped, channel_closed} — a fixed bounded enum, never a per-entity dimension.
+  def recordSpaWsPush(op: String, result: String): UIO[Unit] =
+    MetricGuard.counter("spa_ws_push_total", Map("op" -> op, "result" -> result))
 
   // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
   // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds

--- a/api/src/policy/PolicySnapshotPublisher.scala
+++ b/api/src/policy/PolicySnapshotPublisher.scala
@@ -26,4 +26,27 @@ object PolicySnapshotPublisher {
   val noop: PolicySnapshotPublisher = new PolicySnapshotPublisher {
     def publish(snap: PolicySnapshot): UIO[Unit] = ZIO.unit
   }
+
+  /**
+   * #1970 (S3, design `docs/design/spa-websocket.md` §5.2.1): widen the single-sink publisher to a
+   * MULTI-subscriber fan-out so a changed snapshot reaches more than one consumer — the
+   * [[wifihaven.api.routes.RouterWsRegistry]] (which fans the full snapshot out as a `policy`
+   * frame) AND the SPA push path (which derives a `now` recompute + `stale` nudge from "policy
+   * changed").
+   *
+   * Behavior-PRESERVING for the router subscriber: `broadcast` invokes each sink's `publish` in
+   * order, SYNCHRONOUSLY, exactly as the old single sink was invoked — so the router's #1846/#1849
+   * push timing (reconcile-tick fan-out, first-policy-on-connect) is unchanged. We deliberately do
+   * NOT route the snapshot through a `Hub` here: a Hub would interpose an async consumer fiber
+   * between [[PolicyService.reevaluate]] and the router fan-out, changing that timing and risking
+   * the router-ws tests; the SPA side instead gets its OWN async hub
+   * ([[wifihaven.api.routes.SpaEventBus]]) fed by a thin sink in this list (`snap =>
+   * spaEventBus.publish(NowChanged)`), so the router path stays synchronous and the SPA path is
+   * decoupled. A failing/never-failing sink can't affect the others — each `publish` returns `UIO`.
+   */
+  def broadcast(sinks: List[PolicySnapshotPublisher]): PolicySnapshotPublisher =
+    new PolicySnapshotPublisher {
+      def publish(snap: PolicySnapshot): UIO[Unit] =
+        ZIO.foreachDiscard(sinks)(_.publish(snap))
+    }
 }

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -54,47 +54,78 @@ object DashboardNowRoutes {
             visibleDevs <- filterDevices(claims, allDevices, userProfileRepo)
             allProfiles <- profileRepo.listAll.mapError(ApiError.Db(_))
             visibleProf <- visibleProfiles(claims, allProfiles, userProfileRepo)
-            visibleMacs = visibleDevs.map(_.mac)
-            // Both inputs in parallel.
-            since       = now.minus(TopHostsWindow)
-            connSince   = now.minus(RecentActivityWindow)
-            lastSeenF  <- connRepo.lastSeenByMacSince(connSince).fork
-            rowsF      <- trafficRepo
-              .listTrafficRollupRows(
-                TrafficRollupFilter(
-                  macs = Some(visibleMacs),
-                  host = None,
-                  since = Some(since),
-                  until = None,
-                ),
-              )
-              .fork
-            // #1559: per-profile active-app host-set, fed into [[dropBackground]] so an
-            // app-attributed background-pattern host stays in the ranking (attribution beats
-            // suppression, same #1506 contract counting surfaces use). Read through the
-            // canonical [[ProfileAppDispositions]] fold so the dashboard cannot disagree
-            // with the counting paths on what "active app host" means (#1532 / #1560).
-            appLimitsF <- appTimeLimitRepo.listAll.fork
-            lastSeen   <- lastSeenF.join.mapError(ApiError.Db(_))
-            rows       <- rowsF.join.mapError(ApiError.Db(_))
-            appLimits  <- appLimitsF.join.mapError(ApiError.Db(_))
-            appHostPatternsByProfile = appLimits
-              .groupBy(_.profileId)
-              .view
-              .mapValues(ProfileAppDispositions.from(_).appHostPatterns)
-              .toMap
-            response                 = buildResponse(
-              now = now,
-              profiles = visibleProf,
-              devices = visibleDevs,
-              lastSeen = lastSeen,
-              rows = rows,
-              appHostPatternsByProfile = appHostPatternsByProfile,
+            // #1970: the gather-and-assemble is shared with the SPA-websocket `now` push (S3) so the
+            // streamed body and this GET body are produced by ONE builder (SSOT) — recomputed on
+            // change for the push, per-request here.
+            response    <- computeNow(
+              now,
+              visibleProf,
+              visibleDevs,
+              trafficRepo,
+              connRepo,
+              appTimeLimitRepo,
             )
+              .mapError(ApiError.Db(_))
           } yield Response.json(response.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
     )
+
+  /**
+   * #1970: gather the NOW inputs and assemble the [[DashboardNow]] body. The single implementation
+   * of the NOW snapshot (design `docs/design/spa-websocket.md` §5.2 / `AGENTS.md`
+   * single-source-of-truth) — the `GET /api/dashboard/now` handler calls it per-request, and the
+   * SPA websocket `now` push ([[SpaPush]]) calls it on change. `profiles`/`devices` are the
+   * caller's already-visibility-filtered lists (the GET filters by claims; the push passes the full
+   * set since `now` is visible only to roles the GET shows everything to, §4.4), so this method is
+   * agnostic to the authz model. Reads run in parallel; a repo failure surfaces as the
+   * [[Throwable]].
+   *
+   * #1559: per-profile active-app host-set is read through the canonical [[ProfileAppDispositions]]
+   * fold so the dashboard cannot disagree with the counting paths on what "active app host" means
+   * (#1532 / #1560).
+   */
+  def computeNow(
+      now: Instant,
+      profiles: List[Profile],
+      devices: List[Device],
+      trafficRepo: TrafficReportRepo,
+      connRepo: ConnectionEventRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+  ): Task[DashboardNow] = {
+    val visibleMacs = devices.map(_.mac)
+    val since       = now.minus(TopHostsWindow)
+    val connSince   = now.minus(RecentActivityWindow)
+    for {
+      lastSeenF  <- connRepo.lastSeenByMacSince(connSince).fork
+      rowsF      <- trafficRepo
+        .listTrafficRollupRows(
+          TrafficRollupFilter(
+            macs = Some(visibleMacs),
+            host = None,
+            since = Some(since),
+            until = None,
+          ),
+        )
+        .fork
+      appLimitsF <- appTimeLimitRepo.listAll.fork
+      lastSeen   <- lastSeenF.join
+      rows       <- rowsF.join
+      appLimits  <- appLimitsF.join
+      appHostPatternsByProfile = appLimits
+        .groupBy(_.profileId)
+        .view
+        .mapValues(ProfileAppDispositions.from(_).appHostPatterns)
+        .toMap
+    } yield buildResponse(
+      now = now,
+      profiles = profiles,
+      devices = devices,
+      lastSeen = lastSeen,
+      rows = rows,
+      appHostPatternsByProfile = appHostPatternsByProfile,
+    )
+  }
 
   /**
    * Pure assembly — exposed for unit tests.

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -32,6 +32,13 @@ final class RouterIngestService(
     connEventRepo: ConnectionEventRepo,
     alertRepo: AlertRepo,
     householdSettingsRepo: HouseholdSettingsRepo,
+    // #1970 (S3): the SPA-websocket change-source bus. Each ingest is also a write site that may move
+    // the browser's live surface, so it publishes a one-line change event (design §5.2.2) — a `now`
+    // recompute trigger, the new connection-events head, an `alerts` stale nudge. Defaults to
+    // [[SpaEventBus.noop]] so the REST/router-ws ingest call sites and tests that don't exercise the
+    // push path are unchanged; `Main` wires the real bus. Publishing NEVER blocks or fails ingest
+    // (sliding hub, UIO) — the push surface is a latency/UX layer over the authoritative write.
+    bus: SpaEventBus = SpaEventBus.noop,
 ) {
   import RouterIngestService.*
 
@@ -79,6 +86,10 @@ final class RouterIngestService(
         settings <- householdSettingsRepo.get.mapError(ApiError.Db(_))
         _        <- handleUsage(router.id, ps, pe, records, settings)
         _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
+        // #1970 (S3): newly-credited usage moves last_seen / per-device activity, so the dashboard
+        // NOW surface may have changed — trigger a `now` recompute (trafficUsage/timeStatus pushes
+        // are S4/S6a; this step only emits the event). One-liner, never fails ingest.
+        _        <- ZIO.when(records.nonEmpty)(bus.publish(SpaEvent.NowChanged))
       } yield ()
     }
 
@@ -354,6 +365,14 @@ final class RouterIngestService(
       // moments later").
       _         <- ZIO.foreachDiscard(enriched)(backfillFromFqdn)
       _         <- ZIO.foreachDiscard(events)(applyDhcpOrFirstSeen)
+      // #1970 (S3): a successful connection-events ingest is the `connectionEvents` write site —
+      // push the new head (carrying the earliest inserted ts so SpaPush re-reads exactly the new
+      // rows via the GET query) plus a `now` recompute trigger (a fresh connection = device
+      // activity). Only when ≥1 row was genuinely new (replays insert 0). Never fails ingest.
+      _         <- ZIO.when(inserted > 0) {
+        val since = enriched.map(_.ts).min
+        bus.publish(SpaEvent.ConnectionEventsIngested(since)) *> bus.publish(SpaEvent.NowChanged)
+      }
     } yield ()
   }
 
@@ -428,7 +447,11 @@ final class RouterIngestService(
                   .unit *>
                   alertRepo
                     .raiseNewDevice(mac, ts)
-                    .mapError(ApiError.Db(_))
+                    .mapError(ApiError.Db(_)) *>
+                  // #1970 (S3): a raised alert is a class-(3) write site → nudge `stale{alerts}`
+                  // so an open dashboard re-fetches the alerts list. Idempotent on `mac`, so a
+                  // replayed event won't re-nudge a meaningful change. Never fails ingest.
+                  bus.publish(SpaEvent.Stale(StaleTopic.Alerts))
             }
           } yield ()
       }

--- a/api/src/routes/SpaEvents.scala
+++ b/api/src/routes/SpaEvents.scala
@@ -1,0 +1,104 @@
+package wifihaven.api.routes
+
+import zio.*
+
+import java.time.Instant
+
+/**
+ * #1970 (S3, SPA-websocket design `docs/design/spa-websocket.md` §5.2.2): the change-event
+ * vocabulary the SPA push path translates into subscription-gated, role-filtered server→SPA frames.
+ *
+ * Each case is published from an EXISTING write site as a one-line `bus.publish(...)` — there is no
+ * new polling/diffing loop (design §5.2: "consume existing write sites, don't rebuild"). The events
+ * carry only what the [[SpaPush]] consumer needs to recompute the body it pushes; the bodies
+ * themselves are always an existing REST read model rebuilt through its canonical builder (§0.3 —
+ * zero new read-model shapes), so the stream and the matching `GET` can never disagree.
+ *
+ *   - [[SpaEvent.NowChanged]] — "who's online / what they're watching" may have moved (a
+ *     connection- events or usage ingest, or a policy reevaluate #1849). The consumer rebuilds
+ *     [[DashboardNow]] once via the shared [[DashboardNowRoutes.computeNow]] builder and pushes it
+ *     to `now` subscribers (class-(2) thick push). Contentless trigger — latest-wins (§6.3).
+ *   - [[SpaEvent.ConnectionEventsIngested]] — new connection_events rows landed at/after `since`.
+ *     The consumer re-reads the head via the same `connRepo.query` the `/api/logs` GET uses (SSOT),
+ *     keeps the rows at/after `since` (the genuinely-new ones), and appends them to each
+ *     `connectionEvents` subscriber whose filter params match (class-(1) live edge).
+ *   - [[SpaEvent.Stale]] — a class-(3) occasionally-changing resource mutated; the consumer fans a
+ *     contentless `{topic, scope?}` nudge to `stale` subscribers so they invalidate the mapped
+ *     query (§3.2). Coalescing-friendly (idempotent).
+ */
+enum SpaEvent {
+  case NowChanged
+  case ConnectionEventsIngested(since: Instant)
+  case Stale(topic: StaleTopic, scope: Option[String] = None)
+}
+
+/**
+ * The bounded `topic` enum a `stale{topic, scope?}` nudge carries (design §1.2 / §3.2). One value
+ * per class-(3) resource the SPA caches; kept a fixed small enum so it can ride a metric label
+ * (`spa_ws_push_total{op="stale"}`) and the topic→query-key map on the client stays closed.
+ */
+enum StaleTopic {
+  case Alerts, Profiles, Devices, Schedules
+}
+
+object StaleTopic {
+  def wire(t: StaleTopic): String = t match {
+    case Alerts    => "alerts"
+    case Profiles  => "profiles"
+    case Devices   => "devices"
+    case Schedules => "schedules"
+  }
+}
+
+/**
+ * #1970: the in-memory `Hub[SpaEvent]` (design §5.2.2 "SpaEventHub") fed by the existing write
+ * sites and drained by the single [[SpaPush]] consumer fiber. A tiny seam (like
+ * [[wifihaven.api.policy.PolicySnapshotPublisher]]) so write sites — [[RouterIngestService]], the
+ * route mutation callbacks wired in `Main` — depend only on `publish`, never on the Hub or the push
+ * machinery, and tests can substitute [[SpaEventBus.noop]].
+ *
+ * Backed by a SLIDING hub (design §6.3): a wedged/slow consumer must NEVER block a write site — an
+ * overflowing publish drops the oldest buffered event rather than back-pressuring ingest. The push
+ * surface is a latency/UX layer (§6.5); losing a buffered change degrades to the next push (or the
+ * client's reconnect refetch, §6.1), it never blocks or fails the write.
+ *
+ * Single-process, single-instance — the right shape for the one-API-process household; cross-
+ * instance fan-out is out of scope (#1952).
+ */
+trait SpaEventBus {
+
+  /** Publish a change event. Never blocks, never fails (sliding-drop on overflow). */
+  def publish(event: SpaEvent): UIO[Unit]
+
+  /**
+   * Subscribe a fresh consumer. Only events published AFTER the returned [[Dequeue]] is acquired
+   * are delivered; the subscription is released when the enclosing scope closes.
+   */
+  def subscribe: ZIO[Scope, Nothing, Dequeue[SpaEvent]]
+}
+
+object SpaEventBus {
+
+  /** The no-publish bus used before wiring and in tests that don't exercise the push path. */
+  val noop: SpaEventBus = new SpaEventBus {
+    def publish(event: SpaEvent): UIO[Unit]               = ZIO.unit
+    def subscribe: ZIO[Scope, Nothing, Dequeue[SpaEvent]] =
+      ZIO.acquireRelease(Queue.unbounded[SpaEvent])(_.shutdown)
+  }
+
+  /**
+   * The production bus: a sliding hub so an overflowing publish drops oldest, never blocks ingest.
+   */
+  def make: UIO[SpaEventBus] =
+    Hub.sliding[SpaEvent](BufferSize).map { hub =>
+      new SpaEventBus {
+        def publish(event: SpaEvent): UIO[Unit]               = hub.publish(event).unit
+        def subscribe: ZIO[Scope, Nothing, Dequeue[SpaEvent]] = hub.subscribe
+      }
+    }
+
+  // Buffer of recent unconsumed events. Generous — the single consumer drains continuously and each
+  // event is tiny; this only matters if the consumer stalls, in which case sliding-drop keeps the
+  // freshest BufferSize events and discards older ones (a missed `now`/`stale` self-heals next push).
+  private val BufferSize = 256
+}

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -1,0 +1,152 @@
+package wifihaven.api.routes
+
+import wifihaven.api.db.*
+import wifihaven.api.observability.LogContext
+import wifihaven.shared.Clock
+import zio.{Clock as _, *}
+import zio.json.*
+import zio.json.ast.Json
+
+import java.time.{Duration, Instant}
+
+/**
+ * #1970 (S3, SPA-websocket design `docs/design/spa-websocket.md` §5.2): the single consumer fiber
+ * that drains the [[SpaEventBus]] and translates each [[SpaEvent]] into subscription-gated,
+ * role-filtered server→SPA frames via [[SpaWsRegistry]]. This is the "translate" half of the change
+ * sources — the write sites publish (one-liners), this fiber rebuilds the affected body through its
+ * canonical builder and fans it out.
+ *
+ *   - [[SpaEvent.NowChanged]] → rebuild [[wifihaven.shared.DashboardNow]] ONCE via the shared
+ *     [[DashboardNowRoutes.computeNow]] builder (SSOT — the same code `GET /api/dashboard/now`
+ *     runs) and push it to `now` subscribers. Built over the FULL profile/device set because `now`
+ *     is visible only to admin/adult (`SpaTopic.visibleTo`), the roles the GET shows everything to
+ *     (§4.4) — so one body is correct for every recipient and the registry's role gate is the
+ *     filter.
+ *   - [[SpaEvent.ConnectionEventsIngested]] → re-read the head rows through the same
+ *     `connRepo.query` the `/api/logs` GET uses (SSOT), keep the genuinely-new rows (ts at/after
+ *     the event's `since`), and let the registry append them to each `connectionEvents` subscriber
+ *     whose filter matches.
+ *   - [[SpaEvent.Stale]] → fan a contentless nudge to `stale` subscribers.
+ *
+ * The loop NEVER fails: each event's build is wrapped so a transient repo error is logged and
+ * skipped (the push surface is a latency/UX layer, design §6.5 — a missed push self-heals on the
+ * next change or the client's reconnect refetch, §6.1), it never crashes the consumer. The clock is
+ * always the INJECTED [[Clock]] (never wall-clock).
+ */
+object SpaPush {
+
+  /**
+   * Subscribe to the bus and process events forever in a forked fiber. Scoped: the Hub subscription
+   * and the fiber are released when the enclosing scope closes (forkScoped, like the rollup loops
+   * in `Main`). Returns once subscribed + forked, so events published after `run` returns are seen.
+   */
+  def run(
+      bus: SpaEventBus,
+      registry: SpaWsRegistry,
+      trafficRepo: TrafficReportRepo,
+      connRepo: ConnectionEventRepo,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      clock: Clock,
+  ): ZIO[Scope, Nothing, Unit] =
+    bus.subscribe.flatMap { queue =>
+      queue.take
+        .flatMap(
+          handle(
+            _,
+            registry,
+            trafficRepo,
+            connRepo,
+            deviceRepo,
+            profileRepo,
+            appTimeLimitRepo,
+            clock,
+          ),
+        )
+        .forever
+        .forkScoped
+        .unit
+    }
+
+  private def handle(
+      event: SpaEvent,
+      registry: SpaWsRegistry,
+      trafficRepo: TrafficReportRepo,
+      connRepo: ConnectionEventRepo,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      clock: Clock,
+  ): UIO[Unit] =
+    event match {
+      case SpaEvent.NowChanged                      =>
+        pushNow(registry, trafficRepo, connRepo, deviceRepo, profileRepo, appTimeLimitRepo, clock)
+          .catchAllCause(c => ZIO.logErrorCause("spa ws push: now recompute failed", c))
+      case SpaEvent.ConnectionEventsIngested(since) =>
+        pushConnectionEvents(registry, connRepo, clock, since)
+          .catchAllCause(c => ZIO.logErrorCause("spa ws push: connectionEvents fan-out failed", c))
+      case SpaEvent.Stale(topic, scope)             =>
+        LogContext.annotate(LogContext.Op, "stale") {
+          registry.fanOutStale(topic, scope)
+        }
+    }
+
+  /** Rebuild `DashboardNow` over the full profile/device set and push to `now` subscribers. */
+  private def pushNow(
+      registry: SpaWsRegistry,
+      trafficRepo: TrafficReportRepo,
+      connRepo: ConnectionEventRepo,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      clock: Clock,
+  ): Task[Unit] =
+    for {
+      now      <- clock.instant
+      profiles <- profileRepo.listAll
+      devices  <- deviceRepo.listAll
+      body     <- DashboardNowRoutes.computeNow(
+        now,
+        profiles,
+        devices,
+        trafficRepo,
+        connRepo,
+        appTimeLimitRepo,
+      )
+      _        <- registry.fanOut(SpaTopic.Now, body.toJsonAST.getOrElse(Json.Obj()))
+    } yield ()
+
+  /**
+   * Re-read the connection-events head through the `/api/logs` query and append the genuinely-new
+   * rows (ts at/after `since`) to matching subscribers. Re-querying via the GET path keeps the
+   * pushed `QueryLog` rows byte-identical to what the page loads (joins, FQDN resolution — SSOT);
+   * the `since` floor is what makes the push carry only the NEW rows (an ingest that didn't match a
+   * subscriber's filter then pushes nothing to it).
+   */
+  private def pushConnectionEvents(
+      registry: SpaWsRegistry,
+      connRepo: ConnectionEventRepo,
+      clock: Clock,
+      since: Instant,
+  ): Task[Unit] =
+    for {
+      now <- clock.instant
+      // Window covers [since, now]; the head is then trimmed to ts >= since to drop older rows the
+      // window may include. Cap at 24h so a stale `since` can't widen the scan unboundedly.
+      hrs = math.min(24, math.max(1, Duration.between(since, now).toHours.toInt + 1))
+      rows <- connRepo.query(LogFilter(hours = hrs, limit = ConnEventHeadLimit, until = Some(now)))
+      fresh = rows.filter(r => atOrAfter(r.ts, since))
+      _ <- ZIO.when(fresh.nonEmpty)(registry.fanOutConnectionEvents(fresh))
+    } yield ()
+
+  // True iff the `/api/logs` row timestamp is at/after `since` (the genuinely-new edge). The row ts
+  // is always ISO-8601 UTC ("…Z", ConnectionEventRepo `to_char(... 'Z')`), so a parse never fails in
+  // practice; on the impossible malformed case KEEP the row rather than silently drop a real new one.
+  private def atOrAfter(ts: String, since: Instant): Boolean =
+    scala.util.Try(Instant.parse(ts)).map(!_.isBefore(since)).getOrElse(true)
+
+  // Head-row cap per connectionEvents push. Matches the `/api/logs` default page; the client dedups
+  // by id and the feed is "recent" anyway, so the newest 200 is plenty for the live edge (§3.1).
+  private val ConnEventHeadLimit = 200
+}

--- a/api/src/routes/SpaWsRegistry.scala
+++ b/api/src/routes/SpaWsRegistry.scala
@@ -1,9 +1,11 @@
 package wifihaven.api.routes
 
 import wifihaven.api.metrics.AppMetrics
-import wifihaven.shared.UserRole
+import wifihaven.shared.{QueryLog, UserRole}
+import wifihaven.shared.types.ProfileId
 import zio.*
-import zio.http.WebSocketChannel
+import zio.http.{ChannelEvent, WebSocketChannel, WebSocketFrame}
+import zio.json.*
 import zio.json.ast.Json
 
 import java.time.Instant
@@ -124,6 +126,34 @@ trait SpaWsRegistry {
 
   /** Total open channels across all connections — backs `spa_ws_connections_active`. */
   def activeCount: UIO[Int]
+
+  /**
+   * #1970 (S3): fan a class-(2) thick push (`now`) out to every connection that BOTH subscribed to
+   * `topic` (§1.4) AND whose role may see it (§4.4 — `SpaTopic.visibleTo`). The body is built ONCE
+   * by the caller ([[SpaPush]], via the shared `DashboardNowRoutes.computeNow` builder) and sent
+   * verbatim; the role gate is the per-role filter (the topics pushed this way — `now` — are
+   * visible only to roles the matching GET shows everything to, so one body is correct for all
+   * recipients). A send failure (racing disconnect) is metered
+   * `spa_ws_push_total{result="channel_closed"}` and deregisters the dead channel; a success is
+   * metered `result="ok"`.
+   */
+  def fanOut(topic: SpaTopic, payload: Json): UIO[Unit]
+
+  /**
+   * #1970 (S3): append new `connectionEvents` head rows (class-(1) live edge). For each connection
+   * subscribed to `ConnectionEvents` and authorized, the rows are filtered by THAT connection's
+   * subscription params (the verbatim `/api/logs` filter — `blocked`/`macs`/`profileIds`/`domain`,
+   * §1.4); a frame is sent only if ≥1 row matches, so an ingest that doesn't match a subscriber's
+   * filter pushes nothing to it. Metered per send like [[fanOut]].
+   */
+  def fanOutConnectionEvents(rows: List[QueryLog]): UIO[Unit]
+
+  /**
+   * #1970 (S3): fan a contentless class-(3) `stale{topic, scope?}` nudge to every connection
+   * subscribed to `Stale` and authorized (§3.2 — the client invalidates the mapped query). Metered
+   * `spa_ws_push_total{op="stale", ...}`.
+   */
+  def fanOutStale(topic: StaleTopic, scope: Option[String]): UIO[Unit]
 }
 
 object SpaWsRegistry {
@@ -198,4 +228,107 @@ final class SpaWsRegistryLive(
 
   def activeCount: UIO[Int] =
     state.get.map(_.size)
+
+  // ── #1970 (S3) change-source fan-out ────────────────────────────────────────────────────────
+  // Each fan-out snapshots the connection map once and sends to the gated subset. The two gates are
+  // independent (design §5.1): a connection receives a topic only if it SUBSCRIBED to it (§1.4) AND
+  // its role is AUTHORIZED for it (§4.4 — `SpaTopic.visibleTo`). A send failure means the channel
+  // raced a disconnect: meter `channel_closed` and drop it (the receive loop's `ensuring` also
+  // deregisters; doing it here keeps the gauges honest if the push won the race).
+
+  def fanOut(topic: SpaTopic, payload: Json): UIO[Unit] =
+    state.get.flatMap { m =>
+      val op    = SpaTopic.wire(topic)
+      val frame = frameText(op, payload.toJson)
+      ZIO.foreachDiscard(m.toList) { case (id, s) =>
+        ZIO.when(s.subscriptions.contains(topic) && SpaTopic.visibleTo(topic, s.role))(
+          sendPush(id, s.channel, op, frame),
+        )
+      }
+    }
+
+  def fanOutConnectionEvents(rows: List[QueryLog]): UIO[Unit] =
+    state.get.flatMap { m =>
+      val op = SpaTopic.wire(SpaTopic.ConnectionEvents)
+      ZIO.foreachDiscard(m.toList) { case (id, s) =>
+        val gated =
+          s.subscriptions.get(SpaTopic.ConnectionEvents).filter { _ =>
+            SpaTopic.visibleTo(SpaTopic.ConnectionEvents, s.role)
+          }
+        gated match {
+          case None         => ZIO.unit
+          case Some(params) =>
+            val filter  = LogSubParams.decode(params)
+            val matched = rows.filter(filter.matches)
+            ZIO.when(matched.nonEmpty)(
+              sendPush(id, s.channel, op, frameText(op, matched.toJson)),
+            )
+        }
+      }
+    }
+
+  def fanOutStale(topic: StaleTopic, scope: Option[String]): UIO[Unit] =
+    state.get.flatMap { m =>
+      val op      = SpaTopic.wire(SpaTopic.Stale)
+      val payload = scope match {
+        case Some(sc) => s"""{"topic":"${StaleTopic.wire(topic)}","scope":${Json.Str(sc).toJson}}"""
+        case None     => s"""{"topic":"${StaleTopic.wire(topic)}"}"""
+      }
+      val frame   = frameText(op, payload)
+      ZIO.foreachDiscard(m.toList) { case (id, s) =>
+        ZIO.when(
+          s.subscriptions.contains(SpaTopic.Stale) && SpaTopic.visibleTo(SpaTopic.Stale, s.role),
+        )(
+          sendPush(id, s.channel, op, frame),
+        )
+      }
+    }
+
+  /** The `{op, payload}` push envelope (design §2.2), payload already serialized. */
+  private def frameText(op: String, payloadJson: String): String =
+    s"""{"op":"$op","payload":$payloadJson}"""
+
+  private def sendPush(
+      id: SpaConnId,
+      channel: WebSocketChannel,
+      op: String,
+      frame: String,
+  ): UIO[Unit] =
+    channel
+      .send(ChannelEvent.read(WebSocketFrame.text(frame)))
+      .foldZIO(
+        _ => AppMetrics.recordSpaWsPush(op, "channel_closed") *> deregister(id),
+        _ =>
+          AppMetrics.recordSpaWsPush(op, "ok") *>
+            AppMetrics.recordSpaWsFrame(op, "out", "ok"),
+      )
+}
+
+/**
+ * #1970 (S3): the decoded `connectionEvents` subscription params — the verbatim `/api/logs` filter
+ * vocabulary (§1.4 / §0.3). Each field is an OPTIONAL narrowing; an absent field matches
+ * everything, so the dashboard's `{blocked:true}` keeps only blocked rows while the Connection
+ * Events page's richer filter narrows by mac/profile/domain too. Unknown params are ignored
+ * (forward-compat).
+ */
+private final case class LogSubParams(
+    blocked: Option[Boolean] = None,
+    macs: Option[List[String]] = None,
+    profileIds: Option[List[ProfileId]] = None,
+    domain: Option[String] = None,
+) derives JsonDecoder {
+
+  /** True iff `row` passes every present narrowing (mirrors `LogFilter`'s AND-of-clauses). */
+  def matches(row: QueryLog): Boolean =
+    blocked.forall(_ == row.blocked) &&
+      macs.forall(ms => ms.isEmpty || row.mac.exists(m => ms.contains(m.value))) &&
+      profileIds.forall(ps => ps.isEmpty || row.profileId.exists(ps.contains)) &&
+      domain.forall(d => row.host.value.toLowerCase.contains(d.toLowerCase))
+}
+
+private object LogSubParams {
+
+  /** Decode a subscribe-params blob; a missing/garbage blob is the match-everything default. */
+  def decode(params: Json): LogSubParams =
+    params.toJson.fromJson[LogSubParams].getOrElse(LogSubParams())
 }

--- a/api/src/routes/SpaWsRegistry.scala
+++ b/api/src/routes/SpaWsRegistry.scala
@@ -318,7 +318,19 @@ private final case class LogSubParams(
     domain: Option[String] = None,
 ) derives JsonDecoder {
 
-  /** True iff `row` passes every present narrowing (mirrors `LogFilter`'s AND-of-clauses). */
+  /**
+   * True iff `row` passes every present narrowing (an absent field matches everything). This is the
+   * in-memory twin of the `/api/logs` SQL filter in `ConnectionEventRepo.query` — the fan-out can't
+   * round-trip SQL per subscriber, so the predicate is duplicated, an ACCEPT-divergence (no single
+   * collapse point). It MUST stay byte-aligned with that SQL's clauses:
+   *   - `blocked` ↔ `ce.allowed = !b` (QueryLog.blocked = NOT allowed)
+   *   - `macs` ↔ `ce.mac IN (...)` (exact match on the mac string)
+   *   - `profileIds` ↔ `d.profile_id IN (...)` (exact match on the joined profile)
+   *   - `domain` ↔ `COALESCE(resolved_host_value, host_value) ILIKE '%d%'` (case-insensitive
+   *     substring; `QueryLog.host` is already the coalesced resolved-or-host value, so matching on
+   *     `row.host.value` is equivalent).
+   * If the SQL filter grows a clause, mirror it here (and extend `SpaWsS3Spec`'s coverage).
+   */
   def matches(row: QueryLog): Boolean =
     blocked.forall(_ == row.blocked) &&
       macs.forall(ms => ms.isEmpty || row.mac.exists(m => ms.contains(m.value))) &&

--- a/api/test/src/feature/SpaWsS3Spec.scala
+++ b/api/test/src/feature/SpaWsS3Spec.scala
@@ -1,0 +1,365 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.WsConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.PolicySnapshotPublisher
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.json.*
+import zio.test.*
+
+import java.time.LocalDateTime
+
+/**
+ * #1970 (S3 of the SPA-websocket rollout, design `docs/design/spa-websocket.md` §5.2): the change
+ * sources. Exercises the FULL chain end to end — a real [[Server]] + ws [[Client]], the forked
+ * [[SpaPush]] consumer draining the [[SpaEventBus]], and the REAL [[RouterIngestService]] write
+ * site over an embedded Postgres (never mocked) — proving that a write site's one-line publish
+ * becomes a subscription-gated, role-filtered `now`/`connectionEvents`/`stale` frame, and that a
+ * connection receives a topic ONLY if it both subscribed AND is authorized (the two gates,
+ * §1.4/§4.4).
+ *
+ * The publisher widening (§5.2.1) is proven behavior-PRESERVING for the router subscriber: the
+ * existing `RouterWsSpec`/`RouterWsAgentMetricsAllowlistSpec` stay green (the router sink is
+ * invoked synchronously, unchanged), and the focused broadcast test here asserts a router sink
+ * still receives the full snapshot while the SPA sink additionally derives a `now` trigger.
+ */
+object SpaWsS3Spec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
+
+  private val testClockAt: LocalDateTime = LocalDateTime.of(2026, 6, 25, 14, 0, 0)
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(testClockAt)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  // Origin enforcement OFF (self-hosted same-origin shape) keeps the client connect to just the
+  // cookie — S2 already covers the Origin allowlist; S3 is about the change-source fan-out.
+  private val openCfg = WsConfig(allowedOrigins = "", expiryCheckSeconds = 60)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  // Events are dated just before the test clock's "now" so SpaPush's `until = now` head query
+  // (`ts <= now`) includes them.
+  private val eventTs  = "2026-06-25T13:59:30Z"
+  private val knownMac = "aa:bb:cc:11:22:33"
+
+  private def makeAuth(clock: Clock): URIO[UserRepo, AuthServiceLive] =
+    ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg, clock))
+
+  private def tokenFor(
+      auth: AuthService,
+      role: String,
+      username: String,
+  ): ZIO[UserRepo, Throwable, String] =
+    for {
+      hash <- auth.hashPassword("pass")
+      _    <- ZIO.serviceWithZIO[UserRepo](_.create(username, hash, role))
+      tok  <- auth.login(username, "pass").mapError(e => new RuntimeException(s"login: $e"))
+    } yield tok.token.value
+
+  private def adminToken(auth: AuthService): ZIO[Any, Throwable, String] =
+    auth
+      .login("admin", "changeme")
+      .mapError(e => new RuntimeException(s"login: $e"))
+      .map(_.token.value)
+
+  /**
+   * Seed an enrolled router and return the resolved [[Router]] the ingest service ingests against.
+   */
+  private def seedRouter: ZIO[RouterRepo, Throwable, Router] =
+    for {
+      rRepo  <- ZIO.service[RouterRepo]
+      id     <- rRepo.create("test-router", Sha256Hex.unsafe("m" * 64))
+      _      <- rRepo.completeEnrollment(
+        id,
+        Sha256Hex.unsafe(RouterAuth.sha256Hex("ROUTER_TOKEN_PLAIN")),
+      )
+      router <- rRepo.findById(id).someOrFail(new RuntimeException("router not found after seed"))
+    } yield router
+
+  private def seedDevice: ZIO[DeviceRepo & ProfileRepo, Throwable, Unit] =
+    for {
+      pRepo <- ZIO.service[ProfileRepo]
+      dRepo <- ZIO.service[DeviceRepo]
+      pid   <- pRepo.create("Kids", List(BlocklistId.unsafe("adult")))
+      _     <- dRepo.upsert(MacAddress.unsafe(knownMac), "kid-ipad", Some(pid), "192.168.1.10")
+    } yield ()
+
+  private def connEvent(host: String, allowed: Boolean): RouterEvent =
+    RouterEvent(
+      "connection_attempt",
+      mac = Some(MacAddress.unsafe(knownMac)),
+      host = Some(HostId.Fqdn(Hostname.unsafe(host))),
+      destIp = Some(IpAddress.unsafe("1.2.3.4")),
+      allowed = Some(allowed),
+      reason = Some(if allowed then "allow" else "blocked"),
+      ts = eventTs,
+      eventId = Some(java.util.UUID.randomUUID()),
+    )
+
+  private def ingestEvents(
+      ingest: RouterIngestService,
+      router: Router,
+      evs: RouterEvent*,
+  ): Task[Unit] =
+    ingest
+      .ingestEvents(router, RouterEventsRequest(router.id, evs.toList).toJson)
+      .mapError(e => new RuntimeException(s"ingest: $e"))
+
+  private def pushCount(op: String, result: String): UIO[Double] =
+    zio.metrics.Metric
+      .counter("spa_ws_push_total")
+      .tagged("op", op)
+      .tagged("result", result)
+      .value
+      .map(_.count)
+
+  /**
+   * Connect a ws client, send `hello` + the given subscribe frames, wait for the subscribe `ack`
+   * (so the subscription is registered server-side before the trigger fires), run `trigger` (a real
+   * write site), then resolve to the first frame matching `until` within `wait` (None on timeout).
+   * Also returns every frame received, for asserting the `ack` outcome. The forked [[SpaPush]]
+   * consumer must already be running in the enclosing scope.
+   */
+  private def flow(
+      port: Int,
+      token: String,
+      subscribeFrames: List[String],
+      trigger: Task[Unit],
+      until: String => Boolean,
+      wait: Duration,
+      awaitAck: Boolean = true,
+  ): ZIO[Client, Throwable, (Option[String], Chunk[String])] =
+    for {
+      ackP    <- Promise.make[Nothing, Unit]
+      matched <- Promise.make[Nothing, String]
+      frames  <- Ref.make(Chunk.empty[String])
+      app = Handler.webSocket { channel =>
+        channel.receiveAll {
+          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            ZIO.foreachDiscard("""{"op":"hello"}""" :: subscribeFrames)(f =>
+              channel.send(ChannelEvent.read(WebSocketFrame.text(f))),
+            )
+          case ChannelEvent.Read(WebSocketFrame.Text(t))                    =>
+            frames.update(_ :+ t) *>
+              ZIO.when(t.contains("\"op\":\"ack\""))(ackP.succeed(())) *>
+              ZIO.when(until(t))(matched.succeed(t)).unit
+          case _                                                            =>
+            ZIO.unit
+        }
+      }
+      res <- ZIO.scoped {
+        for {
+          _   <- app
+            .connect(s"ws://localhost:$port/api/ws", Headers("Cookie", s"wh_ws=$token"))
+            .forkScoped
+          _   <- ZIO
+            .when(awaitAck)(
+              ackP.await.timeoutFail(new RuntimeException("no subscribe ack"))(20.seconds),
+            )
+          _   <- trigger
+          m   <- matched.await.timeout(wait)
+          all <- frames.get
+        } yield (m, all)
+      }
+    } yield res
+
+  /**
+   * Stand up the registry + bus + ingest, fork the SpaPush consumer in the scope, install the
+   * `/api/ws` server, and run `body` with the bound port + the three collaborators.
+   */
+  private type BootstrapEnv =
+    TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]
+
+  private def withHarness[A](
+      body: (
+          Int,
+          RouterIngestService,
+          SpaEventBus,
+          Router,
+      ) => ZIO[Client & BootstrapEnv, Throwable, A],
+  ): ZIO[BootstrapEnv, Throwable, A] =
+    (for {
+      _           <- cleanDb
+      clock       <- ZIO.service[Clock]
+      auth        <- makeAuth(clock)
+      trafficRepo <- ZIO.service[TrafficReportRepo]
+      connRepo    <- ZIO.service[ConnectionEventRepo]
+      deviceRepo  <- ZIO.service[DeviceRepo]
+      profileRepo <- ZIO.service[ProfileRepo]
+      atlRepo     <- ZIO.service[AppTimeLimitRepo]
+      usageRepo   <- ZIO.service[TimeUsageRepo]
+      alertRepo   <- ZIO.service[AlertRepo]
+      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
+      routerRepo  <- ZIO.service[RouterRepo]
+      _           <- seedDevice
+      router      <- seedRouter
+      reg         <- SpaWsRegistry.make
+      bus         <- SpaEventBus.make
+      ingest = new RouterIngestService(
+        routerRepo,
+        trafficRepo,
+        usageRepo,
+        deviceRepo,
+        connRepo,
+        alertRepo,
+        hsRepo,
+        bus,
+      )
+      routes = SpaWsRoutes.routes(auth, reg, clock, openCfg)
+      port <- Server.install(routes)
+      out  <- ZIO.scoped {
+        SpaPush.run(bus, reg, trafficRepo, connRepo, deviceRepo, profileRepo, atlRepo, clock) *>
+          body(port, ingest, bus, router)
+      }
+    } yield out).provideSome[BootstrapEnv](Server.defaultWithPort(0), Client.default)
+
+  def spec = suite("SPA websocket S3 change sources (#1970)")(
+    test("connectionEvents{blocked:true} subscriber receives the new BLOCKED head row on ingest") {
+      withHarness { (port, ingest, _, router) =>
+        for {
+          adminTok     <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          before       <- pushCount("connectionEvents", "ok")
+          (matched, _) <- flow(
+            port,
+            adminTok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"connectionEvents","params":{"blocked":true}}}""",
+            ),
+            trigger = ingestEvents(ingest, router, connEvent("youtube.com", allowed = false)),
+            until = _.contains("\"op\":\"connectionEvents\""),
+            wait = 20.seconds,
+          )
+          after        <- pushCount("connectionEvents", "ok")
+        } yield assertTrue(matched.exists(_.contains("youtube.com"))) &&
+          assertTrue(matched.exists(_.contains("\"blocked\":true"))) &&
+          assertTrue(after - before >= 1.0)
+      }
+    },
+    test(
+      "connectionEvents{blocked:true} subscriber gets NOTHING when only an ALLOWED event ingests",
+    ) {
+      withHarness { (port, ingest, _, router) =>
+        for {
+          adminTok     <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          (matched, _) <- flow(
+            port,
+            adminTok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"connectionEvents","params":{"blocked":true}}}""",
+            ),
+            trigger = ingestEvents(ingest, router, connEvent("khanacademy.org", allowed = true)),
+            until = _.contains("\"op\":\"connectionEvents\""),
+            wait = 4.seconds,
+          )
+        } yield assertTrue(matched.isEmpty)
+      }
+    },
+    test("a non-subscriber receives NO connectionEvents frame on a blocked ingest") {
+      withHarness { (port, ingest, _, router) =>
+        for {
+          adminTok     <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          (matched, _) <- flow(
+            port,
+            adminTok,
+            subscribeFrames = Nil, // subscribe to nothing
+            trigger = ingestEvents(ingest, router, connEvent("youtube.com", allowed = false)),
+            until = _.contains("\"op\":\"connectionEvents\""),
+            wait = 4.seconds,
+            awaitAck = false,
+          )
+        } yield assertTrue(matched.isEmpty)
+      }
+    },
+    test("a `now` subscriber receives a recomputed DashboardNow on connection-events ingest") {
+      withHarness { (port, ingest, _, router) =>
+        for {
+          adminTok     <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          (matched, _) <- flow(
+            port,
+            adminTok,
+            List("""{"op":"subscribe","payload":{"topic":"now"}}"""),
+            trigger = ingestEvents(ingest, router, connEvent("youtube.com", allowed = false)),
+            until = _.contains("\"op\":\"now\""),
+            wait = 20.seconds,
+          )
+        } yield assertTrue(matched.exists(_.contains("\"op\":\"now\""))) &&
+          // DashboardNow body carries `asOf` + `profiles` (reused GET body, §0.3).
+          assertTrue(matched.exists(f => f.contains("\"asOf\"") && f.contains("\"profiles\"")))
+      }
+    },
+    test(
+      "a `stale` subscriber gets the {topic:profiles} nudge when a profile-mutation event publishes",
+    ) {
+      withHarness { (port, _, bus, _) =>
+        for {
+          adminTok     <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          (matched, _) <- flow(
+            port,
+            adminTok,
+            List("""{"op":"subscribe","payload":{"topic":"stale"}}"""),
+            // exactly what Main's profile-mutation callback publishes after policy.invalidate.
+            trigger = bus.publish(SpaEvent.Stale(StaleTopic.Profiles)),
+            until = _.contains("\"op\":\"stale\""),
+            wait = 20.seconds,
+          )
+        } yield assertTrue(matched.exists(_.contains("\"topic\":\"profiles\"")))
+      }
+    },
+    test("role gate: a child's `now` subscribe is acked reject and no `now` frame is ever pushed") {
+      withHarness { (port, ingest, _, router) =>
+        for {
+          childTok <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "child", "kid"))
+          (matched, all) <- flow(
+            port,
+            childTok,
+            List("""{"op":"subscribe","payload":{"topic":"now"}}"""),
+            trigger = ingestEvents(ingest, router, connEvent("youtube.com", allowed = false)),
+            until = _.contains("\"op\":\"now\""),
+            wait = 4.seconds,
+          )
+        } yield assertTrue(matched.isEmpty) &&
+          assertTrue(
+            all.exists(f =>
+              f.contains("\"op\":\"ack\"") && f.contains("\"topic\":\"now\"") &&
+                f.contains("\"status\":\"reject\""),
+            ),
+          )
+      }
+    },
+    // ── publisher widening is behavior-preserving (§5.2.1) ──────────────────────
+    test("broadcast publisher still drives the router sink AND derives a SPA `now` trigger") {
+      for {
+        received <- Ref.make(Option.empty[PolicySnapshot])
+        bus      <- SpaEventBus.make
+        routerSink = new PolicySnapshotPublisher {
+          def publish(s: PolicySnapshot): UIO[Unit] = received.set(Some(s))
+        }
+        spaSink    = new PolicySnapshotPublisher {
+          def publish(s: PolicySnapshot): UIO[Unit] = bus.publish(SpaEvent.NowChanged)
+        }
+        pub        = PolicySnapshotPublisher.broadcast(List(routerSink, spaSink))
+        snap       = PolicySnapshot(
+          etag = ETag.unsafe("etag-test"),
+          generatedAt = "2026-06-25T14:00:00Z",
+          devices = Map.empty,
+          profiles = Map.empty,
+          blocklists = Map.empty,
+        )
+        spaEvent <- ZIO.scoped(bus.subscribe.flatMap(q => pub.publish(snap) *> q.take))
+        got      <- received.get
+      } yield assertTrue(got.contains(snap)) && assertTrue(spaEvent == SpaEvent.NowChanged)
+    },
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.timeout(120.seconds)
+}

--- a/deploy/grafana/dashboards/spa-ws.json
+++ b/deploy/grafana/dashboards/spa-ws.json
@@ -142,7 +142,7 @@
         "uid": "${datasource}"
       },
       "title": "SPA ws frame rate by op/direction/result (#1968)",
-      "description": "sum by (op, direction, result) (rate(spa_ws_frames_total[5m])) — frame throughput across the {op,payload} demux. op ∈ {hello,ready,subscribe,unsubscribe,ack,ping,pong,unknown}; direction ∈ {in,out}; result ∈ {ok,reject,unknown_op}. A rising result=reject share means clients are sending frames the server rejects (e.g. a subscribe to a topic the role can't see); result=unknown_op is the forward-compat counter for frames whose op the server does not recognize (design §2.2).",
+      "description": "sum by (op, direction, result) (rate(spa_ws_frames_total[5m])) — frame throughput across the {op,payload} demux. op ∈ {hello,ready,subscribe,unsubscribe,ack,ping,pong,unknown} plus the S3 push ops {now,connectionEvents,stale} (sent as direction=out frames by SpaWsRegistry.sendPush); direction ∈ {in,out}; result ∈ {ok,reject,unknown_op}. A rising result=reject share means clients are sending frames the server rejects (e.g. a subscribe to a topic the role can't see); result=unknown_op is the forward-compat counter for frames whose op the server does not recognize (design §2.2).",
       "type": "timeseries",
       "gridPos": {
         "h": 8,

--- a/deploy/grafana/dashboards/spa-ws.json
+++ b/deploy/grafana/dashboards/spa-ws.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven SPA websocket transport (#1968/#1969, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1+S2) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry), spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux), and spa_ws_auth_total{result} (S2 upgrade auth). The SPA has no ws client yet (S5), so until then these read 0/flat. Push fan-out (spa_ws_push_total, S3/S4) panels land with that series. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
+  "description": "WifiHaven SPA websocket transport (#1968/#1969, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1+S2) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry), spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux), and spa_ws_auth_total{result} (S2 upgrade auth). #1970 (S3) adds spa_ws_push_total{op,result} (SpaWsRegistry change-source fan-out — now/connectionEvents/stale). The SPA has no ws client yet (S5), so until then these read 0/flat; trafficUsage (S4) + timeStatus/appUsage (S6a) join the push panel as those topics start pushing. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -388,6 +388,63 @@
           },
           "expr": "sum by (result) (rate(spa_ws_auth_total{env=\"$env\",result=~\"bad_origin|invalid_jwt\"}[5m]))",
           "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "SPA ws push fan-out health by op,result (#1970)",
+      "description": "sum by (op, result) (rate(spa_ws_push_total[5m])) — the change-source fan-out health (design §5.2/§6.3). op is the pushed topic: now|connectionEvents|stale ship in S3 (trafficUsage in S4, timeStatus|appUsage in S6a — they appear here as those topics start pushing). result ∈ {ok, coalesced, dropped, channel_closed}: ok dominates once the SPA ws client ships (S5); rising channel_closed/dropped is the slow-client/backpressure tripwire — a wedged browser whose mailbox overflowed or whose socket the server gave up on. coalesced is the latest-wins/coalesce-by-topic saving (a slow client served only the freshest now/stale). Until S5 there are no subscribers, so this reads 0/flat.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (op, result) (rate(spa_ws_push_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}} {{result}}",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
Closes #1970. Step **S3** of the SPA-websocket rollout (design [`docs/design/spa-websocket.md`](docs/design/spa-websocket.md) **§5.2**; umbrella #1955). Builds on S1 (#1968 registry/subscriptions) and S2 (#1990 cookie upgrade auth).

Wires the **change sources** — *consume existing write sites, no new polling/diffing loop* — and fans each change out as a **subscription-gated, role-filtered** server→SPA frame. Scoped tightly to S3's three ops: `now` / `connectionEvents` / `stale`.

## What's here

- **Widen `PolicySnapshotPublisher` to multi-subscriber (§5.2.1).** A synchronous `broadcast(List[PolicySnapshotPublisher])` combinator. **Behavior-preserving for the router subscriber** — its sink is invoked synchronously and unchanged, so the #1846/#1849 router push timing (reconcile fan-out, first-policy-on-connect) is untouched. `Main` installs `broadcast([routerSink, spaNowTrigger])`; the SPA side gets its **own** async `Hub` so the router path stays synchronous (a `Hub` on the router path would interpose an async fiber and change that timing — deliberately avoided).
- **`SpaEventBus` — a sliding `Hub[SpaEvent]` (§5.2.2)** fed by existing write sites, each a **one-line publish**: connection-events ingest → `ConnectionEventsIngested` + `NowChanged`; usage ingest → `NowChanged`; policy reevaluate → `NowChanged`; new-device alert → `Stale(alerts)`; profile/schedule/device mutation callbacks (`Main`) → `Stale(...)`. Sliding so a wedged consumer **never blocks or fails ingest**.
- **`SpaWsRegistry` fan-out** — `fanOut(now)`, `fanOutConnectionEvents` (filters the new head rows per connection's `/api/logs` params), `fanOutStale` — each gated on **both** subscription (§1.4) **and** role (§4.4 `visibleTo`).
- **`SpaPush` consumer** drains the bus and rebuilds bodies through **canonical builders**: `now` reuses the extracted `DashboardNowRoutes.computeNow` (**SSOT — one NOW implementation**, recomputed on change, not a second snapshot); `connectionEvents` re-reads the head via the **same** `connRepo.query` the GET uses and keeps only `ts ≥ since` (the genuinely-new rows, so a non-matching ingest pushes nothing).
- **Metrics + dashboard** — `spa_ws_push_total{op,result}` via `AppMetrics`/`MetricGuard.Allowed` (bounded enums only); `spa-ws.json` push-health panel `by (op,result)` targeting the series actually emitted (`now`/`connectionEvents`/`stale`).

`trafficUsage` (S4) and `timeStatus`/`appUsage` (S6a) are **out of scope** — the bus emits the triggers, but those handlers land later.

## Router path is unchanged
The router subscriber receives the full `PolicySnapshot` exactly as before (synchronous broadcast). Proven by: `RouterWsSpec` + `RouterWsAgentMetricsAllowlistSpec` + `RouterIngestSpec` stay green, plus a focused `SpaWsS3Spec` test asserting a router sink still gets the snapshot while the SPA sink additionally derives a `now` trigger.

## Tests (TDD — RED commit then GREEN)
`SpaWsS3Spec` drives the full chain (real Server + ws Client + forked `SpaPush` + **real** `RouterIngestService` over embedded Postgres, no mocks):
- `connectionEvents{blocked:true}` → frame on a blocked ingest; **nothing** on an allowed ingest; **nothing** to a non-subscriber
- `now` subscriber → recomputed `DashboardNow` on ingest
- `stale{profiles}` subscriber → nudge on the profile-mutation publish
- child role gate → `now` subscribe acked **reject**, no `now` frame ever pushed
- broadcast publisher → router sink still receives the snapshot + SPA `now` trigger derived

All green; `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)