### PR TITLE
ci(#1999): bump Gate 2 VM e2e timeout 50→75min (ipk exceeds cap after #1945)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -77,7 +77,17 @@ jobs:
     # while the ipk arm passed at 32m30s. The pack itself is healthy (per-step
     # times unchanged); the cap just needs to grow with the scenario count.
     # 50m restores ~10m headroom on the slow arm without masking a regression.
-    timeout-minutes: 50
+    #
+    # Bumped 50→75m (#1999) after #1945 (PR #1994) added the
+    # test_ws_push_apply.py push→apply→enforce scenario: that extra ~2m
+    # snapshot-restore + boot + enforcement-flip cost tipped the slower ipk
+    # arm past the cap, which was cancelled at exactly 50m twice in a row
+    # (Master Router CD runs ~00:09→00:59Z) while the apk arm fit in ~35m.
+    # ipk is consistently slower (packaging/boot overhead + shared-host load
+    # on api.lan), and the pack had already run as close as 49m44s before this
+    # scenario landed. 75m re-establishes ~20m+ headroom on the slow arm
+    # without masking a regression in the scenario pack itself.
+    timeout-minutes: 75
     # #685: matrix over ipk-23.05 and apk-25.12 router images. fail-fast=false
     # so a regression in one flavor still reports the other arm's status
     # (needed to surface apk-only regressions like the #531 history case).


### PR DESCRIPTION
## Problem
Master Router CD **Gate 2 — router fake-API e2e** (`e2e-vm-fake.yml`) is deterministically RED: the **ipk** matrix arm is cancelled at **exactly 50 minutes**, twice in a row (job 00:09:31Z → 00:59:54Z → `The operation was canceled.`), while the **apk** arm of the same suite passes in ~35 min. This is the only thing keeping Master Router CD red — the staging-OOM incident (#1984/#1989/#1992) is resolved (Gate 3a green, Gate 2 apk green, no oomKilled).

Not a transient flake (proven twice), not OOM.

## Root cause
Gate 2 had already run as close as **49m44s** (run 28177601079) before this. **#1945** (PR #1994) added a new Gate-2 enforcement-flip scenario (`scripts/e2e/scenarios_fake/test_ws_push_apply.py`, push→apply→enforce). Each VM scenario carries a fixed ~2m snapshot-restore + boot cost; that extra runtime tipped the consistently-slower **ipk** arm past the 50m cap. ipk is slower for packaging/boot overhead + shared-host load on api.lan; apk still fits.

## Fix
Bump `timeout-minutes` 50 → 75 in `e2e-vm-fake.yml`. Both matrix arms (ipk + apk) share the single job-level cap (line 80), so this covers both. Verified there is **no second timeout**: the called scripts (`e2e-vm.sh`, `conftest.py`) only have per-fixture waits, and the `workflow_call` site in `master-router.yml` (`gate-2-router-fake-api`) sets no `timeout-minutes`. Precedent: prior 40→50m and 30→40m bumps as the scenario count grew.

This is the accepted unblock per #1999; the ipk slowness is uniform packaging/boot overhead rather than one pathological test (see issue diagnosis), so no per-test fix is bundled here.

Closes #1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)