### PR TITLE
feat: add A-Z Animals app template

### DIFF
--- a/api/resources/app_templates/_index.yml
+++ b/api/resources/app_templates/_index.yml
@@ -43,3 +43,5 @@ slugs:
   # #1922: traffic-driven catalog pass (see evidence/classification-1922.md)
   - math-playground
   - dance-mat-typing
+  # operator request: A-Z Animals reference site
+  - a-z-animals

--- a/api/resources/app_templates/a-z-animals.yml
+++ b/api/resources/app_templates/a-z-animals.yml
@@ -1,0 +1,6 @@
+slug: a-z-animals
+name: A-Z Animals
+icon: "https://icons.duckduckgo.com/ip3/a-z-animals.com.ico"
+icon_type: url
+hosts:
+  - a-z-animals.com

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -153,6 +153,8 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           // #1922: traffic-driven catalog pass
           "math-playground",
           "dance-mat-typing",
+          // operator request: A-Z Animals reference site
+          "a-z-animals",
         )
         val slugs    = templates.map(_.slug.value).toSet
         assertTrue(slugs == expected) &&


### PR DESCRIPTION
Adds the **a-z-animals.com** app to the app catalog per operator request.

## Change
- New template `api/resources/app_templates/a-z-animals.yml` — apex-only host-set (`a-z-animals.com`, covers all subdomains via HostMatch), favicon icon (`icon_type: url`).
- Registered the `a-z-animals` slug in `_index.yml`.
- Updated the `AppTemplatesSpec` catalog fixture to include the new slug.

## Notes
- Apex-only per the README's conservative-hosts + shared-pool collateral guidance — no off-domain CDN/vendor host needed.
- `AppTemplatesSpec` passes (37 tests): index↔file sync, slug format, uniqueness, distinctive-host rule, shared-host global consistency, favicon-not-emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)