### PR TITLE
feat(#2005): block Cloudflare IPv6 DoH on :443 (hardcoded-IP DoH bypass) under blockEncryptedDns

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/encrypted_dns.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/encrypted_dns.lua
@@ -74,6 +74,22 @@ M.RESOLVER_IPS_V6 = {
   "2620:fe::fe",                                    -- Quad9
 }
 
+-- ── Cloudflare IPv6 DoH-on-:443 subset → drop :443 (tcp+udp) ─────────────────
+-- The ONE place we drop :443 to a resolver IP (#2005, epic #1903). Deliberately
+-- IPv6-Cloudflare-ONLY — v4 :443 and Google/Quad9 :443 are intentionally
+-- EXCLUDED, for the same dual-use reason the :53 rules are port-scoped above:
+-- 1.1.1.1 / 8.8.8.8 / 9.9.9.9 are the world's most common "am I online?"
+-- connectivity-check targets, and Cloudflare serves a real HTTPS site on
+-- 1.1.1.1 — a :443 drop there would strand probing devices. A v6 :443
+-- connection to a resolver literal carries none of that collateral: generic
+-- connectivity checks never target the resolver's v6 literal, so it is
+-- near-pure DoH signal (the observed prod leak: 2606:4700:4700::1001 = 1.0.0.1
+-- as unattributed v6 traffic). Cloudflare only here per the operator decision
+-- in #2005; v4 :443 is a possible follow-up, not in this subset.
+M.CF_DOH_IPS_V6 = {
+  "2606:4700:4700::1111", "2606:4700:4700::1001",  -- Cloudflare only
+}
+
 -- dnsmasq_lines() → { "local=/<host>/", ... }
 -- `local=/<host>/` answers the domain authoritatively-empty (NODATA) instead of
 -- forwarding it upstream — the negative answer Apple's Private-Relay disable
@@ -113,6 +129,17 @@ function M.nft_rules()
     "ip6 daddr { %s } udp dport 53 counter drop comment \"wh_encrypted_dns:resolver53\"", v6)
   rules[#rules + 1] = string.format(
     "ip6 daddr { %s } tcp dport 53 counter drop comment \"wh_encrypted_dns:resolver53\"", v6)
+  -- Hardcoded-IP DoH on :443 to Cloudflare's v6 resolver literals (#2005). The
+  -- one sanctioned :443 resolver drop — Cloudflare IPv6 ONLY (see CF_DOH_IPS_V6
+  -- for why v4 :443 and Google/Quad9 :443 are deliberately excluded). BOTH
+  -- tcp/443 and udp/443: Cloudflare serves DoH over HTTP/3, so udp/443 must be
+  -- covered too. Non-`wh_drop:` comment so the per-MAC attribution parsers
+  -- ignore it, consistent with the resolver53 rules above.
+  local cfv6 = table.concat(M.CF_DOH_IPS_V6, ", ")
+  rules[#rules + 1] = string.format(
+    "ip6 daddr { %s } tcp dport 443 counter drop comment \"wh_encrypted_dns:cf_doh443_v6\"", cfv6)
+  rules[#rules + 1] = string.format(
+    "ip6 daddr { %s } udp dport 443 counter drop comment \"wh_encrypted_dns:cf_doh443_v6\"", cfv6)
   return rules
 end
 

--- a/openwrt/test/encrypted_dns_spec.lua
+++ b/openwrt/test/encrypted_dns_spec.lua
@@ -83,6 +83,18 @@ describe("encrypted_dns module — curated lists", function()
     assert.is_true(set["2001:4860:4860::8844"])
     assert.is_true(set["2620:fe::fe"])
   end)
+
+  it("exposes a Cloudflare-ONLY IPv6 DoH :443 subset (no Google/Quad9) (#2005)", function()
+    local set = {}
+    for _, ip in ipairs(encrypted_dns.CF_DOH_IPS_V6) do set[ip] = true end
+    -- exactly the two Cloudflare v6 literals
+    assert.is_true(set["2606:4700:4700::1111"])
+    assert.is_true(set["2606:4700:4700::1001"])
+    -- Google / Quad9 must NOT leak into the :443 subset
+    assert.is_nil(set["2001:4860:4860::8888"])
+    assert.is_nil(set["2001:4860:4860::8844"])
+    assert.is_nil(set["2620:fe::fe"])
+  end)
 end)
 
 -- ── dnsmasq NODATA directives (module) ───────────────────────────────────────
@@ -121,10 +133,43 @@ describe("encrypted_dns.nft_rules", function()
     assert.truthy(joined:find("2606:4700:4700::1111", 1, true))
   end)
 
-  it("does NOT drop :443 or ICMP to the resolver IPs (connectivity probes survive)", function()
+  it("does NOT drop ICMP to the resolver IPs (connectivity probes survive)", function()
     local joined = table.concat(encrypted_dns.nft_rules(), "\n")
-    assert.is_nil(joined:find("443", 1, true))
     assert.is_nil(joined:find("icmp", 1, true))
+  end)
+
+  -- #2005: hardcoded-IP DoH on :443 to Cloudflare's v6 resolver literals is the
+  -- observed leak. Scoped to Cloudflare IPv6 ONLY — see the rule's rationale.
+  it("drops Cloudflare IPv6 DoH on :443 (BOTH tcp and udp) (#2005)", function()
+    local tcp443, udp443 = false, false
+    for _, rule in ipairs(encrypted_dns.nft_rules()) do
+      if rule:find("dport 443", 1, true) then
+        -- every :443 rule must be v6 and target ONLY the Cloudflare v6 literals
+        assert.truthy(rule:find("ip6 daddr", 1, true), ":443 rule not v6 — " .. rule)
+        assert.truthy(rule:find("2606:4700:4700::1111", 1, true)
+          and rule:find("2606:4700:4700::1001", 1, true),
+          ":443 rule not Cloudflare-v6 — " .. rule)
+        if rule:find("tcp dport 443", 1, true) then tcp443 = true end
+        if rule:find("udp dport 443", 1, true) then udp443 = true end
+      end
+    end
+    assert.is_true(tcp443, "missing Cloudflare v6 tcp/443 drop")
+    assert.is_true(udp443, "missing Cloudflare v6 udp/443 drop (HTTP/3 DoH)")
+  end)
+
+  it("emits NO :443 rule containing any v4 IP or any Google/Quad9 IP (#2005)", function()
+    local forbidden = {
+      "1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4", "9.9.9.9", "149.112.112.112",
+      "2001:4860:4860::8888", "2001:4860:4860::8844", "2620:fe::fe",
+    }
+    for _, rule in ipairs(encrypted_dns.nft_rules()) do
+      if rule:find("dport 443", 1, true) then
+        for _, ip in ipairs(forbidden) do
+          assert.is_nil(rule:find(ip, 1, true),
+            ":443 rule must not contain " .. ip .. " — " .. rule)
+        end
+      end
+    end
   end)
 
   it("does NOT emit a blanket all-traffic drop to the resolver IPs", function()


### PR DESCRIPTION
Closes #2005. Parent epic #1903 (filter-bypass prevention); related #1911 (blockEncryptedDns agent enforcement).

## Problem
A device hardcoding Cloudflare's v6 resolver literals and doing **DoH over :443** bypasses filtering and shows as unattributed v6 traffic — observed in prod as `2606:4700:4700::1001` (= Cloudflare `1.0.0.1`). `nft_rules()` dropped the curated resolver IPs on **:53 only** (plus DoT tcp/853), so DoH-by-IP on :443 was uncaught.

## Change
`openwrt/files/usr/lib/lua/wifihaven/encrypted_dns.lua`:
- New `M.CF_DOH_IPS_V6 = { 2606:4700:4700::1111, 2606:4700:4700::1001 }` — Cloudflare v6 only.
- `nft_rules()` emits two new drops to that set on **dport 443, BOTH tcp and udp** (udp/443 = HTTP/3 DoH — Cloudflare serves DoH over h3). Comment tag `wh_encrypted_dns:cf_doh443_v6` (non-`wh_drop:`, so per-MAC attribution parsers ignore it, consistent with the existing `resolver53` rules).

### Deliberately scoped — IPv6 Cloudflare ONLY
v4 :443 and Google/Quad9 :443 are **intentionally excluded** (code comment spells out the rationale): `1.1.1.1` / `8.8.8.8` / `9.9.9.9` double as the world's most common "am I online?" connectivity-check targets, and Cloudflare serves a real HTTPS site on `1.1.1.1`. A v6 resolver-literal :443 hit carries none of that collateral — near-pure DoH signal. Operator decision in #2005; v4 :443 is a possible follow-up, out of scope here.

## Architecture
Sanctioned **Truth-#1 connection-layer exception** (nftables drop), NOT a DNS mechanism. No dnsmasq lines touched. Gated by the existing `blockEncryptedDns` flag via `render.lua` — no new toggle, no new wire field.

## Tests (TDD: red commit then green)
`openwrt/test/encrypted_dns_spec.lua`:
- Asserts the Cloudflare v6 :443 drops are emitted for **both** tcp and udp.
- Asserts every :443 rule is v6 and Cloudflare-only.
- Asserts **no** :443 rule contains any v4 IP or any Google/Quad9 IP.
- Adds a `CF_DOH_IPS_V6` curated-subset check (Cloudflare only, no Google/Quad9).

Full openwrt suite green (960 busted successes; includes the `nft -c -f -` chain syntax validation). **Validated on real Lua 5.1.5** (openwrt.lan): module loads clean and both `cf_doh443_v6` rules render; `nft -c` accepts the rule syntax on-target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)