### PR TITLE
fix(#2012): single-flight TimeStatusCache to stop /api/time/status CD timeout

### DIFF
--- a/api/src/cache/TimeStatusCache.scala
+++ b/api/src/cache/TimeStatusCache.scala
@@ -6,6 +6,7 @@ import zio.*
 
 import java.time.LocalDate
 import java.time.Duration as JDuration
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.LongAdder
 
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
@@ -141,6 +142,16 @@ object TimeStatusCache {
     private val hits   = new LongAdder
     private val misses = new LongAdder
 
+    // #2012: per-key single-flight. Without it, concurrent missers for the SAME (profileId, date)
+    // each independently run the O(N-profile) `load` and stampede the small DB pool — which timed
+    // out `/api/time/status` when CD Gate 1 + Gate 3b hit a freshly-deployed, cold-cache staging
+    // in parallel (reproduced: 1 cold call ~5s, 3 concurrent ~13s, 10 concurrent >30s). With it,
+    // the caller that wins `putIfAbsent` runs `load`; every other concurrent caller awaits that one
+    // in-flight Promise and does no DB work. The slot is always freed on completion (success,
+    // failure, OR interrupt) so a failed/interrupted load never wedges followers or caches a bad
+    // value — followers just see the same outcome and the next caller re-loads.
+    private val inFlight = new ConcurrentHashMap[Key, Promise[Throwable, AnyRef]]()
+
     def getOrLoadDaily(
         profileId: ProfileId,
         date: LocalDate,
@@ -173,10 +184,24 @@ object TimeStatusCache {
       val cache = if isTodayMode then todayCache else pastCache
       ZIO.succeed(Option(cache.getIfPresent(key))).flatMap {
         case Some(v) =>
-          ZIO.succeed(hits.increment()) *> ZIO.succeed(v.asInstanceOf[V])
+          ZIO.succeed(hits.increment()).as(v.asInstanceOf[V])
         case None    =>
-          ZIO.succeed(misses.increment()) *>
-            load.tap(v => ZIO.succeed(cache.put(key, v)))
+          // #2012 single-flight: register an in-flight Promise for this key. The caller that wins
+          // `putIfAbsent` owns the load; concurrent missers await its result instead of stampeding
+          // the DB pool with N redundant builds.
+          Promise.make[Throwable, AnyRef].flatMap { mine =>
+            Option(inFlight.putIfAbsent(key, mine)) match {
+              case Some(existing) =>
+                existing.await.map(_.asInstanceOf[V])
+              case None           =>
+                ZIO.succeed(misses.increment()) *>
+                  load
+                    .tap(v => ZIO.succeed(cache.put(key, v)))
+                    // Always free the slot and publish the outcome to followers — even on failure
+                    // or interrupt — so the in-flight entry can never wedge waiters or leak.
+                    .onExit(exit => ZIO.succeed(inFlight.remove(key, mine)) *> mine.done(exit))
+            }
+          }
       }
     }
 

--- a/api/src/cache/TimeStatusCache.scala
+++ b/api/src/cache/TimeStatusCache.scala
@@ -192,7 +192,9 @@ object TimeStatusCache {
           Promise.make[Throwable, AnyRef].flatMap { mine =>
             Option(inFlight.putIfAbsent(key, mine)) match {
               case Some(existing) =>
-                existing.await.map(_.asInstanceOf[V])
+                // Served off the in-flight load — no DB work — so it counts as a hit, keeping the
+                // periodic hit-rate stats representative of how much load the cache actually saved.
+                ZIO.succeed(hits.increment()) *> existing.await.map(_.asInstanceOf[V])
               case None           =>
                 ZIO.succeed(misses.increment()) *>
                   load

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -281,6 +281,43 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         finalStats.hits == statsAfterGrant.hits + 1L,
       )
     },
+    test("concurrent misses for one key collapse to a single load (single-flight, #2012)") {
+      // #2012: the `/api/time/status` page is fetched concurrently by several callers at once
+      // (e.g. CD Gate 1 + Gate 3b hitting staging in parallel right after a deploy, cold cache).
+      // Without single-flight every concurrent miss independently runs the O(58-profile) build,
+      // stampeding the small DB pool until the endpoint times out. Assert that N concurrent
+      // `getOrLoadDaily` calls for the SAME key invoke `load` exactly once; the followers await
+      // the in-flight result instead of launching their own build.
+      //
+      // Deterministic: `gate` is held until every caller has passed the cache's miss decision, so
+      // no load completes (and nothing is `put`) during the window. Without single-flight all N
+      // callers therefore miss and run `load` (count == N); with it, exactly one runs `load` and
+      // the rest await the in-flight result (count == 1). The settle below only needs to let the
+      // forked fibers reach that decision — it never races a completion, because the gate is shut.
+      val n      = 25
+      val today  = LocalDate.parse("2026-06-27")
+      val pid    = ProfileId(7L)
+      val sample =
+        ProfileTimeStatus(pid, "Kid", today.toString, Some(60), 0, 0, Some(60), Nil, Nil, Nil)
+      for {
+        cache   <- TimeStatusCache.make()
+        loads   <- Ref.make(0)
+        arrived <- Ref.make(0)
+        gate    <- Promise.make[Nothing, Unit]
+        load = loads.update(_ + 1) *> gate.await.as(sample)
+        call = arrived.update(_ + 1) *> cache.getOrLoadDaily(pid, today, today)(load)
+        fiber <- ZIO.foreachPar(1 to n)(_ => call).fork
+        _     <- arrived.get.repeatUntil(_ == n) // all N have entered their getOrLoad call
+        _       <- ZIO.sleep(200.millis) // …let each reach the miss decision (gate still shut)
+        _       <- gate.succeed(())
+        results <- fiber.join
+        count   <- loads.get
+      } yield assertTrue(
+        count == 1,                 // single-flight: one build despite N concurrent missers
+        results.length == n,        // every caller still gets a result
+        results.forall(_ == sample),// …the same in-flight result
+      )
+    } @@ TestAspect.withLiveClock,
     test("Cache-Control: no-store for today, max-age=3600 for past") {
       for {
         _           <- cleanDb


### PR DESCRIPTION
## CD incident fix — closes #2012

**Master API/UI CD has been red on `main` since #1974** (3 consecutive Gate 3b failures: #1974, #2004, #2010) with `TimeoutError: The read operation timed out` on the `/api/time/status` cross-check.

### Root cause — a concurrency cliff, **not** a #1974 GET regression
The #1974 GET refactor (extraction of `TimeStatusService.assembleProfileTimeStatus`) is **byte-identical** — verified by diff. The real defect:

`TimeStatusCache.getOrLoad` had **no single-flight** (`getIfPresent` → miss → `load` → `put`). So N concurrent missers for the same `(profileId, date)` each independently run the **sequential O(N-profile) build** (`dayState` + `listPresenceRows` + `listForProfile` per profile) and **stampede the 8-connection pool** (`WIFIHAVEN_DB_POOL_SIZE=8`, render.yaml).

After `deploy-staging`, three jobs hit the **same** staging API **in parallel** on a cold 30s cache:
- `smoke-staging`
- Gate 1 `api-smoke-staging` → `scripts/e2e-tests.sh:179` hits `/api/time/status`
- Gate 3b `gate-3b-api-staging` → `test_smoke.py:97` hits `/api/time/status`

The concurrent calls stampede and exceed their read timeouts.

### Reproduced on staging (58 profiles)
| concurrency | latency |
|---|---|
| 1 cold call | ~4.8s |
| 3 concurrent cold | ~12.7s each (at the 15s gate edge) |
| 10 concurrent cold | **all > 30s** (curl timeout) |

(`/api/logs` baseline: ~0.3s.)

### Fix
Per-key single-flight via a `ConcurrentHashMap[Key, Promise]`: the caller that wins `putIfAbsent` owns the load; every other concurrent miss **awaits that one in-flight result and does no DB work**. The slot is always freed on completion — success, failure, **or interrupt** — so a failed/interrupted load can never wedge followers or cache a bad value.

This restores the **pre-#1974 single-build latency** (which was green: one ~5s build per 30s window shared across all gate callers, vs the multiplicative stampede that blew past the timeout). No parallelism is introduced — `api/src` is deliberately all-sequential for pool discipline. The #1974 consumer push path (`SpaPush.pushTimeStatus`) is subscription-gated (no ws subscriber in CI) and is left unchanged.

### Tests (TDD)
- `TimeStatusCacheSpec` gains a single-flight guard: N concurrent `getOrLoadDaily` for one key behind a shut gate (every caller misses concurrently) must invoke `load` exactly once. Committed **red first** (`count == 25`), green after the fix.
- Re-ran `TimeStatusCacheSpec` (6), `TimeApiSpec` (52), `TimeStatusServiceSpec` (36), `SpaWsS6aSpec` (6), `RouterIngestSpec` (9) — all pass. `mill __.compile` + scalafmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)