### PR TITLE
ci(#1995): make Gate 1 #1912 blockEncryptedDns smoke set/restore instead of asserting ambient default

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -91,6 +91,12 @@ pass "profile id=$PID name=$PROFILE_NAME"
 EXTRA_DEVICES=()
 EXTRA_PROFILES=()
 
+# Original household blockEncryptedDns, captured by the #1912 step before it
+# round-trips the singleton, so cleanup() can restore staging to as-we-found-it
+# regardless of the starting value (it is a shared, persistent DB — we must not
+# assume, or leave behind, a particular default). Empty until the step runs.
+BED_ORIG=""
+
 # Register cleanup so test data is removed even on failure.
 cleanup() {
   echo
@@ -104,6 +110,13 @@ cleanup() {
   for p in "${EXTRA_PROFILES[@]:-}"; do
     [ -n "$p" ] && curl -s -X DELETE "$BASE/api/profiles/$p" "${AUTH[@]}" >/dev/null 2>&1 || true
   done
+  # Restore the household blockEncryptedDns singleton to its pre-run value (#1912
+  # round-trips it). Skipped if the step never ran or it was already as-found.
+  if [ -n "$BED_ORIG" ]; then
+    curl -s -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
+      -H 'content-type: application/json' \
+      -d "{\"blockEncryptedDns\":$BED_ORIG}" >/dev/null 2>&1 || true
+  fi
   pass "test profile + device + router removed"
 }
 trap cleanup EXIT
@@ -1286,11 +1299,17 @@ pass "#932: /api/usage/series returns topHosts + buckets arrays"
 # as the additive top-level boolean `blockEncryptedDns` (sibling of global /
 # devices / profiles / blocklists). The router agent (#1911) bakes the curated
 # relay/DoH host + resolver-IP lists itself; the API only ships the boolean.
-# Assert: default is false, flipping the household setting flips the wire flag,
-# and we reset it so the run is idempotent against persistent staging.
+#
+# What "reflects the household setting" means is the *round-trip*: flipping the
+# household setting flips the wire flag, both ways. We deliberately do NOT assert
+# an ambient default here — blockEncryptedDns is a household SINGLETON in a
+# shared, persistent staging DB, so its starting value is whatever a prior run /
+# manual test left (#1995 — it was left `true` after #1919/#1921 testing). We
+# capture the starting value, drive it to both states explicitly, and restore it
+# in cleanup() so the run is idempotent regardless of where it started.
 step "#1912: blockEncryptedDns reflects the household setting"
 
-read_bed() {  # → "true"/"false" from a fresh /api/router/policy read
+read_bed() {  # → "true"/"false"/"MISSING" from a fresh /api/router/policy read
   curl -fsS "${RAUTH[@]}" "$BASE/api/router/policy" >"$TMP/snap_bed.json"
   _py "
 import json
@@ -1299,42 +1318,35 @@ print('true' if snap.get('blockEncryptedDns') is True else ('false' if snap.get(
 "
 }
 
-# Default (household setting untouched this run) must be a present, false bool —
-# never absent (the field is non-optional on the wire).
-BED0="$(read_bed)"
-[ "$BED0" = "false" ] || fail "#1912: expected default blockEncryptedDns=false, got: $BED0"
-pass "#1912: default blockEncryptedDns=false"
+# Set the household singleton and poll the wire until it reflects the new value
+# (staging Render rollover may briefly serve a stale instance — same pattern as
+# the TimeLimit step above). Args: <want true|false>.
+set_bed() {
+  local want="$1" got=""
+  curl -fsS -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
+    -H 'content-type: application/json' \
+    -d "{\"blockEncryptedDns\":$want}" >/dev/null
+  local deadline=$(( $(date +%s) + 15 ))
+  while (( $(date +%s) < deadline )); do
+    got="$(read_bed)"
+    [ "$got" = "$want" ] && return 0
+    sleep 1
+  done
+  fail "#1912: expected blockEncryptedDns=$want on the wire, got: $got"
+}
 
-curl -fsS -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
-  -H 'content-type: application/json' \
-  -d '{"blockEncryptedDns":true}' >/dev/null
-pass "#1912: household setting → blockEncryptedDns=true"
+# Capture the starting value first — it is a present, non-optional bool, never
+# absent — and stash it so cleanup() restores staging as-we-found-it.
+BED_ORIG="$(read_bed)"
+[ "$BED_ORIG" = "true" ] || [ "$BED_ORIG" = "false" ] \
+  || fail "#1912: blockEncryptedDns missing/non-bool on the wire, got: $BED_ORIG"
+pass "#1912: blockEncryptedDns present on the wire (starting value=$BED_ORIG)"
 
-# Poll (staging Render rollover may briefly serve a stale instance — same
-# pattern as the TimeLimit step above).
-BED1=""
-deadline=$(( $(date +%s) + 15 ))
-while (( $(date +%s) < deadline )); do
-  BED1="$(read_bed)"
-  [ "$BED1" = "true" ] && break
-  sleep 1
-done
-[ "$BED1" = "true" ] || fail "#1912: expected blockEncryptedDns=true after toggle, got: $BED1"
-pass "#1912: snapshot blockEncryptedDns=true after enabling"
-
-# Reset to false so persistent staging is left as we found it.
-curl -fsS -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
-  -H 'content-type: application/json' \
-  -d '{"blockEncryptedDns":false}' >/dev/null
-BED2=""
-deadline=$(( $(date +%s) + 15 ))
-while (( $(date +%s) < deadline )); do
-  BED2="$(read_bed)"
-  [ "$BED2" = "false" ] && break
-  sleep 1
-done
-[ "$BED2" = "false" ] || fail "#1912: expected blockEncryptedDns=false after reset, got: $BED2"
-pass "#1912: snapshot blockEncryptedDns=false after disabling"
+# Round-trip both ways — this is the actual contract under test.
+set_bed false
+pass "#1912: household setting → wire blockEncryptedDns=false"
+set_bed true
+pass "#1912: household setting → wire blockEncryptedDns=true"
 
 echo
 echo "All router e2e checks passed."

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -111,7 +111,8 @@ cleanup() {
     [ -n "$p" ] && curl -s -X DELETE "$BASE/api/profiles/$p" "${AUTH[@]}" >/dev/null 2>&1 || true
   done
   # Restore the household blockEncryptedDns singleton to its pre-run value (#1912
-  # round-trips it). Skipped if the step never ran or it was already as-found.
+  # round-trips it). Skipped only if the step never ran (BED_ORIG unset); when it
+  # ran we re-assert the captured value (an idempotent no-op if already as-found).
   if [ -n "$BED_ORIG" ]; then
     curl -s -X PATCH "$BASE/api/household/settings" "${AUTH[@]}" \
       -H 'content-type: application/json' \


### PR DESCRIPTION
Fixes #1995.

## Problem
Master API/UI CD **Gate 1** (API contract smoke against staging) fails at:
```
▶ #1912: blockEncryptedDns reflects the household setting
✗ #1912: expected default blockEncryptedDns=false, got: true
```
This was the last blocker to green CD — the staging OOM is fixed (#1992, staging now on Render standard), Gate 3b passes, no `oomKilled`; only this assertion failed once the OOM stopped masking the step (run 28256444289).

## Root cause
`blockEncryptedDns` is a **household-singleton** setting. The code default is `false` (`V61__household_block_encrypted_dns.sql`: `... DEFAULT FALSE`), but staging's household row persists `true` — left enabled during #1919/#1921 `blockEncryptedDns` testing. The `#1912` step in `scripts/e2e-router.sh` (Gate 1's staging smoke — *not* the `scenarios_fake` Gate-2 tests) asserted the **ambient default is `false`** before round-tripping. Asserting a default on a **mutable singleton in a shared, persistent staging DB** is inherently fragile and wrong.

## Fix (durable, test-isolation)
Make `#1912` self-contained — independent of the starting value:
- **Capture** the household's current `blockEncryptedDns` (assert only that it's a present bool — the field is non-optional on the wire).
- **Round-trip both ways** via PATCH → poll the wire: set `false` → assert `false`; set `true` → assert `true`. That round-trip is what "reflects the household setting" actually verifies.
- **Restore** the original value in `cleanup()` (same trap-fire pattern as the test profiles/devices/router), so the run is idempotent and leaves staging as-found.
- **Drop** the "expected default=false" precondition assertion entirely.

The PATCH/poll is factored into a small `set_bed <true|false>` helper. The existing `curl-retry.sh` override still wraps every call, so the new helper rides out transient staging 502s.

## Validation
- `bash -n scripts/e2e-router.sh` clean.
- Confirmed endpoint/JSON shape against `api/src/routes/Routes.scala`: `PATCH /api/household/settings` accepts `{"blockEncryptedDns": <bool>}`, and the flag surfaces top-level on `/api/router/policy`.
- `scripts/**` is on the `master-api-ui.yml` push-path filter and Gate 1 runs `scripts/e2e-router.sh`, so this change re-triggers Gate 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)