### PR TITLE
fix(#2001): ws apply-on-push e2e — poll/startup save clobbers sidecar-pushed snapshot

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -364,14 +364,39 @@ end
 
 local SNAPSHOT_PATH = "/etc/wifihaven/policy.json"
 
--- save_snapshot(snap, write_fn, rename_fn) → bool
+-- save_snapshot(snap, write_fn, rename_fn, log[, read_fn, expect_etag]) → bool
 --   write_fn(path, content)  → ok, err
 --   rename_fn(from_path, to) → ok[, err]
+--   read_fn(path)            → content|nil  (optional — enables the #2001 guard)
+--   expect_etag              → string|nil   (the etag we fetched against)
 -- Atomic: writes to <path>.tmp then renames over <path>. Skips the rename
 -- if the write fails, so a torn or partial write never replaces a good
 -- on-disk snapshot.
-function M.save_snapshot(snap, write_fn, rename_fn, log)
+--
+-- #2001 compare-and-swap guard: when ws push is the IN channel (#1849/#1945)
+-- the sidecar ALSO writes policy.json. A poll/startup save that fetched an
+-- OLDER snapshot must not clobber a NEWER one the sidecar persisted while the
+-- (slow, under-load) apply was in flight — otherwise the frozen-poll agent
+-- never re-applies the push and enforcement silently reverts. When a `read_fn`
+-- is supplied we re-read the on-disk etag just before the rename and SKIP the
+-- write (returning true — the fresher file is intentionally kept) iff the
+-- on-disk etag is a different, non-nil value than both `expect_etag` (what we
+-- fetched against) and the snapshot we're about to write. With no `read_fn`
+-- the behaviour is the unconditional write legacy callers/tests expect.
+function M.save_snapshot(snap, write_fn, rename_fn, log, read_fn, expect_etag)
   log = log or default_log()
+  if read_fn then
+    local on_disk = M.load_snapshot(read_fn, log)
+    local disk_etag = on_disk and on_disk.etag or nil
+    if disk_etag ~= nil
+       and disk_etag ~= expect_etag
+       and disk_etag ~= (snap and snap.etag) then
+      log.info("policy.save_snapshot: on-disk etag=%s differs from expected=%s "
+               .. "and from to-write=%s — keeping the fresher (ws-pushed) snapshot (#2001)",
+               tostring(disk_etag), tostring(expect_etag), tostring(snap and snap.etag))
+      return true
+    end
+  end
   local jsonc = require("luci.jsonc")
   local body = jsonc.stringify(snap)
   local tmp = SNAPSHOT_PATH .. ".tmp"

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -792,9 +792,14 @@ end
 -- so enforcement resumes within seconds instead of waiting on the first
 -- successful poll. The boot-time default-deny skeleton (#308) stays in
 -- effect until apply() succeeds.
+-- #2001: the etag the agent last observed on flash, so the startup save below
+-- can detect a concurrent ws-sidecar push that arrived during the (slow) apply
+-- and avoid clobbering it. nil when there is no cached snapshot.
+local startup_disk_etag = nil
 do
   local cached = policy.load_snapshot(read_file, log)
   if cached then
+    startup_disk_etag = cached.etag
     local t0 = clock.monotonic_seconds()
     local applied = policy.apply(cached, write_file, run_cmd, log,
                                  { on_apply = record_apply("boot") })
@@ -836,7 +841,9 @@ do
       ts.current_etag = etag
       ts.last_snapshot = snap
       policy.mark_poll_success(os.time())
-      policy.save_snapshot(snap, write_file, rename_file, log)
+      -- #2001: don't clobber a fresher snapshot the ws sidecar persisted while
+      -- this initial apply was in flight (we fetched against `startup_disk_etag`).
+      policy.save_snapshot(snap, write_file, rename_file, log, read_file, startup_disk_etag)
       log.info("startup: applied initial policy etag=%s", tostring(etag))
     end
   else
@@ -1030,6 +1037,9 @@ conntrack.watch({
       metrics.observe(mreg, "snapshot_poll_duration_seconds", {},
                       clock.monotonic_seconds() - pt0)
       local fetch_ok
+      -- #2001: the etag we fetched against (If-None-Match); the save below uses
+      -- it to detect a concurrent ws-sidecar push and avoid clobbering it.
+      local prev_etag = ts.current_etag
       if snap then
         record_poll("200")
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.
@@ -1049,7 +1059,7 @@ conntrack.watch({
           ts.current_etag = etag
           ts.last_snapshot = snap
           policy.mark_poll_success(wall)
-          policy.save_snapshot(snap, write_file, rename_file, log)
+          policy.save_snapshot(snap, write_file, rename_file, log, read_file, prev_etag)
           -- #1945: refresh the ws apply-on-push cadence anchor so the disk-read
           -- tick doesn't immediately re-apply the snapshot this poll just wrote.
           ts.last_ws_apply_run = mono

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -645,6 +645,97 @@ describe("policy.save_snapshot", function()
 
 end)
 
+-- ── policy.save_snapshot compare-and-swap guard (#2001) ──────────────────
+--
+-- When the ws sidecar (#1849/#1945) is the IN channel, two writers touch
+-- policy.json: the agent's poll/startup `save_snapshot` AND the sidecar's
+-- atomic push-persist. If a poll fetched snapshot S (slow apply under load)
+-- while the sidecar concurrently persisted a NEWER pushed snapshot P, the
+-- poll's save must NOT clobber P back to S — otherwise the frozen-poll agent
+-- never re-applies P and enforcement silently reverts (the #2001 Gate-2
+-- flake: startup save of BASE landed after the sidecar wrote PAUSED, so the
+-- apply-on-push tick saw BASE==current_etag forever and the drop never
+-- installed). The guard: when a `read_fn` is supplied, skip the write if the
+-- on-disk etag is a DIFFERENT, non-nil value than both the `expect_etag` we
+-- fetched against and the snapshot we're about to write.
+describe("policy.save_snapshot clobber guard (#2001)", function()
+
+  local SNAPSHOT_PATH = "/etc/wifihaven/policy.json"
+
+  local function decode_snap()
+    local json = require("cjson")
+    return json.decode(SNAPSHOT_JSON)
+  end
+
+  -- A read_fn that returns a snapshot JSON carrying `etag` (nil → absent file).
+  local function disk_with_etag(etag)
+    return function(_path)
+      if etag == nil then return nil end
+      local json = require("cjson")
+      return json.encode({ etag = etag, profiles = {}, devices = {}, blocklists = {} })
+    end
+  end
+
+  local function save_guarded(snap, read_fn, expect_etag)
+    local writes, renames = {}, {}
+    local ok = policy.save_snapshot(snap,
+      function(path, content) writes[path] = content; return true, nil end,
+      function(from, to) table.insert(renames, { from = from, to = to }); return true end,
+      nil, read_fn, expect_etag)
+    return ok, writes, renames
+  end
+
+  it("skips the write when the on-disk etag is a fresher concurrent push", function()
+    -- poll fetched snap (etag sha256:abc123) against expect "sha256:old", but
+    -- the sidecar already persisted "sha256:ws-pushed" → don't clobber it.
+    local ok, _writes, renames = save_guarded(
+      decode_snap(), disk_with_etag("sha256:ws-pushed"), "sha256:old")
+    assert.is_true(ok)            -- not an error; the fresher file is intentionally kept
+    assert.equal(0, #renames)     -- nothing written / renamed
+  end)
+
+  it("skips the write at startup (expect=nil) when disk holds a pushed snapshot", function()
+    -- The exact #2001 race: startup had no cached policy (expect=nil) and
+    -- fetched BASE (sha256:abc123), but the sidecar wrote PAUSED first.
+    local ok, _writes, renames = save_guarded(
+      decode_snap(), disk_with_etag("sha256:ws-pushed-paused"), nil)
+    assert.is_true(ok)
+    assert.equal(0, #renames)
+  end)
+
+  it("writes when the on-disk etag matches expect_etag (no concurrent writer)", function()
+    local ok, _writes, renames = save_guarded(
+      decode_snap(), disk_with_etag("sha256:old"), "sha256:old")
+    assert.is_true(ok)
+    assert.equal(1, #renames)
+    assert.equal(SNAPSHOT_PATH, renames[1].to)
+  end)
+
+  it("writes when the on-disk file is absent (fresh install / ws off)", function()
+    local ok, _writes, renames = save_guarded(decode_snap(), disk_with_etag(nil), nil)
+    assert.is_true(ok)
+    assert.equal(1, #renames)
+  end)
+
+  it("writes (idempotent) when the on-disk etag already equals the snapshot's", function()
+    -- decode_snap()'s etag is sha256:abc123; disk already holds it.
+    local ok, _writes, renames = save_guarded(
+      decode_snap(), disk_with_etag("sha256:abc123"), "sha256:old")
+    assert.is_true(ok)
+    assert.equal(1, #renames)
+  end)
+
+  it("writes unconditionally when no read_fn is supplied (legacy callers)", function()
+    local renames = {}
+    local ok = policy.save_snapshot(decode_snap(),
+      function(_p, _c) return true, nil end,
+      function(from, to) table.insert(renames, { from = from, to = to }); return true end)
+    assert.is_true(ok)
+    assert.equal(1, #renames)
+  end)
+
+end)
+
 describe("policy.load_snapshot", function()
 
   it("returns the decoded snapshot when the read returns valid JSON", function()

--- a/scripts/e2e/scenarios_fake/conftest.py
+++ b/scripts/e2e/scenarios_fake/conftest.py
@@ -313,6 +313,27 @@ def pytest_runtest_makereport(item, call):
             sections.append(("router agent log", (r.stdout or "") + (r.stderr or "")))
         except Exception as e:  # noqa: BLE001
             sections.append(("router agent log", f"<unavailable: {e}>"))
+        # #2001: the on-disk snapshot etag + the live per-MAC drop rules. The
+        # absence of these two facts (was policy.json BASE or PAUSED? was any
+        # wh_drop installed?) is exactly what made the ws apply-on-push flake so
+        # hard to diagnose — capture them so any future enforcement/snapshot
+        # divergence is a one-look read rather than a re-run.
+        try:
+            r = router_ssh(
+                "echo 'policy.json etag:'; "
+                # The etag value is itself a quoted HTTP etag (\"\\\"sha256:..\\\"\"),
+                # so match to the field delimiter (comma), not the next quote, or we
+                # truncate at the escaped inner quote and never show BASE vs PAUSED.
+                "grep -o '\"etag\":[^,]*' /etc/wifihaven/policy.json 2>/dev/null "
+                "|| echo '(policy.json absent/unreadable)'; "
+                "echo 'wh_drop rules:'; "
+                "nft list table inet wifihaven 2>/dev/null | grep -F 'wh_drop:' "
+                "|| echo '(no wh_drop rules)'",
+                check=False, timeout=10,
+            )
+            sections.append(("router policy.json + nft drops", (r.stdout or "") + (r.stderr or "")))
+        except Exception as e:  # noqa: BLE001
+            sections.append(("router policy.json + nft drops", f"<unavailable: {e}>"))
         try:
             fake = item.funcargs.get("fake_api")
             client_obj = item.funcargs.get("client")

--- a/scripts/e2e/scenarios_fake/test_ws_push_apply.py
+++ b/scripts/e2e/scenarios_fake/test_ws_push_apply.py
@@ -136,7 +136,7 @@ def _ws_health_present() -> bool:
 
 
 def _nudge_conntrack() -> None:
-    """Emit one LAN-side flow so the agent's conntrack-driven `on_tick` fires.
+    """Emit a small burst of LAN-side flows so the agent's `on_tick` fires.
 
     The agent's cooperative scheduler — the policy poll, usage/metrics timers,
     and the #1945 apply-on-push tick — all run inside `conntrack.watch`'s loop,
@@ -149,11 +149,21 @@ def _nudge_conntrack() -> None:
     exactly as a live network's traffic does continuously. The GET carries NO
     policy (the HTTP poll stays frozen at 3600s, and a bare /healthz hit is not a
     snapshot fetch), so the enforcement flip remains attributable to the ws push.
+
+    #2001: we fire a *burst* (not a single GET) because `conntrack -E`'s stdout
+    is block-buffered when piped (no `stdbuf` on OpenWRT), so under VM load a lone
+    sparse event can sit in conntrack's ~4 KiB buffer for tens of seconds before
+    it flushes to the agent's reader — starving `on_tick` and stretching the
+    apply latency. A handful of flows per wait-iteration fills that buffer sooner,
+    so `on_tick` (and the apply-on-push tick it rides) runs promptly. Still bounded
+    and policy-free, so the push remains the sole enforcement source.
     """
     router_ssh(
-        'curl -s -m 3 -o /dev/null "$(uci get wifihaven.wifihaven.api_url)/healthz" '
-        "2>/dev/null || true",
-        check=False, timeout=10,
+        'u="$(uci get wifihaven.wifihaven.api_url)"; '
+        "for _ in 1 2 3 4 5; do "
+        'curl -s -m 2 -o /dev/null "$u/healthz" 2>/dev/null || true; '
+        "done",
+        check=False, timeout=20,
     )
 
 


### PR DESCRIPTION
## Summary
Fixes #2001 — `test_ws_policy_push_applies_enforcement_live` (#1945) intermittently timed out on **both Gate 2 arms across runs** waiting for the per-MAC `wh_drop:<mac>:Paused` forward-drop. This was the only thing keeping Master Router CD red.

## Root cause — a real apply-path race, not test fragility
Diagnosed from the failing run's captured agent log (run 28276547036, ipk):

```
ws: connected
wifihaven-ws: persisted pushed policy snapshot etag="...enforce-base-v1"   (on-connect push)
wifihaven-ws: persisted pushed policy snapshot etag="...enforce-paused-v2" (push-on-change → disk=PAUSED)
startup: applied initial policy etag="...enforce-base-v1"                   (startup save writes BASE over PAUSED)
```

When ws is the IN channel, **two writers touch `/etc/wifihaven/policy.json`**: the agent's poll/startup `save_snapshot` and the ws sidecar's atomic push-persist. The sidecar wrote BASE then PAUSED early, but the agent's still-in-flight startup fetch-apply (slow under load) then wrote **BASE over PAUSED**. With the poll frozen at 3600s, the apply-on-push tick forever saw `disk-etag == current_etag (BASE)` → never installed the drop → 180s timeout.

It's intermittent because under load the startup save lands *after* the push; on a fast VM it lands before (prior run passed). The test's `wait disk==BASE` is satisfied by the sidecar's *on-connect* BASE write, which opens the race window.

## Fix
**Agent (root cause):** `policy.save_snapshot` gains an optional compare-and-swap guard. With a `read_fn` supplied it re-reads the on-disk etag and **skips the write** (keeping the fresher file) iff that etag differs from both the etag we fetched against *and* the one we're about to write. Poll + startup call sites pass the etag they fetched against (`prev_etag` / `startup_disk_etag`). The apply-on-push tick (which never saves) then re-applies the preserved push. No behaviour change for ws-off / legacy callers (no `read_fn` → unconditional write).

**Defense-in-depth (e2e):** the conntrack `on_tick` nudge fires a small burst so conntrack's block-buffered stdout flushes promptly under VM load (no `stdbuf` on OpenWRT); the fake-scenario failure capture now dumps the on-disk `policy.json` etag + live `wh_drop` rules — the two facts whose absence made this hard to diagnose.

## TDD + validation
- New busted CAS cases in `policy_spec.lua` (red → green). Full openwrt busted: **888/0**.
- Validated on **real Lua 5.1.5** (openwrt.lan, per repo convention): agent + `policy.lua` `loadfile` OK; guard KAT + real-filesystem clobber-prevention pass; apply-on-push enforcement flip still ~4s with **0 misses across 11 base→paused cycles**.

## Notes
- Hardware (#1945's outstanding item): push→apply→enforce flip demonstrated live on openwrt.lan against api.lan with the poll frozen. Prod ws-enablement go/no-go in the issue thread.
- CI: the touched e2e + agent are on the Master Router CD push-path; `e2e-vm-fake.yml` exercises both arms on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)