### PR TITLE
feat(#1973): SPA-ws S5 — browser ws client + realtime dashboard pilot

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from '@/hooks/useAuth'
+import { WsProvider } from '@/hooks/useWs'
 import { AlertsNotifier } from '@/hooks/useNotifyOnNewAlerts'
 import { Layout } from '@/components/layout/Layout'
 import { LoginPage } from '@/pages/LoginPage'
@@ -47,7 +48,7 @@ function AppRoutes() {
         change-password form even when the server-side flag is set (#586).
         All other protected routes redirect to /account until the flag clears.
       */}
-      <Route path="/" element={<RequireAuth><><AlertsNotifier /><Layout /></></RequireAuth>}>
+      <Route path="/" element={<RequireAuth><WsProvider><AlertsNotifier /><Layout /></WsProvider></RequireAuth>}>
         <Route path="account" element={<AccountPage />} />
         <Route index element={<RequirePwChanged><Navigate to="/dashboard" replace /></RequirePwChanged>} />
         <Route path="dashboard" element={<RequirePwChanged><DashboardPage /></RequirePwChanged>} />

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -12,7 +12,7 @@ import type {
   ProfileTimeStatus,
   ProfileAppWeeklyUsage,
   ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
-  QueryLog, UsageConfig, UsageSeriesResponse,
+  QueryLog, TrafficUsageBucket, TrafficUsageGroupBy, UsageConfig, UsageSeriesResponse,
 } from '@/types/api'
 
 const MIN = 60_000
@@ -131,6 +131,16 @@ export const qk = {
   // tracks the daily rollup the per-app cap reads.
   profileAppWeekly: (profileId: number, to?: string) =>
     ['profiles', profileId, 'usage', 'app', 'weekly', to ?? 'current'] as const,
+  // #1973 (SPA-ws S5): the live trafficUsage series key (design §3.1). The ws push
+  // (live edge) and the future S6b Traffic Usage page produce the key HERE so they
+  // share one cache entry — the push patches exactly the key the page renders.
+  trafficUsageLive: (params: { groupBy: TrafficUsageGroupBy[]; bucket: TrafficUsageBucket }) =>
+    ['usage', 'traffic', 'live', params.bucket, [...params.groupBy].sort().join(',')] as const,
+  // #1973: the live connectionEvents feed key (design §3.1). The dashboard's "Recently
+  // Blocked" panel keeps its own `recentBlocked()` key (the 15-min window view); this
+  // is the shared key the future S6b Connection Events page streams into.
+  connectionEventsLive: (filter: Record<string, unknown>) =>
+    ['logs', 'live', JSON.stringify(filter)] as const,
 }
 
 type QueryOpts<T> = Omit<UseQueryOptions<T, Error, T, readonly unknown[]>, 'queryKey' | 'queryFn'>

--- a/web/src/api/wsCache.test.ts
+++ b/web/src/api/wsCache.test.ts
@@ -1,0 +1,208 @@
+// #1973 (SPA-ws S5): the pure cache-merge helpers (design §3.1) — tested in isolation
+// from the transport. These prove the live-edge splice: replace the head bucket in
+// place while it accumulates, prepend on rollover, never touch history; prepend +
+// dedup connection events; derive B/s from bytes-over-bucket; derive NOW KPIs.
+import { describe, it, expect } from 'vitest'
+import {
+  bucketSeconds,
+  deriveNowKpis,
+  headBucketRows,
+  mergeHeadBucket,
+  overallRate,
+  prependHead,
+  rateFor,
+} from './wsCache'
+import type {
+  DashboardNow,
+  QueryLog,
+  TrafficUsageAggregateRow,
+  TrafficUsageResponse,
+} from '@/types/api'
+
+function aggRow(over: Partial<TrafficUsageAggregateRow> & { windowStart: string }): TrafficUsageAggregateRow {
+  return {
+    groups: {},
+    windowEnd: over.windowStart,
+    totalBytesIn: 0,
+    totalBytesOut: 0,
+    totalSeconds: 0,
+    ...over,
+  }
+}
+
+function series(rows: TrafficUsageAggregateRow[], over: Partial<TrafficUsageResponse> = {}): TrafficUsageResponse {
+  return {
+    bucket: '1m',
+    groupBy: ['profile'],
+    from: '2026-06-26T10:00:00Z',
+    to: '2026-06-26T10:05:00Z',
+    tz: 'UTC',
+    rawRows: [],
+    aggregateRows: rows,
+    ...over,
+  }
+}
+
+describe('mergeHeadBucket (#1973 §3.1)', () => {
+  it('seeds the series when there is no prior cache', () => {
+    const live = series([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 })])
+    expect(mergeHeadBucket(undefined, live)).toBe(live)
+  })
+
+  it('replaces the head bucket in place while it accumulates (same windowStart)', () => {
+    const prev = series([
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 }),
+      aggRow({ windowStart: '2026-06-26T10:04:00Z', totalBytesIn: 999 }),
+    ])
+    const live = series([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 250 })])
+    const merged = mergeHeadBucket(prev, live)
+    expect(merged.aggregateRows).toHaveLength(2)
+    // head replaced with the fresher byte count, older bucket untouched
+    expect(merged.aggregateRows[0].totalBytesIn).toBe(250)
+    expect(merged.aggregateRows[1].windowStart).toBe('2026-06-26T10:04:00Z')
+    expect(merged.aggregateRows[1].totalBytesIn).toBe(999)
+  })
+
+  it('prepends a new head when the bucket rolls over (new windowStart)', () => {
+    const prev = series([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 })])
+    const live = series([aggRow({ windowStart: '2026-06-26T10:06:00Z', totalBytesIn: 5 })])
+    const merged = mergeHeadBucket(prev, live)
+    expect(merged.aggregateRows.map(r => r.windowStart)).toEqual([
+      '2026-06-26T10:06:00Z',
+      '2026-06-26T10:05:00Z',
+    ])
+  })
+
+  it('keeps multiple rows that share the head windowStart (groupBy:profile)', () => {
+    const prev = series([
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Kids' }, totalBytesIn: 1 }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Adults' }, totalBytesIn: 2 }),
+    ])
+    const live = series([
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Kids' }, totalBytesIn: 10 }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Adults' }, totalBytesIn: 20 }),
+    ])
+    const merged = mergeHeadBucket(prev, live)
+    expect(merged.aggregateRows).toHaveLength(2)
+    expect(merged.aggregateRows.map(r => r.totalBytesIn)).toEqual([10, 20])
+  })
+
+  it('merges nothing on an empty live head (boundary tick), keeping the prior series', () => {
+    const prev = series([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 })])
+    const live = series([])
+    expect(mergeHeadBucket(prev, live)).toBe(prev)
+  })
+})
+
+describe('headBucketRows', () => {
+  it('returns only the newest windowStart rows', () => {
+    const s = series([
+      aggRow({ windowStart: '2026-06-26T10:06:00Z', groups: { profile: 'Kids' } }),
+      aggRow({ windowStart: '2026-06-26T10:06:00Z', groups: { profile: 'Adults' } }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Kids' } }),
+    ])
+    expect(headBucketRows(s)).toHaveLength(2)
+  })
+  it('empty for an empty/undefined series', () => {
+    expect(headBucketRows(undefined)).toEqual([])
+    expect(headBucketRows(series([]))).toEqual([])
+  })
+})
+
+describe('B/s derivation (#1973 §1.3)', () => {
+  it('divides bytes by the nominal bucket width', () => {
+    expect(bucketSeconds('1m')).toBe(60)
+    expect(bucketSeconds('1h')).toBe(3600)
+    const row = aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 600, totalBytesOut: 120 })
+    const r = rateFor(row, '1m')
+    expect(r.bytesInPerSec).toBe(10)
+    expect(r.bytesOutPerSec).toBe(2)
+    expect(r.bytesPerSec).toBe(12)
+  })
+
+  it('raw bucket reads the ingest period from the row window span', () => {
+    const row = aggRow({
+      windowStart: '2026-06-26T10:00:00Z',
+      windowEnd: '2026-06-26T10:00:30Z', // 30s ingest period
+      totalBytesIn: 300,
+    })
+    expect(bucketSeconds('raw', row)).toBe(30)
+    expect(rateFor(row, 'raw').bytesInPerSec).toBe(10)
+  })
+
+  it('overallRate sums the per-profile head rows', () => {
+    const rows = [
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 600, totalBytesOut: 0 }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 60, totalBytesOut: 120 }),
+    ]
+    const o = overallRate(rows, '1m')
+    expect(o.bytesInPerSec).toBe(11)
+    expect(o.bytesOutPerSec).toBe(2)
+    expect(o.bytesPerSec).toBe(13)
+  })
+})
+
+describe('prependHead (#1973 §3.1)', () => {
+  const row = (id: number): QueryLog => ({
+    id,
+    mac: null,
+    deviceName: null,
+    profileId: null,
+    profileName: null,
+    host: { type: 'fqdn', value: `h${id}.com` },
+    qtype: 1,
+    blocked: true,
+    reason: { kind: 'manual' },
+    location: null,
+    ts: '2026-06-26T10:00:00Z',
+  })
+
+  it('prepends new head rows, newest first', () => {
+    const out = prependHead([row(2), row(1)], [row(4), row(3)], 20)
+    expect(out.map(r => r.id)).toEqual([4, 3, 2, 1])
+  })
+
+  it('dedups by id (push overlapping the GET boundary)', () => {
+    const out = prependHead([row(2), row(1)], [row(3), row(2)], 20)
+    expect(out.map(r => r.id)).toEqual([3, 2, 1])
+  })
+
+  it('bounds to the limit', () => {
+    const out = prependHead([row(2), row(1)], [row(5), row(4), row(3)], 3)
+    expect(out.map(r => r.id)).toEqual([5, 4, 3])
+  })
+
+  it('handles an undefined prior cache', () => {
+    expect(prependHead(undefined, [row(1)], 20).map(r => r.id)).toEqual([1])
+  })
+})
+
+describe('deriveNowKpis (#1973 §3.1)', () => {
+  const now: DashboardNow = {
+    asOf: '2026-06-26T10:00:00Z',
+    profiles: [
+      {
+        id: 1, name: 'Kids', paused: true,
+        activeDevices: [
+          { id: 1, name: 'iPad', mac: 'a', lastSeenSeconds: 5, topHosts: [] },
+        ],
+      },
+      {
+        id: 2, name: 'Adults', paused: false,
+        activeDevices: [
+          { id: 2, name: 'Phone', mac: 'b', lastSeenSeconds: 5, topHosts: [] },
+          { id: 3, name: 'Laptop', mac: 'c', lastSeenSeconds: 5, topHosts: [] },
+        ],
+      },
+    ],
+  }
+  it('counts online (all active) and blocked (active on paused profiles)', () => {
+    const k = deriveNowKpis(now)
+    expect(k.onlineNow).toBe(3)
+    expect(k.blockedNow).toBe(1)
+  })
+  it('zeroes for an empty/undefined body', () => {
+    expect(deriveNowKpis(undefined)).toEqual({ onlineNow: 0, blockedNow: 0 })
+    expect(deriveNowKpis({ asOf: '', profiles: [] })).toEqual({ onlineNow: 0, blockedNow: 0 })
+  })
+})

--- a/web/src/api/wsCache.ts
+++ b/web/src/api/wsCache.ts
@@ -1,0 +1,156 @@
+// #1973 (SPA-ws S5, design docs/design/spa-websocket.md §3.1): the PURE cache-merge
+// helpers the ws push handlers patch the React Query cache with. Kept side-effect-free
+// (no QueryClient, no socket) so the live-edge merge logic is unit-testable in isolation
+// from the transport. Every payload is an existing REST body (§0.3) — these never invent
+// a shape, they only splice the live edge into the GET-loaded series.
+
+import type {
+  DashboardNow,
+  QueryLog,
+  TrafficUsageAggregateRow,
+  TrafficUsageBucket,
+  TrafficUsageResponse,
+} from '@/types/api'
+
+// ── trafficUsage: merge the live-edge bucket into the GET-loaded series (§3.1) ──────
+//
+// The push carries ONLY the current/most-recent bucket (a TrafficUsageResponse whose
+// window is just that bucket — possibly several rows sharing one windowStart, one per
+// group). We join on `windowStart`: replace the rows of the matching head window while
+// it accumulates, prepend a new head when the window rolls over. History is never
+// refetched or mutated — the older buckets the GET loaded stay exactly put.
+export function mergeHeadBucket(
+  prev: TrafficUsageResponse | undefined,
+  live: TrafficUsageResponse,
+): TrafficUsageResponse {
+  // Empty head (the rare boundary tick where the head window is empty, SpaPush §5.3):
+  // merge nothing — keep prior series, or seed with the empty live shape if first.
+  if (!live.aggregateRows || live.aggregateRows.length === 0) return prev ?? live
+  if (!prev) return live
+  const headStart = live.aggregateRows[0].windowStart
+  // Drop any prior rows in the head window (replace-in-place); keep all older buckets.
+  const kept = prev.aggregateRows.filter(r => r.windowStart !== headStart)
+  return {
+    // Carry the live response's window/bucket metadata (the freshest edge) but keep the
+    // full merged series. `to` advances to the live edge; `from` stays the GET's window
+    // start so the cached series still describes the whole loaded range.
+    ...prev,
+    bucket: live.bucket,
+    to: live.to,
+    aggregateRows: [...live.aggregateRows, ...kept],
+  }
+}
+
+// The head (newest) bucket's rows — the slice the live gauge reads. The series is
+// newest-first (GET orders windowStart DESC, mergeHeadBucket prepends the live edge),
+// so the head windowStart is row[0]'s.
+export function headBucketRows(
+  series: TrafficUsageResponse | undefined,
+): TrafficUsageAggregateRow[] {
+  const rows = series?.aggregateRows ?? []
+  if (rows.length === 0) return []
+  const headStart = rows[0].windowStart
+  return rows.filter(r => r.windowStart === headStart)
+}
+
+// ── B/s derivation: client divides bytes-over-bucket (§1.3) — server stays the source ──
+//
+// The server ships the same `totalBytes*` row the page renders; the gauge derives the
+// rate locally (no second "rate" serializer). bucketSeconds is the bucket's nominal
+// width; `raw` has no fixed width — it's whatever cadence the router sent usage at, so
+// we read it from the row's [windowStart, windowEnd) span (the ingest period), falling
+// back to ~60s (today's REST poll cadence) when no row is available.
+const BUCKET_SECONDS: Record<Exclude<TrafficUsageBucket, 'raw'>, number> = {
+  '1m': 60,
+  '10m': 600,
+  '1h': 3_600,
+  '12h': 43_200,
+  '1d': 86_400,
+  '1w': 604_800,
+}
+
+export function bucketSeconds(
+  bucket: TrafficUsageBucket,
+  row?: TrafficUsageAggregateRow,
+): number {
+  if (bucket !== 'raw') return BUCKET_SECONDS[bucket]
+  if (row) {
+    const span = (new Date(row.windowEnd).getTime() - new Date(row.windowStart).getTime()) / 1000
+    if (Number.isFinite(span) && span > 0) return span
+  }
+  return 60
+}
+
+export interface BandwidthRate {
+  bytesInPerSec: number
+  bytesOutPerSec: number
+  bytesPerSec: number
+}
+
+export function rateFor(
+  row: TrafficUsageAggregateRow,
+  bucket: TrafficUsageBucket,
+): BandwidthRate {
+  const secs = bucketSeconds(bucket, row)
+  const inPs = secs > 0 ? row.totalBytesIn / secs : 0
+  const outPs = secs > 0 ? row.totalBytesOut / secs : 0
+  return { bytesInPerSec: inPs, bytesOutPerSec: outPs, bytesPerSec: inPs + outPs }
+}
+
+// Sum the head-bucket rows into the overall-household rate (groupBy:profile → one row
+// per profile, so the household total is their sum).
+export function overallRate(
+  rows: TrafficUsageAggregateRow[],
+  bucket: TrafficUsageBucket,
+): BandwidthRate {
+  return rows.reduce<BandwidthRate>(
+    (acc, r) => {
+      const x = rateFor(r, bucket)
+      return {
+        bytesInPerSec: acc.bytesInPerSec + x.bytesInPerSec,
+        bytesOutPerSec: acc.bytesOutPerSec + x.bytesOutPerSec,
+        bytesPerSec: acc.bytesPerSec + x.bytesPerSec,
+      }
+    },
+    { bytesInPerSec: 0, bytesOutPerSec: 0, bytesPerSec: 0 },
+  )
+}
+
+// ── connectionEvents: prepend new head rows, bounded + dedup by id (§3.1) ───────────
+//
+// The push carries the genuinely-new head rows (newest-first); cursor-paged history is
+// untouched. We prepend, dedup by id (a row already in the cache is never duplicated —
+// the GET and the push can overlap at the boundary), and cap to `limit` so the live
+// feed stays bounded.
+export function prependHead(
+  prev: QueryLog[] | undefined,
+  rows: QueryLog[],
+  limit: number,
+): QueryLog[] {
+  const merged = [...rows, ...(prev ?? [])]
+  const seen = new Set<number>()
+  const out: QueryLog[] = []
+  for (const r of merged) {
+    if (seen.has(r.id)) continue
+    seen.add(r.id)
+    out.push(r)
+  }
+  return out.slice(0, limit)
+}
+
+// ── now: derived KPIs computed client-side off the pushed DashboardNow (§3.1) ───────
+//
+// "Online now" = the count of active devices across all profiles; "Blocked now" = the
+// active devices whose profile is currently paused (a paused profile blocks all its
+// traffic). Both recompute from the same pushed body — no separate stream.
+export interface NowKpis {
+  onlineNow: number
+  blockedNow: number
+}
+
+export function deriveNowKpis(now: DashboardNow | undefined | null): NowKpis {
+  const profiles = now?.profiles ?? []
+  const activeDevices = profiles.flatMap(p => p.activeDevices)
+  const blocked = profiles.filter(p => p.paused).flatMap(p => p.activeDevices)
+  return { onlineNow: activeDevices.length, blockedNow: blocked.length }
+}

--- a/web/src/api/wsClient.test.ts
+++ b/web/src/api/wsClient.test.ts
@@ -1,0 +1,282 @@
+// #1973 (SPA-ws S5): the transport state machine (design §2/§4/§6), driven by a mock
+// socket + fake timers. Proves: hello→ready flips to live, subscriptions replay on
+// ready, the cookie is set-before-connect / cleared-after-open, re-subscribe sends
+// unsubscribe+subscribe, socket close → backoff → reconnect re-sets cookie + replays +
+// refetches once, `4401` stops reconnecting, and the heartbeat reconnects on a dead pong.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SpaWsClient, wsUrl, type SpaWsClientOptions, type WsSocketLike } from './wsClient'
+
+class MockSocket implements WsSocketLike {
+  static instances: MockSocket[] = []
+  url: string
+  sent: string[] = []
+  closed = false
+  onopen: ((ev?: unknown) => void) | null = null
+  onclose: ((ev: { code: number; reason?: string }) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockSocket.instances.push(this)
+  }
+  send(data: string): void {
+    this.sent.push(data)
+  }
+  close(code?: number, reason?: string): void {
+    this.closed = true
+    this.onclose?.({ code: code ?? 1006, reason })
+  }
+  // ── test helpers ──
+  open(): void {
+    this.onopen?.()
+  }
+  emit(frame: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+  frames(): Array<{ op: string; payload?: unknown }> {
+    return this.sent.map(s => JSON.parse(s))
+  }
+  ops(): string[] {
+    return this.frames().map(f => f.op)
+  }
+}
+
+interface Harness {
+  client: SpaWsClient
+  cookieSet: ReturnType<typeof vi.fn>
+  cookieClear: ReturnType<typeof vi.fn>
+  invalidate: ReturnType<typeof vi.fn>
+  tokenExpired: ReturnType<typeof vi.fn>
+}
+
+function makeClient(over: Partial<SpaWsClientOptions> = {}): Harness {
+  const cookieSet = vi.fn()
+  const cookieClear = vi.fn()
+  const invalidate = vi.fn()
+  const tokenExpired = vi.fn()
+  const client = new SpaWsClient({
+    apiBaseUrl: 'https://api.wifihaven.net',
+    origin: 'https://app.wifihaven.net',
+    getToken: () => 'jwt-abc',
+    socketFactory: (url: string) => new MockSocket(url),
+    setCookie: cookieSet,
+    clearCookie: cookieClear,
+    invalidateQuery: invalidate,
+    onTokenExpired: tokenExpired,
+    heartbeatMs: 1000,
+    reconnectBaseMs: 1000,
+    reconnectCapMs: 30000,
+    random: () => 0, // deterministic backoff: delay = exp/2
+    ...over,
+  })
+  return { client, cookieSet, cookieClear, invalidate, tokenExpired }
+}
+
+function last(): MockSocket {
+  return MockSocket.instances[MockSocket.instances.length - 1]
+}
+
+beforeEach(() => {
+  MockSocket.instances = []
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('wsUrl (§2.1)', () => {
+  it('derives ws:// from the http base, same host', () => {
+    expect(wsUrl('https://api.wifihaven.net', 'https://app.x')).toBe('wss://api.wifihaven.net/api/ws')
+    expect(wsUrl('', 'http://localhost:5173')).toBe('ws://localhost:5173/api/ws')
+  })
+})
+
+describe('connect + handshake (§4.2/§1.4)', () => {
+  it('sets the cookie before connect, sends hello on open, clears the cookie after open', () => {
+    const h = makeClient()
+    h.client.start()
+    expect(h.cookieSet).toHaveBeenCalledWith('jwt-abc')
+    expect(MockSocket.instances).toHaveLength(1)
+    expect(last().url).toBe('wss://api.wifihaven.net/api/ws')
+    expect(h.cookieClear).not.toHaveBeenCalled()
+
+    last().open()
+    expect(h.cookieClear).toHaveBeenCalledTimes(1)
+    expect(last().ops()).toEqual(['hello'])
+  })
+
+  it('ready flips the status to live and notifies listeners', () => {
+    const h = makeClient()
+    const seen: string[] = []
+    h.client.subscribeStatus(() => seen.push(h.client.getStatus()))
+    h.client.start()
+    expect(h.client.getStatus()).toBe('reconnecting')
+    last().open()
+    last().emit({ op: 'ready', payload: { role: 'admin', serverTime: 't' } })
+    expect(h.client.getStatus()).toBe('live')
+    expect(seen).toContain('live')
+  })
+
+  it('replays the subscription set on ready (server starts subscribed to nothing)', () => {
+    const h = makeClient()
+    h.client.start()
+    h.client.subscribe('now', undefined, { onPush: () => {} })
+    h.client.subscribe('trafficUsage', { groupBy: ['profile'], bucket: '1m' }, { onPush: () => {} })
+    // not live yet → no subscribe frames on the wire
+    expect(last().ops().filter(o => o === 'subscribe')).toHaveLength(0)
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    const subs = last().frames().filter(f => f.op === 'subscribe')
+    expect(subs).toHaveLength(2)
+    expect(subs.map(f => (f.payload as { topic: string }).topic).sort()).toEqual(['now', 'trafficUsage'])
+  })
+
+  it('routes a push to the registered handler by topic', () => {
+    const h = makeClient()
+    const onNow = vi.fn()
+    h.client.start()
+    h.client.subscribe('now', undefined, { onPush: onNow })
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    last().emit({ op: 'now', payload: { asOf: 'x', profiles: [] } })
+    expect(onNow).toHaveBeenCalledWith({ asOf: 'x', profiles: [] })
+  })
+
+  it('replies pong to a server ping', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    const before = last().ops().length
+    last().emit({ op: 'ping', payload: {} })
+    expect(last().ops().slice(before)).toContain('pong')
+  })
+})
+
+describe('re-subscribe on param change (#747)', () => {
+  it('sends unsubscribe then subscribe when the bucket changes', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    const dispose = h.client.subscribe('trafficUsage', { groupBy: ['profile'], bucket: '1m' }, { onPush: () => {} })
+    // simulate the React effect cleanup→re-run on bucket change
+    dispose()
+    h.client.subscribe('trafficUsage', { groupBy: ['profile'], bucket: '10m' }, { onPush: () => {} })
+    const ops = last().frames()
+    const idxSub1 = ops.findIndex(f => f.op === 'subscribe' && (f.payload as { params?: { bucket?: string } }).params?.bucket === '1m')
+    const idxUnsub = ops.findIndex(f => f.op === 'unsubscribe')
+    const idxSub2 = ops.findIndex(f => f.op === 'subscribe' && (f.payload as { params?: { bucket?: string } }).params?.bucket === '10m')
+    expect(idxSub1).toBeGreaterThanOrEqual(0)
+    expect(idxUnsub).toBeGreaterThan(idxSub1)
+    expect(idxSub2).toBeGreaterThan(idxUnsub)
+  })
+})
+
+describe('reconnect / backoff (§6.1)', () => {
+  it('on socket close: backs off, reconnects, re-sets cookie, replays subs, refetches once', () => {
+    const h = makeClient()
+    h.client.start()
+    h.client.subscribe('now', undefined, { onPush: () => {}, refetchKey: ['dashboard', 'now'] })
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    expect(h.client.getStatus()).toBe('live')
+    h.cookieSet.mockClear()
+    h.invalidate.mockClear()
+
+    // server drops the connection
+    last().onclose?.({ code: 1006 })
+    expect(h.client.getStatus()).toBe('reconnecting')
+    expect(MockSocket.instances).toHaveLength(1) // not yet — backing off
+
+    // backoff delay = exp/2 = 1000/2 = 500ms (random()=0)
+    vi.advanceTimersByTime(500)
+    expect(MockSocket.instances).toHaveLength(2)
+    expect(h.cookieSet).toHaveBeenCalledWith('jwt-abc') // cookie re-set before reconnect
+
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    // subscriptions replayed on the new connection
+    expect(last().frames().some(f => f.op === 'subscribe' && (f.payload as { topic: string }).topic === 'now')).toBe(true)
+    // live queries refetched ONCE on reconnect
+    expect(h.invalidate).toHaveBeenCalledWith(['dashboard', 'now'])
+    expect(h.invalidate).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT refetch on the FIRST connect (only on reconnect)', () => {
+    const h = makeClient()
+    h.client.start()
+    h.client.subscribe('now', undefined, { onPush: () => {}, refetchKey: ['dashboard', 'now'] })
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    expect(h.invalidate).not.toHaveBeenCalled()
+  })
+
+  it('4401 token-expired stops reconnecting and hands off to /login', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    last().onclose?.({ code: 4401, reason: 'token-expired' })
+    expect(h.client.getStatus()).toBe('offline')
+    expect(h.tokenExpired).toHaveBeenCalledTimes(1)
+    // no reconnect, ever
+    vi.advanceTimersByTime(60_000)
+    expect(MockSocket.instances).toHaveLength(1)
+  })
+})
+
+describe('heartbeat (§6.2)', () => {
+  it('sends a ping each interval and reconnects on a dead pong', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    const sock = last()
+
+    // one interval → ping sent (pong fresh from ready, so not dead yet)
+    vi.advanceTimersByTime(1000)
+    expect(sock.ops()).toContain('ping')
+
+    // no pong arrives; > 2× interval since last pong → treated dead → socket closed → reconnect
+    vi.advanceTimersByTime(2500)
+    expect(sock.closed).toBe(true)
+    expect(h.client.getStatus()).toBe('reconnecting')
+  })
+
+  it('a pong keeps the connection alive', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    const sock = last()
+    vi.advanceTimersByTime(1000)
+    sock.emit({ op: 'pong', payload: {} })
+    vi.advanceTimersByTime(1500)
+    expect(sock.closed).toBe(false)
+    expect(h.client.getStatus()).toBe('live')
+  })
+})
+
+describe('stop()', () => {
+  it('closes the socket, goes offline, and never reconnects', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    h.client.stop()
+    expect(h.client.getStatus()).toBe('offline')
+    vi.advanceTimersByTime(60_000)
+    expect(MockSocket.instances).toHaveLength(1)
+  })
+})
+
+describe('unauthenticated', () => {
+  it('does not open a socket without a token', () => {
+    const h = makeClient({ getToken: () => null })
+    h.client.start()
+    expect(MockSocket.instances).toHaveLength(0)
+    expect(h.client.getStatus()).toBe('offline')
+  })
+})

--- a/web/src/api/wsClient.test.ts
+++ b/web/src/api/wsClient.test.ts
@@ -154,6 +154,48 @@ describe('connect + handshake (§4.2/§1.4)', () => {
   })
 })
 
+describe('subscription ack / topicActive (§1.4)', () => {
+  it('topicActive is true only after an ok ack while live', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    h.client.subscribe('now', undefined, { onPush: () => {} })
+    expect(h.client.topicActive('now')).toBe(false) // pending ack
+    last().emit({ op: 'ack', payload: { topic: 'now', status: 'ok' } })
+    expect(h.client.topicActive('now')).toBe(true)
+  })
+
+  it('a rejected subscription stays inactive (the consumer keeps polling)', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    h.client.subscribe('now', undefined, { onPush: () => {} })
+    last().emit({ op: 'ack', payload: { topic: 'now', status: 'reject', reason: 'forbidden' } })
+    expect(h.client.topicActive('now')).toBe(false)
+  })
+
+  it('topicActive drops to false when the socket goes down, and is pending again after reconnect', () => {
+    const h = makeClient()
+    h.client.start()
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    h.client.subscribe('now', undefined, { onPush: () => {} })
+    last().emit({ op: 'ack', payload: { topic: 'now', status: 'ok' } })
+    expect(h.client.topicActive('now')).toBe(true)
+    last().onclose?.({ code: 1006 })
+    expect(h.client.topicActive('now')).toBe(false)
+    vi.advanceTimersByTime(500)
+    last().open()
+    last().emit({ op: 'ready', payload: {} })
+    // re-subscribed on reconnect → pending again until the new ack
+    expect(h.client.topicActive('now')).toBe(false)
+    last().emit({ op: 'ack', payload: { topic: 'now', status: 'ok' } })
+    expect(h.client.topicActive('now')).toBe(true)
+  })
+})
+
 describe('re-subscribe on param change (#747)', () => {
   it('sends unsubscribe then subscribe when the bucket changes', () => {
     const h = makeClient()

--- a/web/src/api/wsClient.ts
+++ b/web/src/api/wsClient.ts
@@ -105,6 +105,11 @@ export class SpaWsClient {
   private status: WsStatus = 'offline'
   private readonly statusListeners = new Set<() => void>()
   private readonly subs = new Map<SpaTopicName, Subscription>()
+  // Per-topic subscription `ack` outcome (§1.4). A topic is only actually *streaming* once
+  // the server accepts the subscription (`ok`) — a role-rejected topic (e.g. a Child
+  // subscribing `now`) gets `reject` and never receives pushes, so consumers must keep
+  // polling for it even while the socket is live. Cleared (→ pending) on (re)subscribe.
+  private readonly acks = new Map<SpaTopicName, 'ok' | 'reject'>()
   private subToken = 0
   private attempt = 0
   /** True once a `ready` has been seen — distinguishes the first connect from a reconnect. */
@@ -141,10 +146,23 @@ export class SpaWsClient {
     }
   }
 
+  /**
+   * Whether a topic is actually *streaming* right now: the socket is live AND the server
+   * accepted the subscription (`ack:ok`). Consumers gate their poll-pause on THIS, not on
+   * bare connection liveness — a role-rejected topic (e.g. Child + `now`) is live-socket
+   * but never pushed, so its poll must keep running. Notifies via `subscribeStatus`.
+   */
+  topicActive = (topic: SpaTopicName): boolean =>
+    this.status === 'live' && this.acks.get(topic) === 'ok'
+
+  private notify(): void {
+    for (const l of this.statusListeners) l()
+  }
+
   private setStatus(next: WsStatus): void {
     if (this.status === next) return
     this.status = next
-    for (const l of this.statusListeners) l()
+    this.notify()
   }
 
   // ── lifecycle ─────────────────────────────────────────────────────────────────────
@@ -188,7 +206,11 @@ export class SpaWsClient {
     this.socket = socket
     socket.onopen = () => this.handleOpen()
     socket.onmessage = ev => this.handleFrame(ev.data)
-    socket.onclose = ev => this.handleClose(ev?.code ?? 1006)
+    // Guard by socket identity: a late close from a SUPERSEDED socket must not tear down
+    // the current one. (Practically unreachable given the ≥1s backoff, but provably safe.)
+    socket.onclose = ev => {
+      if (this.socket === socket) this.handleClose(ev?.code ?? 1006)
+    }
     socket.onerror = () => {
       // Let onclose drive reconnect; closing here makes the error path deterministic.
       try {
@@ -267,10 +289,17 @@ export class SpaWsClient {
       case 'ping':
         this.send({ op: 'pong', payload: {} })
         return
-      case 'ack':
-        // Subscription confirmation (§1.4) — keyed by topic. Tracked server-side; the
-        // client doesn't gate on it in v1 (a reject just means no pushes arrive).
+      case 'ack': {
+        // Subscription confirmation (§1.4) — keyed by topic. Record ok/reject so consumers
+        // can tell an actually-streaming topic from a role-rejected one (topicActive).
+        const ack = frame.payload as { topic?: unknown; status?: unknown }
+        const topic = typeof ack?.topic === 'string' ? (ack.topic as SpaTopicName) : undefined
+        if (topic && this.subs.has(topic)) {
+          this.acks.set(topic, ack.status === 'ok' ? 'ok' : 'reject')
+          this.notify()
+        }
         return
+      }
       default: {
         // A push frame: op === topic. Route to the registered handler, if any.
         const sub = this.subs.get(op as SpaTopicName)
@@ -343,18 +372,23 @@ export class SpaWsClient {
       // cleanup-then-resubscribe race when params change.
       if (cur && cur.token === token) {
         this.subs.delete(topic)
+        this.acks.delete(topic)
         if (this.status === 'live') this.sendUnsubscribe(topic)
       }
     }
   }
 
   private sendSubscribe(topic: SpaTopicName, params: unknown): void {
+    // Pending until the server acks — clear any prior outcome so topicActive reads false
+    // until this subscription is confirmed (also resets it across a reconnect replay).
+    this.acks.delete(topic)
     const payload =
       params === undefined ? { topic } : { topic, params }
     this.send({ op: 'subscribe', payload })
   }
 
   private sendUnsubscribe(topic: SpaTopicName): void {
+    this.acks.delete(topic)
     this.send({ op: 'unsubscribe', payload: { topic } })
   }
 

--- a/web/src/api/wsClient.ts
+++ b/web/src/api/wsClient.ts
@@ -1,0 +1,390 @@
+// #1973 (SPA-ws S5, design docs/design/spa-websocket.md §2/§4/§6): the browser ws
+// transport client — the connection state machine the dashboard's live surface rides.
+// It is deliberately framework-agnostic (no React, no QueryClient): it owns the socket
+// lifecycle, the hello→ready handshake, the subscribe/unsubscribe protocol (§1.4), the
+// app-level ping/pong heartbeat (§6.2), the set-cookie-then-connect auth dance (§4.2),
+// and exponential-backoff-with-jitter reconnect (§6.1). Cache-patching lives one layer
+// up in the React hooks (useWs.tsx) — this client just routes a push payload to the
+// handler the subscriber registered.
+//
+// The socket factory + cookie helpers + RNG are injectable so the whole machine is
+// unit-testable with a mock socket + fake timers.
+
+import { clearWsAuthCookie, setWsAuthCookie } from '@/api/wsAuth'
+
+export type WsStatus = 'live' | 'reconnecting' | 'offline'
+
+// The server→SPA push topics (design §1.2). A push frame's `op` IS the topic name, so a
+// registered subscription's handler is found by op.
+export type SpaTopicName =
+  | 'trafficUsage'
+  | 'now'
+  | 'connectionEvents'
+  | 'timeStatus'
+  | 'appUsage'
+  | 'stale'
+
+// The slice of the browser `WebSocket` the client uses — injectable so tests drive a
+// mock. The real `WebSocket` satisfies this shape structurally.
+export interface WsSocketLike {
+  send(data: string): void
+  close(code?: number, reason?: string): void
+  onopen: ((ev?: unknown) => void) | null
+  onclose: ((ev: { code: number; reason?: string }) => void) | null
+  onmessage: ((ev: { data: string }) => void) | null
+  onerror: ((ev?: unknown) => void) | null
+}
+
+export type SocketFactory = (url: string) => WsSocketLike
+
+export interface SpaWsSubscribeOpts {
+  /** Invoked with the push payload (an existing REST body, §0.3) each time the topic fires. */
+  onPush: (payload: unknown) => void
+  /**
+   * The React Query key to refetch ONCE on reconnect (§6.1) so a change missed while
+   * disconnected converges. Optional — `stale`-style topics need no refetch.
+   */
+  refetchKey?: unknown
+}
+
+interface Subscription extends SpaWsSubscribeOpts {
+  params: unknown
+  token: number
+}
+
+export interface SpaWsClientOptions {
+  /** Same env var the REST client keys off (client.ts) — empty = same-origin self-hosted. */
+  apiBaseUrl: string
+  /** Defaults to `location.origin`; injectable for tests / SSR-less environments. */
+  origin?: string
+  /** The operator JWT source — same token REST sends as a bearer (SSOT). */
+  getToken: () => string | null
+  socketFactory?: SocketFactory
+  setCookie?: (jwt: string | null | undefined) => void
+  clearCookie?: () => void
+  /** Refetch a live query once on reconnect (§6.1); wired to `qc.invalidateQueries`. */
+  invalidateQuery?: (key: unknown) => void
+  /** Called when the server closes with `4401 token-expired` (§4.3) — hand off to /login. */
+  onTokenExpired?: () => void
+  heartbeatMs?: number
+  reconnectBaseMs?: number
+  reconnectCapMs?: number
+  /** Jitter source, injectable for deterministic backoff tests. */
+  random?: () => number
+  clientVersion?: string
+}
+
+// Derive the ws URL from the same base the REST client targets (§2.1): http→ws,
+// same host. Empty base ⇒ same-origin self-hosted build.
+export function wsUrl(apiBaseUrl: string, origin: string): string {
+  const base = (apiBaseUrl || origin).replace(/^http/, 'ws')
+  return `${base}/api/ws`
+}
+
+const DEFAULT_HEARTBEAT_MS = 30_000
+const DEFAULT_RECONNECT_BASE_MS = 1_000
+const DEFAULT_RECONNECT_CAP_MS = 30_000
+
+export class SpaWsClient {
+  private readonly apiBaseUrl: string
+  private readonly origin: string
+  private readonly getToken: () => string | null
+  private readonly socketFactory: SocketFactory
+  private readonly setCookie: (jwt: string | null | undefined) => void
+  private readonly clearCookie: () => void
+  private readonly invalidateQuery?: (key: unknown) => void
+  private readonly onTokenExpired?: () => void
+  private readonly heartbeatMs: number
+  private readonly reconnectBaseMs: number
+  private readonly reconnectCapMs: number
+  private readonly random: () => number
+  private readonly clientVersion: string
+
+  private started = false
+  private socket: WsSocketLike | null = null
+  private status: WsStatus = 'offline'
+  private readonly statusListeners = new Set<() => void>()
+  private readonly subs = new Map<SpaTopicName, Subscription>()
+  private subToken = 0
+  private attempt = 0
+  /** True once a `ready` has been seen — distinguishes the first connect from a reconnect. */
+  private hadReady = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private lastPongAt = 0
+
+  constructor(opts: SpaWsClientOptions) {
+    this.apiBaseUrl = opts.apiBaseUrl
+    this.origin = opts.origin ?? (typeof location !== 'undefined' ? location.origin : '')
+    this.getToken = opts.getToken
+    this.socketFactory =
+      opts.socketFactory ?? ((url: string) => new WebSocket(url) as unknown as WsSocketLike)
+    this.setCookie = opts.setCookie ?? (jwt => setWsAuthCookie(jwt))
+    this.clearCookie = opts.clearCookie ?? (() => clearWsAuthCookie())
+    this.invalidateQuery = opts.invalidateQuery
+    this.onTokenExpired = opts.onTokenExpired
+    this.heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS
+    this.reconnectBaseMs = opts.reconnectBaseMs ?? DEFAULT_RECONNECT_BASE_MS
+    this.reconnectCapMs = opts.reconnectCapMs ?? DEFAULT_RECONNECT_CAP_MS
+    this.random = opts.random ?? Math.random
+    this.clientVersion = opts.clientVersion ?? '1'
+  }
+
+  // ── status (useSyncExternalStore-compatible; bound for stable identity) ───────────
+
+  getStatus = (): WsStatus => this.status
+
+  subscribeStatus = (listener: () => void): (() => void) => {
+    this.statusListeners.add(listener)
+    return () => {
+      this.statusListeners.delete(listener)
+    }
+  }
+
+  private setStatus(next: WsStatus): void {
+    if (this.status === next) return
+    this.status = next
+    for (const l of this.statusListeners) l()
+  }
+
+  // ── lifecycle ─────────────────────────────────────────────────────────────────────
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.attempt = 0
+    this.hadReady = false
+    this.openConnection()
+  }
+
+  stop(): void {
+    this.started = false
+    this.clearReconnect()
+    this.clearHeartbeat()
+    this.closeSocket()
+    this.setStatus('offline')
+  }
+
+  private openConnection(): void {
+    this.clearReconnect()
+    const token = this.getToken()
+    if (!token) {
+      // No credential — an unauthenticated SPA never opens the socket. Stays offline
+      // until start() is called again after login.
+      this.setStatus('offline')
+      return
+    }
+    // Set the tightly-scoped wh_ws cookie just before connect (§4.2) — re-set on every
+    // (re)connect from the CURRENT token.
+    this.setCookie(token)
+    this.setStatus('reconnecting')
+    let socket: WsSocketLike
+    try {
+      socket = this.socketFactory(wsUrl(this.apiBaseUrl, this.origin))
+    } catch {
+      this.scheduleReconnect()
+      return
+    }
+    this.socket = socket
+    socket.onopen = () => this.handleOpen()
+    socket.onmessage = ev => this.handleFrame(ev.data)
+    socket.onclose = ev => this.handleClose(ev?.code ?? 1006)
+    socket.onerror = () => {
+      // Let onclose drive reconnect; closing here makes the error path deterministic.
+      try {
+        socket.close()
+      } catch {
+        /* already closing */
+      }
+    }
+  }
+
+  private handleOpen(): void {
+    // The cookie's job is done the moment the upgrade completes — clear it so the
+    // credential isn't sitting around (§4.2). The short Max-Age is the backstop.
+    this.clearCookie()
+    this.send({ op: 'hello', payload: { clientVersion: this.clientVersion } })
+    // Stay 'reconnecting' until `ready` — a socket that opens but never readys must not
+    // read as live (§1.4).
+  }
+
+  private handleClose(code: number): void {
+    this.clearHeartbeat()
+    this.socket = null
+    if (!this.started) return
+    if (code === 4401) {
+      // Token expired mid-connection (§4.3): stop reconnecting, fall back to polling +
+      // /login. The next REST call's 401 drives the existing redirect.
+      this.started = false
+      this.setStatus('offline')
+      this.onTokenExpired?.()
+      return
+    }
+    this.scheduleReconnect()
+  }
+
+  // ── reconnect / backoff (§6.1) ──────────────────────────────────────────────────────
+
+  private scheduleReconnect(): void {
+    this.setStatus('reconnecting')
+    const delay = this.backoffDelay(this.attempt)
+    this.attempt += 1
+    this.clearReconnect()
+    this.reconnectTimer = setTimeout(() => this.openConnection(), delay)
+  }
+
+  // Exponential backoff capped at reconnectCapMs, with equal jitter so a fleet of tabs
+  // doesn't reconnect in lockstep. Reset on `ready` (not `open`) — see handleReady.
+  private backoffDelay(attempt: number): number {
+    const exp = Math.min(this.reconnectCapMs, this.reconnectBaseMs * 2 ** attempt)
+    return exp / 2 + this.random() * (exp / 2)
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer != null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+
+  // ── frame handling ──────────────────────────────────────────────────────────────────
+
+  private handleFrame(data: string): void {
+    let frame: { op?: unknown; payload?: unknown }
+    try {
+      frame = JSON.parse(data)
+    } catch {
+      return // undecodable — ignore (forward-compat, §2.2)
+    }
+    const op = typeof frame.op === 'string' ? frame.op : ''
+    switch (op) {
+      case 'ready':
+        this.handleReady()
+        return
+      case 'pong':
+        this.lastPongAt = Date.now()
+        return
+      case 'ping':
+        this.send({ op: 'pong', payload: {} })
+        return
+      case 'ack':
+        // Subscription confirmation (§1.4) — keyed by topic. Tracked server-side; the
+        // client doesn't gate on it in v1 (a reject just means no pushes arrive).
+        return
+      default: {
+        // A push frame: op === topic. Route to the registered handler, if any.
+        const sub = this.subs.get(op as SpaTopicName)
+        if (sub) sub.onPush(frame.payload)
+        // Unknown op with no subscription → ignore (forward-compat).
+        return
+      }
+    }
+  }
+
+  private handleReady(): void {
+    const isReconnect = this.hadReady
+    this.hadReady = true
+    this.attempt = 0 // reset backoff on ready, not merely open (§6.1)
+    this.setStatus('live')
+    // The server starts each connection subscribed to nothing — (re)send the full
+    // subscription set on every ready (§1.4).
+    for (const [topic, sub] of this.subs) this.sendSubscribe(topic, sub.params)
+    // On RECONNECT only, refetch the live queries once so a change missed while
+    // disconnected converges (§6.1); the streams then resume on their next push.
+    if (isReconnect && this.invalidateQuery) {
+      for (const sub of this.subs.values()) {
+        if (sub.refetchKey !== undefined) this.invalidateQuery(sub.refetchKey)
+      }
+    }
+    this.startHeartbeat()
+  }
+
+  // ── heartbeat / liveness (§6.2) ─────────────────────────────────────────────────────
+
+  private startHeartbeat(): void {
+    this.clearHeartbeat()
+    this.lastPongAt = Date.now()
+    this.heartbeatTimer = setInterval(() => this.heartbeatTick(), this.heartbeatMs)
+  }
+
+  private heartbeatTick(): void {
+    // A missed app-pong for 2× the interval ⇒ treat the socket as dead and reconnect
+    // (browsers can't send WS control pings, §0.2.2 — this is the app-level liveness).
+    if (this.lastPongAt && Date.now() - this.lastPongAt > 2 * this.heartbeatMs) {
+      this.closeSocket() // onclose → scheduleReconnect
+      return
+    }
+    this.send({ op: 'ping', payload: {} })
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer != null) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  // ── subscriptions (§1.4) ────────────────────────────────────────────────────────────
+
+  /**
+   * Register a subscription and (if live) send the `subscribe` frame. Lifecycle = the
+   * mounted UI (§1.4): the returned disposer unsubscribes. Re-subscribe on param change
+   * is driven by the caller (a React effect's cleanup→re-run) so the wire sees
+   * unsubscribe-then-subscribe — the server replaces that connection's prior
+   * subscription for the topic.
+   */
+  subscribe(topic: SpaTopicName, params: unknown, opts: SpaWsSubscribeOpts): () => void {
+    const token = ++this.subToken
+    this.subs.set(topic, { params, onPush: opts.onPush, refetchKey: opts.refetchKey, token })
+    if (this.status === 'live') this.sendSubscribe(topic, params)
+    return () => {
+      const cur = this.subs.get(topic)
+      // Only tear down if this disposer still owns the current registration — guards the
+      // cleanup-then-resubscribe race when params change.
+      if (cur && cur.token === token) {
+        this.subs.delete(topic)
+        if (this.status === 'live') this.sendUnsubscribe(topic)
+      }
+    }
+  }
+
+  private sendSubscribe(topic: SpaTopicName, params: unknown): void {
+    const payload =
+      params === undefined ? { topic } : { topic, params }
+    this.send({ op: 'subscribe', payload })
+  }
+
+  private sendUnsubscribe(topic: SpaTopicName): void {
+    this.send({ op: 'unsubscribe', payload: { topic } })
+  }
+
+  // ── low-level send / teardown ───────────────────────────────────────────────────────
+
+  private send(frame: { op: string; payload?: unknown }): void {
+    if (!this.socket) return
+    try {
+      this.socket.send(JSON.stringify(frame))
+    } catch {
+      /* socket racing a close — onclose will drive reconnect */
+    }
+  }
+
+  // Tear down the current socket WITHOUT going through its onclose (we detach all handlers
+  // first, so neither a real socket's async onclose nor a mock's synchronous one re-enters).
+  // Used by stop() (started already false → no reconnect) and the heartbeat-dead path
+  // (started true → drive handleClose(1006) ourselves to schedule a reconnect). The normal
+  // server-initiated close arrives on the live `onclose` handler instead, never here.
+  private closeSocket(): void {
+    const s = this.socket
+    this.socket = null
+    if (!s) return
+    const wasStarted = this.started
+    s.onopen = s.onmessage = s.onerror = s.onclose = null
+    try {
+      s.close()
+    } catch {
+      /* already closing */
+    }
+    if (wasStarted) this.handleClose(1006)
+  }
+}

--- a/web/src/components/ApiUnreachableBanner.tsx
+++ b/web/src/components/ApiUnreachableBanner.tsx
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { apiHealth } from '@/api/apiHealth'
+import { useWsLive } from '@/hooks/useWs'
 
 // #1191 — page-level banner shown at the top of the app shell when the SPA
 // can't reach the API. Replaces the silent "empty list" failure mode where
@@ -9,38 +10,63 @@ import { apiHealth } from '@/api/apiHealth'
 // One Retry button → global invalidate, no auto-retry loop. In-flight
 // mutations (autosave forms — feedback_autosave_default.md) are left
 // untouched; they own their own retry/failure UI.
+//
+// #1973 (SPA-ws S5, design §6.2): the ws liveness lets us draw a distinction the
+// silent poll can't — degraded vs down. REST polls failing (apiHealth.unreachable)
+// is genuinely DOWN → the red banner. But the socket merely reconnecting while REST
+// polls still succeed is DEGRADED, not down → a softer "Reconnecting live updates…"
+// notice (the dashboard has fallen back to polling, §3.3, so data is still fresh-ish).
 export function ApiUnreachableBanner() {
   const snap = useSyncExternalStore(apiHealth.subscribe, apiHealth.snapshot, apiHealth.snapshot)
+  const wsStatus = useWsLive()
   const qc = useQueryClient()
-  if (!snap.unreachable) return null
 
-  function onRetry() {
-    qc.invalidateQueries()
+  // Down trumps degraded: if REST itself is unreachable, the ws being down is moot.
+  if (snap.unreachable) {
+    return (
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="bg-red-600 text-white text-sm"
+        data-testid="api-unreachable-banner"
+      >
+        <div className="max-w-7xl mx-auto px-4 py-2 flex flex-wrap items-center gap-3 justify-between">
+          <div>
+            <strong className="font-semibold">WifiHaven can't reach the API right now.</strong>
+            {' '}
+            <span className="opacity-90">
+              Showing cached data where available.
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => qc.invalidateQueries()}
+            className="bg-white text-red-700 font-semibold px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    )
   }
 
-  return (
-    <div
-      role="alert"
-      aria-live="assertive"
-      className="bg-red-600 text-white text-sm"
-      data-testid="api-unreachable-banner"
-    >
-      <div className="max-w-7xl mx-auto px-4 py-2 flex flex-wrap items-center gap-3 justify-between">
-        <div>
-          <strong className="font-semibold">WifiHaven can't reach the API right now.</strong>
+  // Degraded: live updates paused but REST still answering — soft, non-blocking notice.
+  if (wsStatus === 'reconnecting') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="bg-amber-100 text-amber-800 text-sm border-b border-amber-200"
+        data-testid="api-degraded-banner"
+      >
+        <div className="max-w-7xl mx-auto px-4 py-1.5">
+          <span className="font-medium">Reconnecting live updates…</span>
           {' '}
-          <span className="opacity-90">
-            Showing cached data where available.
-          </span>
+          <span className="opacity-90">Data is refreshing on a slower fallback.</span>
         </div>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="bg-white text-red-700 font-semibold px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
-        >
-          Retry
-        </button>
       </div>
-    </div>
-  )
+    )
+  }
+
+  return null
 }

--- a/web/src/components/dashboard/BandwidthGauges.tsx
+++ b/web/src/components/dashboard/BandwidthGauges.tsx
@@ -1,0 +1,77 @@
+import { useWsTrafficUsage } from '@/hooks/useWs'
+import { BucketSelector } from '@/components/usage/BucketSelector'
+import { fmtBytes } from '@/components/usage/usageHelpers'
+import { EmptyState } from '@/components/EmptyState'
+import type { TrafficUsageAggregateRow } from '@/types/api'
+import type { BandwidthRate } from '@/api/wsCache'
+
+// #1973 (SPA-ws S5, design §1.3/§3.1, #747): the live bandwidth gauges — overall +
+// per-profile in/out B/s, driven entirely by the `trafficUsage` ws stream. The window
+// (bucket) selector re-subscribes on change (#747); the client derives B/s = totalBytes
+// / bucketSeconds (server stays the source of bytes). Live throughput has NO poll
+// fallback (§3.3) — it shows "—" while disconnected or before the first push.
+
+// "X/s" — reuse the page's byte formatter so the units match the Traffic Usage page.
+function fmtRate(bytesPerSec: number): string {
+  return `${fmtBytes(Math.round(bytesPerSec))}/s`
+}
+
+function RateLine({ rate }: { rate: BandwidthRate }) {
+  return (
+    <span className="font-mono text-sm tabular-nums text-brand-text">
+      <span className="text-brand-accent-dark">↓ {fmtRate(rate.bytesInPerSec)}</span>
+      <span className="text-brand-text-muted"> · </span>
+      <span className="text-amber-700">↑ {fmtRate(rate.bytesOutPerSec)}</span>
+    </span>
+  )
+}
+
+export function BandwidthGauges() {
+  const { live, bucket, setBucket, rows, overall, rate } = useWsTrafficUsage('1m')
+
+  // Profile label: groupBy:profile puts the profile name in `groups.profile`.
+  const profileLabel = (row: TrafficUsageAggregateRow) =>
+    row.groups.profile ?? row.soleProfile ?? 'Unknown profile'
+
+  return (
+    <section data-testid="bandwidth-gauges" className="bg-white rounded-2xl border border-brand-border p-5 space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">
+          Live Bandwidth
+        </h2>
+        <BucketSelector value={bucket} onChange={setBucket} />
+      </div>
+
+      <div className="flex items-baseline justify-between gap-3 border-b border-brand-border pb-3">
+        <span className="text-sm font-medium text-brand-ink">Overall</span>
+        {live
+          ? <RateLine rate={overall} />
+          : <span data-testid="bandwidth-overall-idle" className="font-mono text-sm text-brand-text-muted">—</span>}
+      </div>
+
+      {!live
+        ? (
+          <p className="text-xs text-brand-text-muted">
+            Live throughput pauses while the connection is down.
+          </p>
+        )
+        : rows.length === 0
+          ? <EmptyState variant="inline" title="No live traffic right now" />
+          : (
+            <ul className="space-y-2">
+              {rows.map(row => (
+                <li
+                  key={row.groups.profile ?? `${row.windowStart}`}
+                  data-testid={`bandwidth-profile-${row.groups.profile ?? 'unknown'}`}
+                  className="flex items-baseline justify-between gap-3"
+                >
+                  <span className="text-sm text-brand-text truncate">{profileLabel(row)}</span>
+                  <RateLine rate={rate(row)} />
+                </li>
+              ))}
+            </ul>
+          )
+      }
+    </section>
+  )
+}

--- a/web/src/components/dashboard/LiveBadge.tsx
+++ b/web/src/components/dashboard/LiveBadge.tsx
@@ -1,0 +1,25 @@
+import { useWsLive } from '@/hooks/useWs'
+
+// #1973 (SPA-ws S5, design §6.2): the small "Live / Reconnecting…" badge driven by the
+// ws connection's health. The connection's state IS the "is my dashboard live?" signal
+// (§0.1) — a green dot when pushes are flowing, amber while reconnecting, grey when the
+// socket is off (unauthenticated / no provider / token expired → polling fallback).
+export function LiveBadge() {
+  const status = useWsLive()
+  const { dot, text, label } =
+    status === 'live'
+      ? { dot: 'bg-emerald-500', text: 'text-emerald-700', label: 'Live' }
+      : status === 'reconnecting'
+        ? { dot: 'bg-amber-500 animate-pulse', text: 'text-amber-700', label: 'Reconnecting…' }
+        : { dot: 'bg-brand-text-muted', text: 'text-brand-text-muted', label: 'Offline' }
+  return (
+    <span
+      data-testid="ws-live-badge"
+      data-status={status}
+      className={`inline-flex items-center gap-1.5 text-xs font-medium ${text}`}
+    >
+      <span className={`w-2 h-2 rounded-full ${dot}`} aria-hidden />
+      {label}
+    </span>
+  )
+}

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -1,0 +1,203 @@
+// #1973 (SPA-ws S5): the React hook layer (design §3.1) — proves each push patches the
+// SAME React Query key the matching GET populates, that the live indicator flips on
+// ready, and that polling pauses while the socket is live. Driven by the real
+// SpaWsClient over a mock socket so the wire→cache path is exercised end to end.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/client', () => ({
+  api: { dashboard: { now: vi.fn().mockResolvedValue({ asOf: 'x', profiles: [] }) } },
+}))
+
+import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
+import { WsProvider, useWsLive, useWsNow, useWsRecentBlocked, useWsTrafficUsage } from './useWs'
+import { useDashboardNow, qk } from '@/api/queries'
+import { AuthProvider } from '@/hooks/useAuth'
+import type { DashboardNow, QueryLog, TrafficUsageResponse } from '@/types/api'
+
+class MockSocket implements WsSocketLike {
+  static instances: MockSocket[] = []
+  sent: string[] = []
+  onopen: ((ev?: unknown) => void) | null = null
+  onclose: ((ev: { code: number; reason?: string }) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+  constructor(public url: string) {
+    MockSocket.instances.push(this)
+  }
+  send(d: string) {
+    this.sent.push(d)
+  }
+  close() {
+    this.onclose?.({ code: 1006 })
+  }
+  open() {
+    this.onopen?.()
+  }
+  emit(frame: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+  frames() {
+    return this.sent.map(s => JSON.parse(s))
+  }
+}
+const last = () => MockSocket.instances[MockSocket.instances.length - 1]
+
+function makeQc(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false, staleTime: 60_000, gcTime: Infinity },
+    },
+  })
+}
+
+function setup() {
+  const qc = makeQc()
+  const client = new SpaWsClient({
+    apiBaseUrl: 'https://api.x',
+    origin: 'https://app.x',
+    getToken: () => 'jwt',
+    socketFactory: url => new MockSocket(url),
+    setCookie: () => {},
+    clearCookie: () => {},
+    invalidateQuery: key => qc.invalidateQueries({ queryKey: key as readonly unknown[] }),
+    heartbeatMs: 100000,
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <AuthProvider>
+        <WsProvider client={client}>{children}</WsProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+  return { qc, client, wrapper }
+}
+
+function goLive(client: SpaWsClient) {
+  act(() => client.start())
+  act(() => last().open())
+  act(() => last().emit({ op: 'ready', payload: { role: 'admin', serverTime: 't' } }))
+}
+
+beforeEach(() => {
+  MockSocket.instances = []
+  localStorage.clear()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useWsLive (§6.2)', () => {
+  it('flips to live on ready', () => {
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsLive(), { wrapper })
+    expect(result.current).toBe('offline')
+    goLive(client)
+    expect(result.current).toBe('live')
+  })
+
+  it('is offline with no provider', () => {
+    const { result } = renderHook(() => useWsLive())
+    expect(result.current).toBe('offline')
+  })
+})
+
+describe('useWsNow (§3.1)', () => {
+  it('replaces the dashboard-now cache on push', () => {
+    const { qc, client, wrapper } = setup()
+    renderHook(() => useWsNow(), { wrapper })
+    goLive(client)
+    const body: DashboardNow = {
+      asOf: '2026-06-26T10:00:00Z',
+      profiles: [{ id: 1, name: 'Kids', paused: false, activeDevices: [{ id: 1, name: 'iPad', mac: 'a', lastSeenSeconds: 5, topHosts: [] }] }],
+    }
+    act(() => last().emit({ op: 'now', payload: body }))
+    expect(qc.getQueryData(qk.dashboardNow())).toEqual(body)
+  })
+})
+
+describe('useWsRecentBlocked (§3.1)', () => {
+  const row = (id: number): QueryLog => ({
+    id, mac: null, deviceName: null, profileId: null, profileName: null,
+    host: { type: 'fqdn', value: `h${id}.com` }, qtype: 1, blocked: true, reason: { kind: 'manual' }, location: null,
+    ts: '2026-06-26T10:00:00Z',
+  })
+
+  it('prepends + dedups pushed head rows into the recentBlocked cache', () => {
+    const { qc, client, wrapper } = setup()
+    qc.setQueryData(qk.recentBlocked(), [row(2), row(1)])
+    renderHook(() => useWsRecentBlocked(), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'connectionEvents', payload: [row(3), row(2)] }))
+    const cached = qc.getQueryData<QueryLog[]>(qk.recentBlocked())
+    expect(cached?.map(r => r.id)).toEqual([3, 2, 1])
+  })
+})
+
+describe('useWsTrafficUsage (§3.1/#747)', () => {
+  it('merges the live-edge bucket into the series cache and subscribes with the bucket', () => {
+    const { qc, client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+    // subscribed with groupBy:profile + bucket
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')
+    expect(sub.payload.params).toEqual({ groupBy: ['profile'], bucket: '1m' })
+
+    const push: TrafficUsageResponse = {
+      bucket: '1m', groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [],
+      aggregateRows: [
+        { groups: { profile: 'Kids' }, windowStart: '2026-06-26T10:05:00Z', windowEnd: '2026-06-26T10:06:00Z', totalBytesIn: 600, totalBytesOut: 0, totalSeconds: 60 },
+      ],
+    }
+    act(() => last().emit({ op: 'trafficUsage', payload: push }))
+    const key = qk.trafficUsageLive({ groupBy: ['profile'], bucket: '1m' })
+    expect(qc.getQueryData<TrafficUsageResponse>(key)?.aggregateRows).toHaveLength(1)
+    // hook surfaces the derived overall rate (600 bytes / 60s = 10 B/s)
+    expect(result.current.live).toBe(true)
+    expect(result.current.overall.bytesInPerSec).toBe(10)
+  })
+
+  it('re-subscribes (unsubscribe+subscribe) when the bucket selector changes', () => {
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+    act(() => result.current.setBucket('10m'))
+    const ops = last().frames().map(f => `${f.op}:${f.payload?.topic ?? ''}:${f.payload?.params?.bucket ?? ''}`)
+    const i1 = ops.indexOf('subscribe:trafficUsage:1m')
+    const iU = ops.indexOf('unsubscribe:trafficUsage:')
+    const i2 = ops.indexOf('subscribe:trafficUsage:10m')
+    expect(i1).toBeGreaterThanOrEqual(0)
+    expect(iU).toBeGreaterThan(i1)
+    expect(i2).toBeGreaterThan(iU)
+  })
+})
+
+describe('polling pauses while live (§3.3)', () => {
+  it('gates refetchInterval off when wsLive', async () => {
+    vi.useFakeTimers()
+    const { api } = await import('@/api/client')
+    const nowSpy = api.dashboard.now as unknown as ReturnType<typeof vi.fn>
+    const { client, wrapper } = setup()
+    // a component that gates the poll on the live indicator, exactly like NowSection
+    const { result } = renderHook(
+      () => {
+        const live = useWsLive() === 'live'
+        useDashboardNow({ refetchInterval: live ? false : 5_000 })
+        return live
+      },
+      { wrapper },
+    )
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    expect(nowSpy).toHaveBeenCalledTimes(1) // initial fetch
+    // not live yet → polls
+    await act(async () => { await vi.advanceTimersByTimeAsync(5_000) })
+    expect(nowSpy).toHaveBeenCalledTimes(2)
+    // go live → polling pauses
+    act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
+    expect(result.current).toBe(true)
+    await act(async () => { await vi.advanceTimersByTimeAsync(20_000) })
+    expect(nowSpy).toHaveBeenCalledTimes(2) // no further polls while live
+  })
+})

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@/api/client', () => ({
 }))
 
 import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
-import { WsProvider, useWsLive, useWsNow, useWsRecentBlocked, useWsTrafficUsage } from './useWs'
+import { WsProvider, useWsLive, useWsTopicLive, useWsNow, useWsRecentBlocked, useWsTrafficUsage } from './useWs'
 import { useDashboardNow, qk } from '@/api/queries'
 import { AuthProvider } from '@/hooks/useAuth'
 import type { DashboardNow, QueryLog, TrafficUsageResponse } from '@/types/api'
@@ -144,6 +144,8 @@ describe('useWsTrafficUsage (§3.1/#747)', () => {
     // subscribed with groupBy:profile + bucket
     const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')
     expect(sub.payload.params).toEqual({ groupBy: ['profile'], bucket: '1m' })
+    // server accepts the subscription → topic streams (drives the `live` flag)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
 
     const push: TrafficUsageResponse = {
       bucket: '1m', groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [],
@@ -174,30 +176,57 @@ describe('useWsTrafficUsage (§3.1/#747)', () => {
   })
 })
 
-describe('polling pauses while live (§3.3)', () => {
-  it('gates refetchInterval off when wsLive', async () => {
+describe('polling pauses only while the topic streams (§3.3)', () => {
+  it('pauses the poll once the `now` subscription is acked, not on bare socket liveness', async () => {
     vi.useFakeTimers()
     const { api } = await import('@/api/client')
     const nowSpy = api.dashboard.now as unknown as ReturnType<typeof vi.fn>
     const { client, wrapper } = setup()
-    // a component that gates the poll on the live indicator, exactly like NowSection
+    // mirrors NowSection: subscribe `now` + gate the poll on the topic actually streaming
     const { result } = renderHook(
       () => {
-        const live = useWsLive() === 'live'
-        useDashboardNow({ refetchInterval: live ? false : 5_000 })
-        return live
+        const streaming = useWsTopicLive('now')
+        useWsNow()
+        useDashboardNow({ refetchInterval: streaming ? false : 5_000 })
+        return streaming
       },
       { wrapper },
     )
     await act(async () => { await vi.advanceTimersByTimeAsync(0) })
     expect(nowSpy).toHaveBeenCalledTimes(1) // initial fetch
-    // not live yet → polls
+    // socket live but not yet acked → still polling
+    act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
+    expect(result.current).toBe(false)
     await act(async () => { await vi.advanceTimersByTimeAsync(5_000) })
     expect(nowSpy).toHaveBeenCalledTimes(2)
-    // go live → polling pauses
-    act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
+    // server acks the subscription → topic streaming → polling pauses
+    act(() => { last().emit({ op: 'ack', payload: { topic: 'now', status: 'ok' } }) })
     expect(result.current).toBe(true)
     await act(async () => { await vi.advanceTimersByTimeAsync(20_000) })
-    expect(nowSpy).toHaveBeenCalledTimes(2) // no further polls while live
+    expect(nowSpy).toHaveBeenCalledTimes(2) // no further polls while streaming
+  })
+
+  it('keeps polling when the subscription is REJECTED (role can not see the topic)', async () => {
+    vi.useFakeTimers()
+    const { api } = await import('@/api/client')
+    const nowSpy = api.dashboard.now as unknown as ReturnType<typeof vi.fn>
+    const { client, wrapper } = setup()
+    const { result } = renderHook(
+      () => {
+        const streaming = useWsTopicLive('now')
+        useWsNow()
+        useDashboardNow({ refetchInterval: streaming ? false : 5_000 })
+        return streaming
+      },
+      { wrapper },
+    )
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
+    // socket live but the server rejects the subscription → must NOT pause the poll
+    act(() => { last().emit({ op: 'ack', payload: { topic: 'now', status: 'reject', reason: 'forbidden' } }) })
+    expect(result.current).toBe(false)
+    const before = nowSpy.mock.calls.length
+    await act(async () => { await vi.advanceTimersByTimeAsync(5_000) })
+    expect(nowSpy.mock.calls.length).toBe(before + 1) // still polling despite a live socket
   })
 })

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -1,0 +1,225 @@
+// #1973 (SPA-ws S5, design docs/design/spa-websocket.md §3): the React layer over the
+// transport client (wsClient.ts) — the provider that owns one SpaWsClient per tab, the
+// `useWsLive()` liveness hook, the generic subscription effect, and the dashboard's
+// three live-surface hooks (now / connectionEvents / trafficUsage). The cache-patching
+// lives here (the client stays framework-agnostic): each push handler patches the SAME
+// React Query key the matching GET populates (§3.1), so the dashboard and the source
+// page share one cache entry and a reconnect refetch reconciles against the GET.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { qk, RECENT_BLOCKED_LIMIT } from '@/api/queries'
+import { useAuth } from '@/hooks/useAuth'
+import { SpaWsClient, type SpaTopicName, type WsStatus } from '@/api/wsClient'
+import {
+  headBucketRows,
+  mergeHeadBucket,
+  overallRate,
+  prependHead,
+  rateFor,
+  type BandwidthRate,
+} from '@/api/wsCache'
+import type {
+  DashboardNow,
+  QueryLog,
+  TrafficUsageAggregateRow,
+  TrafficUsageBucket,
+  TrafficUsageGroupBy,
+  TrafficUsageResponse,
+} from '@/types/api'
+
+const VITE_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const WsContext = createContext<SpaWsClient | null>(null)
+
+// A SPA with no provider mounted (or rendered outside it — e.g. a unit test) degrades to
+// "offline": no subscriptions, polling stays the source of truth (§6.5 failure
+// independence). These module-level stubs keep `useWsLive` hook-safe without a provider.
+const offlineSubscribe = (): (() => void) => () => {}
+const getOffline = (): WsStatus => 'offline'
+
+/**
+ * Owns one `SpaWsClient` for the tab (§6.4 — socket per tab). Starts the socket when
+ * authenticated, stops it on logout/unmount. The client is created once (a ref) so its
+ * connection survives re-renders; `start()` is idempotent.
+ */
+export function WsProvider({ children, client }: { children: ReactNode; client?: SpaWsClient }) {
+  const qc = useQueryClient()
+  const { token, logout } = useAuth()
+  const clientRef = useRef<SpaWsClient | null>(client ?? null)
+  if (!clientRef.current) {
+    clientRef.current = new SpaWsClient({
+      apiBaseUrl: VITE_API_BASE_URL,
+      getToken: () => localStorage.getItem('token'),
+      // Refetch a live query once on reconnect (§6.1) — the streams then resume on push.
+      invalidateQuery: key => qc.invalidateQueries({ queryKey: key as readonly unknown[] }),
+      // On `4401 token-expired` (§4.3): clear auth so the next REST call's 401 drives the
+      // existing /login redirect (client.ts). v1 has no silent refresh.
+      onTokenExpired: () => logout(),
+    })
+  }
+
+  useEffect(() => {
+    // A test-injected client owns its own lifecycle — the test drives start/stop.
+    if (client) return
+    const c = clientRef.current!
+    if (token) c.start()
+    else c.stop()
+    return () => c.stop()
+  }, [token, client])
+
+  return <WsContext.Provider value={clientRef.current}>{children}</WsContext.Provider>
+}
+
+/** The `'live' | 'reconnecting' | 'offline'` indicator (§6.2). Provider-optional. */
+export function useWsLive(): WsStatus {
+  const client = useContext(WsContext)
+  return useSyncExternalStore(
+    client ? client.subscribeStatus : offlineSubscribe,
+    client ? client.getStatus : getOffline,
+  )
+}
+
+/**
+ * Subscribe to a topic for the lifetime of the calling component (§1.4 — subscription
+ * lifecycle = mounted UI). Re-subscribes when `params` change (the effect cleanup sends
+ * `unsubscribe`, the re-run sends `subscribe` — the wire sees unsubscribe-then-subscribe,
+ * which the server treats as a replace). A no-op without a provider.
+ */
+export function useWsSubscription(
+  topic: SpaTopicName,
+  params: unknown,
+  onPush: (payload: unknown) => void,
+  refetchKey?: unknown,
+  enabled = true,
+): void {
+  const client = useContext(WsContext)
+  const onPushRef = useRef(onPush)
+  onPushRef.current = onPush
+  const paramsKey = JSON.stringify(params ?? null)
+  const refetchKeyJson = JSON.stringify(refetchKey ?? null)
+
+  useEffect(() => {
+    if (!client || !enabled) return
+    const dispose = client.subscribe(topic, params, {
+      onPush: p => onPushRef.current(p),
+      refetchKey,
+    })
+    return dispose
+    // Deliberately keyed on the SERIALIZED params/refetchKey (paramsKey/refetchKeyJson),
+    // not their object identities — an identity-fresh-but-equal object must not churn the
+    // subscription. The latest `params`/`refetchKey` values are captured in the closure.
+  }, [client, topic, paramsKey, refetchKeyJson, enabled])
+}
+
+/**
+ * `now` (§3.1, class 2): the server pushes the whole `DashboardNow` body; we replace the
+ * dashboard-now cache so the existing `useDashboardNow` consumers (and the derived
+ * Online/Blocked KPIs) update sub-second. Refetched once on reconnect.
+ */
+export function useWsNow(): void {
+  const qc = useQueryClient()
+  useWsSubscription(
+    'now',
+    undefined,
+    payload => qc.setQueryData(qk.dashboardNow(), payload as DashboardNow),
+    qk.dashboardNow(),
+  )
+}
+
+/**
+ * `connectionEvents{blocked:true}` (§3.1, class 1): the server pushes the new head rows;
+ * we prepend them (bounded, dedup by id) into the dashboard's "Recently Blocked" cache —
+ * the same `recentBlocked()` key `useRecentBlocked` reads. Refetched once on reconnect.
+ */
+export function useWsRecentBlocked(): void {
+  const qc = useQueryClient()
+  useWsSubscription(
+    'connectionEvents',
+    { blocked: true },
+    payload => {
+      const rows = (payload as QueryLog[]) ?? []
+      qc.setQueryData(qk.recentBlocked(), (prev: QueryLog[] | undefined) =>
+        prependHead(prev, rows, RECENT_BLOCKED_LIMIT),
+      )
+    },
+    qk.recentBlocked(),
+  )
+}
+
+export interface WsTrafficUsage {
+  live: boolean
+  bucket: TrafficUsageBucket
+  setBucket: (b: TrafficUsageBucket) => void
+  /** The head (current) bucket's per-profile rows (one per profile, groupBy:profile). */
+  rows: TrafficUsageAggregateRow[]
+  /** The household total rate (sum of the per-profile head rows). */
+  overall: BandwidthRate
+  /** Per-row B/s derivation helper (server stays the source of bytes; §1.3). */
+  rate: (row: TrafficUsageAggregateRow) => BandwidthRate
+}
+
+/**
+ * `trafficUsage{groupBy:profile, bucket}` (§3.1, class 1): the live bandwidth gauge.
+ * Subscribes with the chosen window (bucket); re-subscribes when the selector changes
+ * (#747). The push carries only the live-edge bucket — we MERGE it into the cached
+ * series by `windowStart` (§3.1). The series is ws-only (no poll fallback, §3.3): it
+ * lives purely in the React Query cache, written by the push and read passively here, so
+ * it shows "—" (empty rows) until the first push lands and while disconnected.
+ */
+export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsTrafficUsage {
+  const qc = useQueryClient()
+  const [bucket, setBucket] = useState<TrafficUsageBucket>(initialBucket)
+  const groupBy = useMemo<TrafficUsageGroupBy[]>(() => ['profile'], [])
+  const params = useMemo(() => ({ groupBy, bucket }), [groupBy, bucket])
+  const key = qk.trafficUsageLive(params)
+  const liveStatus = useWsLive()
+
+  useWsSubscription(
+    'trafficUsage',
+    params,
+    payload => {
+      const body = payload as TrafficUsageResponse
+      qc.setQueryData(key, (prev: TrafficUsageResponse | undefined) => mergeHeadBucket(prev, body))
+    },
+    key,
+  )
+
+  // Passive cache reader: never fetches (§3.3 — no poll fallback for the live rate), just
+  // re-renders when the push writes the series cache. A disabled `useQuery` observer does
+  // NOT get cache-update notifications, so subscribe to the cache directly.
+  const data = useCachedQueryData<TrafficUsageResponse>(qc, key)
+  const rows = headBucketRows(data)
+  return {
+    live: liveStatus === 'live',
+    bucket,
+    setBucket,
+    rows,
+    overall: overallRate(rows, bucket),
+    rate: (row: TrafficUsageAggregateRow) => rateFor(row, bucket),
+  }
+}
+
+/**
+ * Subscribe to a single React Query key's cached data WITHOUT fetching — re-renders when
+ * a `setQueryData` writes it (a disabled `useQuery` observer doesn't receive those). Used
+ * for the ws-only trafficUsage series, which has no GET fallback (§3.3).
+ */
+function useCachedQueryData<T>(qc: QueryClient, key: readonly unknown[]): T | undefined {
+  const keyHash = JSON.stringify(key)
+  const subscribe = useCallback((cb: () => void) => qc.getQueryCache().subscribe(cb), [qc])
+  // Re-read when the key changes (keyHash), not on every render. `key` is intentionally
+  // not a dep — keyHash is its serialized identity.
+  const getSnapshot = useCallback(() => qc.getQueryData<T>(key), [qc, keyHash])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -91,6 +91,22 @@ export function useWsLive(): WsStatus {
 }
 
 /**
+ * Whether `topic` is actually STREAMING — the socket is live AND the server accepted this
+ * connection's subscription (`ack:ok`). This is what a poll-pause gates on (§3.3), NOT bare
+ * `useWsLive()`: a role-rejected topic (e.g. a Child subscribing `now`/`connectionEvents`,
+ * `SpaTopic.visibleTo`) is live-socket but never pushed, so its query must keep polling.
+ */
+export function useWsTopicLive(topic: SpaTopicName): boolean {
+  const client = useContext(WsContext)
+  const subscribe = client ? client.subscribeStatus : offlineSubscribe
+  const getSnapshot = useCallback(
+    () => (client ? client.topicActive(topic) : false),
+    [client, topic],
+  )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
  * Subscribe to a topic for the lifetime of the calling component (§1.4 — subscription
  * lifecycle = mounted UI). Re-subscribes when `params` change (the effect cleanup sends
  * `unsubscribe`, the re-run sends `subscribe` — the wire sees unsubscribe-then-subscribe,
@@ -183,7 +199,9 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
   const groupBy = useMemo<TrafficUsageGroupBy[]>(() => ['profile'], [])
   const params = useMemo(() => ({ groupBy, bucket }), [groupBy, bucket])
   const key = qk.trafficUsageLive(params)
-  const liveStatus = useWsLive()
+  // "live" here = trafficUsage actually streaming (acked), not bare socket liveness — so a
+  // role that can't see trafficUsage shows "—" rather than a misleading "live" with no data.
+  const streaming = useWsTopicLive('trafficUsage')
 
   useWsSubscription(
     'trafficUsage',
@@ -201,7 +219,7 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
   const data = useCachedQueryData<TrafficUsageResponse>(qc, key)
   const rows = headBucketRows(data)
   return {
-    live: liveStatus === 'live',
+    live: streaming,
     bucket,
     setBucket,
     rows,

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -12,7 +12,7 @@ import { HostCell } from '@/components/HostCell'
 import { EmptyState } from '@/components/EmptyState'
 import { AccessRequestsBanner, NewDevicesHint } from '@/components/AlertsPanel'
 import { blockReasonText } from '@/types/blockReason'
-import { useWsLive, useWsNow, useWsRecentBlocked } from '@/hooks/useWs'
+import { useWsTopicLive, useWsNow, useWsRecentBlocked } from '@/hooks/useWs'
 import { deriveNowKpis } from '@/api/wsCache'
 import { LiveBadge } from '@/components/dashboard/LiveBadge'
 import { BandwidthGauges } from '@/components/dashboard/BandwidthGauges'
@@ -115,10 +115,11 @@ export function DashboardPage() {
 export function RecentlyBlockedSection() {
   // #1973: subscribe `connectionEvents{blocked:true}` — pushes prepend into the same
   // `recentBlocked()` cache this query reads (§3.1). Polling stays the PAUSED fallback
-  // (§3.3): gated off while the socket is live, resumes at today's 10s cadence when down.
-  const wsLive = useWsLive() === 'live'
+  // (§3.3): gated off only while the topic is actually STREAMING (subscribed + acked), so
+  // a role whose subscription the server rejects keeps polling instead of going stale.
+  const streaming = useWsTopicLive('connectionEvents')
   useWsRecentBlocked()
-  const { data = null } = useRecentBlocked({ refetchInterval: wsLive ? false : 10_000 })
+  const { data = null } = useRecentBlocked({ refetchInterval: streaming ? false : 10_000 })
 
   return (
     <section data-testid="recently-blocked-section" className="bg-white rounded-2xl border border-brand-border overflow-hidden">
@@ -178,11 +179,12 @@ function formatRelativeTime(tsIso: string): string {
 
 export function NowSection() {
   // #1973: `now` is pushed whole (§3.1) — replace the dashboard-now cache live. Derived
-  // "Online now" KPI recomputes client-side off the pushed body. Polling stays the
-  // paused fallback (§3.3), gated on the socket being live.
-  const wsLive = useWsLive() === 'live'
+  // "Online now" KPI recomputes client-side off the pushed body. Polling stays the paused
+  // fallback (§3.3), gated on the `now` topic actually STREAMING (subscribed + acked) — a
+  // role whose `now` subscription is server-rejected keeps polling rather than freezing.
+  const streaming = useWsTopicLive('now')
   useWsNow()
-  const { data = null } = useDashboardNow({ refetchInterval: wsLive ? false : 10_000 })
+  const { data = null } = useDashboardNow({ refetchInterval: streaming ? false : 10_000 })
   const kpis = deriveNowKpis(data)
 
   return (

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -12,6 +12,10 @@ import { HostCell } from '@/components/HostCell'
 import { EmptyState } from '@/components/EmptyState'
 import { AccessRequestsBanner, NewDevicesHint } from '@/components/AlertsPanel'
 import { blockReasonText } from '@/types/blockReason'
+import { useWsLive, useWsNow, useWsRecentBlocked } from '@/hooks/useWs'
+import { deriveNowKpis } from '@/api/wsCache'
+import { LiveBadge } from '@/components/dashboard/LiveBadge'
+import { BandwidthGauges } from '@/components/dashboard/BandwidthGauges'
 
 export function DashboardPage() {
   const [stats,  setStats]  = useState<DashboardStats | null>(null)
@@ -35,6 +39,8 @@ export function DashboardPage() {
       <AccessRequestsBanner />
 
       <RecentlyBlockedSection />
+
+      <BandwidthGauges />
 
       <NowSection />
 
@@ -107,7 +113,12 @@ export function DashboardPage() {
 // React Query polling + JWT/household scoping via useRecentBlocked.
 
 export function RecentlyBlockedSection() {
-  const { data = null } = useRecentBlocked()
+  // #1973: subscribe `connectionEvents{blocked:true}` — pushes prepend into the same
+  // `recentBlocked()` cache this query reads (§3.1). Polling stays the PAUSED fallback
+  // (§3.3): gated off while the socket is live, resumes at today's 10s cadence when down.
+  const wsLive = useWsLive() === 'live'
+  useWsRecentBlocked()
+  const { data = null } = useRecentBlocked({ refetchInterval: wsLive ? false : 10_000 })
 
   return (
     <section data-testid="recently-blocked-section" className="bg-white rounded-2xl border border-brand-border overflow-hidden">
@@ -166,11 +177,25 @@ function formatRelativeTime(tsIso: string): string {
 // imperative setInterval / try-catch from before is gone.
 
 export function NowSection() {
-  const { data = null } = useDashboardNow()
+  // #1973: `now` is pushed whole (§3.1) — replace the dashboard-now cache live. Derived
+  // "Online now" KPI recomputes client-side off the pushed body. Polling stays the
+  // paused fallback (§3.3), gated on the socket being live.
+  const wsLive = useWsLive() === 'live'
+  useWsNow()
+  const { data = null } = useDashboardNow({ refetchInterval: wsLive ? false : 10_000 })
+  const kpis = deriveNowKpis(data)
 
   return (
     <section data-testid="now-section" className="space-y-3">
-      <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">Now</h2>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">Now</h2>
+        <div className="flex items-center gap-3">
+          <span data-testid="now-kpi-online" className="text-xs text-brand-text-muted">
+            Online now: <span className="font-semibold text-brand-ink tabular-nums">{kpis.onlineNow}</span>
+          </span>
+          <LiveBadge />
+        </div>
+      </div>
       {data === null
         ? <p className="text-brand-text-muted text-sm">Loading live activity…</p>
         : data.profiles.length === 0


### PR DESCRIPTION
**SPA-websocket step S5 — the pilot: the realtime dashboard surface** (design [`docs/design/spa-websocket.md`](docs/design/spa-websocket.md) §3/§6; umbrella #1955). Builds on the merged server side (S1–S4: `/api/ws`, `SpaWsRegistry`, `SpaEventHub`, `trafficUsage` aggregator). **Additive — every other view keeps polling; no flag day.**

Closes #1973.

### What ships
- **`wsClient.ts`** — framework-agnostic `SpaWsClient`: derives the ws URL from `VITE_API_BASE_URL` (`http→ws`, §2.1), runs `setWsAuthCookie` → connect → `clearWsAuthCookie` after open (§4.2), `hello`→`ready` handshake, `subscribe`/`unsubscribe` + topic-keyed `ack` (§1.4), app-level `ping`/`pong` heartbeat (§6.2), exponential-backoff-with-jitter reconnect reset on `ready` (§6.1) — re-sets the cookie + replays the subscription set + refetches live queries **once** on reconnect; on `4401 token-expired` stops reconnecting and hands off to polling + `/login` (§4.3).
- **`wsCache.ts`** — pure merges: `mergeHeadBucket` (live-edge by `windowStart` — replace head while it accumulates, prepend on rollover, history untouched, §3.1), `prependHead` (bounded, dedup by id), B/s = `totalBytes / bucketSeconds` (server stays the source of bytes — no second rate serializer, §1.3), `deriveNowKpis`.
- **`useWs.tsx`** — `WsProvider` (one socket per tab, §6.4), `useWsLive()` (`'live'|'reconnecting'|'offline'`, §6.2), and the three dashboard hooks: `useWsNow` (replaces the dashboard-now cache), `useWsRecentBlocked` (`connectionEvents{blocked:true}` → prepend into `recentBlocked()`), `useWsTrafficUsage` (`trafficUsage{groupBy:profile,bucket}` → merge head bucket; **re-subscribes on the window/bucket selector change**, #747). Each push patches the **same React Query key** its `GET` populates (§3.1).
- **Dashboard**: `BandwidthGauges` (overall + per-profile live B/s with a window selector), `LiveBadge`, a derived **Online-now** KPI. **Polling stays the paused fallback** gated on `wsLive` (§3.3) — **no `refetchInterval` removed** (that's S7), `TIME_STATUS_REFETCH_LADDER` untouched (S6a/S7).
- **`ApiUnreachableBanner`** — degraded (socket reconnecting, REST polls succeeding → soft "Reconnecting live updates…") vs down (REST unreachable → existing red banner) (§6.2).
- **`qk.trafficUsageLive` / `qk.connectionEventsLive`** lifted into the shared `qk` factory so the push and the future S6b page key are produced in one place.

### Scope discipline
- **Zero additions to `web/src/types/api.ts`** — every payload is an existing REST body (§0.3).
- Live throughput has **no poll fallback** — shows "—" while disconnected (§3.3).
- **NOT** in this PR: live time-usage push (S6a), streaming the Traffic/Connection pages (S6b), retiring `refetchInterval`s (S7).

Lights up the redesigned **NOW + bandwidth + Recently-Blocked**; unblocks #1834/#1835. Relates to #747, #1148, #1338, #1834, #1835, #1860, #1955.

### Tests (TDD, RED→GREEN in history)
`nvm use 22 && npm --prefix web test` — 39 files / 451 tests green. New: `wsCache.test.ts` (merge/prepend/dedup/B-s/KPIs), `wsClient.test.ts` (handshake, subscribe replay, re-subscribe, backoff reconnect re-cookie+replay+refetch-once, 4401 stop, heartbeat — fake timers + mock socket), `useWs.test.tsx` (live flip, three cache patches, re-subscribe on bucket change, poll-pauses-while-live). `npm --prefix web run lint` + `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)