### PR TITLE
feat(#2006): IPv6 support in static_ip_labels + Cloudflare/Google v6 DNS labels

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
@@ -54,6 +54,25 @@ M._ranges = {
   { cidr = "1.0.0.1/32",     label = "cloudflare-dns" },
 }
 
+-- IPv6 ranges. Each entry: { cidr, label }. Host /128 entries are the common
+-- case — clients that bypass the local resolver pin these literals.
+--
+-- 2606:4700:4700::1111, ::1001 — Cloudflare Public DNS (the v6 siblings of
+--                      1.1.1.1 / 1.0.0.1).
+--                      <https://developers.cloudflare.com/1.1.1.1/ip-addresses/>
+-- 2001:4860:4860::8888, ::8844 — Google Public DNS (the v6 siblings of
+--                      8.8.8.8 / 8.8.4.4).
+--                      <https://developers.google.com/speed/public-dns/docs/using>
+--
+-- Apple's v6 push ranges (e.g. 2620:149::/32) are intentionally NOT included
+-- yet — larger/messier, deferred to a follow-up with prod evidence (#2006).
+M._ranges_v6 = {
+  { cidr = "2606:4700:4700::1111/128", label = "cloudflare-dns" },
+  { cidr = "2606:4700:4700::1001/128", label = "cloudflare-dns" },
+  { cidr = "2001:4860:4860::8888/128", label = "google-dns"     },
+  { cidr = "2001:4860:4860::8844/128", label = "google-dns"     },
+}
+
 -- Parse "a.b.c.d" → 32-bit unsigned integer, or nil on malformed input.
 local function ipv4_to_uint(ip)
   if type(ip) ~= "string" then return nil end
@@ -94,20 +113,126 @@ for _, entry in ipairs(M._ranges) do
   end
 end
 
+-- Parse a v6 literal → array of 8 hextets (each 0..65535), or nil on
+-- malformed input. We deliberately keep each hextet as a 16-bit Lua double
+-- (NOT a 128-bit int / bit32) so the prefix math below works on Lua 5.1,
+-- which has neither. `::` compression is expanded to fill the address to 8
+-- groups; a leading/trailing/embedded `::` is handled. IPv4-embedded forms
+-- (`::ffff:1.2.3.4`) are NOT supported — the curated map is pure hex, so any
+-- dot is treated as malformed.
+local function parse_group_list(s)
+  -- "" → empty list (the side of a leading/trailing `::`). A dangling colon
+  -- or an empty / over-long / non-hex token is malformed.
+  local out = {}
+  if s == "" then return out end
+  if s:sub(1, 1) == ":" or s:sub(-1) == ":" then return nil end
+  local start = 1
+  while true do
+    local colon = s:find(":", start, true)
+    local tok = colon and s:sub(start, colon - 1) or s:sub(start)
+    -- 1..4 hex digits ⇒ a hextet ≤ 0xFFFF (fits a double). Rejects "",
+    -- non-hex ("gggg"), and >16-bit ("12345") tokens.
+    if not tok:match("^%x%x?%x?%x?$") then return nil end
+    out[#out + 1] = tonumber(tok, 16)
+    if not colon then break end
+    start = colon + 1
+  end
+  return out
+end
+
+local function ipv6_to_hextets(ip)
+  if type(ip) ~= "string" then return nil end
+  if ip:find(".", 1, true) then return nil end -- no IPv4-embedded form
+  local dc_start, dc_end = ip:find("::", 1, true)
+  if dc_start then
+    -- A second "::" is illegal.
+    if ip:find("::", dc_end + 1, true) then return nil end
+    local left = parse_group_list(ip:sub(1, dc_start - 1))
+    local right = parse_group_list(ip:sub(dc_end + 1))
+    if not left or not right then return nil end
+    local nfill = 8 - (#left + #right)
+    if nfill < 1 then return nil end -- "::" must stand for ≥1 zero group
+    local hextets = {}
+    for i = 1, #left do hextets[#hextets + 1] = left[i] end
+    for _ = 1, nfill do hextets[#hextets + 1] = 0 end
+    for i = 1, #right do hextets[#hextets + 1] = right[i] end
+    return hextets
+  end
+  local groups = parse_group_list(ip)
+  if not groups or #groups ~= 8 then return nil end
+  return groups
+end
+
+-- Parse "<v6 addr>/N" → { hextets = {..8}, full, rem }, or nil on malformed.
+-- `full` = number of whole 16-bit hextets the prefix covers; `rem` = the
+-- leftover bit count in the partial hextet. The partial network hextet is
+-- masked here at compile time so the hot path is a plain equality compare.
+local function parse_cidr_v6(cidr)
+  local addr, prefix = cidr:match("^(.+)/(%d+)$")
+  if not addr then return nil end
+  local hextets = ipv6_to_hextets(addr)
+  prefix = tonumber(prefix)
+  -- prefix=0 would match every v6 address (::/0); reject it for the same
+  -- reason as the v4 /0 guard above. Valid v6 prefix is 1..128.
+  if not hextets or not prefix or prefix < 1 or prefix > 128 then return nil end
+  local full = math.floor(prefix / 16)
+  local rem = prefix % 16
+  if rem > 0 then
+    local shift = 2 ^ (16 - rem)
+    hextets[full + 1] = hextets[full + 1] - (hextets[full + 1] % shift)
+  end
+  return { hextets = hextets, full = full, rem = rem }
+end
+
+-- Pre-compile the v6 ranges once at module load, parallel-array style like
+-- compiled_v4 so first-match-wins ordering holds. Malformed entries are
+-- skipped (mirrors the v4 compile step).
+local compiled_v6 = {}
+for _, entry in ipairs(M._ranges_v6) do
+  local parsed = parse_cidr_v6(entry.cidr)
+  if parsed then
+    compiled_v6[#compiled_v6 + 1] = {
+      hextets = parsed.hextets,
+      full    = parsed.full,
+      rem     = parsed.rem,
+      label   = entry.label,
+    }
+  end
+end
+
 -- lookup(ip) → (label, source) | (nil)
 --
--- Returns the first matching (label, M.SOURCE) pair, or nil. v4-only for
--- now; v6 is parsed off (returns nil) so callers can wire it in safely.
--- To add a v6 entry later, extend M._ranges with `family = "v6"` rows and
--- add an ipv6_to_uint128 path here.
+-- Returns the first matching (label, M.SOURCE) pair, or nil. Handles both
+-- v4 and v6 literals (a colon selects the v6 path). Same M.SOURCE wire
+-- string for both families.
 --
 -- Returning the source alongside the label keeps the caller from having to
 -- know which module produced the attribution: build_event can branch on the
 -- presence of a source value to emit type='label' vs type='fqdn'.
 function M.lookup(ip)
   if type(ip) ~= "string" or ip == "" then return nil end
-  -- v6 literals always contain a colon; punt for now (returns nil).
-  if ip:find(":", 1, true) then return nil end
+  -- v6 literals always contain a colon.
+  if ip:find(":", 1, true) then
+    local addr = ipv6_to_hextets(ip)
+    if not addr then return nil end
+    for _, range in ipairs(compiled_v6) do
+      local net = range.hextets
+      local ok = true
+      -- Compare the full hextets the prefix covers.
+      for i = 1, range.full do
+        if addr[i] ~= net[i] then ok = false; break end
+      end
+      -- Then the partial hextet under a modulo mask, if the prefix isn't a
+      -- whole multiple of 16 (no-op for the /128 host entries here).
+      if ok and range.rem > 0 then
+        local shift = 2 ^ (16 - range.rem)
+        local masked = addr[range.full + 1] - (addr[range.full + 1] % shift)
+        if masked ~= net[range.full + 1] then ok = false end
+      end
+      if ok then return range.label, M.SOURCE end
+    end
+    return nil
+  end
   local n = ipv4_to_uint(ip)
   if not n then return nil end
   for _, range in ipairs(compiled_v4) do

--- a/openwrt/test/static_ip_labels_spec.lua
+++ b/openwrt/test/static_ip_labels_spec.lua
@@ -50,8 +50,6 @@ describe("static_ip_labels.lookup", function()
     -- 2001:4860:4860::8888 == 2001:4860:4860:0000:0000:0000:0000:8888
     assert.equal("google-dns", (labels.lookup("2001:4860:4860::8888")))
     assert.equal("google-dns", (labels.lookup("2001:4860:4860:0:0:0:0:8888")))
-    -- Mixed-case hextets normalise too.
-    assert.equal("google-dns", (labels.lookup("2001:4860:4860::8888")))
   end)
 
   it("returns nil for an IPv6 address outside every range", function()
@@ -87,5 +85,9 @@ describe("static_ip_labels.lookup", function()
     -- Growing it is fine — bump this number alongside the new entry.
     assert.is_true(#labels._ranges <= 10,
       "static_ip_labels._ranges should stay <= 10 entries (operator-curated)")
+    -- Same curation guard for the v6 map — keeps a follow-up PR from quietly
+    -- bloating the last-resort v6 map. Growing it is fine; bump alongside.
+    assert.is_true(#labels._ranges_v6 <= 10,
+      "static_ip_labels._ranges_v6 should stay <= 10 entries (operator-curated)")
   end)
 end)

--- a/openwrt/test/static_ip_labels_spec.lua
+++ b/openwrt/test/static_ip_labels_spec.lua
@@ -35,9 +35,37 @@ describe("static_ip_labels.lookup", function()
     assert.is_nil(labels.lookup("256.0.0.1"))         -- out-of-range octet
   end)
 
-  it("returns nil for IPv6 (punted for now)", function()
+  it("returns the well-known DNS labels for IPv6 resolver IPs", function()
+    local l, s
+    l, s = labels.lookup("2606:4700:4700::1111"); assert.equal("cloudflare-dns", l); assert.equal("static-ip-range", s)
+    l, s = labels.lookup("2606:4700:4700::1001"); assert.equal("cloudflare-dns", l); assert.equal("static-ip-range", s)
+    l, s = labels.lookup("2001:4860:4860::8888"); assert.equal("google-dns",     l); assert.equal("static-ip-range", s)
+    l, s = labels.lookup("2001:4860:4860::8844"); assert.equal("google-dns",     l); assert.equal("static-ip-range", s)
+  end)
+
+  it("matches the same IPv6 address whether ::-compressed or fully expanded", function()
+    -- 2606:4700:4700::1001 == 2606:4700:4700:0:0:0:0:1001
+    assert.equal("cloudflare-dns", (labels.lookup("2606:4700:4700::1001")))
+    assert.equal("cloudflare-dns", (labels.lookup("2606:4700:4700:0:0:0:0:1001")))
+    -- 2001:4860:4860::8888 == 2001:4860:4860:0000:0000:0000:0000:8888
+    assert.equal("google-dns", (labels.lookup("2001:4860:4860::8888")))
+    assert.equal("google-dns", (labels.lookup("2001:4860:4860:0:0:0:0:8888")))
+    -- Mixed-case hextets normalise too.
+    assert.equal("google-dns", (labels.lookup("2001:4860:4860::8888")))
+  end)
+
+  it("returns nil for an IPv6 address outside every range", function()
     assert.is_nil(labels.lookup("fe80::1"))
-    assert.is_nil(labels.lookup("2001:4860:4860::8888"))
+    assert.is_nil(labels.lookup("2620:fe::fe"))            -- Quad9, not in map
+    assert.is_nil(labels.lookup("2606:4700:4700::1112"))  -- one past cloudflare
+    assert.is_nil(labels.lookup("::1"))                   -- loopback
+  end)
+
+  it("returns nil for malformed IPv6 literals", function()
+    assert.is_nil(labels.lookup("2606:4700:4700::gggg"))  -- non-hex
+    assert.is_nil(labels.lookup("2606:4700:4700:::1001")) -- triple colon
+    assert.is_nil(labels.lookup("1:2:3:4:5:6:7:8:9"))     -- too many groups
+    assert.is_nil(labels.lookup("12345::1"))              -- hextet > 16 bits
   end)
 
   it("exposes the canonical source string", function()


### PR DESCRIPTION
Closes #2006. Parent epic: #1903 (filter-bypass prevention). **Attribution only — adds no blocking** (that's #2005).

## What
`static_ip_labels.lua` is the last-resort IP-range → label map (attribution only; MUST NOT participate in any drop/carve-out). It already labels the v4 Cloudflare/Google DNS IPs but was v4-only — `M.lookup()` punted on any colon/v6 literal, so v6 resolver flows with no SNI/DNS showed as bare IP literals in the dashboard.

This adds a v6 parse + prefix-match path to the module. No call-site change: `conntrack.lua handle_flow` already calls `static_ip_labels.lookup(flow.dst_ip)` for every flow including v6.

## How
- v6 address held as **8 × 16-bit hextets**, each ≤ 65535 → fits a Lua 5.1 double. **No 128-bit int / bit32 dependency** (neither exists on 5.1).
- `::` compression expanded (leading / trailing / embedded); a second `::`, dangling colon, non-hex or >16-bit token, IPv4-embedded form, or wrong group count → nil.
- Prefix match: compare the first `floor(prefix/16)` full hextets, then the partial hextet under a modulo mask (`h - h % 2^(16-rem)`). For the `/128` host entries here it's full-hextet equality. Mirrors the v4 `/0`-guard / skip-malformed compile behaviour (valid v6 prefix 1..128).
- New `M._ranges_v6` `/128` entries, each cited beside the row:
  - `2606:4700:4700::1111`, `::1001` → `cloudflare-dns`
  - `2001:4860:4860::8888`, `::8844` → `google-dns`
- `M.lookup` returns `(label, "static-ip-range")` for v6 matches — same wire `source` string and `HostId.Label` shape as v4. v4 path unchanged.

Out of scope (per #2006): Apple v6 push ranges; any enforcement/blocking.

## Tests (TDD — red commit then green)
`openwrt/test/static_ip_labels_spec.lua`: each new v6 entry returns its `(label, static-ip-range)` pair; a v6 IP not in the map → nil; `::`-compressed and fully-expanded forms of the same address both match; malformed v6 literals → nil; v4 cases unchanged.

**Real Lua 5.1 validation (mandatory):** module loads clean on a 5.1.5 OpenWRT target and `lookup("2606:4700:4700::1001")` → `cloudflare-dns`, `lookup("2001:4860:4860::8888")` → `google-dns`, `lookup("2620:fe::fe")` → nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)