### PR TITLE
feat(#1945): agent applies ws-pushed policy snapshots live (push→apply→enforce)

### DIFF
--- a/docs/design/websocket-transport.md
+++ b/docs/design/websocket-transport.md
@@ -191,6 +191,22 @@ The ETag stays the snapshot's identity, but the *transfer* inverts:
 The `etag` field and `PolicyService.computeEtag` are unchanged — they remain the
 change-detection key the server uses to decide *whether* to push (§6.2).
 
+> **Implementation note (#1945).** "The agent applies it" is split across the two
+> agent processes to keep a *single enforcement owner*. The `wifihaven-ws` sidecar
+> (the only ws process) merely **persists** a pushed `policy` frame to
+> `/etc/wifihaven/policy.json` via the atomic `policy.save_snapshot` (tmp→rename);
+> it never touches nft/dnsmasq. The **main agent** owns enforcement: an
+> apply-on-push tick in its `on_tick` loop re-reads that file on a short cadence
+> (`wifihaven.ws.apply_interval`, default 2 s) and runs it through the *same*
+> apply pipeline the HTTP poll uses (`refresh_blocklists` → `policy.apply` →
+> `render.update_shared`) **iff the on-disk `etag` differs** from the
+> currently-applied one. The `etag` is the single dedup key shared by the poll
+> and the push, so even while the poll still runs (it is deprecated separately in
+> [#1850](https://github.com/wifihaven/wifihaven/issues/1850)) a snapshot is
+> applied exactly once and there is no two-writer race on the enforcement plane.
+> Before #1945 the sidecar saved the file but nothing re-applied it mid-run, so a
+> push was a no-op for live enforcement until the next poll/restart.
+
 ---
 
 ## 2. Capability negotiation (re-examining #376)

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -122,6 +122,14 @@ end
 local ws_enabled        = uci_get_ws("enabled", "0")
 local ws_fallback_after = tonumber(uci_get_ws("fallback_after", "300"))
 local ws_spool_max      = tonumber(uci_get_ws("spool_max_bytes", "1048576"))
+-- #1945: apply-on-push cadence (seconds). When ws is enabled the sidecar writes
+-- pushed snapshots to /etc/wifihaven/policy.json (the IN channel); the running
+-- agent must APPLY them live, not only at startup. The on_tick loop re-reads the
+-- on-disk snapshot on this cadence and re-applies when its etag changed (a cheap
+-- read+compare otherwise). 2 s keeps push→enforce latency low while staying well
+-- above the cost of one snapshot parse (the HTTP poll already parses one every
+-- ~5 s in non-ws mode). No-op unless ws_enabled == "1".
+local ws_apply_int      = tonumber(uci_get_ws("apply_interval", "2"))
 
 log.init({ debug = debug_opt })
 -- #771: PKG_VERSION baked at install time into /usr/lib/wifihaven/VERSION.
@@ -681,6 +689,39 @@ do
   if f then f:write(block_page_url); f:close() end
 end
 
+-- ── Shared apply pipeline (#1945) ─────────────────────────────────────────────
+-- apply_and_publish(snap, reason) → applied:bool
+-- The single "push this snapshot onto the enforcement plane" sequence, factored
+-- out of on_tick so the HTTP-poll path, the blocklist-refresh path, AND the new
+-- ws apply-on-push path share ONE apply+publish block (single-source-of-truth)
+-- and so on_tick stays under the Lua 5.1 60-upvalue load limit (#1930): the heavy
+-- render / shared-table / metrics upvalues live HERE, not in the on_tick closure.
+--
+-- It does the enforcement-plane work only — capture-before-reset drop counters,
+-- policy.apply (dnsmasq conf + nft), then render.update_shared to rebuild the
+-- conntrack/usage-side per-MAC tables. It deliberately does NOT touch
+-- ts.current_etag / ts.last_snapshot / mark_poll_success / save_snapshot: those
+-- differ per trigger (the poll persists its fetch; the ws path must NOT re-save
+-- the file the sidecar already wrote), so each caller owns them. `reason` flows
+-- to record_apply for dnsmasq_restarts_total{reason}; the ws path reuses
+-- "policy_change" (it IS a policy change — no new bounded label is minted).
+local function apply_and_publish(snap, reason)
+  -- #1325: capture the about-to-reset enforcement-drop counters before apply
+  -- rebuilds the ruleset and zeroes them.
+  fold_enforcement_drops()
+  local at0 = clock.monotonic_seconds()
+  local applied = policy.apply(snap, write_file, run_cmd, log,
+                               { on_apply = record_apply(reason) })
+  metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                  clock.monotonic_seconds() - at0)
+  if applied then
+    render.update_shared(snap, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac,
+                         make_bl_member_iterator(snap))
+  end
+  return applied
+end
+
 -- ── Timer state ───────────────────────────────────────────────────────────────
 
 -- #1930: all mutable per-tick scheduler state lives in ONE table so the big
@@ -706,6 +747,7 @@ local ts = {
   last_metrics_run   = 0,
   last_blocklist_run  = 0,  -- #1412: category blocklist refresh cadence
   last_eb_refresh_run = 0,  -- #1658: eb_/bl_ ipset re-resolve cadence
+  last_ws_apply_run   = 0,  -- #1945: ws apply-on-push poll-of-disk cadence
   last_activity_sample = 0,
   last_nflog_run      = 0,  -- #1126: nflog drop-spool drain cadence
   -- Wall-clock anchor for usage report periodStart. Updated each time the usage
@@ -811,6 +853,7 @@ do
   ts.last_metrics_run       = mono
   ts.last_blocklist_run     = mono
   ts.last_eb_refresh_run    = mono
+  ts.last_ws_apply_run      = mono
   ts.last_activity_sample   = mono
   ts.last_nflog_run         = mono
 end
@@ -999,21 +1042,17 @@ conntrack.watch({
 
         -- Apply with no failover opts. If we were in failover, this
         -- apply already emits a clean ruleset (no failover chain), so we
-        -- just need to clear the flag below.
-        -- #1325: capture the enforcement-drop counters this apply is about to
-        -- reset (the ruleset is fully rebuilt) before they're discarded.
-        fold_enforcement_drops()
-        local at0 = clock.monotonic_seconds()
-        local applied = policy.apply(snap, write_file, run_cmd, log,
-                                     { on_apply = record_apply("policy_change") })
-        metrics.observe(mreg, "policy_apply_duration_seconds", {},
-                        clock.monotonic_seconds() - at0)
-        if applied then
-          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac, make_bl_member_iterator(snap))
+        -- just need to clear the flag below. #1945: the apply+publish block
+        -- (drop-counter capture, policy.apply, render.update_shared) is shared
+        -- with the ws apply-on-push path via apply_and_publish.
+        if apply_and_publish(snap, "policy_change") then
           ts.current_etag = etag
           ts.last_snapshot = snap
           policy.mark_poll_success(wall)
           policy.save_snapshot(snap, write_file, rename_file, log)
+          -- #1945: refresh the ws apply-on-push cadence anchor so the disk-read
+          -- tick doesn't immediately re-apply the snapshot this poll just wrote.
+          ts.last_ws_apply_run = mono
           log.debug("policy timer: applied snapshot etag=%s", tostring(etag))
           fetch_ok = true
         end
@@ -1079,6 +1118,43 @@ conntrack.watch({
       end
     end
 
+    -- ws apply-on-push timer (#1945). When the ws sidecar is enabled it writes
+    -- server-pushed snapshots to /etc/wifihaven/policy.json (the IN channel,
+    -- #1849); the running agent must APPLY them live, not just at startup. The
+    -- HTTP poll above stays the sole transport when ws is OFF, so this block is a
+    -- pure no-op then. When ON, re-read the on-disk snapshot on a short cadence
+    -- and, if its etag differs from the applied one, run it through the SAME
+    -- apply pipeline the poll uses (refresh_blocklists → apply_and_publish).
+    --
+    -- The etag is the single dedup key shared by both appliers: a snapshot the
+    -- poll just applied carries the etag we already hold, so this skips it (and
+    -- vice-versa) — so even with the poll still running there is no double-apply,
+    -- and the agent remains the SINGLE enforcement owner (the sidecar only
+    -- delivers + persists the file; it never touches nft/dnsmasq). We do NOT
+    -- save_snapshot here — the sidecar already wrote the file we just read. A
+    -- torn/missing read returns nil and is retried next tick; the atomic
+    -- tmp→rename the sidecar uses means a reader sees either the old or the new
+    -- complete file, never a partial one. Skipped while in failover (the
+    -- failover chain owns the plane until the poll recovers).
+    if ws_enabled == "1" and not ts.in_failover_render
+       and (mono - ts.last_ws_apply_run) >= ws_apply_int then
+      ts.last_ws_apply_run = mono
+      local pushed = policy.load_snapshot(read_file, log)
+      if pushed and pushed.etag and pushed.etag ~= ts.current_etag then
+        -- Populate category/extraBlocked shards before the apply, exactly as the
+        -- poll path does, so the rendered conf-file= directives resolve.
+        refresh_blocklists(pushed)
+        ts.last_blocklist_run = mono
+        if apply_and_publish(pushed, "policy_change") then
+          ts.current_etag  = pushed.etag
+          ts.last_snapshot = pushed
+          policy.mark_poll_success(wall)
+          log.info("ws apply: applied pushed snapshot etag=%s (poll-independent)",
+                   tostring(pushed.etag))
+        end
+      end
+    end
+
     -- Blocklist refresh timer (#1412). Category ipset population must NOT be
     -- coupled to a snapshot change: the policy poll returns 304 in steady state,
     -- so the only way the old code (re)fetched a blocklist was an admin policy
@@ -1119,16 +1195,8 @@ conntrack.watch({
         end
       end
       if changed then
-        fold_enforcement_drops()
-        local bt0 = clock.monotonic_seconds()
-        local applied = policy.apply(ts.last_snapshot, write_file, run_cmd, log,
-                                     { on_apply = record_apply("policy_change") })
-        metrics.observe(mreg, "policy_apply_duration_seconds", {},
-                        clock.monotonic_seconds() - bt0)
-        if applied then
-          render.update_shared(ts.last_snapshot, nft_sets, blocked_macs, blocked_reason,
-                               eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac,
-                               make_bl_member_iterator(ts.last_snapshot))
+        -- #1945: shared apply+publish block (see apply_and_publish).
+        if apply_and_publish(ts.last_snapshot, "policy_change") then
           log.info("blocklist timer: list version(s) changed, re-applied ruleset")
         end
       end

--- a/openwrt/files/usr/sbin/wifihaven-ws
+++ b/openwrt/files/usr/sbin/wifihaven-ws
@@ -149,13 +149,18 @@ local function split_usage(frame)
   return out
 end
 
--- Apply a pushed `policy` frame: write it to the snapshot file the main agent
--- reads/applies (etag-guarded apply unchanged). Dormant until the server pushes
--- on connect (#1849); wired here so #1849 is purely server-side.
+-- Persist a pushed `policy` frame: write it atomically to the snapshot file the
+-- main agent reads. The sidecar is the IN channel + the single PERSISTER; it
+-- never touches nft/dnsmasq. The running agent's apply-on-push tick (#1945)
+-- picks the file up on its next cadence and applies it etag-guarded — so the
+-- agent stays the single enforcement owner and there is no two-writer race on
+-- the plane. save_snapshot is tmp→rename atomic, so the agent's read sees the
+-- old or the new complete file, never a torn one.
 local function on_policy(snapshot)
   if type(snapshot) ~= "table" then return end
   policy.save_snapshot(snapshot, write_file, rename_file, log)
-  log.info("wifihaven-ws: applied pushed policy snapshot etag=%s", tostring(snapshot.etag))
+  log.info("wifihaven-ws: persisted pushed policy snapshot etag=%s (agent applies on next tick)",
+           tostring(snapshot.etag))
 end
 
 -- ── run the loop under a cqueues controller ──────────────────────────────────

--- a/scripts/e2e/scenarios_fake/test_ws_push_apply.py
+++ b/scripts/e2e/scenarios_fake/test_ws_push_apply.py
@@ -47,19 +47,32 @@ SNAPSHOT_PATH = "/etc/wifihaven/policy.json"
 WS_METRICS_PATH = "/tmp/wifihaven-ws-metrics.txt"
 WS_HEALTH_PATH = "/tmp/wifihaven-ws-health"
 
-# A phantom device MAC — no client VM is booted because this scenario asserts
-# router-side file/metric observables only (snapshot saved + frame received), not
-# client traffic enforcement.
+# A phantom device MAC — no client VM is booted because these scenarios assert
+# router-side file/metric/nft observables only (snapshot saved + frame received +
+# the @blocked_macs set membership), not client traffic enforcement.
 DEV_MAC = "02:e2:9c:00:19:39"
 PID = 1939
 ETAG_ON_CONNECT = '"sha256:ws-push-onconnect-v1"'
 ETAG_ON_CHANGE = '"sha256:ws-push-onchange-v2"'
+# #1945 — distinct etags for the live-apply scenario so its on-disk + nft proofs
+# can't be confused with the save-only scenario above.
+ETAG_ENFORCE_BASE = '"sha256:ws-push-enforce-base-v1"'
+ETAG_ENFORCE_PAUSED = '"sha256:ws-push-enforce-paused-v2"'
 
 
-def _snapshot(*, etag: str, extra_blocked: list[str]) -> dict:
+def _snapshot(*, etag: str, extra_blocked: list[str], paused: bool = False) -> dict:
     return (
         SnapshotBuilder()
-        .add_profile(id=PID, name="e2e-ws-push", extra_blocked=extra_blocked)
+        .add_profile(
+            id=PID,
+            name="e2e-ws-push",
+            # #1945: a paused profile collapses to BlockRules.blocked=true, which
+            # renders the device's MAC into the nft @blocked_macs set — a
+            # client-free enforcement observable the live-apply test asserts on.
+            blocked=paused,
+            block_reason="Paused" if paused else None,
+            extra_blocked=extra_blocked,
+        )
         .add_device(mac=DEV_MAC, name="e2e-ws-push-dev", profile_id=PID)
         .build(etag=etag)
     )
@@ -119,6 +132,15 @@ def _ws_health_present() -> bool:
     return (res.stdout or "").strip() == "yes"
 
 
+def _blocked_macs_set() -> str:
+    """Dump the inet wifihaven @blocked_macs nft set (empty string if absent)."""
+    res = router_ssh(
+        "nft list set inet wifihaven blocked_macs 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    return (res.stdout or "")
+
+
 def test_ws_policy_push_received_and_saved(router, fake_api):
     # The fake serves the on-connect snapshot before the sidecar upgrades.
     fake_api.serve_snapshot(
@@ -170,3 +192,56 @@ def test_ws_policy_push_received_and_saved(router, fake_api):
         timeout_s=60, interval_s=3,
         description="sidecar receives a second policy frame (push-on-change)",
     )
+
+
+def test_ws_policy_push_applies_enforcement_live(router, fake_api):
+    """#1945 — a ws-pushed snapshot is APPLIED live, not just saved.
+
+    The save-only test above proves the push reaches the agent and lands on
+    flash; this proves the running agent then re-applies it to the enforcement
+    plane (nft) WITHOUT an HTTP poll. With the poll frozen at 3600s, the only
+    thing that can move nft state mid-run is the agent's apply-on-push tick
+    reading the snapshot the sidecar wrote.
+
+    Observable: the device's MAC appears in the inet wifihaven @blocked_macs set.
+    That set is rendered directly from BlockRules.blocked (a paused profile),
+    needs no client traffic / DNS resolve / external egress, and so dodges the
+    intermittent runner→resolver flake (#1935). It flips ONLY if the agent
+    actually re-rendered + reloaded nft from the pushed snapshot.
+    """
+    # ── On-connect baseline — device assigned, NOT paused ───────────────────
+    fake_api.serve_snapshot(
+        _snapshot(etag=ETAG_ENFORCE_BASE, extra_blocked=["example.com"])
+    )
+    _enable_ws_and_freeze_poll()
+    fake_api.wait_for_ws_connected(timeout_s=180)
+
+    # The one startup poll applies the base snapshot; the device must NOT be in
+    # @blocked_macs yet (nothing is blocking it).
+    wait_until(
+        lambda: True if _router_snapshot_etag() == ETAG_ENFORCE_BASE else None,
+        timeout_s=90, interval_s=3,
+        description=f"base snapshot applied (etag {ETAG_ENFORCE_BASE})",
+    )
+    assert DEV_MAC not in _blocked_macs_set(), (
+        "device should not be in @blocked_macs at the un-paused baseline"
+    )
+
+    # ── Push a PAUSED snapshot — poll frozen, so push is the only delivery ───
+    push = fake_api.serve_snapshot(
+        _snapshot(etag=ETAG_ENFORCE_PAUSED, extra_blocked=["example.com"], paused=True)
+    )
+    assert push == ETAG_ENFORCE_PAUSED
+
+    # Enforcement flips from the push ALONE: the agent's apply-on-push tick reads
+    # the sidecar-written snapshot and re-renders nft, landing the MAC in
+    # @blocked_macs. Pre-#1945 (save-only) this never happens until the next poll
+    # — frozen here at 3600s — so the assertion is the live-apply proof.
+    wait_until(
+        lambda: True if DEV_MAC in _blocked_macs_set() else None,
+        timeout_s=120, interval_s=3,
+        description="nft @blocked_macs gains the MAC via the ws push with the "
+                    "poll frozen — live apply-on-push (#1945)",
+    )
+    # Sanity: the same push also advanced the on-disk snapshot etag.
+    assert _router_snapshot_etag() == ETAG_ENFORCE_PAUSED

--- a/scripts/e2e/scenarios_fake/test_ws_push_apply.py
+++ b/scripts/e2e/scenarios_fake/test_ws_push_apply.py
@@ -135,6 +135,28 @@ def _ws_health_present() -> bool:
     return (res.stdout or "").strip() == "yes"
 
 
+def _nudge_conntrack() -> None:
+    """Emit one LAN-side flow so the agent's conntrack-driven `on_tick` fires.
+
+    The agent's cooperative scheduler — the policy poll, usage/metrics timers,
+    and the #1945 apply-on-push tick — all run inside `conntrack.watch`'s loop,
+    which calls `on_tick` only after a blocking read returns a `conntrack -E NEW`
+    line (conntrack.lua). `conntrack -E -e NEW` is unfiltered, so ANY new flow —
+    including a router-originated one — drives a tick. This phantom-device
+    scenario boots no client VM, so nothing else reliably generates flows and
+    `on_tick` would be starved; a short HTTP GET to the API the agent already
+    reaches opens a fresh tracked connection → a NEW event → an `on_tick` pass,
+    exactly as a live network's traffic does continuously. The GET carries NO
+    policy (the HTTP poll stays frozen at 3600s, and a bare /healthz hit is not a
+    snapshot fetch), so the enforcement flip remains attributable to the ws push.
+    """
+    router_ssh(
+        'curl -s -m 3 -o /dev/null "$(uci get wifihaven.wifihaven.api_url)/healthz" '
+        "2>/dev/null || true",
+        check=False, timeout=10,
+    )
+
+
 def _paused_drop_rule_present(mac: str) -> bool:
     """True iff the live nft ruleset carries a whole-MAC *paused* forward-drop.
 
@@ -252,10 +274,15 @@ def test_ws_policy_push_applies_enforcement_live(router, fake_api):
     # the sidecar-written snapshot and re-renders nft, installing the per-MAC
     # `wh_drop:<mac>:Paused` forward-drop. Pre-#1945 (save-only) this never
     # happens until the next poll — frozen here at 3600s — so the assertion is
-    # the live-apply proof.
+    # the live-apply proof. Each poll iteration first nudges a flow so the
+    # agent's conntrack-driven `on_tick` (which the apply-on-push tick rides) runs.
+    def _nudged_drop_present() -> bool | None:
+        _nudge_conntrack()
+        return True if _paused_drop_rule_present(DEV_MAC) else None
+
     wait_until(
-        lambda: True if _paused_drop_rule_present(DEV_MAC) else None,
-        timeout_s=120, interval_s=3,
+        _nudged_drop_present,
+        timeout_s=180, interval_s=5,
         description="nft gains a wh_drop:<mac>:Paused forward-drop via the ws "
                     "push with the poll frozen — live apply-on-push (#1945)",
     )

--- a/scripts/e2e/scenarios_fake/test_ws_push_apply.py
+++ b/scripts/e2e/scenarios_fake/test_ws_push_apply.py
@@ -18,17 +18,20 @@ two legs of the push path end-to-end through the real agent:
     to the new value — and because the HTTP poll interval is widened to 3600s for
     this scenario, that flip can ONLY have arrived over the websocket, not a poll.
 
-SCOPE (per #1939 + the operator's "test-only, defer wiring" decision): this
-verifies the push *transport* reaches the real agent and the snapshot is
-*saved*. It deliberately does NOT assert a live enforcement flip from the push:
-the running agent applies policy only from its HTTP poll (the sidecar's on_policy
-saves the snapshot file but the agent never re-reads it mid-run), so a pushed
-snapshot does not change nft/dnsmasq state until the next poll or a restart.
-Wiring agent-side apply-on-push (and extending this scenario with an
-enforcement-flip assertion) is tracked in #1945.
-Asserting only local file/metric observables also keeps the scenario clear of the
-known intermittent runner→public-resolver egress flake (#1935) — no external
-reachability is probed.
+The save-only legs (#1939) prove the push *transport* reaches the real agent and
+the snapshot is *saved* to flash.
+
+#1945 adds a third test — `test_ws_policy_push_applies_enforcement_live` — that
+asserts a live *enforcement* flip from the push alone: with the poll frozen, a
+pushed paused snapshot installs a per-MAC `wh_drop:<mac>:Paused` forward-drop in
+nft, which only happens if the running agent re-reads + applies the snapshot the
+sidecar wrote (the apply-on-push tick). Before #1945 the sidecar saved the file
+but the agent applied policy only from its HTTP poll, so the snapshot never
+changed nft/dnsmasq until the next poll or a restart.
+
+All three tests assert only router-side file/metric/nft observables (no external
+reachability is probed), keeping the scenario clear of the known intermittent
+runner→public-resolver egress flake (#1935).
 """
 from __future__ import annotations
 
@@ -132,13 +135,25 @@ def _ws_health_present() -> bool:
     return (res.stdout or "").strip() == "yes"
 
 
-def _blocked_macs_set() -> str:
-    """Dump the inet wifihaven @blocked_macs nft set (empty string if absent)."""
+def _paused_drop_rule_present(mac: str) -> bool:
+    """True iff the live nft ruleset carries a whole-MAC *paused* forward-drop.
+
+    A paused profile collapses to BlockRules.blocked=true, which render.lua emits
+    as a per-MAC forward-drop labelled `wh_drop:<mac>:Paused`. We key on the
+    `:Paused` reason rather than the @blocked_macs set because a global allowlist
+    (the infra allow set is always present in real deployments, #1307/#1308)
+    routes blocked MACs to per-MAC rules carrying a `!= @global_allow` carve-out
+    instead of the family-agnostic @blocked_macs set — so the set can be empty
+    while the device is fully blocked. The `:Paused` drop is the unambiguous,
+    config-independent enforcement signal, and it is absent for an un-paused
+    device regardless of its extraBlocked/blocklist rules (those carry different
+    drop reasons).
+    """
     res = router_ssh(
-        "nft list set inet wifihaven blocked_macs 2>/dev/null || true",
+        f'nft list table inet wifihaven 2>/dev/null | grep -F "wh_drop:{mac}:Paused" || true',
         check=False, timeout=10,
     )
-    return (res.stdout or "")
+    return bool((res.stdout or "").strip())
 
 
 def test_ws_policy_push_received_and_saved(router, fake_api):
@@ -203,11 +218,11 @@ def test_ws_policy_push_applies_enforcement_live(router, fake_api):
     thing that can move nft state mid-run is the agent's apply-on-push tick
     reading the snapshot the sidecar wrote.
 
-    Observable: the device's MAC appears in the inet wifihaven @blocked_macs set.
-    That set is rendered directly from BlockRules.blocked (a paused profile),
-    needs no client traffic / DNS resolve / external egress, and so dodges the
-    intermittent runner→resolver flake (#1935). It flips ONLY if the agent
-    actually re-rendered + reloaded nft from the pushed snapshot.
+    Observable: a per-MAC `wh_drop:<mac>:Paused` forward-drop rule in the live
+    nft ruleset. It is rendered directly from BlockRules.blocked (a paused
+    profile), needs no client traffic / DNS resolve / external egress (so it
+    dodges the intermittent runner→resolver flake #1935), and flips ONLY if the
+    agent actually re-rendered + reloaded nft from the pushed snapshot.
     """
     # ── On-connect baseline — device assigned, NOT paused ───────────────────
     fake_api.serve_snapshot(
@@ -216,15 +231,15 @@ def test_ws_policy_push_applies_enforcement_live(router, fake_api):
     _enable_ws_and_freeze_poll()
     fake_api.wait_for_ws_connected(timeout_s=180)
 
-    # The one startup poll applies the base snapshot; the device must NOT be in
-    # @blocked_macs yet (nothing is blocking it).
+    # The one startup poll applies the base snapshot; the device must NOT carry a
+    # paused-drop yet (nothing is whole-MAC blocking it).
     wait_until(
         lambda: True if _router_snapshot_etag() == ETAG_ENFORCE_BASE else None,
         timeout_s=90, interval_s=3,
         description=f"base snapshot applied (etag {ETAG_ENFORCE_BASE})",
     )
-    assert DEV_MAC not in _blocked_macs_set(), (
-        "device should not be in @blocked_macs at the un-paused baseline"
+    assert not _paused_drop_rule_present(DEV_MAC), (
+        "device should carry no paused-drop rule at the un-paused baseline"
     )
 
     # ── Push a PAUSED snapshot — poll frozen, so push is the only delivery ───
@@ -234,14 +249,15 @@ def test_ws_policy_push_applies_enforcement_live(router, fake_api):
     assert push == ETAG_ENFORCE_PAUSED
 
     # Enforcement flips from the push ALONE: the agent's apply-on-push tick reads
-    # the sidecar-written snapshot and re-renders nft, landing the MAC in
-    # @blocked_macs. Pre-#1945 (save-only) this never happens until the next poll
-    # — frozen here at 3600s — so the assertion is the live-apply proof.
+    # the sidecar-written snapshot and re-renders nft, installing the per-MAC
+    # `wh_drop:<mac>:Paused` forward-drop. Pre-#1945 (save-only) this never
+    # happens until the next poll — frozen here at 3600s — so the assertion is
+    # the live-apply proof.
     wait_until(
-        lambda: True if DEV_MAC in _blocked_macs_set() else None,
+        lambda: True if _paused_drop_rule_present(DEV_MAC) else None,
         timeout_s=120, interval_s=3,
-        description="nft @blocked_macs gains the MAC via the ws push with the "
-                    "poll frozen — live apply-on-push (#1945)",
+        description="nft gains a wh_drop:<mac>:Paused forward-drop via the ws "
+                    "push with the poll frozen — live apply-on-push (#1945)",
     )
     # Sanity: the same push also advanced the on-disk snapshot etag.
     assert _router_snapshot_etag() == ETAG_ENFORCE_PAUSED


### PR DESCRIPTION
Closes #1945.

## Gap

The websocket push path was wired server→agent for **delivery** but not
**enforcement**. The `wifihaven-ws` sidecar's `on_policy` only called
`policy.save_snapshot` — it wrote the pushed snapshot to
`/etc/wifihaven/policy.json` but did **not** apply it. The running
`wifihaven-agent` reads that file only at startup; its tick loop applied policy
exclusively from the **HTTP poll**. So with `wifihaven.ws.enabled=1`, a pushed
`policy` frame updated the on-disk cache but enforcement (nft/dnsmasq) only
changed on the next poll or a restart — a no-op for live enforcement, and the
gating blocker for enabling the router↔API websocket in prod.

## Change

Add an **apply-on-push tick** to the agent's `on_tick` loop. When ws is enabled,
it re-reads the on-disk snapshot on a short cadence (`wifihaven.ws.apply_interval`,
default 2 s) and, **iff its `etag` differs** from the currently-applied one, runs
it through the **same** apply pipeline the poll uses
(`refresh_blocklists` → `policy.apply` → `render.update_shared`).

The shared apply+publish block is factored out of `on_tick` into
`apply_and_publish()` — reused by the poll-200, blocklist-refresh, and ws paths.
This is required by the **Lua 5.1 60-upvalue load limit** (#1930): inlining the
ws path would have pushed `on_tick` back over the limit. The refactor is a net
upvalue *reduction* for `on_tick`; verified by `loadfile` under real Lua 5.1.

### Architecture: single enforcement owner, no two-writer race
- The **sidecar** is the IN channel + sole **persister** (atomic `tmp→rename`);
  it never touches nft/dnsmasq.
- The **agent** is the sole **applier** of the enforcement plane.
- The **`etag`** is the one dedup key shared by the poll and the push, so a
  snapshot is applied **exactly once** even while the poll still runs (poll
  deprecation is #1850). The ws path does **not** re-save the file the sidecar
  wrote. A torn/missing read is retried next tick; atomic rename means the reader
  sees the old or the new complete file, never a partial one.
- `reason` for `dnsmasq_restarts_total{reason}` reuses the existing
  `policy_change` label — no new bounded label minted (no API allowlist /
  dashboard churn).

This follows AGENTS.md: the router stays a **dumb applier** — no decision logic
added; the ws path reuses the existing poll apply machinery verbatim.

## Tests

**Gate-2 e2e** (`scripts/e2e/scenarios_fake/test_ws_push_apply.py`) extended with
`test_ws_policy_push_applies_enforcement_live`: with the HTTP poll frozen at
3600 s, a pushed **paused** snapshot must install a per-MAC
`wh_drop:<mac>:Paused` forward-drop in nft — an observable that can only flip if
the running agent re-applied the pushed snapshot. Committed failing-first (red),
then green. Keyed on the `:Paused` drop rule rather than the `@blocked_macs` set
because a global allowlist (always present in real deployments, #1307/#1308)
routes blocked MACs to per-MAC rules carrying a `!= @global_allow` carve-out,
leaving `@blocked_macs` empty while the device is fully blocked.

## Real-hardware validation (mandatory — real Lua 5.1)

On **openwrt.lan** (Lua 5.1.5) pointed at the dev API (`api.lan:8080`), ws
enabled, poll frozen at 3600 s, snapshot pushed by simulating the sidecar's exact
atomic `save_snapshot` write (the router lacks `cqueues`, so the sidecar process
can't run there — but its only role in this path is that file write):

| step | on-disk etag | `wh_drop:<mac>:Paused` in nft |
|------|--------------|-------------------------------|
| startup (real dev-API policy) | sha256:56c2… | absent |
| push base (unpaused) | hwval-base-v1 | absent |
| **push paused** | hwval-paused-v2 | **PRESENT** |
| push base again (unpause) | hwval-base-v1 | absent |

Agent log per step: `ws apply: applied pushed snapshot etag=… (poll-independent)`.
The dev API never served the `hwval-*` etags, so the flip is attributable to the
ws push (on-disk read) **alone**. `on_tick` `loadfile`-compiles under real Lua 5.1
(60-upvalue limit satisfied). Router restored to its original state afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)