### PR TITLE
feat(#1975): ws-spa S6b — stream Traffic Usage + Connection Events pages + class-(3) stale invalidation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from '@/hooks/useAuth'
-import { WsProvider } from '@/hooks/useWs'
+import { WsProvider, WsStaleInvalidator } from '@/hooks/useWs'
 import { AlertsNotifier } from '@/hooks/useNotifyOnNewAlerts'
 import { Layout } from '@/components/layout/Layout'
 import { LoginPage } from '@/pages/LoginPage'
@@ -48,7 +48,7 @@ function AppRoutes() {
         change-password form even when the server-side flag is set (#586).
         All other protected routes redirect to /account until the flag clears.
       */}
-      <Route path="/" element={<RequireAuth><WsProvider><AlertsNotifier /><Layout /></WsProvider></RequireAuth>}>
+      <Route path="/" element={<RequireAuth><WsProvider><AlertsNotifier /><WsStaleInvalidator /><Layout /></WsProvider></RequireAuth>}>
         <Route path="account" element={<AccountPage />} />
         <Route index element={<RequirePwChanged><Navigate to="/dashboard" replace /></RequirePwChanged>} />
         <Route path="dashboard" element={<RequirePwChanged><DashboardPage /></RequirePwChanged>} />

--- a/web/src/api/wsCache.test.ts
+++ b/web/src/api/wsCache.test.ts
@@ -7,6 +7,7 @@ import {
   bucketSeconds,
   deriveNowKpis,
   headBucketRows,
+  mergeAggregateHeadRows,
   mergeHeadBucket,
   overallRate,
   prependHead,
@@ -94,6 +95,58 @@ describe('mergeHeadBucket (#1973 §3.1)', () => {
   })
 })
 
+describe('mergeAggregateHeadRows (#1975 S6b §3.1) — page-level row merge', () => {
+  // The Traffic Usage page holds its aggregated series as a bare
+  // TrafficUsageAggregateRow[] in component state (not React Query), so the live
+  // edge merges at the rows level. Same join-on-windowStart semantics that back
+  // mergeHeadBucket — replace the head window in place, prepend on rollover,
+  // never touch paged history.
+  it('replaces the head window in place, leaving older paged rows untouched', () => {
+    const prev = [
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 }),
+      aggRow({ windowStart: '2026-06-26T10:04:00Z', totalBytesIn: 999 }),
+      aggRow({ windowStart: '2026-06-26T10:03:00Z', totalBytesIn: 7 }),
+    ]
+    const live = [aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 250 })]
+    const merged = mergeAggregateHeadRows(prev, live)
+    expect(merged.map(r => r.windowStart)).toEqual([
+      '2026-06-26T10:05:00Z',
+      '2026-06-26T10:04:00Z',
+      '2026-06-26T10:03:00Z',
+    ])
+    expect(merged[0].totalBytesIn).toBe(250)
+    // paged history is byte-identical (never mutated)
+    expect(merged[1]).toBe(prev[1])
+    expect(merged[2]).toBe(prev[2])
+  })
+
+  it('prepends a fresh head when the window rolls over', () => {
+    const prev = [aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 })]
+    const live = [aggRow({ windowStart: '2026-06-26T10:06:00Z', totalBytesIn: 5 })]
+    expect(mergeAggregateHeadRows(prev, live).map(r => r.windowStart)).toEqual([
+      '2026-06-26T10:06:00Z',
+      '2026-06-26T10:05:00Z',
+    ])
+  })
+
+  it('keeps every prior row on an empty live edge', () => {
+    const prev = [aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 })]
+    expect(mergeAggregateHeadRows(prev, [])).toBe(prev)
+  })
+
+  it('keeps all rows sharing the head windowStart (groupBy:profile)', () => {
+    const prev = [
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Kids' }, totalBytesIn: 1 }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Adults' }, totalBytesIn: 2 }),
+    ]
+    const live = [
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Kids' }, totalBytesIn: 10 }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Adults' }, totalBytesIn: 20 }),
+    ]
+    expect(mergeAggregateHeadRows(prev, live).map(r => r.totalBytesIn)).toEqual([10, 20])
+  })
+})
+
 describe('headBucketRows', () => {
   it('returns only the newest windowStart rows', () => {
     const s = series([
@@ -174,6 +227,23 @@ describe('prependHead (#1973 §3.1)', () => {
 
   it('handles an undefined prior cache', () => {
     expect(prependHead(undefined, [row(1)], 20).map(r => r.id)).toEqual([1])
+  })
+
+  // #1975 S6b: the Connection Events page pages its history with infinite scroll,
+  // so prepending the live head must NOT truncate the loaded history — the limit
+  // is optional and omitted there. (The dashboard's "Recently Blocked" feed still
+  // caps to RECENT_BLOCKED_LIMIT.)
+  it('does not truncate history when no limit is given', () => {
+    const prev = Array.from({ length: 25 }, (_, i) => row(25 - i)) // ids 25..1
+    const out = prependHead(prev, [row(27), row(26)])
+    expect(out).toHaveLength(27)
+    expect(out.slice(0, 3).map(r => r.id)).toEqual([27, 26, 25])
+    expect(out[out.length - 1].id).toBe(1)
+  })
+
+  it('still dedups by id with no limit', () => {
+    const out = prependHead([row(2), row(1)], [row(3), row(2)])
+    expect(out.map(r => r.id)).toEqual([3, 2, 1])
   })
 })
 

--- a/web/src/api/wsCache.ts
+++ b/web/src/api/wsCache.ts
@@ -29,9 +29,6 @@ export function mergeHeadBucket(
   // merge nothing — keep prior series, or seed with the empty live shape if first.
   if (!live.aggregateRows || live.aggregateRows.length === 0) return prev ?? live
   if (!prev) return live
-  const headStart = live.aggregateRows[0].windowStart
-  // Drop any prior rows in the head window (replace-in-place); keep all older buckets.
-  const kept = prev.aggregateRows.filter(r => r.windowStart !== headStart)
   return {
     // Carry the live response's window/bucket metadata (the freshest edge) but keep the
     // full merged series. `to` advances to the live edge; `from` stays the GET's window
@@ -39,8 +36,26 @@ export function mergeHeadBucket(
     ...prev,
     bucket: live.bucket,
     to: live.to,
-    aggregateRows: [...live.aggregateRows, ...kept],
+    aggregateRows: mergeAggregateHeadRows(prev.aggregateRows, live.aggregateRows),
   }
+}
+
+// The rows-level head merge (#1975 S6b). The dashboard merges over a whole
+// TrafficUsageResponse (mergeHeadBucket above); the Traffic Usage PAGE holds its
+// aggregated series as a bare TrafficUsageAggregateRow[] in component state (it
+// pages history itself, not via React Query), so its live edge merges at the rows
+// level. ONE join-on-windowStart implementation backs both (SSOT): replace the
+// rows of the head window in place while it accumulates, prepend a fresh head on
+// rollover, never touch paged history. The series is newest-first.
+export function mergeAggregateHeadRows(
+  prev: TrafficUsageAggregateRow[],
+  live: TrafficUsageAggregateRow[],
+): TrafficUsageAggregateRow[] {
+  if (live.length === 0) return prev
+  const headStart = live[0].windowStart
+  // Drop any prior rows in the head window (replace-in-place); keep all older buckets.
+  const kept = prev.filter(r => r.windowStart !== headStart)
+  return [...live, ...kept]
 }
 
 // The head (newest) bucket's rows — the slice the live gauge reads. The series is
@@ -122,12 +137,14 @@ export function overallRate(
 //
 // The push carries the genuinely-new head rows (newest-first); cursor-paged history is
 // untouched. We prepend, dedup by id (a row already in the cache is never duplicated —
-// the GET and the push can overlap at the boundary), and cap to `limit` so the live
-// feed stays bounded.
+// the GET and the push can overlap at the boundary). `limit` bounds the live feed where
+// it must stay small (the dashboard's "Recently Blocked", RECENT_BLOCKED_LIMIT); the
+// Connection Events PAGE (#1975 S6b) pages its history with infinite scroll, so it omits
+// `limit` — prepending the live head must NOT truncate the loaded history.
 export function prependHead(
   prev: QueryLog[] | undefined,
   rows: QueryLog[],
-  limit: number,
+  limit?: number,
 ): QueryLog[] {
   const merged = [...rows, ...(prev ?? [])]
   const seen = new Set<number>()
@@ -137,7 +154,7 @@ export function prependHead(
     seen.add(r.id)
     out.push(r)
   }
-  return out.slice(0, limit)
+  return limit === undefined ? out : out.slice(0, limit)
 }
 
 // ── now: derived KPIs computed client-side off the pushed DashboardNow (§3.1) ───────

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -3,19 +3,33 @@
 // ready, and that polling pauses while the socket is live. Driven by the real
 // SpaWsClient over a mock socket so the wire→cache path is exercised end to end.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 vi.mock('@/api/client', () => ({
-  api: { dashboard: { now: vi.fn().mockResolvedValue({ asOf: 'x', profiles: [] }) } },
+  api: {
+    dashboard: { now: vi.fn().mockResolvedValue({ asOf: 'x', profiles: [] }) },
+    profiles: { list: vi.fn().mockResolvedValue([]) },
+    devices: { list: vi.fn().mockResolvedValue([]) },
+  },
 }))
 
 import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
-import { WsProvider, useWsLive, useWsTopicLive, useWsNow, useWsRecentBlocked, useWsTrafficUsage } from './useWs'
-import { useDashboardNow, qk } from '@/api/queries'
+import {
+  WsProvider,
+  useWsLive,
+  useWsTopicLive,
+  useWsNow,
+  useWsRecentBlocked,
+  useWsTrafficUsage,
+  useWsTrafficUsageLiveEdge,
+  useWsConnectionEventsLiveEdge,
+  useWsStale,
+} from './useWs'
+import { useDashboardNow, useProfiles, useDevices, qk } from '@/api/queries'
 import { AuthProvider } from '@/hooks/useAuth'
-import type { DashboardNow, QueryLog, TrafficUsageResponse } from '@/types/api'
+import type { DashboardNow, QueryLog, TrafficUsageAggregateRow, TrafficUsageResponse } from '@/types/api'
 
 class MockSocket implements WsSocketLike {
   static instances: MockSocket[] = []
@@ -228,5 +242,189 @@ describe('polling pauses only while the topic streams (§3.3)', () => {
     const before = nowSpy.mock.calls.length
     await act(async () => { await vi.advanceTimersByTimeAsync(5_000) })
     expect(nowSpy.mock.calls.length).toBe(before + 1) // still polling despite a live socket
+  })
+})
+
+// ── #1975 (S6b): stream the Traffic Usage + Connection Events PAGES ──────────────────
+//
+// Same topics as the dashboard, the page's own filters (§1.4 / §0.3 one stream, many
+// consumers). The page keeps loading history via its GET; the live edge merges into the
+// page's component state (not React Query), so these hooks forward the parsed body to a
+// setter the page owns.
+
+const aggRow = (over: Partial<TrafficUsageAggregateRow> & { windowStart: string }): TrafficUsageAggregateRow => ({
+  groups: {}, windowEnd: over.windowStart, totalBytesIn: 0, totalBytesOut: 0, totalSeconds: 0, ...over,
+})
+const trafficPush = (rows: TrafficUsageAggregateRow[]): TrafficUsageResponse => ({
+  bucket: '1h', groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [], aggregateRows: rows,
+})
+
+describe('useWsTrafficUsageLiveEdge (#1975 S6b §3.1)', () => {
+  it('subscribes with the page params and merges the head bucket by windowStart, history untouched', () => {
+    const { client, wrapper } = setup()
+    // paged history loaded by the GET (newest-first); the page owns it in component state.
+    let rows: TrafficUsageAggregateRow[] = [
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 }),
+      aggRow({ windowStart: '2026-06-26T10:04:00Z', totalBytesIn: 999 }),
+    ]
+    const setRows = (fn: (prev: TrafficUsageAggregateRow[]) => TrafficUsageAggregateRow[]) => {
+      rows = fn(rows)
+    }
+    renderHook(
+      () => useWsTrafficUsageLiveEdge(
+        { groupBy: ['profile'], bucket: '1h', macs: ['aa'], profileIds: [3], until: null }, setRows,
+      ),
+      { wrapper },
+    )
+    goLive(client)
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')
+    expect(sub.payload.params).toEqual({ groupBy: ['profile'], bucket: '1h', macs: ['aa'], profileIds: [3] })
+
+    act(() => last().emit({ op: 'trafficUsage', payload: trafficPush([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 250 })]) }))
+    // head replaced, older paged bucket untouched
+    expect(rows.map(r => r.windowStart)).toEqual(['2026-06-26T10:05:00Z', '2026-06-26T10:04:00Z'])
+    expect(rows[0].totalBytesIn).toBe(250)
+    expect(rows[1].totalBytesIn).toBe(999)
+  })
+
+  it('does not subscribe in raw mode (push carries aggregate rows, not per-host rawRows)', () => {
+    const { client, wrapper } = setup()
+    renderHook(
+      () => useWsTrafficUsageLiveEdge({ groupBy: [], bucket: 'raw', macs: [], profileIds: [], until: null }, () => {}),
+      { wrapper },
+    )
+    goLive(client)
+    expect(last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')).toBeUndefined()
+  })
+
+  it('does not subscribe while anchored to a past window (until set — no live edge)', () => {
+    const { client, wrapper } = setup()
+    renderHook(
+      () => useWsTrafficUsageLiveEdge(
+        { groupBy: ['profile'], bucket: '1h', macs: [], profileIds: [], until: '2026-01-01T00:00:00Z' }, () => {},
+      ),
+      { wrapper },
+    )
+    goLive(client)
+    expect(last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')).toBeUndefined()
+  })
+
+  it('re-subscribes (unsubscribe+subscribe) when the bucket changes', () => {
+    const { client, wrapper } = setup()
+    const { rerender } = renderHook(
+      ({ bucket }: { bucket: '1h' | '10m' }) =>
+        useWsTrafficUsageLiveEdge({ groupBy: ['profile'], bucket, macs: [], profileIds: [], until: null }, () => {}),
+      { wrapper, initialProps: { bucket: '1h' as '1h' | '10m' } },
+    )
+    goLive(client)
+    act(() => rerender({ bucket: '10m' }))
+    const ops = last().frames().map(f => `${f.op}:${f.payload?.topic ?? ''}:${f.payload?.params?.bucket ?? ''}`)
+    const i1 = ops.indexOf('subscribe:trafficUsage:1h')
+    const iU = ops.indexOf('unsubscribe:trafficUsage:')
+    const i2 = ops.indexOf('subscribe:trafficUsage:10m')
+    expect(i1).toBeGreaterThanOrEqual(0)
+    expect(iU).toBeGreaterThan(i1)
+    expect(i2).toBeGreaterThan(iU)
+  })
+})
+
+describe('useWsConnectionEventsLiveEdge (#1975 S6b §3.1)', () => {
+  const row = (id: number): QueryLog => ({
+    id, mac: null, deviceName: null, profileId: null, profileName: null,
+    host: { type: 'fqdn', value: `h${id}.com` }, qtype: 1, blocked: true, reason: { kind: 'manual' }, location: null,
+    ts: '2026-06-26T10:00:00Z',
+  })
+
+  it('subscribes with the page filters and prepends + dedups the live head without truncating history', () => {
+    const { client, wrapper } = setup()
+    // a long paged history loaded by the GET
+    let logs: QueryLog[] = Array.from({ length: 30 }, (_, i) => row(30 - i)) // ids 30..1
+    const setLogs = (fn: (prev: QueryLog[]) => QueryLog[]) => { logs = fn(logs) }
+    renderHook(
+      () => useWsConnectionEventsLiveEdge(
+        { blocked: true, macs: ['aa'], profileIds: [3], until: null }, setLogs,
+      ),
+      { wrapper },
+    )
+    goLive(client)
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'connectionEvents')
+    expect(sub.payload.params).toEqual({ blocked: true, macs: ['aa'], profileIds: [3] })
+
+    // push overlaps the GET boundary (id 30 already present) → dedup
+    act(() => last().emit({ op: 'connectionEvents', payload: [row(32), row(31), row(30)] }))
+    expect(logs.slice(0, 3).map(r => r.id)).toEqual([32, 31, 30])
+    expect(logs).toHaveLength(32) // 30 history + 2 genuinely new, history not truncated
+    expect(logs[logs.length - 1].id).toBe(1)
+  })
+
+  it('omits absent filters from the subscription params (All status / no device / no profile)', () => {
+    const { client, wrapper } = setup()
+    renderHook(
+      () => useWsConnectionEventsLiveEdge({ blocked: undefined, macs: [], profileIds: [], until: null }, () => {}),
+      { wrapper },
+    )
+    goLive(client)
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'connectionEvents')
+    expect(sub.payload.params).toEqual({})
+  })
+
+  it('does not subscribe while anchored to a past window (until set)', () => {
+    const { client, wrapper } = setup()
+    renderHook(
+      () => useWsConnectionEventsLiveEdge({ blocked: true, macs: [], profileIds: [], until: '2026-01-01T00:00:00Z' }, () => {}),
+      { wrapper },
+    )
+    goLive(client)
+    expect(last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'connectionEvents')).toBeUndefined()
+  })
+
+  it('re-subscribes when the status filter changes', () => {
+    const { client, wrapper } = setup()
+    const { rerender } = renderHook(
+      ({ blocked }: { blocked: boolean | undefined }) =>
+        useWsConnectionEventsLiveEdge({ blocked, macs: [], profileIds: [], until: null }, () => {}),
+      { wrapper, initialProps: { blocked: true as boolean | undefined } },
+    )
+    goLive(client)
+    act(() => rerender({ blocked: undefined }))
+    const ops = last().frames()
+      .filter(f => (f.op === 'subscribe' || f.op === 'unsubscribe') && f.payload?.topic === 'connectionEvents')
+      .map(f => `${f.op}:${JSON.stringify(f.payload?.params ?? null)}`)
+    expect(ops).toEqual([
+      'subscribe:{"blocked":true}',
+      'unsubscribe:null',
+      'subscribe:{}',
+    ])
+  })
+})
+
+describe('useWsStale (#1975 S6b §3.2)', () => {
+  it('invalidates only the mapped, mounted query on stale{topic}', async () => {
+    const { api } = await import('@/api/client')
+    const profilesSpy = api.profiles.list as unknown as ReturnType<typeof vi.fn>
+    const devicesSpy = api.devices.list as unknown as ReturnType<typeof vi.fn>
+    profilesSpy.mockClear(); devicesSpy.mockClear()
+    const { client, wrapper } = setup()
+    renderHook(() => { useWsStale(); useProfiles(); useDevices() }, { wrapper })
+    await waitFor(() => expect(profilesSpy).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(devicesSpy).toHaveBeenCalledTimes(1))
+    goLive(client)
+    // a profiles mutation in ANOTHER tab → stale{profiles}: only the profiles query refetches
+    act(() => last().emit({ op: 'stale', payload: { topic: 'profiles' } }))
+    await waitFor(() => expect(profilesSpy).toHaveBeenCalledTimes(2))
+    expect(devicesSpy).toHaveBeenCalledTimes(1) // devices query left alone
+  })
+
+  it('ignores an unknown stale topic', async () => {
+    const { api } = await import('@/api/client')
+    const profilesSpy = api.profiles.list as unknown as ReturnType<typeof vi.fn>
+    profilesSpy.mockClear()
+    const { client, wrapper } = setup()
+    renderHook(() => { useWsStale(); useProfiles() }, { wrapper })
+    await waitFor(() => expect(profilesSpy).toHaveBeenCalledTimes(1))
+    goLive(client)
+    act(() => last().emit({ op: 'stale', payload: { topic: 'somethingElse' } }))
+    await new Promise(r => setTimeout(r, 20))
+    expect(profilesSpy).toHaveBeenCalledTimes(1) // no refetch
   })
 })

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -416,22 +416,20 @@ export function useWsConnectionEventsLiveEdge(
 // lives. Mounted once globally (WsStaleInvalidator, App.tsx).
 export function useWsStale(): void {
   const inv = useInvalidators()
-  // The single topic→key mapping (§3.2). A bounded enum mirroring the server's `stale`
-  // topics; an unknown topic is ignored (forward-compat).
-  const map = useMemo<Record<string, () => void>>(
-    () => ({
+  // `useWsSubscription` captures the latest onPush closure each render, so we read the
+  // current `inv` directly and build the (tiny) topic→invalidator map on the rare push.
+  useWsSubscription('stale', undefined, payload => {
+    const topic = (payload as { topic?: unknown })?.topic
+    if (typeof topic !== 'string') return
+    // The single topic→key mapping (§3.2). A bounded enum mirroring the server's `stale`
+    // topics; an unknown topic is ignored (forward-compat).
+    const map: Record<string, () => void> = {
       alerts: () => void inv.alerts(),
       profiles: () => void inv.profiles(),
       devices: () => void inv.devices(),
       schedules: () => void inv.schedules(),
-    }),
-    [inv],
-  )
-  const mapRef = useRef(map)
-  mapRef.current = map
-  useWsSubscription('stale', undefined, payload => {
-    const topic = (payload as { topic?: unknown })?.topic
-    if (typeof topic === 'string') mapRef.current[topic]?.()
+    }
+    map[topic]?.()
   })
 }
 

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -18,11 +18,12 @@ import {
   type ReactNode,
 } from 'react'
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
-import { qk, RECENT_BLOCKED_LIMIT } from '@/api/queries'
+import { qk, RECENT_BLOCKED_LIMIT, useInvalidators } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import { SpaWsClient, type SpaTopicName, type WsStatus } from '@/api/wsClient'
 import {
   headBucketRows,
+  mergeAggregateHeadRows,
   mergeHeadBucket,
   overallRate,
   prependHead,
@@ -296,4 +297,150 @@ function useCachedQueryData<T>(qc: QueryClient, key: readonly unknown[]): T | un
   // not a dep — keyHash is its serialized identity.
   const getSnapshot = useCallback(() => qc.getQueryData<T>(key), [qc, keyHash])
   return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+// ── #1975 (S6b): stream the live edge of the Traffic Usage + Connection Events PAGES ──
+//
+// Same topics as the dashboard, the page's own filters (§1.4 / §0.3 — one stream, many
+// consumers). Unlike the dashboard, these pages don't hold their data in React Query —
+// they page history themselves (initial window + cursor paging, #862) and accumulate it
+// in component state. So the live edge merges into a SETTER the page owns, via the pure
+// wsCache helpers, rather than into a query cache. The history GET is untouched; the
+// socket only keeps the newest slice fresh (§3.1). Neither page polls (no refetchInterval
+// to pause, §3.3) — the live edge IS the freshness.
+
+export interface TrafficUsageLiveArgs {
+  groupBy: TrafficUsageGroupBy[]
+  bucket: TrafficUsageBucket
+  macs: string[]
+  profileIds: number[]
+  /** The right-edge anchor; non-null means a past window is pinned → no live edge. */
+  until: string | null
+}
+
+/**
+ * Subscribe `trafficUsage` with the Traffic Usage page's CURRENT params and merge the
+ * pushed head bucket into the page's aggregate-row state by `windowStart` (§3.1). The
+ * page passes its own `setAggRows`. Re-subscribes whenever groupBy / bucket / filters
+ * change (the params change → `useWsSubscription` sends unsubscribe-then-subscribe).
+ *
+ * Streaming is gated to the AGGREGATED view anchored at "now": the push carries
+ * `aggregateRows` (one point per group per ingest period, design §1.3) — the page's `raw`
+ * bucket renders per-host `rawRows`, a different shape the live edge can't merge into; and
+ * a pinned `until` window is history, with no live edge to stream. Returns whether the
+ * topic is actually streaming (acked) for an optional "Live" indicator.
+ */
+export function useWsTrafficUsageLiveEdge(
+  args: TrafficUsageLiveArgs,
+  setRows: (fn: (prev: TrafficUsageAggregateRow[]) => TrafficUsageAggregateRow[]) => void,
+): boolean {
+  const enabled = args.until == null && args.bucket !== 'raw'
+  const params = useMemo(
+    () => ({
+      groupBy: args.groupBy,
+      bucket: args.bucket,
+      ...(args.macs.length ? { macs: args.macs } : {}),
+      ...(args.profileIds.length ? { profileIds: args.profileIds } : {}),
+    }),
+    [args.groupBy, args.bucket, args.macs, args.profileIds],
+  )
+  const setRowsRef = useRef(setRows)
+  setRowsRef.current = setRows
+  useWsSubscription(
+    'trafficUsage',
+    params,
+    payload => {
+      const rows = (payload as TrafficUsageResponse).aggregateRows ?? []
+      if (rows.length) setRowsRef.current(prev => mergeAggregateHeadRows(prev, rows))
+    },
+    undefined,
+    enabled,
+  )
+  const streaming = useWsTopicLive('trafficUsage')
+  return streaming && enabled
+}
+
+export interface ConnectionEventsLiveArgs {
+  /** undefined = no status filter (All); the GET's `blocked` param. */
+  blocked: boolean | undefined
+  macs: string[]
+  profileIds: number[]
+  /** Non-null means a past window is pinned → no live edge. */
+  until: string | null
+}
+
+/**
+ * Subscribe `connectionEvents` with the Connection Events page's CURRENT filters and
+ * PREPEND the pushed head rows (dedup by id) onto the page's raw-log state (§3.1). The
+ * page passes its own `setLogs`. No cap — `prependHead` keeps the paged history intact
+ * (the page pages older rows on scroll). Re-subscribes when the filters change. Gated to
+ * the live ("now") window; a pinned `until` is history. Returns whether the topic streams.
+ */
+export function useWsConnectionEventsLiveEdge(
+  args: ConnectionEventsLiveArgs,
+  setRows: (fn: (prev: QueryLog[]) => QueryLog[]) => void,
+): boolean {
+  const enabled = args.until == null
+  const params = useMemo(
+    () => ({
+      ...(args.blocked !== undefined ? { blocked: args.blocked } : {}),
+      ...(args.macs.length ? { macs: args.macs } : {}),
+      ...(args.profileIds.length ? { profileIds: args.profileIds } : {}),
+    }),
+    [args.blocked, args.macs, args.profileIds],
+  )
+  const setRowsRef = useRef(setRows)
+  setRowsRef.current = setRows
+  useWsSubscription(
+    'connectionEvents',
+    params,
+    payload => {
+      const rows = (payload as QueryLog[]) ?? []
+      if (rows.length) setRowsRef.current(prev => prependHead(prev, rows))
+    },
+    undefined,
+    enabled,
+  )
+  const streaming = useWsTopicLive('connectionEvents')
+  return streaming && enabled
+}
+
+// ── #1975 (S6b §3.2): class-(3) `stale` → invalidate the mapped, mounted query ────────
+//
+// Occasionally-changing resources (alerts / profiles / devices / schedules) stay on
+// request/response; when ANOTHER operator/tab mutates one, the server pushes a contentless
+// `stale{topic}` nudge and we `invalidateQueries` the mapped key (reusing the existing
+// `qk` / `useInvalidators` — the GET stays the sole producer, and per-recipient authz
+// comes free). `invalidateQueries` only refetches MOUNTED queries, so a `stale` for a
+// closed view costs nothing. The topic→invalidator map below is the ONE place the mapping
+// lives. Mounted once globally (WsStaleInvalidator, App.tsx).
+export function useWsStale(): void {
+  const inv = useInvalidators()
+  // The single topic→key mapping (§3.2). A bounded enum mirroring the server's `stale`
+  // topics; an unknown topic is ignored (forward-compat).
+  const map = useMemo<Record<string, () => void>>(
+    () => ({
+      alerts: () => void inv.alerts(),
+      profiles: () => void inv.profiles(),
+      devices: () => void inv.devices(),
+      schedules: () => void inv.schedules(),
+    }),
+    [inv],
+  )
+  const mapRef = useRef(map)
+  mapRef.current = map
+  useWsSubscription('stale', undefined, payload => {
+    const topic = (payload as { topic?: unknown })?.topic
+    if (typeof topic === 'string') mapRef.current[topic]?.()
+  })
+}
+
+/**
+ * Mounts the global `stale` subscription (§3.2). Rendered inside `WsProvider` (App.tsx),
+ * alongside `AlertsNotifier`, so class-(3) invalidation is live for the whole session —
+ * it only refetches whatever class-(3) view happens to be mounted.
+ */
+export function WsStaleInvalidator(): null {
+  useWsStale()
+  return null
 }

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -10,6 +10,8 @@ import { HeaderFilter } from '@/components/usage/HeaderFilter'
 import { FilterShelf } from './TrafficUsagePage'
 import { localTime } from '@/components/usage/usageHelpers'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import { useWsConnectionEventsLiveEdge } from '@/hooks/useWs'
+import { LiveBadge } from '@/components/dashboard/LiveBadge'
 
 // #862: infinite scroll page sizes + lookback. The /api/logs endpoint still
 // requires `hours`, so we ask for a wide band and let the row cap bound.
@@ -302,10 +304,25 @@ function RawEventsView({
     onLoadMore: () => { if (cursor) void load(cursor) },
   })
 
+  // #1975 (S6b): stream the live head of the Connection Events feed — subscribe
+  // `connectionEvents` with the page's current filters and prepend new rows (dedup by id)
+  // onto `logs` without truncating the paged history (the GET still owns paging). Re-
+  // subscribes when the status / device / profile filters change; only while anchored at
+  // "now" (a pinned `until` is history).
+  const liveStreaming = useWsConnectionEventsLiveEdge(
+    { blocked, macs, profileIds, until },
+    setLogs,
+  )
+
   if (error) return <ErrorBanner message={error} />
 
   return (
     <>
+    {liveStreaming && (
+      <div className="flex justify-end">
+        <LiveBadge />
+      </div>
+    )}
     <div className="overflow-x-auto" data-testid="ce-raw-table">
       <table className="min-w-full text-sm">
         <thead className="text-xs uppercase">

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -27,6 +27,8 @@ import {
   localTime,
 } from '@/components/usage/usageHelpers'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import { useWsTrafficUsageLiveEdge } from '@/hooks/useWs'
+import { LiveBadge } from '@/components/dashboard/LiveBadge'
 
 // #846 — Traffic Usage page. Raw + aggregated views over traffic_reports.
 // Column headers double as groupBy toggles (Host=domain, Device=device,
@@ -175,6 +177,15 @@ export function TrafficUsagePage() {
     onLoadMore: () => { if (cursor) void load(cursor) },
   })
 
+  // #1975 (S6b): stream the live edge of the aggregated series — subscribe `trafficUsage`
+  // with the page's current params and merge the pushed head bucket into `aggRows` by
+  // windowStart (the helper gates itself to the aggregated, anchored-at-now view; the GET
+  // still owns history + paging). Re-subscribes when groupBy / bucket / filters change.
+  const liveStreaming = useWsTrafficUsageLiveEdge(
+    { groupBy, bucket, macs, profileIds, until },
+    setAggRows,
+  )
+
   function toggleGroup(key: string) {
     setGroupBy(prev => {
       const next = prev.includes(key as TrafficUsageGroupBy)
@@ -191,7 +202,10 @@ export function TrafficUsagePage() {
   return (
     <div className="space-y-4 min-w-0" data-testid="traffic-usage-page">
       <header>
-        <h1 className="text-xl sm:text-2xl font-bold text-brand-ink">Traffic Usage</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl sm:text-2xl font-bold text-brand-ink">Traffic Usage</h1>
+          {liveStreaming && <LiveBadge />}
+        </div>
         <p className="text-xs sm:text-sm text-brand-text-muted">
           Raw <code className="text-brand-accent">traffic_reports</code> rows plus on-the-fly
           aggregation. Click a column header (Host / Device / Profile) to add it to the


### PR DESCRIPTION
## What

Step **S6b** of the SPA-websocket rollout (`docs/design/spa-websocket.md` §9; design #1860, umbrella #1955). Closes #1975.

Streams the **live edge** of the **Traffic Usage** and **Connection Events** pages over the *same* `trafficUsage` / `connectionEvents` topics the dashboard already uses — just with each page's own filters (design §1.4 / §0.3 — *one stream, many consumers*). Plus class-(3) `stale` invalidation for `alerts` / `profiles` / `devices` / `schedules` (§3.2). Additive, per-page; **polling stays the fallback** and no `refetchInterval` is removed (that's S7 #1976).

## How

- **`wsCache.ts`**
  - `mergeAggregateHeadRows(prev, live)` — rows-level head merge (join on `windowStart`: replace the head window in place, prepend on rollover, never touch history). `mergeHeadBucket` now delegates to it, so the dashboard's response-level merge and the page's rows-level merge share **one** implementation (SSOT).
  - `prependHead` `limit` is now **optional** — the Connection Events page pages its history with infinite scroll, so prepending the live head must not truncate it. The dashboard's "Recently Blocked" still caps to `RECENT_BLOCKED_LIMIT`.
- **`useWs.tsx`**
  - `useWsTrafficUsageLiveEdge(args, setRows)` — subscribes `trafficUsage` with the page's `{groupBy, bucket, macs?, profileIds?}`, merges the pushed head bucket into the page's `aggRows` by `windowStart`. Gated to the **aggregated** view anchored at **now** (the push carries `aggregateRows` per §1.3 — the `raw` per-host table can't consume them; a pinned `until` window is history). Re-subscribes on filter change.
  - `useWsConnectionEventsLiveEdge(args, setRows)` — subscribes `connectionEvents` with the page's `{blocked?, macs?, profileIds?}`, prepends + dedups the pushed head rows into the raw feed (no cap → paged history intact). Re-subscribes on filter change.
  - `useWsStale()` + `WsStaleInvalidator` (mounted in `App.tsx`) — the topic→invalidator map lives in **one place**; reuses `qk`/`useInvalidators`; `invalidateQueries` only refetches **mounted** queries so a `stale` for a closed view is free.
- Both pages keep loading history via their existing `GET` (+ cursor paging #862); the socket only keeps the newest slice fresh; older/paged data is **never** mutated by the stream.

### Notes
- **No poll to pause:** unlike the dashboard / time-status surfaces, these two pages have **no `refetchInterval`** — they load once per filter set. So §3.3's "pause the poll when the topic is live" is satisfied vacuously; the live edge *is* the freshness. A small `LiveBadge` surfaces the streaming state.
- **Zero additions to `web/src/types/api.ts`** — every payload is an existing REST body.

## Tests (TDD — failing tests committed first)
- `wsCache.test.ts`: `mergeAggregateHeadRows` (replace-head / rollover / empty-edge / multi-row head; paged rows byte-identical); `prependHead` with no limit (no truncation, still dedups).
- `useWs.test.tsx`: each page hook subscribes with its current params; head-bucket push merges by `windowStart` while paged history stays untouched; connectionEvents push prepends + dedups without truncating history; absent filters omitted from params; no subscription in `raw`/pinned-`until`; re-subscribe (unsubscribe+subscribe) on bucket/filter change; `stale{profiles}` invalidates only the mounted profiles query (devices untouched); unknown `stale` topic ignored.

Green: `npm --prefix web run lint`, `npm --prefix web test` (476), `npm --prefix web run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)