### PR TITLE
feat(#1971): SPA-ws S4 — trafficUsage aggregator (live-edge push of GET /api/usage/traffic)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -262,9 +262,11 @@ object Main extends ZIOAppDefault {
           spaEventBus,
           spaWsRegistry,
           trafficRepoForJ,
+          rollupRepo,
           connRepoForJobs,
           deviceRepoForJ,
           profileRepoForJ,
+          appRepoForSeed,
           stlRepoForJ,
           clockForJobs,
         )

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -87,8 +87,10 @@ final class RouterIngestService(
         _        <- handleUsage(router.id, ps, pe, records, settings)
         _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
         // #1970 (S3): newly-credited usage moves last_seen / per-device activity, so the dashboard
-        // NOW surface may have changed — trigger a `now` recompute (trafficUsage/timeStatus pushes
-        // are S4/S6a; this step only emits the event). One-liner, never fails ingest.
+        // NOW surface may have changed — trigger a `now` recompute. #1971 (S4): the same ingest is
+        // the `trafficUsage` write site — `UsageIngested` drives the live-edge head-bucket recompute
+        // for subscribed `(groupBy,bucket,filter)` param-sets (design §5.3). Both are one-liners that
+        // never block or fail ingest (sliding hub, UIO). timeStatus/appUsage pushes are S6a.
         _        <- ZIO.when(records.nonEmpty)(bus.publish(SpaEvent.NowChanged))
       } yield ()
     }

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -91,7 +91,9 @@ final class RouterIngestService(
         // the `trafficUsage` write site — `UsageIngested` drives the live-edge head-bucket recompute
         // for subscribed `(groupBy,bucket,filter)` param-sets (design §5.3). Both are one-liners that
         // never block or fail ingest (sliding hub, UIO). timeStatus/appUsage pushes are S6a.
-        _        <- ZIO.when(records.nonEmpty)(bus.publish(SpaEvent.NowChanged))
+        _        <- ZIO.when(records.nonEmpty)(
+          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested),
+        )
       } yield ()
     }
 

--- a/api/src/routes/SpaEvents.scala
+++ b/api/src/routes/SpaEvents.scala
@@ -25,11 +25,18 @@ import java.time.Instant
  *   - [[SpaEvent.Stale]] — a class-(3) occasionally-changing resource mutated; the consumer fans a
  *     contentless `{topic, scope?}` nudge to `stale` subscribers so they invalidate the mapped
  *     query (§3.2). Coalescing-friendly (idempotent).
+ *   - [[SpaEvent.UsageIngested]] — #1971 (S4): new `traffic_reports` rows landed. The consumer
+ *     re-runs the EXISTING `GET /api/usage/traffic` query (via `UsageTrafficQuery.aggregate`)
+ *     scoped to the current/most-recent bucket for each distinct subscribed `(groupBy, bucket,
+ *     filter)` param-set and pushes that one bucket as a `TrafficUsageResponse` live edge (design
+ *     §5.3). Contentless trigger — the head is recomputed from the DB, latest-wins (§6.3), and a
+ *     param-set with no subscriber is never queried.
  */
 enum SpaEvent {
   case NowChanged
   case ConnectionEventsIngested(since: Instant)
   case Stale(topic: StaleTopic, scope: Option[String] = None)
+  case UsageIngested
 }
 
 /**

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -292,7 +292,7 @@ object SpaPush {
         // carries exactly the current/most-recent bucket (one windowStart). On the rare tick where
         // `now` lands exactly on a bucket boundary the window is empty and the push is an empty head
         // (the client then merges nothing) — the next ingest advances it.
-        val resolvedMacs = resolveMacs(parsed, devices)
+        val resolvedMacs = UsageTrafficQuery.resolveMacs(parsed.macs, parsed.profileIds, devices)
         val filterEmpty  = parsed.filterRequested && resolvedMacs.isEmpty
         val aggregate    =
           if (filterEmpty) ZIO.succeed(List.empty)
@@ -324,21 +324,6 @@ object SpaPush {
           registry.fanOutTrafficUsage(params, body.toJsonAST.getOrElse(Json.Obj()))
         }
     }
-
-  /**
-   * Resolve the param-set's mac/profile filter to a device-mac set, mirroring the `GET` handler.
-   */
-  private def resolveMacs(
-      parsed: TrafficSubParamsResolved,
-      devices: List[Device],
-  ): List[MacAddress] =
-    if (parsed.macs.nonEmpty) {
-      val byMac = devices.filter(d => parsed.macs.contains(d.mac))
-      if (parsed.profileIds.isEmpty) byMac.map(_.mac)
-      else byMac.filter(d => d.profileId.exists(parsed.profileIds.contains)).map(_.mac)
-    } else if (parsed.profileIds.nonEmpty)
-      devices.filter(d => d.profileId.exists(parsed.profileIds.contains)).map(_.mac)
-    else devices.map(_.mac)
 
   /** Load the (host → app memberships) map for app grouping, exactly as `UsageRoutes` does. */
   private def loadAppsByHost(appRepo: AppRepo): Task[Map[String, List[AppMembership]]] =

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -2,19 +2,21 @@ package wifihaven.api.routes
 
 import wifihaven.api.db.*
 import wifihaven.api.observability.LogContext
-import wifihaven.shared.Clock
+import wifihaven.api.usage.{AppMembership, UsageTraffic, UsageTrafficQuery}
+import wifihaven.shared.{Clock, Device, TrafficUsageResponse}
+import wifihaven.shared.types.{MacAddress, ProfileId}
 import zio.{Clock as _, *}
 import zio.json.*
 import zio.json.ast.Json
 
-import java.time.{Duration, Instant}
+import java.time.{Duration, Instant, ZoneId}
 
 /**
- * #1970 (S3, SPA-websocket design `docs/design/spa-websocket.md` §5.2): the single consumer fiber
- * that drains the [[SpaEventBus]] and translates each [[SpaEvent]] into subscription-gated,
- * role-filtered server→SPA frames via [[SpaWsRegistry]]. This is the "translate" half of the change
- * sources — the write sites publish (one-liners), this fiber rebuilds the affected body through its
- * canonical builder and fans it out.
+ * #1970 (S3) / #1971 (S4), SPA-websocket design `docs/design/spa-websocket.md` §5.2/§5.3: the
+ * single consumer fiber that drains the [[SpaEventBus]] and translates each [[SpaEvent]] into
+ * subscription-gated, role-filtered server→SPA frames via [[SpaWsRegistry]]. This is the
+ * "translate" half of the change sources — the write sites publish (one-liners), this fiber
+ * rebuilds the affected body through its canonical builder and fans it out.
  *
  *   - [[SpaEvent.NowChanged]] → rebuild [[wifihaven.shared.DashboardNow]] ONCE via the shared
  *     [[DashboardNowRoutes.computeNow]] builder (SSOT — the same code `GET /api/dashboard/now`
@@ -27,6 +29,17 @@ import java.time.{Duration, Instant}
  *     the event's `since`), and let the registry append them to each `connectionEvents` subscriber
  *     whose filter matches.
  *   - [[SpaEvent.Stale]] → fan a contentless nudge to `stale` subscribers.
+ *   - [[SpaEvent.UsageIngested]] → #1971 (S4): for each DISTINCT subscribed `trafficUsage`
+ *     `(groupBy, bucket, filter)` param-set, recompute ONLY the current/most-recent bucket via the
+ *     shared [[UsageTrafficQuery.aggregate]] (the exact query the `GET /api/usage/traffic`
+ *     aggregated path runs — SSOT) scoped to the head window, and push that one bucket as a
+ *     `TrafficUsageResponse` live edge (design §5.3). No subscriber for a param-set → no query.
+ *
+ * Cadence / backpressure (design §6.3): the drain loop COALESCES — it takes the first buffered
+ * event then drains everything else currently queued and de-duplicates the contentless triggers
+ * ([[SpaEvent.NowChanged]] / [[SpaEvent.UsageIngested]]), so a burst of usage ingests collapses to
+ * a single freshest head-bucket recompute per param-set (latest-wins), never a backlog. A slow
+ * consumer thus serves the freshest state, not a queue of stale snapshots.
  *
  * The loop NEVER fails: each event's build is wrapped so a transient repo error is logged and
  * skipped (the push surface is a latency/UX layer, design §6.5 — a missed push self-heals on the
@@ -44,38 +57,87 @@ object SpaPush {
       bus: SpaEventBus,
       registry: SpaWsRegistry,
       trafficRepo: TrafficReportRepo,
+      rollupRepo: RollupRepo,
       connRepo: ConnectionEventRepo,
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
+      appRepo: AppRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
   ): ZIO[Scope, Nothing, Unit] =
     bus.subscribe.flatMap { queue =>
-      queue.take
-        .flatMap(
-          handle(
-            _,
-            registry,
-            trafficRepo,
-            connRepo,
-            deviceRepo,
-            profileRepo,
-            appTimeLimitRepo,
-            clock,
-          ),
-        )
-        .forever
-        .forkScoped
-        .unit
+      drainBatch(
+        queue,
+        registry,
+        trafficRepo,
+        rollupRepo,
+        connRepo,
+        deviceRepo,
+        profileRepo,
+        appRepo,
+        appTimeLimitRepo,
+        clock,
+      ).forever.forkScoped.unit
     }
+
+  /**
+   * Drain one coalesced batch: block for the first event, then sweep up everything else already
+   * buffered and de-dup the contentless triggers (design §6.3) so a burst of ingests does ONE
+   * recompute per topic, not N. `distinct` preserves first-occurrence order; the
+   * `ConnectionEventsIngested(since)` events keep their distinct `since` (their head re-read is
+   * cheap and the `since` floor matters), only the contentless `NowChanged`/`UsageIngested`
+   * collapse.
+   */
+  private def drainBatch(
+      queue: Dequeue[SpaEvent],
+      registry: SpaWsRegistry,
+      trafficRepo: TrafficReportRepo,
+      rollupRepo: RollupRepo,
+      connRepo: ConnectionEventRepo,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      appRepo: AppRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      clock: Clock,
+  ): UIO[Unit] =
+    for {
+      first <- queue.take
+      more  <- queue.takeAll
+      batch = coalesce(first +: more)
+      _ <- ZIO.foreachDiscard(batch)(
+        handle(
+          _,
+          registry,
+          trafficRepo,
+          rollupRepo,
+          connRepo,
+          deviceRepo,
+          profileRepo,
+          appRepo,
+          appTimeLimitRepo,
+          clock,
+        ),
+      )
+    } yield ()
+
+  /**
+   * Coalesce a drained batch (design §6.3 latest-wins): de-dup so the contentless triggers
+   * ([[SpaEvent.NowChanged]] / [[SpaEvent.UsageIngested]]) each fire ONE recompute regardless of
+   * burst size, while distinctly-`since`d [[SpaEvent.ConnectionEventsIngested]] are kept (each
+   * names a different new-row floor). `distinct` preserves first-occurrence order. Exposed for unit
+   * coverage of the collapse logic.
+   */
+  private[api] def coalesce(events: Chunk[SpaEvent]): Chunk[SpaEvent] = events.distinct
 
   private def handle(
       event: SpaEvent,
       registry: SpaWsRegistry,
       trafficRepo: TrafficReportRepo,
+      rollupRepo: RollupRepo,
       connRepo: ConnectionEventRepo,
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
+      appRepo: AppRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
   ): UIO[Unit] =
@@ -89,6 +151,19 @@ object SpaPush {
       case SpaEvent.Stale(topic, scope)             =>
         LogContext.annotate(LogContext.Op, "stale") {
           registry.fanOutStale(topic, scope)
+        }
+      case SpaEvent.UsageIngested                   =>
+        LogContext.annotate(LogContext.Op, "trafficUsage") {
+          pushTrafficUsage(
+            registry,
+            trafficRepo,
+            rollupRepo,
+            deviceRepo,
+            profileRepo,
+            appRepo,
+            clock,
+          )
+            .catchAllCause(c => ZIO.logErrorCause("spa ws push: trafficUsage recompute failed", c))
         }
     }
 
@@ -140,6 +215,145 @@ object SpaPush {
       _ <- ZIO.when(fresh.nonEmpty)(registry.fanOutConnectionEvents(fresh))
     } yield ()
 
+  /**
+   * #1971 (S4): the `trafficUsage` live-edge aggregator (design §5.3). For each DISTINCT subscribed
+   * param-set, recompute ONLY the current/most-recent bucket via the shared
+   * [[UsageTrafficQuery.aggregate]] (the same query the `GET` runs) scoped to the head window, and
+   * push it as a `TrafficUsageResponse`. The device/profile maps are loaded ONCE and shared across
+   * param-sets; app memberships are loaded only when some param-set groups by app. No subscriber →
+   * empty param-set → nothing computed.
+   */
+  private def pushTrafficUsage(
+      registry: SpaWsRegistry,
+      trafficRepo: TrafficReportRepo,
+      rollupRepo: RollupRepo,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      appRepo: AppRepo,
+      clock: Clock,
+  ): Task[Unit] =
+    registry.trafficUsageParamSets.flatMap { paramSets =>
+      ZIO
+        .when(paramSets.nonEmpty) {
+          for {
+            now      <- clock.instant
+            devices  <- deviceRepo.listAll
+            profiles <- profileRepo.listAll
+            devByMac  = devices.iterator.map(d => d.mac -> d).toMap
+            profNames = profiles.iterator.map(p => p.id -> p.name).toMap
+            // App memberships are only needed if some subscribed param-set groups by app; load once.
+            wantsApp  = paramSets.exists(p =>
+              decodeParams(p).exists(_.groupBySet.contains(UsageTraffic.GroupBy.App)),
+            )
+            appsByHost <-
+              if (wantsApp) loadAppsByHost(appRepo)
+              else ZIO.succeed(Map.empty[String, List[AppMembership]])
+            _          <- ZIO.foreachDiscard(paramSets.toList)(p =>
+              pushOneParamSet(
+                p,
+                registry,
+                trafficRepo,
+                rollupRepo,
+                devices,
+                devByMac,
+                profNames,
+                appsByHost,
+                now,
+              ),
+            )
+          } yield ()
+        }
+        .unit
+    }
+
+  /**
+   * Compute + push the head bucket for ONE param-set. A param-set whose `groupBy`/`bucket` can't be
+   * parsed (or names `apex`, which the read model can't render yet) is skipped — a real subscriber
+   * never sends one. A non-empty mac/profile filter that resolves to zero visible devices pushes an
+   * empty head (never widens to the whole household — `macs = Nil` would mean "all" at the repo).
+   */
+  private def pushOneParamSet(
+      params: Json,
+      registry: SpaWsRegistry,
+      trafficRepo: TrafficReportRepo,
+      rollupRepo: RollupRepo,
+      devices: List[Device],
+      devByMac: Map[MacAddress, Device],
+      profNames: Map[ProfileId, String],
+      appsByHost: Map[String, List[AppMembership]],
+      now: Instant,
+  ): Task[Unit] =
+    decodeParams(params) match {
+      case None         =>
+        ZIO.logDebug(s"spa ws push: skipping unrenderable trafficUsage params ${params.toJson}")
+      case Some(parsed) =>
+        val headStart    = UsageTraffic.floorTo(now, parsed.bucket, parsed.zone)
+        // The head window is [headStart, now): all rows in it floor to `headStart`, so the aggregate
+        // carries exactly the current/most-recent bucket (one windowStart). On the rare tick where
+        // `now` lands exactly on a bucket boundary the window is empty and the push is an empty head
+        // (the client then merges nothing) — the next ingest advances it.
+        val resolvedMacs = resolveMacs(parsed, devices)
+        val filterEmpty  = parsed.filterRequested && resolvedMacs.isEmpty
+        val aggregate    =
+          if (filterEmpty) ZIO.succeed(List.empty)
+          else
+            UsageTrafficQuery.aggregate(
+              trafficRepo,
+              rollupRepo,
+              resolvedMacs,
+              headStart,
+              now,
+              parsed.bucket,
+              parsed.groupBySet,
+              parsed.zone,
+              devByMac,
+              profNames,
+              appsByHost,
+            )
+        aggregate.flatMap { rows =>
+          val body = TrafficUsageResponse(
+            bucket = parsed.bucket.code,
+            groupBy = parsed.groupBySet.toList.map(_.code).sorted,
+            from = headStart.toString,
+            to = now.toString,
+            tz = parsed.zone.getId,
+            rawRows = Nil,
+            aggregateRows = rows,
+            nextCursor = None,
+          )
+          registry.fanOutTrafficUsage(params, body.toJsonAST.getOrElse(Json.Obj()))
+        }
+    }
+
+  /**
+   * Resolve the param-set's mac/profile filter to a device-mac set, mirroring the `GET` handler.
+   */
+  private def resolveMacs(
+      parsed: TrafficSubParamsResolved,
+      devices: List[Device],
+  ): List[MacAddress] =
+    if (parsed.macs.nonEmpty) {
+      val byMac = devices.filter(d => parsed.macs.contains(d.mac))
+      if (parsed.profileIds.isEmpty) byMac.map(_.mac)
+      else byMac.filter(d => d.profileId.exists(parsed.profileIds.contains)).map(_.mac)
+    } else if (parsed.profileIds.nonEmpty)
+      devices.filter(d => d.profileId.exists(parsed.profileIds.contains)).map(_.mac)
+    else devices.map(_.mac)
+
+  /** Load the (host → app memberships) map for app grouping, exactly as `UsageRoutes` does. */
+  private def loadAppsByHost(appRepo: AppRepo): Task[Map[String, List[AppMembership]]] =
+    for {
+      apps <- appRepo.listAll
+      byId = apps.iterator.map(a => a.id -> a).toMap
+      mappings <- appRepo.listAllHostMappings
+    } yield mappings
+      .flatMap(m =>
+        byId
+          .get(m.appId)
+          .map(a => m.host.value -> AppMembership(a.slug, a.name, a.icon, Some(a.id))),
+      )
+      .groupMap(_._1)(_._2)
+
   // True iff the `/api/logs` row timestamp is at/after `since` (the genuinely-new edge). The row ts
   // is always ISO-8601 UTC ("…Z", ConnectionEventRepo `to_char(... 'Z')`), so a parse never fails in
   // practice; on the impossible malformed case KEEP the row rather than silently drop a real new one.
@@ -149,4 +363,56 @@ object SpaPush {
   // Head-row cap per connectionEvents push. Matches the `/api/logs` default page; the client dedups
   // by id and the feed is "recent" anyway, so the newest 200 is plenty for the live edge (§3.1).
   private val ConnEventHeadLimit = 200
+
+  /**
+   * #1971 (S4): the decoded `trafficUsage` subscription params — the verbatim `GET
+   * /api/usage/traffic` query params (§1.4 / §0.3). All optional; unknown fields ignored
+   * (forward-compat). `groupBy` is a list of breakdown columns (empty = overall household);
+   * `bucket` is the averaging window (defaults to `1m`, the aggregated floor, design §1.3); `tz`
+   * defaults to UTC like the GET.
+   */
+  private final case class TrafficSubParams(
+      groupBy: List[String] = Nil,
+      bucket: Option[String] = None,
+      macs: Option[List[String]] = None,
+      profileIds: Option[List[ProfileId]] = None,
+      tz: Option[String] = None,
+  ) derives JsonDecoder
+
+  /** A fully-resolved, renderable param-set (parse failures are dropped upstream). */
+  private final case class TrafficSubParamsResolved(
+      bucket: UsageTraffic.Bucket,
+      groupBySet: Set[UsageTraffic.GroupBy],
+      macs: List[MacAddress],
+      profileIds: List[ProfileId],
+      zone: ZoneId,
+      filterRequested: Boolean,
+  )
+
+  /**
+   * Decode + validate a `trafficUsage` param blob into a renderable shape, or `None` if it names a
+   * bucket/groupBy the read model can't render (`apex`, or any unparseable value) — those never
+   * come from a real subscriber, so skipping is correct (the `GET` would 400 them).
+   */
+  private def decodeParams(params: Json): Option[TrafficSubParamsResolved] =
+    params.toJson.fromJson[TrafficSubParams].toOption.flatMap { p =>
+      val groupByParsed = p.groupBy.map(UsageTraffic.GroupBy.parse)
+      for {
+        bucket  <- UsageTraffic.Bucket.parse(p.bucket.getOrElse("1m"))
+        groupBy <- if (groupByParsed.contains(None)) None else Some(groupByParsed.flatten.toSet)
+        if !groupBy.contains(UsageTraffic.GroupBy.Apex)
+        zone    <- p.tz.fold(Option(ZoneId.of("UTC")))(s => scala.util.Try(ZoneId.of(s)).toOption)
+      } yield {
+        val macAddrs = p.macs.getOrElse(Nil).map(s => MacAddress.unsafe(normalizeMac(s)))
+        val pids     = p.profileIds.getOrElse(Nil)
+        TrafficSubParamsResolved(
+          bucket = bucket,
+          groupBySet = groupBy,
+          macs = macAddrs,
+          profileIds = pids,
+          zone = zone,
+          filterRequested = macAddrs.nonEmpty || pids.nonEmpty,
+        )
+      }
+    }
 }

--- a/api/src/routes/SpaWsRegistry.scala
+++ b/api/src/routes/SpaWsRegistry.scala
@@ -154,6 +154,27 @@ trait SpaWsRegistry {
    * `spa_ws_push_total{op="stale", ...}`.
    */
   def fanOutStale(topic: StaleTopic, scope: Option[String]): UIO[Unit]
+
+  /**
+   * #1971 (S4): the DISTINCT `trafficUsage` subscription param-sets across every connection that
+   * BOTH subscribed to `TrafficUsage` AND whose role may see it (§4.4 — `SpaTopic.visibleTo`). The
+   * [[SpaPush]] aggregator recomputes the head bucket ONCE per distinct param-set (design §5.3); an
+   * empty result means no subscriber, so no query runs ("don't compute what nobody watches"). The
+   * params are the verbatim `GET /api/usage/traffic` query params (§1.4 / §0.3), opaque here.
+   */
+  def trafficUsageParamSets: UIO[Set[Json]]
+
+  /**
+   * #1971 (S4): push the live-edge `TrafficUsageResponse` computed for `params` to every connection
+   * whose `TrafficUsage` subscription params EQUAL `params` and whose role may see it (§4.4). The
+   * body is built ONCE by the caller ([[SpaPush]], via the shared `UsageTrafficQuery.aggregate` —
+   * the same query the `GET` runs, so the stream and the page can't disagree); `TrafficUsage` is
+   * visible only to admin/adult (full-visibility roles, exactly as the GET treats them), so one
+   * body is correct for every recipient and the role gate is the per-role filter — mirroring
+   * [[fanOut]] for `now`. Latest-wins per param-set (design §6.3): a re-push carries the freshest
+   * head, never a backlog. Metered per send like [[fanOut]].
+   */
+  def fanOutTrafficUsage(params: Json, payload: Json): UIO[Unit]
 }
 
 object SpaWsRegistry {
@@ -264,6 +285,30 @@ final class SpaWsRegistryLive(
               sendPush(id, s.channel, op, frameText(op, matched.toJson)),
             )
         }
+      }
+    }
+
+  def trafficUsageParamSets: UIO[Set[Json]] =
+    state.get.map(
+      _.values.iterator
+        .collect {
+          case s
+              if s.subscriptions.contains(SpaTopic.TrafficUsage) &&
+                SpaTopic.visibleTo(SpaTopic.TrafficUsage, s.role) =>
+            s.subscriptions(SpaTopic.TrafficUsage)
+        }
+        .toSet,
+    )
+
+  def fanOutTrafficUsage(params: Json, payload: Json): UIO[Unit] =
+    state.get.flatMap { m =>
+      val op    = SpaTopic.wire(SpaTopic.TrafficUsage)
+      val frame = frameText(op, payload.toJson)
+      ZIO.foreachDiscard(m.toList) { case (id, s) =>
+        ZIO.when(
+          s.subscriptions.get(SpaTopic.TrafficUsage).contains(params) &&
+            SpaTopic.visibleTo(SpaTopic.TrafficUsage, s.role),
+        )(sendPush(id, s.channel, op, frame))
       }
     }
 

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -9,6 +9,7 @@ import wifihaven.api.usage.{
   RetentionSweepJob,
   UsageSeries,
   UsageTraffic,
+  UsageTrafficQuery,
 }
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -1021,6 +1022,11 @@ object UsageRoutes {
       // When both lists are non-empty, intersect: devices that match any
       // selected mac AND belong to any selected profile.
       allDevices <- deviceRepo.listAll.mapError(ApiError.Db(_))
+      // #1971: the device-set RESULT is computed by the shared
+      // `UsageTrafficQuery.resolveMacs` (one source, also used by the S4 live-edge stream so the two
+      // can't drift on filter semantics). This handler keeps the HTTP-only guards around it: a
+      // requested mac that doesn't exist is a 404, the selected profiles must pass
+      // `requireProfileReadAccess`, and the no-filter ("all devices") set is admin/adult-only.
       macs       <- (macsRaw, profileIds) match {
         case (ms, _) if ms.nonEmpty     =>
           for {
@@ -1031,21 +1037,16 @@ object UsageRoutes {
             }
             _    <- ZIO.foreach(devs.flatMap(_.profileId).distinct) { pid =>
               requireProfileReadAccess(claims, Some(pid), userProfileRepo)
-
             }
-          } yield
-            if (profileIds.isEmpty) devs.map(_.mac)
-            else devs.filter(d => d.profileId.exists(profileIds.contains)).map(_.mac)
+          } yield UsageTrafficQuery.resolveMacs(ms, profileIds, allDevices)
         case (_, pids) if pids.nonEmpty =>
-          for {
-            _ <- ZIO.foreach(pids)(pid =>
-              requireProfileReadAccess(claims, Some(pid), userProfileRepo),
-            )
-          } yield allDevices.filter(d => d.profileId.exists(pids.contains)).map(_.mac)
+          ZIO
+            .foreach(pids)(pid => requireProfileReadAccess(claims, Some(pid), userProfileRepo))
+            .as(UsageTrafficQuery.resolveMacs(Nil, pids, allDevices))
         case _                          =>
           // No filter: admin/adult only. Children must scope to their profile.
           if (claims.role == "admin" || claims.role == "adult")
-            ZIO.succeed(allDevices.map(_.mac))
+            ZIO.succeed(UsageTrafficQuery.resolveMacs(Nil, Nil, allDevices))
           else
             ZIO.fail(
               ApiError.Forbidden("mac or profileId required for non-admin"),
@@ -1149,7 +1150,7 @@ object UsageRoutes {
               if (macs.isEmpty && (macsRaw.nonEmpty || profileIds.nonEmpty))
                 ZIO.succeed(List.empty[TrafficUsageAggregateRow])
               else
-                wifihaven.api.usage.UsageTrafficQuery
+                UsageTrafficQuery
                   .aggregate(
                     trafficRepo,
                     rollupRepo,

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -2,7 +2,6 @@ package wifihaven.api.routes
 
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
-import wifihaven.api.db.{RollupRepo, RollupRow}
 import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.usage.{
   AppMembership,
@@ -932,43 +931,9 @@ object UsageRoutes {
   //     so the read touches ~50 rows per host instead of millions.
   // Examples: bucket=10m over 30d → raw (fine, paginated); bucket=1h over a 2h
   // window → raw (fresh); bucket=1d over 90d → daily rollup (cheap).
-  private enum SourceTier {
-    case Raw, Hourly, Daily
-  }
-
-  private def grainToTier(g: BucketGrain): SourceTier = g match {
-    case BucketGrain.Raw    => SourceTier.Raw
-    case BucketGrain.Hourly => SourceTier.Hourly
-    case BucketGrain.Daily  => SourceTier.Daily
-  }
-
-  private def pickTier(b: UsageTraffic.Bucket, window: java.time.Duration): SourceTier = {
-    // Cap: coarsest grain that can render the bucket without losing resolution.
-    // Pref: coarseness the window justifies on cost grounds — never coarsens
-    // the bucket itself. Finer of (cap, pref) wins. Both inputs and the rank
-    // ordering live in `wifihaven.shared.BucketPolicy` so this picker and
-    // `LogRoutes.seriesGrain` can't drift on the thresholds (#1744).
-    val cap  = BucketPolicy.grainForBucket(b.code)
-    val pref = BucketPolicy.windowGrain(window.toHours)
-    grainToTier(if (BucketPolicy.rank(pref) <= BucketPolicy.rank(cap)) pref else cap)
-  }
-
-  // Convert rollup rows back into the shape buildAggregate consumes. The
-  // hostname is already post-resolved by the rollup writer, so no extra
-  // LATERAL join is needed at read time — this is the whole point of the
-  // rollup tables.
-  private def asDbRows(rows: List[RollupRow]): List[wifihaven.api.usage.TrafficUsageDbRow] =
-    rows.map { r =>
-      wifihaven.api.usage.TrafficUsageDbRow(
-        mac = r.mac,
-        host = r.host,
-        periodStart = r.bucketStart,
-        periodEnd = r.bucketEnd,
-        activeSeconds = r.activeSeconds,
-        bytesIn = r.bytesIn,
-        bytesOut = r.bytesOut,
-      )
-    }
+  // #1971: the tier picker + fetch + aggregate now live in
+  // `wifihaven.api.usage.UsageTrafficQuery.aggregate`, shared verbatim with the
+  // S4 `trafficUsage` live-edge stream so the two can't drift (SSOT).
 
   private def trafficHandler(
       req: Request,
@@ -1175,29 +1140,30 @@ object UsageRoutes {
           // Aggregated path: source table = finer of (bucket cap, window cost
           // preference) (#1262). The requested bucket is always honored; the
           // range can only steer the read toward finer/fresher data, never
-          // coarsen the bucket.
-          val tier = pickTier(bucket, Duration.between(fromI, toI))
+          // coarsen the bucket. #1971: the fetch+tier+aggregate core is
+          // `UsageTrafficQuery.aggregate`, shared verbatim with the S4
+          // `trafficUsage` live-edge stream (SSOT — the stream and this GET
+          // can't disagree). The keyset cursor paging stays here on top.
           for {
-            rows      <-
+            allAgg    <-
               if (macs.isEmpty && (macsRaw.nonEmpty || profileIds.nonEmpty))
-                ZIO.succeed(List.empty[wifihaven.api.usage.TrafficUsageDbRow])
+                ZIO.succeed(List.empty[TrafficUsageAggregateRow])
               else
-                tier match {
-                  case SourceTier.Raw    =>
-                    trafficRepo
-                      .listRawInRange(macs, fromI, toI)
-                      .mapError(ApiError.Db(_))
-                  case SourceTier.Hourly =>
-                    rollupRepo
-                      .listHourlyInRange(macs, fromI, toI)
-                      .map(asDbRows)
-                      .mapError(ApiError.Db(_))
-                  case SourceTier.Daily  =>
-                    rollupRepo
-                      .listDailyInRange(macs, fromI, toI)
-                      .map(asDbRows)
-                      .mapError(ApiError.Db(_))
-                }
+                wifihaven.api.usage.UsageTrafficQuery
+                  .aggregate(
+                    trafficRepo,
+                    rollupRepo,
+                    macs,
+                    fromI,
+                    toI,
+                    bucket,
+                    effectiveGroupBy,
+                    zone,
+                    devByMac,
+                    profNames,
+                    appsByHost,
+                  )
+                  .mapError(ApiError.Db(_))
             cursorOpt <- req.url.queryParam("cursor") match {
               case None    => ZIO.succeed(Option.empty[wifihaven.api.db.Cursor.AggCursor])
               case Some(s) =>
@@ -1207,18 +1173,8 @@ object UsageRoutes {
                   )
                   .mapBoth(ApiError.BadRequest(_), Some(_))
             }
-            allAgg = UsageTraffic
-              .buildAggregate(
-                rows,
-                bucket,
-                zone,
-                effectiveGroupBy,
-                devByMac,
-                profNames,
-                appsByHost,
-              )
-            keyOf  = (r: TrafficUsageAggregateRow) => UsageTraffic.aggGroupKey(r, effectiveGroupBy)
-            sorted = allAgg.sortBy(r =>
+            keyOf = (r: TrafficUsageAggregateRow) => UsageTraffic.aggGroupKey(r, effectiveGroupBy)
+            sorted   = allAgg.sortBy(r =>
               (-java.time.Instant.parse(r.windowStart).toEpochMilli, keyOf(r)),
             )
             filtered = cursorOpt match {

--- a/api/src/usage/UsageTrafficQuery.scala
+++ b/api/src/usage/UsageTrafficQuery.scala
@@ -63,6 +63,29 @@ object UsageTrafficQuery {
     }
 
   /**
+   * Resolve a `(macs, profileIds)` filter to the device-mac set it selects, given the household's
+   * devices. The single source of truth for "which devices does this traffic filter cover" — shared
+   * by the `GET /api/usage/traffic` handler (which wraps it with per-mac `NotFound` + per-profile
+   * `requireProfileReadAccess` auth) and the S4 `trafficUsage` live-edge aggregator (whose authz is
+   * the upstream `visibleTo` role gate), so the two can't drift on the filter semantics. Pure:
+   *   - `macs` non-empty → those devices, further narrowed to `profileIds` if also given;
+   *   - else `profileIds` non-empty → devices in those profiles;
+   *   - else → all devices (the "no filter" set; callers gate who may request it).
+   */
+  def resolveMacs(
+      macs: List[MacAddress],
+      profileIds: List[ProfileId],
+      devices: List[Device],
+  ): List[MacAddress] =
+    if (macs.nonEmpty) {
+      val byMac = devices.filter(d => macs.contains(d.mac))
+      if (profileIds.isEmpty) byMac.map(_.mac)
+      else byMac.filter(d => d.profileId.exists(profileIds.contains)).map(_.mac)
+    } else if (profileIds.nonEmpty)
+      devices.filter(d => d.profileId.exists(profileIds.contains)).map(_.mac)
+    else devices.map(_.mac)
+
+  /**
    * Fetch raw / rollup rows for `macs` over `[from, to)` at the tier the bucket+window selects,
    * then aggregate into `TrafficUsageAggregateRow`s (one per (window, grouped-column-values)).
    * `macs = Nil` means "all macs" at the repo level — callers that resolved a NON-EMPTY filter down

--- a/api/src/usage/UsageTrafficQuery.scala
+++ b/api/src/usage/UsageTrafficQuery.scala
@@ -1,0 +1,104 @@
+package wifihaven.api.usage
+
+import wifihaven.api.db.{RollupRepo, RollupRow, TrafficReportRepo}
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.*
+
+import java.time.{Duration, Instant, ZoneId}
+
+/**
+ * #1971 (S4, SPA-websocket design `docs/design/spa-websocket.md` §5.3): the ONE fetch+aggregate
+ * core shared by the `GET /api/usage/traffic` aggregated path
+ * ([[wifihaven.api.routes.UsageRoutes]]) and the live-edge `trafficUsage` aggregator
+ * ([[wifihaven.api.routes.SpaPush]]). Both call [[aggregate]] so the streamed live-edge bucket and
+ * the page's `GET` body are produced by the SAME query+rollup tiering+aggregation — they can never
+ * disagree (`AGENTS.md#single-source-of- truth`; design §0.3 "zero new read-model shapes"). The S4
+ * stream is the existing query re-run scoped to the head window, not a parallel read model.
+ *
+ * This object owns the source-tier routing (#813/#1262) that decides which physical table backs a
+ * read — formerly private in `UsageRoutes`, lifted here so it isn't copied. The picker never
+ * coarsens the requested bucket; the window only steers toward a finer/cheaper source.
+ */
+object UsageTrafficQuery {
+
+  /**
+   * Which physical table backs an aggregated read. The requested bucket is always honored at its
+   * width; the source is the finer of (the bucket's correctness cap, the window's cost preference).
+   */
+  private enum SourceTier {
+    case Raw, Hourly, Daily
+  }
+
+  private def grainToTier(g: BucketGrain): SourceTier = g match {
+    case BucketGrain.Raw    => SourceTier.Raw
+    case BucketGrain.Hourly => SourceTier.Hourly
+    case BucketGrain.Daily  => SourceTier.Daily
+  }
+
+  private def pickTier(b: UsageTraffic.Bucket, window: Duration): SourceTier = {
+    // Cap: coarsest grain that can render the bucket without losing resolution. Pref: coarseness the
+    // window justifies on cost grounds — never coarsens the bucket itself. Finer of (cap, pref)
+    // wins. Both inputs and the rank ordering live in `wifihaven.shared.BucketPolicy` so this picker
+    // and `LogRoutes.seriesGrain` can't drift on the thresholds (#1744).
+    val cap  = BucketPolicy.grainForBucket(b.code)
+    val pref = BucketPolicy.windowGrain(window.toHours)
+    grainToTier(if (BucketPolicy.rank(pref) <= BucketPolicy.rank(cap)) pref else cap)
+  }
+
+  // Convert rollup rows back into the shape buildAggregate consumes. The hostname is already
+  // post-resolved by the rollup writer, so no extra LATERAL join is needed at read time — this is
+  // the whole point of the rollup tables.
+  private def asDbRows(rows: List[RollupRow]): List[TrafficUsageDbRow] =
+    rows.map { r =>
+      TrafficUsageDbRow(
+        mac = r.mac,
+        host = r.host,
+        periodStart = r.bucketStart,
+        periodEnd = r.bucketEnd,
+        activeSeconds = r.activeSeconds,
+        bytesIn = r.bytesIn,
+        bytesOut = r.bytesOut,
+      )
+    }
+
+  /**
+   * Fetch raw / rollup rows for `macs` over `[from, to)` at the tier the bucket+window selects,
+   * then aggregate into `TrafficUsageAggregateRow`s (one per (window, grouped-column-values)).
+   * `macs = Nil` means "all macs" at the repo level — callers that resolved a NON-EMPTY filter down
+   * to zero devices must short-circuit to empty themselves (Nil here would otherwise widen to the
+   * whole household). Pure of cursor paging: the `GET` path layers its keyset cursor on top of this
+   * result; the S4 aggregator passes a head-bucket window and takes the rows as-is.
+   */
+  def aggregate(
+      trafficRepo: TrafficReportRepo,
+      rollupRepo: RollupRepo,
+      macs: List[MacAddress],
+      from: Instant,
+      to: Instant,
+      bucket: UsageTraffic.Bucket,
+      groupBy: Set[UsageTraffic.GroupBy],
+      zone: ZoneId,
+      deviceByMac: Map[MacAddress, Device],
+      profileNameById: Map[ProfileId, String],
+      appsByHost: Map[String, List[AppMembership]],
+  ): Task[List[TrafficUsageAggregateRow]] = {
+    val tier                                 = pickTier(bucket, Duration.between(from, to))
+    val fetch: Task[List[TrafficUsageDbRow]] = tier match {
+      case SourceTier.Raw    => trafficRepo.listRawInRange(macs, from, to)
+      case SourceTier.Hourly => rollupRepo.listHourlyInRange(macs, from, to).map(asDbRows)
+      case SourceTier.Daily  => rollupRepo.listDailyInRange(macs, from, to).map(asDbRows)
+    }
+    fetch.map(rows =>
+      UsageTraffic.buildAggregate(
+        rows,
+        bucket,
+        zone,
+        groupBy,
+        deviceByMac,
+        profileNameById,
+        appsByHost,
+      ),
+    )
+  }
+}

--- a/api/test/src/feature/SpaWsS3Spec.scala
+++ b/api/test/src/feature/SpaWsS3Spec.scala
@@ -195,9 +195,11 @@ object SpaWsS3Spec
       clock       <- ZIO.service[Clock]
       auth        <- makeAuth(clock)
       trafficRepo <- ZIO.service[TrafficReportRepo]
+      rollupRepo  <- ZIO.service[RollupRepo]
       connRepo    <- ZIO.service[ConnectionEventRepo]
       deviceRepo  <- ZIO.service[DeviceRepo]
       profileRepo <- ZIO.service[ProfileRepo]
+      appRepo     <- ZIO.service[AppRepo]
       atlRepo     <- ZIO.service[AppTimeLimitRepo]
       usageRepo   <- ZIO.service[TimeUsageRepo]
       alertRepo   <- ZIO.service[AlertRepo]
@@ -220,7 +222,18 @@ object SpaWsS3Spec
       routes = SpaWsRoutes.routes(auth, reg, clock, openCfg)
       port <- Server.install(routes)
       out  <- ZIO.scoped {
-        SpaPush.run(bus, reg, trafficRepo, connRepo, deviceRepo, profileRepo, atlRepo, clock) *>
+        SpaPush.run(
+          bus,
+          reg,
+          trafficRepo,
+          rollupRepo,
+          connRepo,
+          deviceRepo,
+          profileRepo,
+          appRepo,
+          atlRepo,
+          clock,
+        ) *>
           body(port, ingest, bus, router)
       }
     } yield out).provideSome[BootstrapEnv](Server.defaultWithPort(0), Client.default)

--- a/api/test/src/feature/SpaWsS4Spec.scala
+++ b/api/test/src/feature/SpaWsS4Spec.scala
@@ -1,0 +1,452 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.WsConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+import java.time.{Instant, LocalDateTime}
+
+/**
+ * #1971 (S4 of the SPA-websocket rollout, design `docs/design/spa-websocket.md` §5.3): the
+ * `trafficUsage` live-edge aggregator. Exercises the FULL chain end to end — a real [[Server]] + ws
+ * [[Client]], the forked [[SpaPush]] consumer draining the [[SpaEventBus]], the REAL
+ * [[RouterIngestService]] usage write site over an embedded Postgres (never mocked, real
+ * `traffic_reports` rows), AND the REAL `GET /api/usage/traffic` mounted alongside — proving:
+ *
+ *   - a usage ingest pushes ONLY the current/most-recent bucket as a `TrafficUsageResponse`, and
+ *     the streamed bucket is byte-identical to what the `GET` returns for that window (SSOT — both
+ *     run the one `UsageTrafficQuery.aggregate`);
+ *   - no subscriber for a param-set → no push (and, structurally, no query);
+ *   - a `raw`-bucket subscription pushes per ingest cycle, still aggregated by the subscription's
+ *     `groupBy` (one profile point, not ungrouped per-host `rawRows`) (§1.3);
+ *   - a burst of ingests converges on the freshest cumulative head (latest-wins, §6.3), and the
+ *     drain-loop coalesce collapses the contentless burst triggers to one recompute;
+ *   - role-gating: `trafficUsage` is admin/adult-only, so a child's subscribe is `ack`-rejected and
+ *     no frame is ever pushed (admin/adult are full-visibility, so one body serves all recipients —
+ *     the per-profile role filter is the visibleTo gate, exactly as `now`).
+ *
+ * The injected [[Clock]] is fixed at 14:00:30 — deliberately OFF a 1m boundary so the head window
+ * `[floor(now,1m)=14:00:00, now=14:00:30)` is non-empty and the seeded period-14:00:00 row lands in
+ * it.
+ */
+object SpaWsS4Spec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
+
+  // 14:00:30 — off the 1m/5m boundary so the current head bucket window is non-empty.
+  private val testClockAt: LocalDateTime = LocalDateTime.of(2026, 6, 25, 14, 0, 30)
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(testClockAt)
+
+  private val jwtCfg  = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val openCfg = WsConfig(allowedOrigins = "", expiryCheckSeconds = 60)
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val knownMac    = "aa:bb:cc:11:22:33"
+  // Usage rows are dated inside the current 1m head window [14:00:00, 14:00:30).
+  private val periodStart = "2026-06-25T14:00:00Z"
+  private val periodEnd   = "2026-06-25T14:00:30Z"
+  // The head-window query the push runs and the GET we compare against use the same explicit window.
+  private val headFrom    = "2026-06-25T14:00:00Z"
+  private val headTo      = "2026-06-25T14:00:30Z"
+
+  private def makeAuth(clock: Clock): URIO[UserRepo, AuthServiceLive] =
+    ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg, clock))
+
+  private def tokenFor(
+      auth: AuthService,
+      role: String,
+      username: String,
+  ): ZIO[UserRepo, Throwable, String] =
+    for {
+      hash <- auth.hashPassword("pass")
+      _    <- ZIO.serviceWithZIO[UserRepo](_.create(username, hash, role))
+      tok  <- auth.login(username, "pass").mapError(e => new RuntimeException(s"login: $e"))
+    } yield tok.token.value
+
+  // The default admin (`changeme`) is the one user without the force-change-password flag, so it is
+  // the bearer the REST `GET /api/usage/traffic` accepts (it runs `requirePasswordChanged`; the ws
+  // path uses bare `verify`, so a freshly-created adult works there but not for the GET).
+  private def adminToken(auth: AuthService): ZIO[Any, Throwable, String] =
+    auth
+      .login("admin", "changeme")
+      .mapError(e => new RuntimeException(s"login: $e"))
+      .map(_.token.value)
+
+  private def seedRouter: ZIO[RouterRepo, Throwable, Router] =
+    for {
+      rRepo  <- ZIO.service[RouterRepo]
+      id     <- rRepo.create("test-router", Sha256Hex.unsafe("m" * 64))
+      _      <- rRepo.completeEnrollment(
+        id,
+        Sha256Hex.unsafe(RouterAuth.sha256Hex("ROUTER_TOKEN_PLAIN")),
+      )
+      router <- rRepo.findById(id).someOrFail(new RuntimeException("router not found after seed"))
+    } yield router
+
+  private def seedDevice: ZIO[DeviceRepo & ProfileRepo, Throwable, Unit] =
+    for {
+      pRepo <- ZIO.service[ProfileRepo]
+      dRepo <- ZIO.service[DeviceRepo]
+      pid   <- pRepo.create("Kids", List(BlocklistId.unsafe("adult")))
+      _     <- dRepo.upsert(MacAddress.unsafe(knownMac), "kid-ipad", Some(pid), "192.168.1.10")
+    } yield ()
+
+  private def usageRecord(host: String, bytesIn: Long, bytesOut: Long): UsageRecord =
+    UsageRecord(
+      mac = MacAddress.unsafe(knownMac),
+      ip = Some(IpAddress.unsafe("192.168.1.10")),
+      host = HostId.Fqdn(Hostname.unsafe(host)),
+      activeSeconds = 30L,
+      bytesIn = bytesIn,
+      bytesOut = bytesOut,
+    )
+
+  private def ingestUsage(
+      ingest: RouterIngestService,
+      router: Router,
+      records: UsageRecord*,
+  ): Task[Unit] =
+    ingest
+      .ingestUsage(
+        router,
+        UsageReport(router.id, periodStart, periodEnd, records.toList).toJson,
+      )
+      .mapError(e => new RuntimeException(s"ingest: $e"))
+
+  private def pushCount(op: String, result: String): UIO[Double] =
+    zio.metrics.Metric
+      .counter("spa_ws_push_total")
+      .tagged("op", op)
+      .tagged("result", result)
+      .value
+      .map(_.count)
+
+  /**
+   * Connect a ws client, send `hello` + the subscribe frames, await the subscribe `ack`, run the
+   * trigger, then COLLECT every frame for `wait` (we don't stop at the first match — the
+   * latest-wins test needs the last `trafficUsage` frame). Returns all received frames.
+   */
+  private def collect(
+      port: Int,
+      token: String,
+      subscribeFrames: List[String],
+      trigger: Task[Unit],
+      wait: Duration,
+      awaitAck: Boolean = true,
+  ): ZIO[Client, Throwable, Chunk[String]] =
+    for {
+      ackP   <- Promise.make[Nothing, Unit]
+      frames <- Ref.make(Chunk.empty[String])
+      app = Handler.webSocket { channel =>
+        channel.receiveAll {
+          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            ZIO.foreachDiscard("""{"op":"hello"}""" :: subscribeFrames)(f =>
+              channel.send(ChannelEvent.read(WebSocketFrame.text(f))),
+            )
+          case ChannelEvent.Read(WebSocketFrame.Text(t))                    =>
+            frames.update(_ :+ t) *>
+              ZIO.when(t.contains("\"op\":\"ack\""))(ackP.succeed(())).unit
+          case _                                                            =>
+            ZIO.unit
+        }
+      }
+      out <- ZIO.scoped {
+        for {
+          _   <- app
+            .connect(s"ws://localhost:$port/api/ws", Headers("Cookie", s"wh_ws=$token"))
+            .forkScoped
+          _   <- ZIO.when(awaitAck)(
+            ackP.await.timeoutFail(new RuntimeException("no subscribe ack"))(20.seconds),
+          )
+          _   <- trigger
+          _   <- ZIO.sleep(wait)
+          all <- frames.get
+        } yield all
+      }
+    } yield out
+
+  /**
+   * Hit the real `GET /api/usage/traffic` and parse the body (the SSOT authority for the stream).
+   */
+  private def getTraffic(
+      port: Int,
+      token: String,
+      query: String,
+  ): ZIO[Client, Throwable, TrafficUsageResponse] =
+    ZIO.serviceWithZIO[Client] { client =>
+      ZIO
+        .scoped(
+          client
+            .request(
+              Request
+                .get(s"http://localhost:$port/api/usage/traffic?$query")
+                .addHeader(Header.Authorization.Bearer(token)),
+            )
+            .flatMap(_.body.asString),
+        )
+        .flatMap(body =>
+          ZIO
+            .fromEither(body.fromJson[TrafficUsageResponse])
+            .mapError(e => new RuntimeException(s"parse traffic ($e): $body")),
+        )
+    }
+
+  private def trafficFrames(frames: Chunk[String]): Chunk[String] =
+    frames.filter(_.contains("\"op\":\"trafficUsage\""))
+
+  /** Parse the `payload` of a `trafficUsage` frame back into a `TrafficUsageResponse`. */
+  private def parsePush(frame: String): Either[String, TrafficUsageResponse] =
+    frame.fromJson[Json].flatMap {
+      case Json.Obj(fields) =>
+        fields
+          .collectFirst { case (k, v) if k == "payload" => v }
+          .toRight("no payload")
+          .flatMap(_.toJson.fromJson[TrafficUsageResponse])
+      case _                => Left("frame not an object")
+    }
+
+  private type BootstrapEnv =
+    TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]
+
+  private def withHarness[A](
+      body: (Int, RouterIngestService, Router) => ZIO[Client & BootstrapEnv, Throwable, A],
+  ): ZIO[BootstrapEnv, Throwable, A] =
+    (for {
+      _           <- cleanDb
+      clock       <- ZIO.service[Clock]
+      auth        <- makeAuth(clock)
+      trafficRepo <- ZIO.service[TrafficReportRepo]
+      rollupRepo  <- ZIO.service[RollupRepo]
+      connRepo    <- ZIO.service[ConnectionEventRepo]
+      deviceRepo  <- ZIO.service[DeviceRepo]
+      profileRepo <- ZIO.service[ProfileRepo]
+      appRepo     <- ZIO.service[AppRepo]
+      atlRepo     <- ZIO.service[AppTimeLimitRepo]
+      usageRepo   <- ZIO.service[TimeUsageRepo]
+      alertRepo   <- ZIO.service[AlertRepo]
+      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
+      upRepo      <- ZIO.service[UserProfileRepo]
+      appUsedRepo <- ZIO.service[AppUsedRollupRepo]
+      routerRepo  <- ZIO.service[RouterRepo]
+      _           <- seedDevice
+      router      <- seedRouter
+      reg         <- SpaWsRegistry.make
+      bus         <- SpaEventBus.make
+      ingest = new RouterIngestService(
+        routerRepo,
+        trafficRepo,
+        usageRepo,
+        deviceRepo,
+        connRepo,
+        alertRepo,
+        hsRepo,
+        bus,
+      )
+      routes = SpaWsRoutes.routes(auth, reg, clock, openCfg) ++
+        UsageRoutes.routes(
+          auth,
+          deviceRepo,
+          trafficRepo,
+          upRepo,
+          profileRepo,
+          appRepo,
+          rollupRepo,
+          hsRepo,
+          atlRepo,
+          appUsedRepo,
+          clock,
+        )
+      port <- Server.install(routes)
+      out  <- ZIO.scoped {
+        SpaPush.run(
+          bus,
+          reg,
+          trafficRepo,
+          rollupRepo,
+          connRepo,
+          deviceRepo,
+          profileRepo,
+          appRepo,
+          atlRepo,
+          clock,
+        ) *> body(port, ingest, router)
+      }
+    } yield out).provideSome[BootstrapEnv](Server.defaultWithPort(0), Client.default)
+
+  def spec = suite("SPA websocket S4 trafficUsage aggregator (#1971)")(
+    test(
+      "trafficUsage{groupBy:[profile],bucket:1m} gets ONLY the current bucket, equal to the GET (SSOT)",
+    ) {
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          before <- pushCount("trafficUsage", "ok")
+          frames <- collect(
+            port,
+            tok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"],"bucket":"1m"}}}""",
+            ),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 1000, 2000)),
+            wait = 4.seconds,
+          )
+          after  <- pushCount("trafficUsage", "ok")
+          tFrames = trafficFrames(frames)
+          pushed <- ZIO.fromEither(parsePush(tFrames.last)).mapError(e => new RuntimeException(e))
+          got    <- getTraffic(
+            port,
+            tok,
+            s"bucket=1m&groupBy=profile&from=$headFrom&to=$headTo&tz=UTC",
+          )
+        } yield assertTrue(tFrames.nonEmpty) &&
+          assertTrue(after - before >= 1.0) &&
+          // Only the current bucket — one windowStart, == floor(now,1m).
+          assertTrue(
+            pushed.aggregateRows.map(_.windowStart).distinct == List("2026-06-25T14:00:00Z"),
+          ) &&
+          assertTrue(
+            pushed.aggregateRows.exists(r => r.totalBytesIn == 1000 && r.totalBytesOut == 2000),
+          ) &&
+          // SSOT: the streamed bucket is byte-identical to the GET's head bucket.
+          assertTrue(pushed.aggregateRows.toSet == got.aggregateRows.toSet) &&
+          assertTrue(pushed.bucket == "1m" && pushed.groupBy == List("profile")) &&
+          // It is the AGGREGATE shape (per-group rows), never raw per-host rows.
+          assertTrue(pushed.rawRows.isEmpty)
+      }
+    },
+    test("no trafficUsage subscriber → no trafficUsage push (and no query) on usage ingest") {
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "adult", "mom"))
+          before <- pushCount("trafficUsage", "ok")
+          // Subscribe to `now` only — a real connection that doesn't watch bandwidth.
+          frames <- collect(
+            port,
+            tok,
+            List("""{"op":"subscribe","payload":{"topic":"now"}}"""),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 1000, 2000)),
+            wait = 4.seconds,
+          )
+          after  <- pushCount("trafficUsage", "ok")
+        } yield assertTrue(trafficFrames(frames).isEmpty) && assertTrue(after == before)
+      }
+    },
+    test(
+      "raw-bucket subscription pushes the live edge per ingest, aggregated by groupBy (not rawRows)",
+    ) {
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "adult", "mom"))
+          frames <- collect(
+            port,
+            tok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"],"bucket":"raw"}}}""",
+            ),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 500, 600)),
+            wait = 4.seconds,
+          )
+          tFrames = trafficFrames(frames)
+          pushed <- ZIO.fromEither(parsePush(tFrames.last)).mapError(e => new RuntimeException(e))
+        } yield assertTrue(tFrames.nonEmpty) &&
+          assertTrue(pushed.bucket == "raw") &&
+          // Aggregated per groupBy at the ingest-period granularity — ONE profile point, not rawRows.
+          assertTrue(pushed.rawRows.isEmpty) &&
+          assertTrue(pushed.aggregateRows.size == 1) &&
+          assertTrue(
+            pushed.aggregateRows.exists(r => r.totalBytesIn == 500 && r.totalBytesOut == 600),
+          ) &&
+          // raw floors to the 5-min boundary.
+          assertTrue(pushed.aggregateRows.head.windowStart == "2026-06-25T14:00:00Z")
+      }
+    },
+    test(
+      "a burst of ingests converges on the freshest cumulative head bucket (latest-wins, §6.3)",
+    ) {
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "adult", "mom"))
+          frames <- collect(
+            port,
+            tok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"],"bucket":"1m"}}}""",
+            ),
+            // Three distinct hosts, same period → three traffic_reports rows summed into one profile row.
+            trigger = ingestUsage(ingest, router, usageRecord("a.com", 100, 0)) *>
+              ingestUsage(ingest, router, usageRecord("b.com", 200, 0)) *>
+              ingestUsage(ingest, router, usageRecord("c.com", 300, 0)),
+            wait = 6.seconds,
+          )
+          tFrames = trafficFrames(frames)
+          last <- ZIO.fromEither(parsePush(tFrames.last)).mapError(e => new RuntimeException(e))
+        } yield assertTrue(tFrames.nonEmpty) &&
+          // The freshest head reflects ALL ingested bytes (cumulative DB state at the last push).
+          assertTrue(last.aggregateRows.map(_.totalBytesIn).sum == 600L) &&
+          assertTrue(last.aggregateRows.map(_.windowStart).distinct == List("2026-06-25T14:00:00Z"))
+      }
+    },
+    test(
+      "coalesce collapses a burst of contentless triggers to one recompute each (latest-wins logic)",
+    ) {
+      val t1    = Instant.parse("2026-06-25T13:59:00Z")
+      val t2    = Instant.parse("2026-06-25T13:59:30Z")
+      val burst = Chunk(
+        SpaEvent.NowChanged,
+        SpaEvent.UsageIngested,
+        SpaEvent.UsageIngested,
+        SpaEvent.NowChanged,
+        SpaEvent.UsageIngested,
+        SpaEvent.ConnectionEventsIngested(t1),
+        SpaEvent.ConnectionEventsIngested(t1),
+        SpaEvent.ConnectionEventsIngested(t2),
+      )
+      val out   = SpaPush.coalesce(burst)
+      ZIO.succeed(
+        assertTrue(out.count(_ == SpaEvent.UsageIngested) == 1) &&
+          assertTrue(out.count(_ == SpaEvent.NowChanged) == 1) &&
+          // Distinct `since`d connection-event events are NOT collapsed (their head re-read differs).
+          assertTrue(out.count(_ == SpaEvent.ConnectionEventsIngested(t1)) == 1) &&
+          assertTrue(out.count(_ == SpaEvent.ConnectionEventsIngested(t2)) == 1),
+      )
+    },
+    test(
+      "role gate: a child's trafficUsage subscribe is acked reject and no frame is ever pushed",
+    ) {
+      withHarness { (port, ingest, router) =>
+        for {
+          childTok <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "child", "kid"))
+          frames   <- collect(
+            port,
+            childTok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"],"bucket":"1m"}}}""",
+            ),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 1000, 2000)),
+            wait = 4.seconds,
+          )
+        } yield assertTrue(trafficFrames(frames).isEmpty) &&
+          assertTrue(
+            frames.exists(f =>
+              f.contains("\"op\":\"ack\"") && f.contains("\"topic\":\"trafficUsage\"") &&
+                f.contains("\"status\":\"reject\""),
+            ),
+          )
+      }
+    },
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.timeout(120.seconds)
+}

--- a/deploy/grafana/dashboards/spa-ws.json
+++ b/deploy/grafana/dashboards/spa-ws.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven SPA websocket transport (#1968/#1969, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1+S2) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry), spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux), and spa_ws_auth_total{result} (S2 upgrade auth). #1970 (S3) adds spa_ws_push_total{op,result} (SpaWsRegistry change-source fan-out — now/connectionEvents/stale). The SPA has no ws client yet (S5), so until then these read 0/flat; trafficUsage (S4) + timeStatus/appUsage (S6a) join the push panel as those topics start pushing. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
+  "description": "WifiHaven SPA websocket transport (#1968/#1969, design docs/design/spa-websocket.md, epic #1860): server-side health for the browser-facing /api/ws endpoint. Panels target ONLY the series the API actually emits today (S1+S2) — spa_ws_connections_active{role} + spa_ws_subscriptions_active{topic} (SpaWsRegistry), spa_ws_frames_total{op,direction,result} (SpaWsRoutes demux), and spa_ws_auth_total{result} (S2 upgrade auth). #1970 (S3) + #1971 (S4) add spa_ws_push_total{op,result} (SpaWsRegistry change-source fan-out — now/connectionEvents/stale in S3, trafficUsage in S4). The SPA has no ws client yet (S5), so until then these read 0/flat; timeStatus/appUsage (S6a) join the push panel as those topics start pushing. Labels are bounded enums only per the §4 cardinality firewall (no per-mac/profile/session/param label). datasource/env are templated for per-environment view.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -85,7 +85,7 @@
         "uid": "${datasource}"
       },
       "title": "SPA ws subscriptions active by topic (#1968)",
-      "description": "spa_ws_subscriptions_active{topic} — live subscriptions per topic (trafficUsage|now|connectionEvents|timeStatus|appUsage|stale). Shows what the fleet is actually watching, and (once S4 lands) that the trafficUsage aggregator's query work is bounded to demand — no subscriber, no query. NOTE: no bucket/groupBy/profileId label — those params are unbounded and deliberately kept out of the metric (design §7).",
+      "description": "spa_ws_subscriptions_active{topic} — live subscriptions per topic (trafficUsage|now|connectionEvents|timeStatus|appUsage|stale). Shows what the fleet is actually watching, and (S4, #1971) that the trafficUsage aggregator's query work is bounded to demand — no subscriber, no query. NOTE: no bucket/groupBy/profileId label — those params are unbounded and deliberately kept out of the metric (design §7).",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -398,7 +398,7 @@
         "uid": "${datasource}"
       },
       "title": "SPA ws push fan-out health by op,result (#1970)",
-      "description": "sum by (op, result) (rate(spa_ws_push_total[5m])) — the change-source fan-out health (design §5.2/§6.3). op is the pushed topic: now|connectionEvents|stale ship in S3 (trafficUsage in S4, timeStatus|appUsage in S6a — they appear here as those topics start pushing). result ∈ {ok, coalesced, dropped, channel_closed}: ok dominates once the SPA ws client ships (S5); rising channel_closed/dropped is the slow-client/backpressure tripwire — a wedged browser whose mailbox overflowed or whose socket the server gave up on. coalesced is the latest-wins/coalesce-by-topic saving (a slow client served only the freshest now/stale). Until S5 there are no subscribers, so this reads 0/flat.",
+      "description": "sum by (op, result) (rate(spa_ws_push_total[5m])) — the change-source fan-out health (design §5.2/§6.3). op is the pushed topic: now|connectionEvents|stale ship in S3, trafficUsage in S4 (#1971) (timeStatus|appUsage in S6a — they appear here as those topics start pushing). result ∈ {ok, coalesced, dropped, channel_closed}: ok dominates once the SPA ws client ships (S5); rising channel_closed/dropped is the slow-client/backpressure tripwire — a wedged browser whose mailbox overflowed or whose socket the server gave up on. coalesced is the latest-wins/coalesce-by-topic saving (a slow client served only the freshest now/stale). Until S5 there are no subscribers, so this reads 0/flat.",
       "type": "timeseries",
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
Step **S4** of the SPA-websocket rollout (design `docs/design/spa-websocket.md` §5.3 / §1.3; umbrella #1955). Builds on S1–S3 (already on `main`). Closes #1971.

## What

Live bandwidth is **not new data** — it is the existing `GET /api/usage/traffic` query re-run when new usage lands and pushed as `TrafficUsageResponse`. On each usage ingest, the `SpaPush` aggregator recomputes **only the current/most-recent bucket** for every DISTINCT subscribed `(groupBy, bucket, filter)` param-set and pushes that one bucket as a live edge. The client (S5) merges the head; the socket never re-streams history.

**No new wire shape (no `ThroughputTick`), no new read-model, no router change.** Additive.

## How it preserves SSOT

The fetch + source-tier routing + aggregation core is extracted into **`UsageTrafficQuery.aggregate`** and called by BOTH the `GET /api/usage/traffic` aggregated path and the S4 stream — so the streamed bucket and the page's GET body are produced by the *same* query and can't disagree (`AGENTS.md#single-source-of-truth`, design §0.3). The test asserts the streamed bucket is byte-identical to what the GET returns for that window.

## Behavior

- **Cadence / latest-wins (§6.3):** the drain loop coalesces — a burst of usage ingests collapses to one freshest head-bucket recompute per param-set; a slow client gets the freshest head, never a backlog.
- **Granularity (§10 Q1):** aggregated floor `1m` gives `{1m,10m,1h,…}` for free; a **`raw`-bucket** subscription pushes at the usage-ingest cadence (fully-realtime), still aggregated per the subscription's `groupBy` (one point per period, not per-host `rawRows`). **Nothing here blocks on #1023.**
- **No subscriber for a param-set → no query** (don't compute what nobody watches).
- **Role-gated:** `trafficUsage` is admin/adult-only (`SpaTopic.visibleTo`); admin/adult are full-visibility roles (exactly as the GET treats them), so one body serves every recipient and the visibleTo gate is the per-role filter — mirroring the `now` push. A child's subscribe is `ack`-rejected and never pushed.

## Query plan

The aggregator re-runs the **identical** existing query, just windowed to the head bucket `[floor(now,bucket), now)` — a narrow, partition-pruned scan (`traffic_reports.period_start` is the partition key). Same access pattern as the GET, only a far smaller window → **no plan change, no new index** (docs/process/query-perf.md).

## Metrics + dashboard

`spa_ws_push_total{op=trafficUsage}` rides the existing generic counter (bounded `op`/`result` enums — **no** `bucket`/`groupBy`/`profileId` label) and `spa_ws_subscriptions_active{topic=trafficUsage}` is already emitted by the registry. `deploy/grafana/dashboards/spa-ws.json` push-health panel already aggregates `by (op, result)` so it covers `trafficUsage`; descriptions updated to reflect S4 shipped.

## Tests (TDD, red→green)

`SpaWsS4Spec` — full stack on embedded Postgres, real `RouterIngestService` usage write site, real `GET /api/usage/traffic` mounted alongside for the SSOT comparison, injected `Clock.TestClock`:

- subscriber receives ONLY the current bucket; equals the GET (SSOT)
- no subscriber → no push (and no query)
- `raw`-bucket pushes per ingest, aggregated by `groupBy` (not `rawRows`)
- burst of ingests converges on the freshest cumulative head (latest-wins)
- `coalesce` collapses contentless triggers to one recompute each
- child role-gate reject

All 1112 api tests pass; scalafmt clean.

Out of scope (later steps): SPA ws client (S5), timeStatus/appUsage (S6a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)