### PR TITLE
feat(#1974): SPA-ws S6a — live time-usage push (timeStatus + appUsage)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -201,7 +201,13 @@ object Main extends ZIOAppDefault {
               },
               new wifihaven.api.policy.PolicySnapshotPublisher {
                 def publish(snap: wifihaven.shared.PolicySnapshot): UIO[Unit] =
-                  spaEventBus.publish(SpaEvent.NowChanged)
+                  // #1974 (S6a): the #1849 reevaluate (fixed-interval ticker + every policy mutation)
+                  // can change a profile's remaining-minutes / over-limit WITHOUT new usage (schedule
+                  // boundary, cap exhaustion, unpause, +Time), so it is a `timeStatus`/`appUsage` push
+                  // write site too (design §5.2). `now` for the dashboard, `TimeStatusChanged` for the
+                  // live screen-time surface.
+                  spaEventBus.publish(SpaEvent.NowChanged) *>
+                    spaEventBus.publish(SpaEvent.TimeStatusChanged)
               },
             ),
           ),
@@ -256,8 +262,11 @@ object Main extends ZIOAppDefault {
         // fans out subscription-gated, role-filtered `now`/`connectionEvents`/`stale` frames over
         // `/api/ws` (design §5.2). forkScoped (inside `run`) so it is interrupted before the Hikari
         // pool closes on shutdown, like the rollup loops. `now` rebuilds via the shared
-        // DashboardNowRoutes.computeNow builder (SSOT). No SPA ws client ships until S5, so this
-        // reads idle in prod until then; it is additive and never blocks ingest.
+        // DashboardNowRoutes.computeNow builder (SSOT). #1974 (S6a): the same consumer also drives the
+        // live `timeStatus`/`appUsage` pushes — wire its extra deps (canonical minutes, settings, the
+        // per-child profile filter). It is additive and never blocks ingest.
+        timeStatusForPush <- ZIO.service[wifihaven.api.policy.TimeStatusService]
+        upRepoForPush     <- ZIO.service[UserProfileRepo]
         _                 <- SpaPush.run(
           spaEventBus,
           spaWsRegistry,
@@ -269,6 +278,7 @@ object Main extends ZIOAppDefault {
           appRepoForSeed,
           stlRepoForJ,
           clockForJobs,
+          Some(SpaPush.TimeUsageDeps(timeStatusForPush, hsRepo, upRepoForPush)),
         )
         _                 <- ZIO.logInfo("spa-ws push consumer fiber forked")
         // #1243: poll the HikariCP MXBean into the Prometheus pool gauges. forkDaemon so it lives
@@ -460,6 +470,8 @@ object Main extends ZIOAppDefault {
           timeCache,
           // #1849: a +Time grant can lift a TimeLimit block, so bust the computed-snapshot cache.
           policy.invalidate,
+          // #1974 (S6a): the grant changes remaining-minutes — push fresh timeStatus/appUsage live.
+          spaEventBus,
         ) ++
           LogRoutes.routes(auth, connRepo, upRepo) ++
           UsageRoutes.routes(

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -259,11 +259,12 @@ object MetricGuard {
     // fixed 6-value enum; bounded, no per-user/session dimension. A spike in
     // bad_origin/invalid_jwt is the CSWSH/forgery-probe tripwire (alert in spa-ws.json).
     "spa_ws_auth_total"                         -> Set("result"),
-    // #1970 (S3) — per-topic fan-out health for the change-source push path (design §6.3/§7).
-    // `op` ∈ {now, connectionEvents, stale} today (trafficUsage/timeStatus/appUsage land with
-    // S4/S6a as those topics start pushing); `result` ∈ {ok, coalesced, dropped, channel_closed}.
-    // Both bounded enums — no per-mac / per-profile / per-session / param dimension. A rising
-    // channel_closed/dropped is the slow-client tripwire surfaced by spa-ws.json's push-health panel.
+    // #1970 (S3) / #1974 (S6a) — per-topic fan-out health for the change-source push path (design
+    // §6.3/§7). `op` ∈ {now, connectionEvents, stale} (S3), trafficUsage (S4), timeStatus, appUsage
+    // (S6a — the per-recipient time-usage pushes via SpaWsRegistry.deliver); `result` ∈ {ok,
+    // coalesced, dropped, channel_closed}. Both bounded enums — no per-mac / per-profile /
+    // per-session / param dimension. A rising channel_closed/dropped is the slow-client tripwire
+    // surfaced by spa-ws.json's push-health panel.
     "spa_ws_push_total"                         -> Set("op", "result"),
     // #1848 — AGENT-side websocket transport metrics. The wifihaven-ws sidecar has no metrics
     // registry of its own, so it writes a cumulative tally that the agent folds into its

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -723,6 +723,74 @@ object TimeStatusService {
    * `presence` must already be scoped to the profile's devices (as the live read paths and the
    * routes both do).
    */
+  /**
+   * #1974 (SPA-ws S6a): the SINGLE place that assembles the `/api/time/status` per-profile wire
+   * shape ([[ProfileTimeStatus]]) from a canonical [[ProfileDayState]] plus the day's presence
+   * rows. Both the REST `GET /api/time/status` builder (`TimeRoutes.buildProfileTimeStatus`) and
+   * the live `timeStatus` ws push ([[wifihaven.api.routes.SpaPush]]) call this, so the streamed
+   * body is byte-identical to what the GET returns (AGENTS.md §single-source-of-truth). The
+   * cap/used/ remaining/extension numbers come verbatim off `state` — this NEVER recomputes
+   * minutes; only the presence-derived per-device and top-N host views (which the snapshot doesn't
+   * carry) are folded in here, exactly as before. `presence` must already be scoped to the
+   * profile's devices.
+   */
+  def assembleProfileTimeStatus(
+      profile: Profile,
+      devices: List[Device],
+      state: ProfileDayState,
+      presence: List[PresenceRow],
+      appLimits: List[AppTimeLimit],
+      settings: HouseholdSettings,
+  ): ProfileTimeStatus = {
+    // #1546: per-device minutes come from the canonical per-mac decomposition of the headline total,
+    // so they share one exempt-pattern + overlap definition with `state.usedMinutes` and cannot drift
+    // from it.
+    val perMacSeconds   = usedSecondsByMac(profile, devices, appLimits, presence, settings)
+    val appUsage        = state.perApp.map { s =>
+      AppUsage(
+        s.label,
+        s.domainPattern,
+        s.dailyLimitMinutes,
+        s.usedMinutes,
+        s.dailyLimitMinutes.map(lim => (lim - s.usedMinutes).max(0)),
+      )
+    }
+    val deviceSummaries = devices.map { d =>
+      DeviceUsageSummary(d.mac, d.name, (perMacSeconds.getOrElse(d.mac, 0L) / 60L).toInt)
+    }
+    // #262 — top-N host attribution across all profile devices for the day. `usedMins` is bucket-
+    // presence and `proportionalMins` is the #715 byte-share-weighted attribution; UI defaults to the
+    // latter. Hosts with zero presence are dropped so the top-10 isn't padded by buckets the host
+    // merely touched.
+    val hostUsage       = {
+      val presenceMins = Presence.hostMinutes(presence, settings.heartbeatFilter)
+      val proportional = Presence.proportionalHostMinutes(
+        presence,
+        profile.crossDeviceOverlapMode,
+        settings.heartbeatFilter,
+        settings.presenceContinuationSeconds,
+      )
+      presenceMins.iterator
+        .filter(_._2 > 0)
+        .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
+        .toList
+        .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
+        .take(10)
+    }
+    ProfileTimeStatus(
+      profile.id,
+      profile.name,
+      state.date.toString,
+      state.dailyLimitMinutes,
+      state.usedMinutes,
+      state.extensionMinutes,
+      state.remainingMinutes,
+      appUsage,
+      deviceSummaries,
+      hostUsage,
+    )
+  }
+
   def usedSecondsByMac(
       profile: Profile,
       devices: List[Device],

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -89,10 +89,13 @@ final class RouterIngestService(
         // #1970 (S3): newly-credited usage moves last_seen / per-device activity, so the dashboard
         // NOW surface may have changed — trigger a `now` recompute. #1971 (S4): the same ingest is
         // the `trafficUsage` write site — `UsageIngested` drives the live-edge head-bucket recompute
-        // for subscribed `(groupBy,bucket,filter)` param-sets (design §5.3). Both are one-liners that
-        // never block or fail ingest (sliding hub, UIO). timeStatus/appUsage pushes are S6a.
+        // for subscribed `(groupBy,bucket,filter)` param-sets (design §5.3). #1974 (S6a): the new
+        // minutes also move per-profile used/remaining + per-app minutes — `TimeStatusChanged` drives
+        // the `timeStatus`/`appUsage` push (design §5.2). All one-liners that never block or fail
+        // ingest (sliding hub, UIO).
         _        <- ZIO.when(records.nonEmpty)(
-          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested),
+          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested) *>
+            bus.publish(SpaEvent.TimeStatusChanged),
         )
       } yield ()
     }

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -836,6 +836,11 @@ object TimeRoutes {
       // drop the computed-snapshot cache so the fleet sees the unblock at once. Defaulted to a no-op
       // for test call sites; production passes `policy.invalidate`.
       invalidateSnapshot: UIO[Unit] = ZIO.unit,
+      // #1974 (SPA-ws S6a): a +Time grant immediately changes remaining-minutes, so it is a
+      // `timeStatus` push write site (design §5.2). One-liner publish on the SPA change bus; never
+      // blocks/fails the grant (sliding hub, UIO). Defaulted to the noop for test call sites that
+      // don't exercise the push path.
+      spaBus: SpaEventBus = SpaEventBus.noop,
   ): Routes[Any, Response] =
     Routes(
       // #777 — collapsed accordion summary. One batched presence query over ALL devices
@@ -1181,6 +1186,9 @@ object TimeRoutes {
             // #1849: a grant can lift a TimeLimit block — snapshot content — so drop the
             // computed-snapshot cache too.
             _  <- invalidateSnapshot
+            // #1974 (S6a): the grant changed remaining-minutes — push fresh `timeStatus`/`appUsage`
+            // to live SPA subscribers (design §5.2). Contentless trigger; the consumer rebuilds.
+            _  <- spaBus.publish(SpaEvent.TimeStatusChanged)
           } yield Response.json(s"""{"id":${id.value},"grantedMinutes":${ger.extraMinutes}}""")
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -1248,59 +1256,12 @@ object TimeRoutes {
       )
       presence  <- trafficRepo.listPresenceRows(macs, date)
       appLimits <- appTimeLimitRepo.listForProfile(profile.id)
-      // #1546: per-device minutes come from the canonical per-mac decomposition of the headline
-      // total, so they share one exempt-pattern + overlap definition with `state.usedMinutes` and
-      // cannot drift from it (no open-coded `totalMinutesByMac` recompute). Under Dedup this is a
-      // disjoint attribution of the union, so the summaries reconcile with the headline instead of
-      // summing to >100%.
-      perMacSeconds   = wifihaven.api.policy.TimeStatusService
-        .usedSecondsByMac(profile, devices, appLimits, presence, settings)
-      appUsage        = state.perApp.map { s =>
-        AppUsage(
-          s.label,
-          s.domainPattern,
-          s.dailyLimitMinutes,
-          s.usedMinutes,
-          s.dailyLimitMinutes.map(lim => (lim - s.usedMinutes).max(0)),
-        )
-      }
-      deviceSummaries = devices.map { d =>
-        DeviceUsageSummary(d.mac, d.name, (perMacSeconds.getOrElse(d.mac, 0L) / 60L).toInt)
-      }
-      // #262 — top-N host attribution across all profile devices for the day.
-      // `usedMins` is bucket-presence and `proportionalMins` is the #715
-      // byte-share-weighted attribution; UI defaults to the latter. Hosts
-      // with zero presence are dropped so the top-10 list isn't padded by
-      // hosts that exist only because the bucket touched them at all.
-      hostUsage       = {
-        val presenceMins =
-          wifihaven.api.presence.Presence.hostMinutes(presence, settings.heartbeatFilter)
-        val proportional = wifihaven.api.presence.Presence
-          .proportionalHostMinutes(
-            presence,
-            profile.crossDeviceOverlapMode,
-            settings.heartbeatFilter,
-            settings.presenceContinuationSeconds,
-          )
-        presenceMins.iterator
-          .filter(_._2 > 0)
-          .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
-          .toList
-          .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
-          .take(10)
-      }
-    } yield ProfileTimeStatus(
-      profile.id,
-      profile.name,
-      state.date.toString,
-      state.dailyLimitMinutes,
-      state.usedMinutes,
-      state.extensionMinutes,
-      state.remainingMinutes,
-      appUsage,
-      deviceSummaries,
-      hostUsage,
-    )
+      // #1974: the wire shape is assembled by the SINGLE shared builder so the live `timeStatus` ws
+      // push and this GET produce byte-identical bodies (AGENTS.md §single-source-of-truth). It reads
+      // `state`'s cap/used/remaining verbatim (no minute recompute) and folds in the presence-derived
+      // per-device + top-N host views the snapshot doesn't carry.
+    } yield wifihaven.api.policy.TimeStatusService
+      .assembleProfileTimeStatus(profile, devices, state, presence, appLimits, settings)
   }
 
   /**

--- a/api/src/routes/SpaEvents.scala
+++ b/api/src/routes/SpaEvents.scala
@@ -31,12 +31,22 @@ import java.time.Instant
  *     filter)` param-set and pushes that one bucket as a `TrafficUsageResponse` live edge (design
  *     §5.3). Contentless trigger — the head is recomputed from the DB, latest-wins (§6.3), and a
  *     param-set with no subscriber is never queried.
+ *   - [[SpaEvent.TimeStatusChanged]] — #1974 (S6a): a profile's used/remaining minutes moved. The
+ *     consumer rebuilds the `/api/time/status` `ProfileTimeStatus[]` body (via
+ *     `TimeStatusService.dayStateAllLive`, role-filtered like the GET) and pushes it to
+ *     `timeStatus` subscribers, and rebuilds the per-app `/api/profiles/{id}/usage-by-app` body
+ *     (via the shared `UsageRoutes.buildUsageByApp`) for each subscribed `appUsage{profileId}`
+ *     (design §1.2/§3.1). Published from THREE write sites (§5.2): usage credit (new minutes), the
+ *     #1849 time-boundary ticker (schedule boundary / cap exhaustion change remaining without new
+ *     usage), and the `POST /api/time/extend` grant. Contentless trigger — bodies are recomputed
+ *     from the DB, latest-wins (§6.3), and a topic with no subscriber is never queried.
  */
 enum SpaEvent {
   case NowChanged
   case ConnectionEventsIngested(since: Instant)
   case Stale(topic: StaleTopic, scope: Option[String] = None)
   case UsageIngested
+  case TimeStatusChanged
 }
 
 /**

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -465,8 +465,12 @@ object SpaPush {
    * #1974 (S6a): the `appUsage` push (design §1.2/§3.1, class-(2)). For each DISTINCT subscribed +
    * ENTITLED `profileId`, rebuild the `/api/profiles/{id}/usage-by-app` today body via the shared
    * [[UsageRoutes.buildUsageByApp]] (SSOT — the same repo-load + compute the GET runs) and deliver
-   * it to the matching recipients. `from == to == clock.today` (the GET's today default). A child
-   * only receives a profileId it is linked to (design §4.4). No subscriber → no query.
+   * it to the matching recipients. `from == to ==` the HOUSEHOLD-LOCAL today (same as the
+   * `timeStatus` push, [[PolicyService.householdLocalDate]]) — the household-tz day the browser's
+   * own local-today maps to, so the pushed body lands on the same per-app cache window the card
+   * renders even for non-UTC households (a UTC `clock.today` would skew a tz-crossing household by
+   * a day until refetch). A child only receives a profileId it is linked to (design §4.4). No
+   * subscriber → no query.
    */
   private def pushAppUsage(
       registry: SpaWsRegistry,
@@ -490,8 +494,9 @@ object SpaPush {
                 Option.when(visible.forall(_.contains(pid)))(r -> pid)
               }
             }
-            today <- clock.today
+            now <- clock.instant
             settings <- deps.hsRepo.get
+            today        = PolicyService.householdLocalDate(now, settings)
             distinctPids = entitled.map(_._2).distinct
             // Build each entitled profile's body ONCE; a NotFound/etc. drops that profile's push only.
             bodies <- ZIO.foreach(distinctPids) { pid =>

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -2,14 +2,15 @@ package wifihaven.api.routes
 
 import wifihaven.api.db.*
 import wifihaven.api.observability.LogContext
+import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.api.usage.{AppMembership, UsageTraffic, UsageTrafficQuery}
-import wifihaven.shared.{Clock, Device, TrafficUsageResponse}
+import wifihaven.shared.{Clock, Device, Profile, ProfileTimeStatus, TrafficUsageResponse, UserRole}
 import wifihaven.shared.types.{MacAddress, ProfileId}
 import zio.{Clock as _, *}
 import zio.json.*
 import zio.json.ast.Json
 
-import java.time.{Duration, Instant, ZoneId}
+import java.time.{Duration, Instant, LocalDate, ZoneId}
 
 /**
  * #1970 (S3) / #1971 (S4), SPA-websocket design `docs/design/spa-websocket.md` §5.2/§5.3: the
@@ -49,6 +50,19 @@ import java.time.{Duration, Instant, ZoneId}
 object SpaPush {
 
   /**
+   * #1974 (S6a): the extra services the `timeStatus`/`appUsage` pushes need, bundled `Option`al so
+   * the S3/S4 harnesses (which never publish [[SpaEvent.TimeStatusChanged]]) construct `run`
+   * without them. `timeStatusService` provides the canonical `dayStateAllLive` minutes; `hsRepo`
+   * the household settings (today/heartbeat); `userProfileRepo` the per-child profile filter the
+   * GET uses (design §4.4). Production always passes `Some(...)`.
+   */
+  final case class TimeUsageDeps(
+      timeStatusService: TimeStatusService,
+      hsRepo: HouseholdSettingsRepo,
+      userProfileRepo: UserProfileRepo,
+  )
+
+  /**
    * Subscribe to the bus and process events forever in a forked fiber. Scoped: the Hub subscription
    * and the fiber are released when the enclosing scope closes (forkScoped, like the rollup loops
    * in `Main`). Returns once subscribed + forked, so events published after `run` returns are seen.
@@ -64,6 +78,7 @@ object SpaPush {
       appRepo: AppRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
+      timeUsage: Option[TimeUsageDeps] = None,
   ): ZIO[Scope, Nothing, Unit] =
     bus.subscribe.flatMap { queue =>
       drainBatch(
@@ -77,6 +92,7 @@ object SpaPush {
         appRepo,
         appTimeLimitRepo,
         clock,
+        timeUsage,
       ).forever.forkScoped.unit
     }
 
@@ -99,6 +115,7 @@ object SpaPush {
       appRepo: AppRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
+      timeUsage: Option[TimeUsageDeps],
   ): UIO[Unit] =
     for {
       first <- queue.take
@@ -116,6 +133,7 @@ object SpaPush {
           appRepo,
           appTimeLimitRepo,
           clock,
+          timeUsage,
         ),
       )
     } yield ()
@@ -140,6 +158,7 @@ object SpaPush {
       appRepo: AppRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
+      timeUsage: Option[TimeUsageDeps],
   ): UIO[Unit] =
     event match {
       case SpaEvent.NowChanged                      =>
@@ -164,6 +183,43 @@ object SpaPush {
             clock,
           )
             .catchAllCause(c => ZIO.logErrorCause("spa ws push: trafficUsage recompute failed", c))
+        }
+      case SpaEvent.TimeStatusChanged               =>
+        // #1974 (S6a): the same change drives BOTH live time-usage topics (design §5.2). Each is
+        // independently subscriber-gated (no subscriber → no query) and wrapped so a transient repo
+        // error on one never blocks the other or crashes the consumer.
+        timeUsage match {
+          case None       => ZIO.unit // S3/S4 harness — no time-usage deps wired
+          case Some(deps) =>
+            LogContext.annotate(LogContext.Op, "timeStatus") {
+              pushTimeStatus(
+                registry,
+                deviceRepo,
+                profileRepo,
+                trafficRepo,
+                appTimeLimitRepo,
+                clock,
+                deps,
+              )
+                .catchAllCause(c =>
+                  ZIO.logErrorCause("spa ws push: timeStatus recompute failed", c),
+                )
+            } *>
+              LogContext.annotate(LogContext.Op, "appUsage") {
+                pushAppUsage(
+                  registry,
+                  deviceRepo,
+                  profileRepo,
+                  trafficRepo,
+                  appRepo,
+                  appTimeLimitRepo,
+                  clock,
+                  deps,
+                )
+                  .catchAllCause(c =>
+                    ZIO.logErrorCause("spa ws push: appUsage recompute failed", c),
+                  )
+              }
         }
     }
 
@@ -324,6 +380,180 @@ object SpaPush {
           registry.fanOutTrafficUsage(params, body.toJsonAST.getOrElse(Json.Obj()))
         }
     }
+
+  /**
+   * #1974 (S6a): the `timeStatus` push (design §1.2/§3.1, class-(2) thick push). For each
+   * subscribed connection, push the `/api/time/status` `ProfileTimeStatus[]` body — built ONCE over
+   * all profiles via the canonical [[TimeStatusService.dayStateAllLive]] minutes + the shared
+   * [[TimeStatusService.assembleProfileTimeStatus]] wire-shape builder (SSOT — byte-identical to
+   * the GET) — then DELIVERED per recipient with the GET's per-child profile filter (design §4.4):
+   * an admin/adult gets all profiles, a child only their linked ones. No subscriber → no
+   * `dayStateAllLive` query.
+   */
+  private def pushTimeStatus(
+      registry: SpaWsRegistry,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      trafficRepo: TrafficReportRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      clock: Clock,
+      deps: TimeUsageDeps,
+  ): Task[Unit] =
+    registry.timeStatusRecipients.flatMap { recipients =>
+      ZIO
+        .when(recipients.nonEmpty) {
+          for {
+            now      <- clock.instant
+            settings <- deps.hsRepo.get
+            date = PolicyService.householdLocalDate(now, settings)
+            states   <- deps.timeStatusService.dayStateAllLive(now, date, settings)
+            profiles <- profileRepo.listAll
+            devices  <- deviceRepo.listAll
+            devsByPid = devices.groupBy(_.profileId).collect { case (Some(pid), ds) => pid -> ds }
+            // The full per-profile body, in profileRepo.listAll order (the GET's order). Built once;
+            // each recipient receives its role-visible subset of it (design §4.4).
+            rows          <- ZIO.foreach(profiles) { p =>
+              val devs = devsByPid.getOrElse(p.id, Nil)
+              buildOneTimeStatus(
+                p,
+                devs,
+                states.get(p.id),
+                trafficRepo,
+                appTimeLimitRepo,
+                date,
+                settings,
+              )
+                .map(p.id -> _)
+            }
+            visibleByUser <- resolveVisibleSets(recipients, deps.userProfileRepo)
+            _             <- ZIO.foreachDiscard(recipients) { r =>
+              val visible = visibleByUser(visibilityKey(r))
+              val body    = rows.collect { case (pid, ts) if visible.forall(_.contains(pid)) => ts }
+              registry.deliver(r.id, "timeStatus", body.toJsonAST.getOrElse(Json.Arr()))
+            }
+          } yield ()
+        }
+        .unit
+    }
+
+  /** Build one profile's `ProfileTimeStatus` exactly as the GET does (shared assembler — SSOT). */
+  private def buildOneTimeStatus(
+      profile: Profile,
+      devices: List[Device],
+      state: Option[wifihaven.api.policy.ProfileDayState],
+      trafficRepo: TrafficReportRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      date: LocalDate,
+      settings: wifihaven.shared.HouseholdSettings,
+  ): Task[ProfileTimeStatus] =
+    for {
+      presence  <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
+      appLimits <- appTimeLimitRepo.listForProfile(profile.id)
+      st = state.getOrElse(
+        wifihaven.api.policy.ProfileDayState(profile.id, date, None, 0, 0, None, false, None, Nil),
+      )
+    } yield TimeStatusService.assembleProfileTimeStatus(
+      profile,
+      devices,
+      st,
+      presence,
+      appLimits,
+      settings,
+    )
+
+  /**
+   * #1974 (S6a): the `appUsage` push (design §1.2/§3.1, class-(2)). For each DISTINCT subscribed +
+   * ENTITLED `profileId`, rebuild the `/api/profiles/{id}/usage-by-app` today body via the shared
+   * [[UsageRoutes.buildUsageByApp]] (SSOT — the same repo-load + compute the GET runs) and deliver
+   * it to the matching recipients. `from == to == clock.today` (the GET's today default). A child
+   * only receives a profileId it is linked to (design §4.4). No subscriber → no query.
+   */
+  private def pushAppUsage(
+      registry: SpaWsRegistry,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      trafficRepo: TrafficReportRepo,
+      appRepo: AppRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
+      clock: Clock,
+      deps: TimeUsageDeps,
+  ): Task[Unit] =
+    registry.appUsageRecipients.flatMap { recipients =>
+      ZIO
+        .when(recipients.nonEmpty) {
+          for {
+            visibleByUser <- resolveVisibleSets(recipients, deps.userProfileRepo)
+            // (recipient, subscribed profileId) pairs the recipient is entitled to see.
+            entitled = recipients.flatMap { r =>
+              decodeAppUsageProfileId(r.params).flatMap { pid =>
+                val visible = visibleByUser(visibilityKey(r))
+                Option.when(visible.forall(_.contains(pid)))(r -> pid)
+              }
+            }
+            today <- clock.today
+            settings <- deps.hsRepo.get
+            distinctPids = entitled.map(_._2).distinct
+            // Build each entitled profile's body ONCE; a NotFound/etc. drops that profile's push only.
+            bodies <- ZIO.foreach(distinctPids) { pid =>
+              UsageRoutes
+                .buildUsageByApp(
+                  pid,
+                  today,
+                  today,
+                  profileRepo,
+                  deviceRepo,
+                  trafficRepo,
+                  appRepo,
+                  appTimeLimitRepo,
+                  settings,
+                )
+                .map(b => Some(pid -> b))
+                .catchAll(e =>
+                  ZIO.logWarning(s"spa ws push: appUsage build failed for $pid: $e").as(None),
+                )
+            }
+            byPid = bodies.flatten.toMap
+            _      <- ZIO.foreachDiscard(entitled) { case (r, pid) =>
+              byPid.get(pid) match {
+                case Some(body) =>
+                  registry.deliver(r.id, "appUsage", body.toJsonAST.getOrElse(Json.Obj()))
+                case None       => ZIO.unit
+              }
+            }
+          } yield ()
+        }
+        .unit
+    }
+
+  /**
+   * #1974 (S6a): resolve each recipient's visible-profile set, reusing the GET's filter (design
+   * §4.4). Admin/adult see ALL profiles (`None` = no restriction); a child sees only the profiles
+   * linked to its username (`UserProfileRepo.listProfilesForUsername`). Keyed by [[visibilityKey]]
+   * so the per-child repo lookup runs once per distinct child, not once per connection.
+   */
+  private def resolveVisibleSets(
+      recipients: List[SpaRecipient],
+      userProfileRepo: UserProfileRepo,
+  ): Task[Map[(UserRole, Option[String]), Option[Set[ProfileId]]]] =
+    ZIO
+      .foreach(recipients.map(visibilityKey).distinct) {
+        case key @ (UserRole.Admin | UserRole.Adult, _) =>
+          ZIO.succeed(key -> Option.empty[Set[ProfileId]])
+        case key @ (UserRole.Child, username)           =>
+          username
+            .fold(ZIO.succeed(List.empty[ProfileId]))(userProfileRepo.listProfilesForUsername)
+            .map(pids => key -> Some(pids.toSet))
+      }
+      .map(_.toMap)
+
+  private def visibilityKey(r: SpaRecipient): (UserRole, Option[String]) = (r.role, r.username)
+
+  /** Decode the `appUsage` subscription's `{profileId}` param (the expanded card). */
+  private def decodeAppUsageProfileId(params: Json): Option[ProfileId] =
+    params.toJson.fromJson[AppUsageSubParams].toOption.map(p => ProfileId(p.profileId))
+
+  /** The `appUsage` subscription params — just the expanded card's `profileId` (§1.2). */
+  private final case class AppUsageSubParams(profileId: Long) derives JsonDecoder
 
   /** Load the (host → app memberships) map for app grouping, exactly as `UsageRoutes` does. */
   private def loadAppsByHost(appRepo: AppRepo): Task[Map[String, List[AppMembership]]] =

--- a/api/src/routes/SpaWsRegistry.scala
+++ b/api/src/routes/SpaWsRegistry.scala
@@ -75,6 +75,26 @@ final case class SpaConnState(
     role: UserRole,
     subscriptions: Map[SpaTopic, Json],
     jwtExp: Option[Instant],
+    // #1974 (S6a): the authenticated username (JWT `sub`), captured at upgrade. Needed to reuse the
+    // GET's per-child profile filter for the class-(2) `timeStatus`/`appUsage` thick pushes (design
+    // §4.4 — "the body is filtered per-role before send, exactly as the matching GET filters"): an
+    // admin/adult sees all profiles, a child only the profiles they're linked to
+    // (`UserProfileRepo.listProfilesForUsername`). `None` only for pre-auth/test registrations.
+    username: Option[String] = None,
+)
+
+/**
+ * #1974 (S6a): a connection eligible to receive a class-(2) `timeStatus`/`appUsage` push — it
+ * SUBSCRIBED to the topic AND its role may see it (§4.4). Carries the identity the per-recipient
+ * GET filter needs (`role` + `username`) and the subscription `params` (e.g. `appUsage`'s
+ * `profileId`). [[SpaPush]] resolves each recipient's visible-profile set and delivers the filtered
+ * body.
+ */
+final case class SpaRecipient(
+    id: SpaConnId,
+    role: UserRole,
+    username: Option[String],
+    params: Json,
 )
 
 /**
@@ -98,8 +118,17 @@ final case class SpaConnState(
  */
 trait SpaWsRegistry {
 
-  /** Record a freshly-upgraded channel with its resolved role; returns its connection id. */
-  def register(channel: WebSocketChannel, role: UserRole, jwtExp: Option[Instant]): UIO[SpaConnId]
+  /**
+   * Record a freshly-upgraded channel with its resolved role + (S6a) authenticated username;
+   * returns its connection id. The username is the JWT `sub`, captured so the class-(2)
+   * `timeStatus`/ `appUsage` pushes can reuse the GET's per-child profile filter (design §4.4).
+   */
+  def register(
+      channel: WebSocketChannel,
+      role: UserRole,
+      jwtExp: Option[Instant],
+      username: Option[String] = None,
+  ): UIO[SpaConnId]
 
   /** Drop a closed/closing connection. Idempotent. Refreshes the gauges. */
   def deregister(id: SpaConnId): UIO[Unit]
@@ -175,6 +204,34 @@ trait SpaWsRegistry {
    * head, never a backlog. Metered per send like [[fanOut]].
    */
   def fanOutTrafficUsage(params: Json, payload: Json): UIO[Unit]
+
+  /**
+   * #1974 (S6a): the connections eligible for a `timeStatus` push — subscribed to `TimeStatus` AND
+   * role-visible (§4.4). Each carries the `(role, username)` the per-child GET filter needs;
+   * [[SpaPush]] builds the full `ProfileTimeStatus[]` once, then delivers each recipient its
+   * role-visible subset (admin/adult: all; child: their linked profiles). Empty ⇒ no subscriber ⇒
+   * no `dayStateAllLive` query ("don't compute what nobody watches").
+   */
+  def timeStatusRecipients: UIO[List[SpaRecipient]]
+
+  /**
+   * #1974 (S6a): the connections eligible for an `appUsage` push — subscribed to `AppUsage` AND
+   * role-visible (§4.4). Each recipient's `params` carries the subscribed `{profileId}` (the
+   * expanded card). [[SpaPush]] builds the per-app body once per DISTINCT entitled `profileId` and
+   * delivers it to the matching recipients. Empty ⇒ no subscriber ⇒ no query.
+   */
+  def appUsageRecipients: UIO[List[SpaRecipient]]
+
+  /**
+   * #1974 (S6a): deliver a pre-built class-(2) frame to ONE connection (the per-recipient body the
+   * `timeStatus`/`appUsage` thick pushes need — each recipient may receive a differently-filtered
+   * body, so the fan-out can't share one frame). Looks up the live channel; a no-longer-registered
+   * id is a no-op. Metered exactly like the other pushes (`spa_ws_push_total{op,result}` + frames-
+   * out on success); a send failure (racing disconnect) meters `channel_closed` and deregisters.
+   * The caller is responsible for the subscription + role gate (it got `id` from
+   * [[timeStatusRecipients]]/[[appUsageRecipients]]).
+   */
+  def deliver(id: SpaConnId, op: String, payload: Json): UIO[Unit]
 }
 
 object SpaWsRegistry {
@@ -207,11 +264,18 @@ final class SpaWsRegistryLive(
       )
   }
 
-  def register(channel: WebSocketChannel, role: UserRole, jwtExp: Option[Instant]): UIO[SpaConnId] =
+  def register(
+      channel: WebSocketChannel,
+      role: UserRole,
+      jwtExp: Option[Instant],
+      username: Option[String] = None,
+  ): UIO[SpaConnId] =
     for {
       n <- seq.updateAndGet(_ + 1)
       id = SpaConnId(n)
-      m <- state.updateAndGet(_.updated(id, SpaConnState(channel, role, Map.empty, jwtExp)))
+      m <- state.updateAndGet(
+        _.updated(id, SpaConnState(channel, role, Map.empty, jwtExp, username)),
+      )
       _ <- publishGauges(m)
     } yield id
 
@@ -326,6 +390,36 @@ final class SpaWsRegistryLive(
         )(
           sendPush(id, s.channel, op, frame),
         )
+      }
+    }
+
+  // ── #1974 (S6a) timeStatus / appUsage recipients + per-recipient delivery ──────────────────────
+  // These class-(2) thick pushes filter the body PER recipient (admin/adult see all profiles, a
+  // child only their linked ones — design §4.4), so unlike `now`/`trafficUsage` the fan-out can't
+  // share one frame. The registry exposes the gated recipient list (subscription AND role) plus a
+  // per-connection `deliver`; SpaPush owns the body build + the userProfileRepo-backed filter.
+
+  def timeStatusRecipients: UIO[List[SpaRecipient]] =
+    recipientsFor(SpaTopic.TimeStatus)
+
+  def appUsageRecipients: UIO[List[SpaRecipient]] =
+    recipientsFor(SpaTopic.AppUsage)
+
+  private def recipientsFor(topic: SpaTopic): UIO[List[SpaRecipient]] =
+    state.get.map(
+      _.iterator
+        .collect {
+          case (id, s) if s.subscriptions.contains(topic) && SpaTopic.visibleTo(topic, s.role) =>
+            SpaRecipient(id, s.role, s.username, s.subscriptions(topic))
+        }
+        .toList,
+    )
+
+  def deliver(id: SpaConnId, op: String, payload: Json): UIO[Unit] =
+    state.get.flatMap { m =>
+      m.get(id) match {
+        case Some(s) => sendPush(id, s.channel, op, frameText(op, payload.toJson))
+        case None    => ZIO.unit // raced a disconnect — nothing to deliver to
       }
     }
 

--- a/api/src/routes/SpaWsRoutes.scala
+++ b/api/src/routes/SpaWsRoutes.scala
@@ -82,7 +82,9 @@ object SpaWsRoutes {
   /**
    * The resolved upgrade identity captured once and authoritative for the connection's lifetime.
    */
-  private final case class Authorized(role: UserRole, jwtExp: Instant)
+  // #1974 (S6a): `username` (JWT `sub`) is captured alongside the role so the class-(2)
+  // `timeStatus`/`appUsage` pushes can reuse the GET's per-child profile filter (design §4.4).
+  private final case class Authorized(role: UserRole, jwtExp: Instant, username: String)
 
   /**
    * Why an upgrade was refused. Each case carries its `spa_ws_auth_total{result}` label and the
@@ -149,6 +151,7 @@ object SpaWsRoutes {
             Authorized(
               role = UserRole.parse(claims.role).getOrElse(fallbackRole),
               jwtExp = Instant.ofEpochSecond(claims.exp),
+              username = claims.sub,
             )
           }
     }
@@ -170,18 +173,20 @@ object SpaWsRoutes {
         _        <- channel
           .receiveAll {
             case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
-              registry.register(channel, authd.role, Some(authd.jwtExp)).flatMap { id =>
-                idRef.set(Some(id)) *>
-                  watchExpiry(
-                    channel,
-                    id,
-                    authd.jwtExp,
-                    registry,
-                    clock,
-                    cfg.expiryCheckInterval,
-                  ).forkDaemon
-                    .flatMap(f => fiberRef.set(Some(f)))
-              } *> ZIO.logInfo("spa ws: connected")
+              registry
+                .register(channel, authd.role, Some(authd.jwtExp), Some(authd.username))
+                .flatMap { id =>
+                  idRef.set(Some(id)) *>
+                    watchExpiry(
+                      channel,
+                      id,
+                      authd.jwtExp,
+                      registry,
+                      clock,
+                      cfg.expiryCheckInterval,
+                    ).forkDaemon
+                      .flatMap(f => fiberRef.set(Some(f)))
+                } *> ZIO.logInfo("spa ws: connected")
             case ChannelEvent.Read(WebSocketFrame.Text(text))                 =>
               idRef.get.flatMap {
                 case Some(id) =>

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -471,7 +471,12 @@ object UsageRoutes {
   // same proportionalSeconds/presenceSeconds units as an app row, so the SPA
   // can render them side-by-side with real apps. "Other" only ever appears as
   // a top-N display rollup at the SPA layer.
-  private def buildUsageByApp(
+  // #1974 (SPA-ws S6a): `private[routes]` (was object-private) so the `appUsage` ws push
+  // ([[SpaPush]], same package) rebuilds the per-app body through the EXACT same repo-load + compute
+  // path the GET runs — the streamed body is byte-identical to `GET /api/profiles/{id}/usage-by-app`
+  // (AGENTS.md §single-source-of-truth). The push calls it with `from == to == clock.today` (the
+  // GET's today default).
+  private[routes] def buildUsageByApp(
       pid: ProfileId,
       from: LocalDate,
       to: LocalDate,

--- a/api/test/src/feature/SpaWsS6aSpec.scala
+++ b/api/test/src/feature/SpaWsS6aSpec.scala
@@ -1,0 +1,456 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.WsConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.TimeStatusServiceLive
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.http.ChannelEvent.UserEvent
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+import java.time.LocalDateTime
+
+/**
+ * #1974 (S6a of the SPA-websocket rollout, design `docs/design/spa-websocket.md` §1.2/§3.1/§5.2):
+ * the live time-usage pushes — `timeStatus` (per-profile used/remaining, the `/api/time/status`
+ * `ProfileTimeStatus[]` body) and `appUsage` (per-app minutes, the
+ * `/api/profiles/{id}/usage-by-app` body). Exercises the FULL chain end to end — a real [[Server]]
+ * + ws [[Client]], the forked [[SpaPush]] consumer draining the [[SpaEventBus]], the REAL
+ * [[RouterIngestService]] usage write site and the REAL `POST /api/time/extend` grant over an
+ * embedded Postgres (never mocked), AND the REAL `GET /api/time/status` + `GET
+ * /api/profiles/{id}/usage-by-app` mounted alongside — proving:
+ *
+ *   - crediting usage pushes a `timeStatus` body byte-identical to what the `GET` returns (SSOT —
+ *     both run `TimeStatusService` + the one `assembleProfileTimeStatus` wire-shape builder);
+ *   - a #1849 time-boundary tick (modelled as the publisher sink's `TimeStatusChanged` with NO new
+ *     usage) still pushes a fresh `timeStatus`;
+ *   - a `POST /api/time/extend` grant pushes a fresh `timeStatus` (the grant moves
+ *     remaining-minutes);
+ *   - an `appUsage{profileId}` subscriber gets a body byte-identical to the matching `GET` (SSOT);
+ *   - per-role filtering: a child linked to ONE profile receives ONLY that profile's `timeStatus`,
+ *     never a sibling's (design §4.4 — the same `UserProfileRepo` filter the GET uses);
+ *   - no subscriber for `timeStatus`/`appUsage` → no push (and structurally no query).
+ *
+ * The injected [[Clock]] is fixed at 2026-06-25 14:00:30 (matching S4) so the seeded usage lands in
+ * the household-local "today" both the push and the GET read.
+ */
+object SpaWsS6aSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
+
+  private val testClockAt: LocalDateTime = LocalDateTime.of(2026, 6, 25, 14, 0, 30)
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(testClockAt)
+
+  private val jwtCfg  = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val openCfg = WsConfig(allowedOrigins = "", expiryCheckSeconds = 60)
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val knownMac    = "aa:bb:cc:11:22:33"
+  private val periodStart = "2026-06-25T14:00:00Z"
+  private val periodEnd   = "2026-06-25T14:00:30Z"
+
+  private def makeAuth(clock: Clock): URIO[UserRepo, AuthServiceLive] =
+    ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg, clock))
+
+  private def tokenFor(
+      auth: AuthService,
+      role: String,
+      username: String,
+  ): ZIO[UserRepo, Throwable, (String, UserId)] =
+    for {
+      hash <- auth.hashPassword("pass")
+      uid  <- ZIO.serviceWithZIO[UserRepo](_.create(username, hash, role))
+      tok  <- auth.login(username, "pass").mapError(e => new RuntimeException(s"login: $e"))
+    } yield (tok.token.value, uid)
+
+  // The default admin (`changeme`) is the one user without the force-change-password flag, so it is
+  // the bearer the REST GETs accept (`requireAuth` runs `requirePasswordChanged`); the ws path uses
+  // bare `verify`, so a freshly-created child works there but not for the GET.
+  private def adminToken(auth: AuthService): ZIO[Any, Throwable, String] =
+    auth
+      .login("admin", "changeme")
+      .mapError(e => new RuntimeException(s"login: $e"))
+      .map(_.token.value)
+
+  private def seedRouter: ZIO[RouterRepo, Throwable, Router] =
+    for {
+      rRepo  <- ZIO.service[RouterRepo]
+      id     <- rRepo.create("test-router", Sha256Hex.unsafe("m" * 64))
+      _      <- rRepo.completeEnrollment(
+        id,
+        Sha256Hex.unsafe(RouterAuth.sha256Hex("ROUTER_TOKEN_PLAIN")),
+      )
+      router <- rRepo.findById(id).someOrFail(new RuntimeException("router not found after seed"))
+    } yield router
+
+  // One profile "Kids" with a device + a daily limit, so used/remaining minutes are meaningful.
+  private def seedKids: ZIO[DeviceRepo & ProfileRepo & TimeLimitRepo, Throwable, ProfileId] =
+    for {
+      pRepo <- ZIO.service[ProfileRepo]
+      dRepo <- ZIO.service[DeviceRepo]
+      tlr   <- ZIO.service[TimeLimitRepo]
+      pid   <- pRepo.create("Kids", List(BlocklistId.unsafe("adult")))
+      _     <- dRepo.upsert(MacAddress.unsafe(knownMac), "kid-ipad", Some(pid), "192.168.1.10")
+      _     <- tlr.upsert(pid, 120)
+    } yield pid
+
+  private def usageRecord(host: String, secs: Long): UsageRecord =
+    UsageRecord(
+      mac = MacAddress.unsafe(knownMac),
+      ip = Some(IpAddress.unsafe("192.168.1.10")),
+      host = HostId.Fqdn(Hostname.unsafe(host)),
+      activeSeconds = secs,
+      bytesIn = 1000,
+      bytesOut = 2000,
+    )
+
+  private def ingestUsage(
+      ingest: RouterIngestService,
+      router: Router,
+      records: UsageRecord*,
+  ): Task[Unit] =
+    ingest
+      .ingestUsage(
+        router,
+        UsageReport(router.id, periodStart, periodEnd, records.toList).toJson,
+      )
+      .mapError(e => new RuntimeException(s"ingest: $e"))
+
+  private def pushCount(op: String, result: String): UIO[Double] =
+    zio.metrics.Metric
+      .counter("spa_ws_push_total")
+      .tagged("op", op)
+      .tagged("result", result)
+      .value
+      .map(_.count)
+
+  /**
+   * Connect a ws client, send `hello` + the subscribe frames, await the subscribe `ack`, run the
+   * trigger, then COLLECT every frame for `wait` (latest-wins needs the last matching frame).
+   */
+  private def collect(
+      port: Int,
+      token: String,
+      subscribeFrames: List[String],
+      trigger: ZIO[Client, Throwable, Unit],
+      wait: Duration,
+  ): ZIO[Client, Throwable, Chunk[String]] =
+    for {
+      ackP   <- Promise.make[Nothing, Unit]
+      frames <- Ref.make(Chunk.empty[String])
+      app = Handler.webSocket { channel =>
+        channel.receiveAll {
+          case ChannelEvent.UserEventTriggered(UserEvent.HandshakeComplete) =>
+            ZIO.foreachDiscard("""{"op":"hello"}""" :: subscribeFrames)(f =>
+              channel.send(ChannelEvent.read(WebSocketFrame.text(f))),
+            )
+          case ChannelEvent.Read(WebSocketFrame.Text(t))                    =>
+            frames.update(_ :+ t) *>
+              ZIO.when(t.contains("\"op\":\"ack\""))(ackP.succeed(())).unit
+          case _                                                            =>
+            ZIO.unit
+        }
+      }
+      out <- ZIO.scoped {
+        for {
+          _   <- app
+            .connect(s"ws://localhost:$port/api/ws", Headers("Cookie", s"wh_ws=$token"))
+            .forkScoped
+          _   <- ackP.await.timeoutFail(new RuntimeException("no subscribe ack"))(20.seconds)
+          _   <- trigger
+          _   <- ZIO.sleep(wait)
+          all <- frames.get
+        } yield all
+      }
+    } yield out
+
+  private def getStr(port: Int, token: String, path: String): ZIO[Client, Throwable, String] =
+    ZIO.serviceWithZIO[Client] { client =>
+      ZIO.scoped(
+        client
+          .request(
+            Request
+              .get(s"http://localhost:$port$path")
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          .flatMap(_.body.asString),
+      )
+    }
+
+  private def framesOf(frames: Chunk[String], op: String): Chunk[String] =
+    frames.filter(_.contains(s"\"op\":\"$op\""))
+
+  private def payloadOf(frame: String): Either[String, Json] =
+    frame.fromJson[Json].flatMap {
+      case Json.Obj(fields) =>
+        fields.collectFirst { case (k, v) if k == "payload" => v }.toRight("no payload")
+      case _                => Left("frame not an object")
+    }
+
+  private def parseTimeStatus(frame: String): Either[String, List[ProfileTimeStatus]] =
+    payloadOf(frame).flatMap(_.toJson.fromJson[List[ProfileTimeStatus]])
+
+  private def parseAppUsage(frame: String): Either[String, ProfileUsageByApp] =
+    payloadOf(frame).flatMap(_.toJson.fromJson[ProfileUsageByApp])
+
+  private type BootstrapEnv =
+    TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]
+
+  private def withHarness[A](
+      body: (
+          Int,
+          RouterIngestService,
+          Router,
+          SpaEventBus,
+      ) => ZIO[Client & BootstrapEnv, Throwable, A],
+  ): ZIO[BootstrapEnv, Throwable, A] =
+    (for {
+      _           <- cleanDb
+      clock       <- ZIO.service[Clock]
+      auth        <- makeAuth(clock)
+      trafficRepo <- ZIO.service[TrafficReportRepo]
+      rollupRepo  <- ZIO.service[RollupRepo]
+      connRepo    <- ZIO.service[ConnectionEventRepo]
+      deviceRepo  <- ZIO.service[DeviceRepo]
+      profileRepo <- ZIO.service[ProfileRepo]
+      appRepo     <- ZIO.service[AppRepo]
+      atlRepo     <- ZIO.service[AppTimeLimitRepo]
+      tlRepo      <- ZIO.service[TimeLimitRepo]
+      extRepo     <- ZIO.service[TimeExtensionRepo]
+      usageRepo   <- ZIO.service[TimeUsageRepo]
+      alertRepo   <- ZIO.service[AlertRepo]
+      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
+      upRepo      <- ZIO.service[UserProfileRepo]
+      appUsedRepo <- ZIO.service[AppUsedRollupRepo]
+      routerRepo  <- ZIO.service[RouterRepo]
+      _           <- seedKids
+      router      <- seedRouter
+      reg         <- SpaWsRegistry.make
+      bus         <- SpaEventBus.make
+      timeStatus = new TimeStatusServiceLive(
+        profileRepo,
+        tlRepo,
+        atlRepo,
+        deviceRepo,
+        trafficRepo,
+        extRepo,
+      )
+      ingest     = new RouterIngestService(
+        routerRepo,
+        trafficRepo,
+        usageRepo,
+        deviceRepo,
+        connRepo,
+        alertRepo,
+        hsRepo,
+        bus,
+      )
+      routes     = SpaWsRoutes.routes(auth, reg, clock, openCfg) ++
+        TimeRoutes.routes(
+          auth,
+          deviceRepo,
+          tlRepo,
+          atlRepo,
+          trafficRepo,
+          extRepo,
+          profileRepo,
+          upRepo,
+          hsRepo,
+          timeStatus,
+          clock,
+          spaBus = bus,
+        ) ++
+        UsageRoutes.routes(
+          auth,
+          deviceRepo,
+          trafficRepo,
+          upRepo,
+          profileRepo,
+          appRepo,
+          rollupRepo,
+          hsRepo,
+          atlRepo,
+          appUsedRepo,
+          clock,
+        )
+      port <- Server.install(routes)
+      out  <- ZIO.scoped {
+        SpaPush.run(
+          bus,
+          reg,
+          trafficRepo,
+          rollupRepo,
+          connRepo,
+          deviceRepo,
+          profileRepo,
+          appRepo,
+          atlRepo,
+          clock,
+          Some(SpaPush.TimeUsageDeps(timeStatus, hsRepo, upRepo)),
+        ) *> body(port, ingest, router, bus)
+      }
+    } yield out).provideSome[BootstrapEnv](Server.defaultWithPort(0), Client.default)
+
+  private val subTimeStatus = """{"op":"subscribe","payload":{"topic":"timeStatus"}}"""
+  private def subAppUsage(pid: ProfileId) =
+    s"""{"op":"subscribe","payload":{"topic":"appUsage","params":{"profileId":${pid.value}}}}"""
+
+  def spec = suite("SPA websocket S6a live time-usage push (#1974)")(
+    test("crediting usage pushes a timeStatus body byte-identical to GET /api/time/status (SSOT)") {
+      withHarness { (port, ingest, router, _) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          before <- pushCount("timeStatus", "ok")
+          frames <- collect(
+            port,
+            tok,
+            List(subTimeStatus),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 120)),
+            wait = 4.seconds,
+          )
+          after  <- pushCount("timeStatus", "ok")
+          tFrames = framesOf(frames, "timeStatus")
+          pushed  <- ZIO.fromEither(parseTimeStatus(tFrames.last)).mapError(new RuntimeException(_))
+          getBody <- getStr(port, tok, "/api/time/status")
+          got     <- ZIO
+            .fromEither(getBody.fromJson[List[ProfileTimeStatus]])
+            .mapError(e => new RuntimeException(s"parse GET ($e): $getBody"))
+        } yield assertTrue(tFrames.nonEmpty) &&
+          assertTrue(after - before >= 1.0) &&
+          assertTrue(pushed.toSet == got.toSet) &&
+          assertTrue(pushed.exists(_.profileName == "Kids"))
+      }
+    },
+    test(
+      "a #1849 boundary tick (TimeStatusChanged, no new usage) still pushes a fresh timeStatus",
+    ) {
+      withHarness { (port, ingest, router, bus) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          // Seed some usage FIRST so used/remaining are non-trivial, then the boundary tick fires
+          // with NO new usage — exactly the schedule-edge / cap-exhaustion path (design §5.2).
+          _      <- ingestUsage(ingest, router, usageRecord("youtube.com", 120))
+          frames <- collect(
+            port,
+            tok,
+            List(subTimeStatus),
+            trigger = bus.publish(SpaEvent.TimeStatusChanged),
+            wait = 4.seconds,
+          )
+          tFrames = framesOf(frames, "timeStatus")
+          pushed  <- ZIO.fromEither(parseTimeStatus(tFrames.last)).mapError(new RuntimeException(_))
+          getBody <- getStr(port, tok, "/api/time/status")
+          got     <- ZIO
+            .fromEither(getBody.fromJson[List[ProfileTimeStatus]])
+            .mapError(e => new RuntimeException(s"parse GET ($e): $getBody"))
+        } yield assertTrue(tFrames.nonEmpty) && assertTrue(pushed.toSet == got.toSet)
+      }
+    },
+    test("POST /api/time/extend grant pushes a fresh timeStatus reflecting the new extension") {
+      withHarness { (port, ingest, router, _) =>
+        for {
+          tok <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          pid <- ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.head.id)
+          grant = ZIO.serviceWithZIO[Client] { client =>
+            ZIO
+              .scoped(
+                client.request(
+                  Request
+                    .post(
+                      s"http://localhost:$port/api/time/extend",
+                      Body.fromString(
+                        s"""{"profileId":${pid.value},"extraMinutes":15}""",
+                      ),
+                    )
+                    .addHeader(Header.Authorization.Bearer(tok)),
+                ),
+              )
+              .unit
+          }
+          frames <- collect(port, tok, List(subTimeStatus), trigger = grant, wait = 4.seconds)
+          tFrames = framesOf(frames, "timeStatus")
+          pushed <- ZIO.fromEither(parseTimeStatus(tFrames.last)).mapError(new RuntimeException(_))
+        } yield assertTrue(tFrames.nonEmpty) &&
+          assertTrue(pushed.exists(p => p.profileName == "Kids" && p.extensionMins == 15))
+      }
+    },
+    test("appUsage{profileId} push equals GET /api/profiles/{id}/usage-by-app (SSOT)") {
+      withHarness { (port, ingest, router, _) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          pid    <- ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.head.id)
+          before <- pushCount("appUsage", "ok")
+          frames <- collect(
+            port,
+            tok,
+            List(subAppUsage(pid)),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 120)),
+            wait = 4.seconds,
+          )
+          after  <- pushCount("appUsage", "ok")
+          aFrames = framesOf(frames, "appUsage")
+          pushed  <- ZIO.fromEither(parseAppUsage(aFrames.last)).mapError(new RuntimeException(_))
+          getBody <- getStr(port, tok, s"/api/profiles/${pid.value}/usage-by-app")
+          got     <- ZIO
+            .fromEither(getBody.fromJson[ProfileUsageByApp])
+            .mapError(e => new RuntimeException(s"parse GET ($e): $getBody"))
+        } yield assertTrue(aFrames.nonEmpty) &&
+          assertTrue(after - before >= 1.0) &&
+          assertTrue(pushed == got)
+      }
+    },
+    test("role filter: a child linked to one profile receives ONLY that profile's timeStatus") {
+      withHarness { (port, ingest, router, _) =>
+        for {
+          // A second profile the child must NOT see, plus the child linked to Kids only.
+          kidsPid <- ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.head.id)
+          _       <- ZIO.serviceWithZIO[ProfileRepo](_.create("Teens", Nil))
+          childTk <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "child", "kid"))
+          (childTok, childUid) = childTk
+          _      <- ZIO.serviceWithZIO[UserProfileRepo](_.addLink(childUid, kidsPid))
+          frames <- collect(
+            port,
+            childTok,
+            List(subTimeStatus),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 120)),
+            wait = 4.seconds,
+          )
+          tFrames = framesOf(frames, "timeStatus")
+          pushed <- ZIO.fromEither(parseTimeStatus(tFrames.last)).mapError(new RuntimeException(_))
+        } yield assertTrue(tFrames.nonEmpty) &&
+          assertTrue(pushed.map(_.profileName) == List("Kids"))
+      }
+    },
+    test("no timeStatus/appUsage subscriber → no timeStatus/appUsage push on usage ingest") {
+      withHarness { (port, ingest, router, _) =>
+        for {
+          tok     <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "adult", "mom"))
+          beforeT <- pushCount("timeStatus", "ok")
+          beforeA <- pushCount("appUsage", "ok")
+          frames  <- collect(
+            port,
+            tok._1,
+            List("""{"op":"subscribe","payload":{"topic":"now"}}"""),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 120)),
+            wait = 4.seconds,
+          )
+          afterT  <- pushCount("timeStatus", "ok")
+          afterA  <- pushCount("appUsage", "ok")
+        } yield assertTrue(framesOf(frames, "timeStatus").isEmpty) &&
+          assertTrue(framesOf(frames, "appUsage").isEmpty) &&
+          assertTrue(afterT == beforeT) && assertTrue(afterA == beforeA)
+      }
+    },
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential @@ TestAspect.timeout(120.seconds)
+}

--- a/deploy/grafana/dashboards/spa-ws.json
+++ b/deploy/grafana/dashboards/spa-ws.json
@@ -397,8 +397,8 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "title": "SPA ws push fan-out health by op,result (#1970)",
-      "description": "sum by (op, result) (rate(spa_ws_push_total[5m])) — the change-source fan-out health (design §5.2/§6.3). op is the pushed topic: now|connectionEvents|stale ship in S3, trafficUsage in S4 (#1971) (timeStatus|appUsage in S6a — they appear here as those topics start pushing). result ∈ {ok, coalesced, dropped, channel_closed}: ok dominates once the SPA ws client ships (S5); rising channel_closed/dropped is the slow-client/backpressure tripwire — a wedged browser whose mailbox overflowed or whose socket the server gave up on. coalesced is the latest-wins/coalesce-by-topic saving (a slow client served only the freshest now/stale). Until S5 there are no subscribers, so this reads 0/flat.",
+      "title": "SPA ws push fan-out health by op,result (#1970/#1974)",
+      "description": "sum by (op, result) (rate(spa_ws_push_total[5m])) — the change-source fan-out health (design §5.2/§6.3). op is the pushed topic: now|connectionEvents|stale ship in S3, trafficUsage in S4 (#1971), timeStatus|appUsage in S6a (#1974 — emitted by SpaWsRegistry.deliver on the per-recipient time-usage pushes). result ∈ {ok, coalesced, dropped, channel_closed}: ok dominates once a ws client is subscribed (timeStatus on the dashboard/profiles views, appUsage on an expanded profile card); rising channel_closed/dropped is the slow-client/backpressure tripwire — a wedged browser whose mailbox overflowed or whose socket the server gave up on. coalesced is the latest-wins/coalesce-by-topic saving (a slow client served only the freshest now/stale). With no subscriber for a topic, that op reads 0/flat (no query runs).",
       "type": "timeseries",
       "gridPos": {
         "h": 8,

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -277,14 +277,19 @@ export function useRecentBlocked(opts?: QueryOpts<QueryLog[]>) {
   })
 }
 
-export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]>) {
+// #1974 (SPA-ws S6a, §3.3): when the `timeStatus` push is live (`wsLive`), the adaptive ladder goes
+// DORMANT — the push keeps the cache fresh, so polling is redundant. The ladder is NOT removed
+// (that's S7); it stays the disconnected fallback, resuming the instant the socket drops. The
+// caller passes `wsLive` from `useWsTopicLive('timeStatus')`.
+export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]> & { wsLive?: boolean }) {
+  const { wsLive, ...rest } = opts ?? {}
   return useQuery({
     queryKey: qk.timeStatusToday(),
     queryFn: () => api.time.statusAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: q => timeStatusRefetchInterval(q.state.data),
+    refetchInterval: wsLive ? false : q => timeStatusRefetchInterval(q.state.data),
     refetchIntervalInBackground: false,
-    ...opts,
+    ...rest,
   })
 }
 
@@ -311,14 +316,17 @@ export function useTimeStatusWeek(
 }
 
 // #777 — summary endpoints: lightweight rollups for the collapsed accordion view.
-export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]>) {
+export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]> & { wsLive?: boolean }) {
+  // #1974 (S6a): pause the adaptive ladder while the `timeStatus` push is live (§3.3) — the push
+  // patches this (summary-projected) cache, so polling is redundant; it resumes on disconnect.
+  const { wsLive, ...rest } = opts ?? {}
   return useQuery({
     queryKey: qk.timeStatusSummaryToday(),
     queryFn: () => api.time.summaryAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: q => timeStatusRefetchInterval(q.state.data),
+    refetchInterval: wsLive ? false : q => timeStatusRefetchInterval(q.state.data),
     refetchIntervalInBackground: false,
-    ...opts,
+    ...rest,
   })
 }
 
@@ -338,15 +346,18 @@ export function useTimeStatusSummaryWeek(
 // The query stays cached for the page mount so collapse + re-expand doesn't refetch.
 export function useTimeStatusProfileToday(
   profileId: number,
-  opts?: QueryOpts<ProfileTimeStatus | undefined>,
+  opts?: QueryOpts<ProfileTimeStatus | undefined> & { wsLive?: boolean },
 ) {
+  // #1974 (S6a): pause the ladder while the `timeStatus` push is live (§3.3); the push patches this
+  // per-profile-today key off the same body, so it stays fresh without polling.
+  const { wsLive, ...rest } = opts ?? {}
   return useQuery({
     queryKey: qk.timeStatusProfileToday(profileId),
     queryFn: () => api.time.statusAll(undefined, profileId).then(rows => rows[0]),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: q => timeStatusRefetchInterval(q.state.data),
+    refetchInterval: wsLive ? false : q => timeStatusRefetchInterval(q.state.data),
     refetchIntervalInBackground: false,
-    ...opts,
+    ...rest,
   })
 }
 

--- a/web/src/api/wsCache.ts
+++ b/web/src/api/wsCache.ts
@@ -6,6 +6,8 @@
 
 import type {
   DashboardNow,
+  ProfileTimeStatus,
+  ProfileTimeSummary,
   QueryLog,
   TrafficUsageAggregateRow,
   TrafficUsageBucket,
@@ -153,4 +155,25 @@ export function deriveNowKpis(now: DashboardNow | undefined | null): NowKpis {
   const activeDevices = profiles.flatMap(p => p.activeDevices)
   const blocked = profiles.filter(p => p.paused).flatMap(p => p.activeDevices)
   return { onlineNow: activeDevices.length, blockedNow: blocked.length }
+}
+
+// ── timeStatus: project the pushed ProfileTimeStatus[] onto the lighter summary shape ───
+//
+// #1974 (S6a, §3.1): the `timeStatus` push carries the full `/api/time/status`
+// ProfileTimeStatus[] body. The /profiles collapsed list reads the lighter
+// `/api/time/status/summary` shape (ProfileTimeSummary[], #777). ProfileTimeSummary is a
+// strict field-subset of ProfileTimeStatus, so we PROJECT the one pushed body onto it (no
+// recompute — pure field selection) and patch the summary cache too, so the collapsed bars
+// live-update AND their adaptive ladder can safely go dormant while the push is live (§3.3).
+// One pushed body is the single source for both caches.
+export function projectTimeStatusToSummary(rows: ProfileTimeStatus[]): ProfileTimeSummary[] {
+  return rows.map(r => ({
+    profileId: r.profileId,
+    profileName: r.profileName,
+    date: r.date,
+    dailyLimitMins: r.dailyLimitMins,
+    usedMins: r.usedMins,
+    extensionMins: r.extensionMins,
+    remainingMins: r.remainingMins,
+  }))
 }

--- a/web/src/components/usage/ProfileUsageBreakdown.tsx
+++ b/web/src/components/usage/ProfileUsageBreakdown.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useProfileUsageByApp } from '@/api/queries'
+import { useWsAppUsage } from '@/hooks/useWs'
 import type {
   HostUsage, OrphanHostUsage, ProfileAppUsage, ProfileUsageByApp,
 } from '@/types/api'
@@ -35,6 +36,13 @@ export function ProfileUsageBreakdown({ profileId, enabled = true, from, to }: {
   const f = from ?? today()
   const t = to ?? f
   const q = useProfileUsageByApp(profileId, f, t, { enabled })
+  // #1974 (SPA-ws S6a, §3.1): while this card is expanded on the LIVE (today) window, subscribe the
+  // per-app `appUsage{profileId}` push so the minutes-used rows update live; collapsing unmounts
+  // this component and the subscription effect's cleanup unsubscribes (subscription = mounted UI,
+  // §1.4). Only the today window is streamed — past windows are immutable, so the push never
+  // touches them; the subscription is gated on `enabled && f === t === today`.
+  const isLiveWindow = enabled && f === today() && t === today()
+  useWsAppUsage(profileId, f, t, isLiveWindow)
 
   if (!enabled) return null
   if (q.isLoading) {

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -26,11 +26,14 @@ import {
   mergeHeadBucket,
   overallRate,
   prependHead,
+  projectTimeStatusToSummary,
   rateFor,
   type BandwidthRate,
 } from '@/api/wsCache'
 import type {
   DashboardNow,
+  ProfileTimeStatus,
+  ProfileUsageByApp,
   QueryLog,
   TrafficUsageAggregateRow,
   TrafficUsageBucket,
@@ -170,6 +173,52 @@ export function useWsRecentBlocked(): void {
       )
     },
     qk.recentBlocked(),
+  )
+}
+
+/**
+ * `timeStatus` (§3.1, class 2): the server pushes the whole `/api/time/status`
+ * `ProfileTimeStatus[]` body whenever a profile's used/remaining minutes move (usage credit /
+ * #1849 boundary tick / +Time grant). We patch every cache the live screen-time surface reads off
+ * the ONE pushed body (SSOT — no recompute):
+ *   - `timeStatusToday()` (the full list, design §3.1),
+ *   - `timeStatusSummaryToday()` (the lighter /profiles collapsed shape, projected — so its
+ *     adaptive ladder can pause while the push is live, §3.3, without the bars freezing),
+ *   - `timeStatusProfileToday(pid)` per row (the expanded per-profile detail).
+ * Refetched once on reconnect via the summary key (the surface the page actively renders).
+ */
+export function useWsTimeStatus(): void {
+  const qc = useQueryClient()
+  useWsSubscription(
+    'timeStatus',
+    undefined,
+    payload => {
+      const rows = (payload as ProfileTimeStatus[]) ?? []
+      qc.setQueryData(qk.timeStatusToday(), rows)
+      qc.setQueryData(qk.timeStatusSummaryToday(), projectTimeStatusToSummary(rows))
+      for (const r of rows) qc.setQueryData(qk.timeStatusProfileToday(r.profileId), r)
+    },
+    qk.timeStatusSummaryToday(),
+  )
+}
+
+/**
+ * `appUsage{profileId}` (§3.1, class 2): subscribed while a profile card is expanded
+ * (subscription = mounted UI, §1.4). The server pushes the per-app `/api/profiles/{id}/usage-by-app`
+ * body for TODAY; we patch ONLY the live today-window key `profileUsageByApp(profileId, from, to)`
+ * — past windows are immutable, so the push never touches them (§3.1). `from`/`to` are the card's
+ * today window (the same local-today the page's query uses), so the patch lands on exactly the key
+ * the breakdown renders. Refetched once on reconnect.
+ */
+export function useWsAppUsage(profileId: number, from: string, to: string, enabled = true): void {
+  const qc = useQueryClient()
+  const key = qk.profileUsageByApp(profileId, from, to)
+  useWsSubscription(
+    'appUsage',
+    { profileId },
+    payload => qc.setQueryData(key, payload as ProfileUsageByApp),
+    key,
+    enabled,
   )
 }
 

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -207,8 +207,15 @@ export function useWsTimeStatus(): void {
  * (subscription = mounted UI, §1.4). The server pushes the per-app `/api/profiles/{id}/usage-by-app`
  * body for TODAY; we patch ONLY the live today-window key `profileUsageByApp(profileId, from, to)`
  * — past windows are immutable, so the push never touches them (§3.1). `from`/`to` are the card's
- * today window (the same local-today the page's query uses), so the patch lands on exactly the key
- * the breakdown renders. Refetched once on reconnect.
+ * today window (the same local-today the page's query uses); the server computes its body for the
+ * household-local today, which the browser's local-today maps to, so the patch lands on the key the
+ * breakdown renders. Refetched once on reconnect.
+ *
+ * v1 LIMITATION: the transport holds ONE subscription per topic (wsClient.subs), so with several
+ * profile cards expanded at once only the most-recently-mounted card's `appUsage` streams (and a
+ * collapse can drop a sibling's). It degrades gracefully — each card still shows its initial
+ * `useProfileUsageByApp` fetch (no wrong data), and live-updates resume when a single card is open.
+ * Multi-subscription-per-topic is the SharedWorker direction (design §6.4/S8).
  */
 export function useWsAppUsage(profileId: number, from: string, to: string, enabled = true): void {
   const qc = useQueryClient()

--- a/web/src/hooks/useWsTimeUsage.test.tsx
+++ b/web/src/hooks/useWsTimeUsage.test.tsx
@@ -1,0 +1,214 @@
+// #1974 (SPA-ws S6a): the live time-usage hooks (design §3.1/§3.3). Proves the `timeStatus` push
+// patches the time-status caches off the one pushed body, the `appUsage` push patches ONLY the
+// live today-window key (past windows immutable), the adaptive ladder goes dormant while the
+// `timeStatus` push streams, and expanding/collapsing a card subscribes/unsubscribes `appUsage`.
+// Driven by the real SpaWsClient over a mock socket so the wire→cache path is exercised end to end.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    time: { summaryAll: vi.fn().mockResolvedValue([]) },
+    profiles: { usageByApp: vi.fn().mockResolvedValue({ profileId: 1, profileName: 'Kids', from: 'x', to: 'x', apps: [], orphanHosts: [] }) },
+  },
+}))
+
+import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
+import { WsProvider, useWsTopicLive, useWsTimeStatus, useWsAppUsage } from './useWs'
+import { useTimeStatusSummary, qk } from '@/api/queries'
+import { AuthProvider } from '@/hooks/useAuth'
+import type { ProfileTimeStatus, ProfileUsageByApp } from '@/types/api'
+
+class MockSocket implements WsSocketLike {
+  static instances: MockSocket[] = []
+  sent: string[] = []
+  onopen: ((ev?: unknown) => void) | null = null
+  onclose: ((ev: { code: number; reason?: string }) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+  constructor(public url: string) {
+    MockSocket.instances.push(this)
+  }
+  send(d: string) {
+    this.sent.push(d)
+  }
+  close() {
+    this.onclose?.({ code: 1006 })
+  }
+  open() {
+    this.onopen?.()
+  }
+  emit(frame: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+  frames() {
+    return this.sent.map(s => JSON.parse(s))
+  }
+}
+const last = () => MockSocket.instances[MockSocket.instances.length - 1]
+
+function makeQc(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false, staleTime: 60_000, gcTime: Infinity },
+    },
+  })
+}
+
+function setup() {
+  const qc = makeQc()
+  const client = new SpaWsClient({
+    apiBaseUrl: 'https://api.x',
+    origin: 'https://app.x',
+    getToken: () => 'jwt',
+    socketFactory: url => new MockSocket(url),
+    setCookie: () => {},
+    clearCookie: () => {},
+    invalidateQuery: key => qc.invalidateQueries({ queryKey: key as readonly unknown[] }),
+    // Huge so the 5-minute ladder advance below never trips the heartbeat's missed-pong reconnect
+    // (which would clear acks and break the streaming-state assertion). Heartbeat is not under test.
+    heartbeatMs: 100_000_000,
+  })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <AuthProvider>
+        <WsProvider client={client}>{children}</WsProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+  return { qc, client, wrapper }
+}
+
+function goLive(client: SpaWsClient) {
+  act(() => client.start())
+  act(() => last().open())
+  act(() => last().emit({ op: 'ready', payload: { role: 'admin', serverTime: 't' } }))
+}
+
+const tsRow = (id: number, name: string): ProfileTimeStatus => ({
+  profileId: id,
+  profileName: name,
+  date: '2026-06-26',
+  dailyLimitMins: 120,
+  usedMins: 30,
+  extensionMins: 0,
+  remainingMins: 90,
+  appUsage: [],
+  devices: [],
+  hostUsage: [],
+})
+
+beforeEach(() => {
+  MockSocket.instances = []
+  localStorage.clear()
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('useWsTimeStatus (§3.1)', () => {
+  it('patches the today + summary + per-profile-today caches off the one pushed body', () => {
+    const { qc, client, wrapper } = setup()
+    renderHook(() => useWsTimeStatus(), { wrapper })
+    goLive(client)
+    const rows = [tsRow(1, 'Kids'), tsRow(2, 'Teens')]
+    act(() => last().emit({ op: 'timeStatus', payload: rows }))
+
+    expect(qc.getQueryData(qk.timeStatusToday())).toEqual(rows)
+    // projected summary subset (no appUsage/devices/hostUsage)
+    expect(qc.getQueryData(qk.timeStatusSummaryToday())).toEqual([
+      { profileId: 1, profileName: 'Kids', date: '2026-06-26', dailyLimitMins: 120, usedMins: 30, extensionMins: 0, remainingMins: 90 },
+      { profileId: 2, profileName: 'Teens', date: '2026-06-26', dailyLimitMins: 120, usedMins: 30, extensionMins: 0, remainingMins: 90 },
+    ])
+    // per-profile-today caches (the expanded-card detail key)
+    expect(qc.getQueryData(qk.timeStatusProfileToday(1))).toEqual(rows[0])
+    expect(qc.getQueryData(qk.timeStatusProfileToday(2))).toEqual(rows[1])
+  })
+})
+
+describe('useWsAppUsage (§3.1)', () => {
+  const body = (pid: number, used: number): ProfileUsageByApp => ({
+    profileId: pid,
+    profileName: 'Kids',
+    from: '2026-06-26',
+    to: '2026-06-26',
+    apps: [{ appId: 5, appName: 'YouTube', appIcon: null, appIconType: null, proportionalSeconds: used, presenceSeconds: used, hosts: [] }],
+    orphanHosts: [],
+  })
+
+  it('patches ONLY the live today-window key and leaves past-window keys untouched', () => {
+    const { qc, client, wrapper } = setup()
+    const today = '2026-06-26'
+    const past = '2026-06-20'
+    // Pre-seed an immutable past window + a stale today entry.
+    const pastBody = body(1, 999)
+    qc.setQueryData(qk.profileUsageByApp(1, past, past), pastBody)
+    qc.setQueryData(qk.profileUsageByApp(1, today, today), body(1, 1))
+
+    renderHook(() => useWsAppUsage(1, today, today, true), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'appUsage', status: 'ok' } }))
+    const push = body(1, 300)
+    act(() => last().emit({ op: 'appUsage', payload: push }))
+
+    expect(qc.getQueryData(qk.profileUsageByApp(1, today, today))).toEqual(push)
+    // past window is immutable — the push must never touch it
+    expect(qc.getQueryData(qk.profileUsageByApp(1, past, past))).toEqual(pastBody)
+  })
+
+  it('subscribes appUsage{profileId} on mount and unsubscribes on unmount (= card expand/collapse)', () => {
+    const { client, wrapper } = setup()
+    const { unmount } = renderHook(() => useWsAppUsage(7, '2026-06-26', '2026-06-26', true), { wrapper })
+    goLive(client)
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload?.topic === 'appUsage')
+    expect(sub?.payload?.params).toEqual({ profileId: 7 })
+    // collapsing the card unmounts the component → the subscription effect cleanup unsubscribes
+    act(() => unmount())
+    const unsub = last().frames().find(f => f.op === 'unsubscribe' && f.payload?.topic === 'appUsage')
+    expect(unsub).toBeTruthy()
+  })
+
+  it('does NOT subscribe while disabled (collapsed card / past window)', () => {
+    const { client, wrapper } = setup()
+    renderHook(() => useWsAppUsage(7, '2026-06-26', '2026-06-26', false), { wrapper })
+    goLive(client)
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload?.topic === 'appUsage')
+    expect(sub).toBeUndefined()
+  })
+})
+
+describe('adaptive ladder pauses while timeStatus streams (§3.3)', () => {
+  it('pauses the summary poll once the timeStatus subscription is acked, resumes if never acked', async () => {
+    vi.useFakeTimers()
+    const { api } = await import('@/api/client')
+    const summarySpy = api.time.summaryAll as unknown as ReturnType<typeof vi.fn>
+    const { client, wrapper } = setup()
+    // mirrors ProfilesPage: subscribe timeStatus + gate the summary ladder on the topic streaming.
+    const { result } = renderHook(
+      () => {
+        const live = useWsTopicLive('timeStatus')
+        useWsTimeStatus()
+        useTimeStatusSummary({ wsLive: live })
+        return live
+      },
+      { wrapper },
+    )
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) })
+    expect(summarySpy).toHaveBeenCalledTimes(1) // initial fetch
+
+    // socket live but not yet acked → ladder still runs (baseline 5m cadence, remaining=90 → 5m)
+    act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
+    expect(result.current).toBe(false)
+    await act(async () => { await vi.advanceTimersByTimeAsync(300_000) })
+    expect(summarySpy).toHaveBeenCalledTimes(2)
+
+    // server acks the subscription → topic streaming → ladder dormant
+    act(() => { last().emit({ op: 'ack', payload: { topic: 'timeStatus', status: 'ok' } }) })
+    expect(result.current).toBe(true)
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_200_000) })
+    expect(summarySpy).toHaveBeenCalledTimes(2) // no further polls while streaming
+  })
+})

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -4,6 +4,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useBlocklists, useGlobalProfile, useProfiles, useDevices, useInvalidators, useNamedSchedules, useProfileUsageByApp, useTimeStatusSummary } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
+import { useWsTimeStatus, useWsTopicLive } from '@/hooks/useWs'
 import { useDebouncedSave, type SaveStatus } from '@/hooks/useDebouncedSave'
 import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 import { SchedulePicker } from '@/components/SchedulePicker'
@@ -122,7 +123,12 @@ export function ProfilesPage() {
   // admin and the page already gates most editing on `isAdmin`).
   const globalProfileQuery = useGlobalProfile({ enabled: isAdmin })
   const devicesQuery  = useDevices()
-  const summariesQuery = useTimeStatusSummary()
+  // #1974 (SPA-ws S6a): subscribe the live `timeStatus` push (patches the summary cache off the
+  // pushed body), and pause the summary's adaptive ladder while that push is streaming (§3.3 — the
+  // ladder stays the disconnected fallback, it is not removed until S7).
+  useWsTimeStatus()
+  const timeStatusLive = useWsTopicLive('timeStatus')
+  const summariesQuery = useTimeStatusSummary({ wsLive: timeStatusLive })
   const profiles  = useMemo(() => {
     const list = profilesQuery.data ?? []
     const g    = globalProfileQuery.data


### PR DESCRIPTION
**SPA-websocket rollout step S6a** (`docs/design/spa-websocket.md` §1.2/§3.1/§5.2, umbrella #1955). Closes #1974. Additive — polling stays the fallback (no flag day).

Lights up the **live screen-time surface** (`/profiles`): per-profile used/remaining and per-app minutes now stream over `/api/ws` instead of the hand-rolled adaptive refetch ladder.

## Server
- **`SpaEvent.TimeStatusChanged`** published from the three §5.2 write sites: usage credit (`RouterIngestService`), the #1849 reevaluate ticker / every policy mutation (the `PolicySnapshotPublisher` SPA sink in `Main`), and `POST /api/time/extend`.
- **`timeStatus` push** — the `/api/time/status` `ProfileTimeStatus[]` body via `TimeStatusService.dayStateAllLive` + a new shared `assembleProfileTimeStatus` wire-shape builder that the GET also calls, so the streamed body is **byte-identical** to the GET (AGENTS.md §single-source-of-truth — minutes never recomputed).
- **`appUsage{profileId}` push** — the `/api/profiles/{id}/usage-by-app` today body via the shared `UsageRoutes.buildUsageByApp` (the exact repo-load + compute the GET runs).
- **Subscription-gated** (no subscriber → no query) and **per-recipient role-filtered**: the JWT username is captured at upgrade so the fan-out reuses the GET's `UserProfileRepo` child filter (design §4.4) — a child sees only their linked profiles, admin/adult all. Latest-wins per the coalescing drain loop.
- **Metrics**: rides the existing bounded `spa_ws_push_total{op}` (op ∈ …+timeStatus,appUsage via `SpaWsRegistry.deliver`) and `spa_ws_subscriptions_active{topic}`. No per-profile/unbounded labels. `spa-ws.json` push panel + `Metrics.scala` docs updated to name the new ops.

## SPA (§3.1/§3.3)
- `useWsTimeStatus()` patches the today list (`qk.timeStatusToday`), the projected summary cache (`qk.timeStatusSummaryToday`) and each per-profile-today key off the **one** pushed body (pure projection — SSOT).
- `useWsAppUsage(profileId, from, to)` subscribed while a card is expanded on the **live today window**; patches **only** that today key — past windows are immutable. Subscription = mounted UI (expand subscribes / collapse unsubscribes).
- The adaptive `TIME_STATUS_REFETCH_LADDER` goes **dormant** while the push streams (gated on `useWsTopicLive('timeStatus')`), but is **not removed** — it stays the disconnected fallback (deletion is S7).

## Tests (TDD)
- **Server** `SpaWsS6aSpec` (full-stack, embedded Postgres, real ingest + extend + GETs): SSOT vs both GETs, usage-credit / boundary-tick / extend triggers, child role-filter, no-subscriber→no-push. 6/6 green.
- **Web** `useWsTimeUsage.test.tsx`: timeStatus patches the caches, appUsage patches only today (past untouched), ladder pauses on `timeStatus` ack, expand/collapse subscribes/unsubscribes. 5/5 green.
- Full `mill api.test` + `npm --prefix web test` + `npm run build` green; no additions to `web/src/types/api.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)