### PR TITLE
fix(#2004): trafficUsage live-edge head stuck at 0 B/s — anchor head bucket on ingested period, not floor(now)

### DIFF
--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -92,7 +92,7 @@ final class RouterIngestService(
         // for subscribed `(groupBy,bucket,filter)` param-sets (design §5.3). Both are one-liners that
         // never block or fail ingest (sliding hub, UIO). timeStatus/appUsage pushes are S6a.
         _        <- ZIO.when(records.nonEmpty)(
-          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested),
+          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested(ps)),
         )
       } yield ()
     }

--- a/api/src/routes/SpaEvents.scala
+++ b/api/src/routes/SpaEvents.scala
@@ -25,18 +25,23 @@ import java.time.Instant
  *   - [[SpaEvent.Stale]] — a class-(3) occasionally-changing resource mutated; the consumer fans a
  *     contentless `{topic, scope?}` nudge to `stale` subscribers so they invalidate the mapped
  *     query (§3.2). Coalescing-friendly (idempotent).
- *   - [[SpaEvent.UsageIngested]] — #1971 (S4): new `traffic_reports` rows landed. The consumer
- *     re-runs the EXISTING `GET /api/usage/traffic` query (via `UsageTrafficQuery.aggregate`)
- *     scoped to the current/most-recent bucket for each distinct subscribed `(groupBy, bucket,
- *     filter)` param-set and pushes that one bucket as a `TrafficUsageResponse` live edge (design
- *     §5.3). Contentless trigger — the head is recomputed from the DB, latest-wins (§6.3), and a
- *     param-set with no subscriber is never queried.
+ *   - [[SpaEvent.UsageIngested]] — #1971 (S4): new `traffic_reports` rows landed for the batch's
+ *     `[periodStart, periodEnd)`. The consumer re-runs the EXISTING `GET /api/usage/traffic` query
+ *     (via `UsageTrafficQuery.aggregate`) scoped to the bucket the new rows actually landed in —
+ *     the one containing `periodStart` (rows are bucketed by `period_start`, `UsageTrafficQuery`) —
+ *     for each distinct subscribed `(groupBy, bucket, filter)` param-set and pushes that one bucket
+ *     as a `TrafficUsageResponse` live edge (design §5.3). #2004: the head MUST be anchored on the
+ *     ingested `periodStart`, NOT wall-clock `now` — a ~60s report covers the *prior* minute, so
+ *     its `period_start` floors to the previous bucket; scoping to `floor(now)` left the head
+ *     perpetually empty and the dashboard LIVE BANDWIDTH panel stuck at 0 B/s. Latest-wins (§6.3):
+ *     a burst coalesces to the freshest `periodStart`, and a param-set with no subscriber is never
+ *     queried.
  */
 enum SpaEvent {
   case NowChanged
   case ConnectionEventsIngested(since: Instant)
   case Stale(topic: StaleTopic, scope: Option[String] = None)
-  case UsageIngested
+  case UsageIngested(periodStart: Instant)
 }
 
 /**

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -339,6 +339,10 @@ object SpaPush {
               appsByHost,
             )
         aggregate.flatMap { rows =>
+          // `from`/`to` describe the head BUCKET window `[headStart, headEnd)` — not wall-clock
+          // "live edge time". `to` is therefore the bucket end and can sit slightly ahead of `now`
+          // for an in-progress bucket; it's metadata only (the client merges by `windowStart` and
+          // derives B/s from the bucket width, never from this `to`).
           val body = TrafficUsageResponse(
             bucket = parsed.bucket.code,
             groupBy = parsed.groupBySet.toList.map(_.code).sorted,

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -30,16 +30,18 @@ import java.time.{Duration, Instant, ZoneId}
  *     whose filter matches.
  *   - [[SpaEvent.Stale]] → fan a contentless nudge to `stale` subscribers.
  *   - [[SpaEvent.UsageIngested]] → #1971 (S4): for each DISTINCT subscribed `trafficUsage`
- *     `(groupBy, bucket, filter)` param-set, recompute ONLY the current/most-recent bucket via the
- *     shared [[UsageTrafficQuery.aggregate]] (the exact query the `GET /api/usage/traffic`
- *     aggregated path runs — SSOT) scoped to the head window, and push that one bucket as a
- *     `TrafficUsageResponse` live edge (design §5.3). No subscriber for a param-set → no query.
+ *     `(groupBy, bucket, filter)` param-set, recompute ONLY the bucket the just-ingested rows
+ *     landed in — the one containing the event's `periodStart` (#2004) — via the shared
+ *     [[UsageTrafficQuery.aggregate]] (the exact query the `GET /api/usage/traffic` aggregated path
+ *     runs — SSOT) scoped to that single bucket, and push it as a `TrafficUsageResponse` live edge
+ *     (design §5.3). No subscriber for a param-set → no query.
  *
  * Cadence / backpressure (design §6.3): the drain loop COALESCES — it takes the first buffered
- * event then drains everything else currently queued and de-duplicates the contentless triggers
- * ([[SpaEvent.NowChanged]] / [[SpaEvent.UsageIngested]]), so a burst of usage ingests collapses to
- * a single freshest head-bucket recompute per param-set (latest-wins), never a backlog. A slow
- * consumer thus serves the freshest state, not a queue of stale snapshots.
+ * event then drains everything else currently queued and de-duplicates the triggers
+ * ([[SpaEvent.NowChanged]] to one, [[SpaEvent.UsageIngested]] to the freshest `periodStart`), so a
+ * burst of usage ingests collapses to a single freshest head-bucket recompute per param-set
+ * (latest-wins), never a backlog. A slow consumer thus serves the freshest state, not a queue of
+ * stale snapshots.
  *
  * The loop NEVER fails: each event's build is wrapped so a transient repo error is logged and
  * skipped (the push surface is a latency/UX layer, design §6.5 — a missed push self-heals on the
@@ -82,11 +84,10 @@ object SpaPush {
 
   /**
    * Drain one coalesced batch: block for the first event, then sweep up everything else already
-   * buffered and de-dup the contentless triggers (design §6.3) so a burst of ingests does ONE
-   * recompute per topic, not N. `distinct` preserves first-occurrence order; the
-   * `ConnectionEventsIngested(since)` events keep their distinct `since` (their head re-read is
-   * cheap and the `since` floor matters), only the contentless `NowChanged`/`UsageIngested`
-   * collapse.
+   * buffered and coalesce (design §6.3) so a burst of ingests does ONE recompute per topic, not N.
+   * The `ConnectionEventsIngested(since)` events keep their distinct `since` (their head re-read is
+   * cheap and the `since` floor matters); `NowChanged` collapses to one and `UsageIngested` to the
+   * freshest `periodStart` (latest-wins).
    */
   private def drainBatch(
       queue: Dequeue[SpaEvent],
@@ -121,13 +122,31 @@ object SpaPush {
     } yield ()
 
   /**
-   * Coalesce a drained batch (design §6.3 latest-wins): de-dup so the contentless triggers
-   * ([[SpaEvent.NowChanged]] / [[SpaEvent.UsageIngested]]) each fire ONE recompute regardless of
-   * burst size, while distinctly-`since`d [[SpaEvent.ConnectionEventsIngested]] are kept (each
-   * names a different new-row floor). `distinct` preserves first-occurrence order. Exposed for unit
-   * coverage of the collapse logic.
+   * Coalesce a drained batch (design §6.3 latest-wins): de-dup so a burst of triggers fires ONE
+   * recompute per topic regardless of burst size, while distinctly-`since`d
+   * [[SpaEvent.ConnectionEventsIngested]] are kept (each names a different new-row floor).
+   *   - [[SpaEvent.NowChanged]] → collapses to one (contentless).
+   *   - [[SpaEvent.UsageIngested]] → collapses to the one with the LATEST `periodStart` (#2004):
+   *     the head bucket is anchored on the ingested period, so a burst must converge on the
+   *     freshest period (latest-wins) — a plain `distinct` would keep N distinct-period events and
+   *     recompute each, and an older period must never overwrite the live edge with a stale bucket.
+   *   - [[SpaEvent.ConnectionEventsIngested]] → distinct `since`s kept (their head re-read
+   *     differs).
+   * `distinct` preserves first-occurrence order. Exposed for unit coverage of the collapse logic.
    */
-  private[api] def coalesce(events: Chunk[SpaEvent]): Chunk[SpaEvent] = events.distinct
+  private[api] def coalesce(events: Chunk[SpaEvent]): Chunk[SpaEvent] = {
+    val latestUsage: Option[Instant] =
+      events
+        .collect { case SpaEvent.UsageIngested(p) => p }
+        .foldLeft(Option.empty[Instant])((acc, p) =>
+          Some(acc.fold(p)(a => if (p.isAfter(a)) p else a)),
+        )
+    val withoutUsage                 = events.filter {
+      case SpaEvent.UsageIngested(_) => false
+      case _                         => true
+    }.distinct
+    latestUsage.fold(withoutUsage)(p => withoutUsage :+ SpaEvent.UsageIngested(p))
+  }
 
   private def handle(
       event: SpaEvent,
@@ -152,7 +171,7 @@ object SpaPush {
         LogContext.annotate(LogContext.Op, "stale") {
           registry.fanOutStale(topic, scope)
         }
-      case SpaEvent.UsageIngested                   =>
+      case SpaEvent.UsageIngested(periodStart)      =>
         LogContext.annotate(LogContext.Op, "trafficUsage") {
           pushTrafficUsage(
             registry,
@@ -161,7 +180,7 @@ object SpaPush {
             deviceRepo,
             profileRepo,
             appRepo,
-            clock,
+            periodStart,
           )
             .catchAllCause(c => ZIO.logErrorCause("spa ws push: trafficUsage recompute failed", c))
         }
@@ -217,11 +236,18 @@ object SpaPush {
 
   /**
    * #1971 (S4): the `trafficUsage` live-edge aggregator (design §5.3). For each DISTINCT subscribed
-   * param-set, recompute ONLY the current/most-recent bucket via the shared
-   * [[UsageTrafficQuery.aggregate]] (the same query the `GET` runs) scoped to the head window, and
-   * push it as a `TrafficUsageResponse`. The device/profile maps are loaded ONCE and shared across
-   * param-sets; app memberships are loaded only when some param-set groups by app. No subscriber →
-   * empty param-set → nothing computed.
+   * param-set, recompute ONLY the bucket the just-ingested rows landed in via the shared
+   * [[UsageTrafficQuery.aggregate]] (the same query the `GET` runs) scoped to that single bucket,
+   * and push it as a `TrafficUsageResponse`. The device/profile maps are loaded ONCE and shared
+   * across param-sets; app memberships are loaded only when some param-set groups by app. No
+   * subscriber → empty param-set → nothing computed.
+   *
+   * #2004: `anchor` is the ingested batch's `periodStart` (traffic rows are bucketed by
+   * `period_start`, `UsageTrafficQuery.listRawInRange`), NOT wall-clock `now`. A ~60s router report
+   * covers the *prior* minute, so its `period_start` floors to the previous bucket; anchoring the
+   * head on `now` left `[floor(now), now)` perpetually empty (the fresh row sits one bucket back)
+   * and the dashboard LIVE BANDWIDTH panel stuck at 0 B/s. Anchoring on the period pushes the
+   * bucket the data is actually in.
    */
   private def pushTrafficUsage(
       registry: SpaWsRegistry,
@@ -230,13 +256,12 @@ object SpaPush {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       appRepo: AppRepo,
-      clock: Clock,
+      anchor: Instant,
   ): Task[Unit] =
     registry.trafficUsageParamSets.flatMap { paramSets =>
       ZIO
         .when(paramSets.nonEmpty) {
           for {
-            now      <- clock.instant
             devices  <- deviceRepo.listAll
             profiles <- profileRepo.listAll
             devByMac  = devices.iterator.map(d => d.mac -> d).toMap
@@ -258,7 +283,7 @@ object SpaPush {
                 devByMac,
                 profNames,
                 appsByHost,
-                now,
+                anchor,
               ),
             )
           } yield ()
@@ -281,17 +306,20 @@ object SpaPush {
       devByMac: Map[MacAddress, Device],
       profNames: Map[ProfileId, String],
       appsByHost: Map[String, List[AppMembership]],
-      now: Instant,
+      anchor: Instant,
   ): Task[Unit] =
     decodeParams(params) match {
       case None         =>
         ZIO.logDebug(s"spa ws push: skipping unrenderable trafficUsage params ${params.toJson}")
       case Some(parsed) =>
-        val headStart    = UsageTraffic.floorTo(now, parsed.bucket, parsed.zone)
-        // The head window is [headStart, now): all rows in it floor to `headStart`, so the aggregate
-        // carries exactly the current/most-recent bucket (one windowStart). On the rare tick where
-        // `now` lands exactly on a bucket boundary the window is empty and the push is an empty head
-        // (the client then merges nothing) — the next ingest advances it.
+        // #2004: anchor the head bucket on the ingested `periodStart`, then scope to exactly that ONE
+        // bucket `[headStart, headEnd)` where `headEnd = headStart + bucketWidth`. Rows are bucketed
+        // by `period_start`, so this captures precisely the bucket the fresh rows landed in (one
+        // `windowStart`) — the client's single-bucket head-merge (`wsCache.mergeHeadBucket`) requires
+        // a single window. Anchoring on wall-clock `now` instead left this window empty in steady
+        // state (a ~60s report's period sits one bucket back), the prod defect this fixes.
+        val headStart    = UsageTraffic.floorTo(anchor, parsed.bucket, parsed.zone)
+        val headEnd      = headStart.plus(UsageTraffic.stepOf(parsed.bucket))
         val resolvedMacs = UsageTrafficQuery.resolveMacs(parsed.macs, parsed.profileIds, devices)
         val filterEmpty  = parsed.filterRequested && resolvedMacs.isEmpty
         val aggregate    =
@@ -302,7 +330,7 @@ object SpaPush {
               rollupRepo,
               resolvedMacs,
               headStart,
-              now,
+              headEnd,
               parsed.bucket,
               parsed.groupBySet,
               parsed.zone,
@@ -315,7 +343,7 @@ object SpaPush {
             bucket = parsed.bucket.code,
             groupBy = parsed.groupBySet.toList.map(_.code).sorted,
             from = headStart.toString,
-            to = now.toString,
+            to = headEnd.toString,
             tz = parsed.zone.getId,
             rawRows = Nil,
             aggregateRows = rows,

--- a/api/test/src/feature/SpaWsS4Spec.scala
+++ b/api/test/src/feature/SpaWsS4Spec.scala
@@ -38,9 +38,10 @@ import java.time.{Instant, LocalDateTime}
  *     no frame is ever pushed (admin/adult are full-visibility, so one body serves all recipients —
  *     the per-profile role filter is the visibleTo gate, exactly as `now`).
  *
- * The injected [[Clock]] is fixed at 14:00:30 — deliberately OFF a 1m boundary so the head window
- * `[floor(now,1m)=14:00:00, now=14:00:30)` is non-empty and the seeded period-14:00:00 row lands in
- * it.
+ * The injected [[Clock]] is fixed at 14:00:30. #2004: the head bucket is anchored on the ingested
+ * `periodStart` (not wall-clock `now`), so the seeded period-14:00:00 row lands in the 14:00 bucket
+ * `[14:00:00, 14:01:00)` regardless of the clock; the REGRESSION case below seeds a prior-minute
+ * period to prove the head follows the data, not `floor(now)`.
  */
 object SpaWsS4Spec
     extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
@@ -458,21 +459,30 @@ object SpaWsS4Spec
     test(
       "coalesce collapses a burst of contentless triggers to one recompute each (latest-wins logic)",
     ) {
-      val t1    = Instant.parse("2026-06-25T13:59:00Z")
-      val t2    = Instant.parse("2026-06-25T13:59:30Z")
-      val burst = Chunk(
+      val t1     = Instant.parse("2026-06-25T13:59:00Z")
+      val t2     = Instant.parse("2026-06-25T13:59:30Z")
+      // #2004: UsageIngested now carries the batch's periodStart. A burst must collapse to the ONE
+      // with the LATEST period (latest-wins) so the live edge never regresses to a stale bucket.
+      val pEarly = Instant.parse("2026-06-25T13:58:00Z")
+      val pMid   = Instant.parse("2026-06-25T13:59:00Z")
+      val pLate  = Instant.parse("2026-06-25T14:00:00Z")
+      val burst  = Chunk(
         SpaEvent.NowChanged,
-        SpaEvent.UsageIngested,
-        SpaEvent.UsageIngested,
+        SpaEvent.UsageIngested(pMid),
+        SpaEvent.UsageIngested(pLate),
         SpaEvent.NowChanged,
-        SpaEvent.UsageIngested,
+        SpaEvent.UsageIngested(pEarly),
         SpaEvent.ConnectionEventsIngested(t1),
         SpaEvent.ConnectionEventsIngested(t1),
         SpaEvent.ConnectionEventsIngested(t2),
       )
-      val out   = SpaPush.coalesce(burst)
+      val out    = SpaPush.coalesce(burst)
       ZIO.succeed(
-        assertTrue(out.count(_ == SpaEvent.UsageIngested) == 1) &&
+        // Exactly one UsageIngested survives, and it carries the LATEST period (not first-seen).
+        assertTrue(
+          out.collect { case e: SpaEvent.UsageIngested => e }.toList ==
+            List(SpaEvent.UsageIngested(pLate)),
+        ) &&
           assertTrue(out.count(_ == SpaEvent.NowChanged) == 1) &&
           // Distinct `since`d connection-event events are NOT collapsed (their head re-read differs).
           assertTrue(out.count(_ == SpaEvent.ConnectionEventsIngested(t1)) == 1) &&

--- a/api/test/src/feature/SpaWsS4Spec.scala
+++ b/api/test/src/feature/SpaWsS4Spec.scala
@@ -120,10 +120,22 @@ object SpaWsS4Spec
       router: Router,
       records: UsageRecord*,
   ): Task[Unit] =
+    ingestUsagePeriod(ingest, router, periodStart, periodEnd, records*)
+
+  // #2004: ingest with an EXPLICIT period (not the module default) so a test can place the report in
+  // a bucket that precedes the current wall-clock minute — the real prod cadence (a ~60s report
+  // covers the *prior* minute, so its `period_start` floors to the previous bucket, not `floor(now)`).
+  private def ingestUsagePeriod(
+      ingest: RouterIngestService,
+      router: Router,
+      ps: String,
+      pe: String,
+      records: UsageRecord*,
+  ): Task[Unit] =
     ingest
       .ingestUsage(
         router,
-        UsageReport(router.id, periodStart, periodEnd, records.toList).toJson,
+        UsageReport(router.id, ps, pe, records.toList).toJson,
       )
       .mapError(e => new RuntimeException(s"ingest: $e"))
 
@@ -325,6 +337,49 @@ object SpaWsS4Spec
           assertTrue(pushed.aggregateRows.toSet == got.aggregateRows.toSet) &&
           assertTrue(pushed.bucket == "1m" && pushed.groupBy == List("profile")) &&
           // It is the AGGREGATE shape (per-group rows), never raw per-host rows.
+          assertTrue(pushed.rawRows.isEmpty)
+      }
+    },
+    test(
+      "REGRESSION #2004: a ~60s report whose period PRECEDES the current wall-clock minute still " +
+        "pushes a NON-EMPTY head bucket (anchor the head on the ingested period, not floor(now))",
+    ) {
+      // The injected clock is fixed at 14:00:30. A real router posts every ~60s, so the report that
+      // lands at ~14:00:30 covers the PRIOR minute [13:59:00, 14:00:00) — its `period_start` is
+      // 13:59:00, which floors to the 13:59 bucket, NOT the current `floor(now,1m) = 14:00` bucket.
+      // The buggy code scoped the push window to `[floor(now), now) = [14:00:00, 14:00:30)`, which
+      // EXCLUDES the just-ingested row → an empty head bucket → the dashboard's LIVE BANDWIDTH panel
+      // stays at 0 B/s despite live traffic (#2004). The fix anchors the head bucket on the ingested
+      // period, so the push carries the 13:59 bucket with the real bytes.
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          frames <- collect(
+            port,
+            tok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"],"bucket":"1m"}}}""",
+            ),
+            trigger = ingestUsagePeriod(
+              ingest,
+              router,
+              "2026-06-25T13:59:00Z",
+              "2026-06-25T14:00:00Z",
+              usageRecord("youtube.com", 4242, 1313),
+            ),
+            wait = 4.seconds,
+          )
+          tFrames = trafficFrames(frames)
+          pushed <- ZIO.fromEither(parsePush(tFrames.last)).mapError(e => new RuntimeException(e))
+        } yield assertTrue(tFrames.nonEmpty) &&
+          // The pushed head bucket is the one the data actually landed in (13:59), carrying its bytes.
+          assertTrue(
+            pushed.aggregateRows.map(_.windowStart).distinct == List("2026-06-25T13:59:00Z"),
+          ) &&
+          assertTrue(
+            pushed.aggregateRows.exists(r => r.totalBytesIn == 4242 && r.totalBytesOut == 1313),
+          ) &&
+          assertTrue(pushed.bucket == "1m" && pushed.groupBy == List("profile")) &&
           assertTrue(pushed.rawRows.isEmpty)
       }
     },


### PR DESCRIPTION
Fixes #2004.

## Symptom (prod)
The SPA dashboard **LIVE BANDWIDTH** panel showed `Overall ↓ 0 B/s · ↑ 0 B/s — "No live traffic right now"` despite heavy real traffic (~206 MB ingesting, `GET /api/usage/traffic` returning fresh `aggregateRows`). The socket connected, `ready`d, and the `trafficUsage{groupBy:['profile'],bucket:'1m'}` subscribe `ack`ed `ok` — but no usable `trafficUsage` data ever reached the gauge, while `now`/`connectionEvents` pushed fine. `trafficUsage` (class-1) has **no poll fallback** by design, so the defect is fully user-visible.

## Root cause (S4 — #1971, `api/src/routes/SpaPush.scala`)
Not the registry/param-key path (suspects 1 & 2 ruled out — `now`/`connectionEvents` share that machinery and work). The live-edge aggregator scoped its recompute to `[floor(now,1m), now)` and `UsageTrafficQuery.listRawInRange` filters `traffic_reports` on **`period_start`**.

A router usage report covers the **prior ~60s** (`periodStart ≈ now − 60s`, `periodEnd ≈ now`). So a freshly-ingested row's `period_start` floors to the **previous** bucket, not `floor(now)`. In steady state the head window `[floor(now), now)` therefore **never contains the just-ingested rows** → the push carries **empty `aggregateRows`** → the client's `headBucketRows` (`web/src/api/wsCache.ts`) sees no head data → `"No live traffic right now"` / 0 B/s.

The existing S4 tests masked this by contriving `periodStart == floor(clock)` (clock 14:00:30, period [14:00:00, 14:00:30)), so the seeded row happened to land in the current bucket.

## Fix — anchor the head bucket on the ingested *period*, not wall-clock `now`
- `SpaEvent.UsageIngested` now carries the batch's `periodStart`.
- `SpaPush` recomputes/pushes the **single bucket the new rows actually landed in**: `[floor(periodStart, bucket), +bucketWidth)`. Rows are bucketed by `period_start`, so this captures exactly that bucket (one `windowStart`). The single-bucket wire shape is preserved — the client's `mergeHeadBucket` requires a single window.
- `coalesce` collapses a burst of `UsageIngested` to the one with the **latest** `periodStart` (latest-wins), so an older period can't overwrite the live edge with a stale bucket.

No wire-shape change (still a single-bucket `TrafficUsageResponse`); no web change required.

## Tests (red → green)
- **RED first** (`test(#2004)` commit): a new `SpaWsS4Spec` case ingests a report whose period **precedes** the current wall-clock minute (`[13:59:00, 14:00:00)` under clock 14:00:30) and asserts the push carries the `13:59` bucket with the real bytes. Failed on old code with `aggregateRows = Nil` — reproducing the prod symptom.
- **GREEN** after the fix; full `mill api.test` suite passes (192 suites).
- Updated the `coalesce` unit test to assert the **latest-period** `UsageIngested` survives a burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)