### PR TITLE
feat(#1833): drop Recent Queries firehose + rename queries→connection events on /dashboard

### DIFF
--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -36,13 +36,6 @@ const stats: DashboardStats = {
   ],
 }
 
-const recent: QueryLog = {
-  id: 1, mac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad",
-  profileId: 1, profileName: 'Kids',
-  host: { type: 'fqdn', value: 'example.com' }, qtype: 1, blocked: false, reason: { kind: 'allow' },
-  location: 'home', ts: '2026-05-07T10:15:30Z',
-}
-
 // #1338: a recent connection-layer drop, returned by /api/logs?blocked=true.
 // ts must be inside the panel's 15-min recency window, so derive it from now.
 const recentBlockedTs = () => new Date(Date.now() - 12_000).toISOString() // 12s ago
@@ -93,14 +86,13 @@ const mockAlerts = () => api.alerts.list as unknown as ReturnType<typeof vi.fn>
 beforeEach(() => {
   vi.resetAllMocks()
   mockStats().mockResolvedValue(stats)
-  // #1338: the "Most recently blocked" panel and the "Recent Queries" table
-  // both hit api.logs.query; split the canned response by the blocked filter so
-  // each surface renders its own (distinct) fixture.
+  // #1833: the unfiltered "Recent Queries" firehose is gone; only the
+  // "Most recently blocked" panel hits api.logs.query (blocked=true).
   mockQuery().mockImplementation((params?: { blocked?: boolean }) =>
     Promise.resolve(
       params?.blocked
         ? { rows: [blockedRow], nextCursor: null }
-        : { rows: [recent], nextCursor: null },
+        : { rows: [], nextCursor: null },
     ),
   )
   mockNow().mockResolvedValue(emptyNow)
@@ -108,7 +100,7 @@ beforeEach(() => {
 })
 
 describe('DashboardPage', () => {
-  it('renders stat cards, top-blocked, per-device, and recent queries', async () => {
+  it('renders stat cards, top-blocked, and per-device', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
     expect(await screen.findByText('1234')).toBeInTheDocument()
     expect(screen.getByText('56')).toBeInTheDocument()
@@ -117,24 +109,30 @@ describe('DashboardPage', () => {
     expect(screen.getByText('evil.com')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
     expect(screen.getAllByText("Kid's iPad").length).toBeGreaterThan(0)
-    expect(screen.getByText('500 queries')).toBeInTheDocument()
+    expect(screen.getByText('500 events')).toBeInTheDocument()
     expect(screen.getByText('20 blocked')).toBeInTheDocument()
-    expect(screen.getByText('example.com')).toBeInTheDocument()
-
-    expect(api.logs.query).toHaveBeenCalledWith({ limit: 30 })
   })
 
-  it('shows empty state when no blocked queries', async () => {
+  it('does not render the unfiltered Recent Queries firehose (#823)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    await screen.findByText('1234')
+    expect(screen.queryByText('Recent Queries')).not.toBeInTheDocument()
+    // The firehose's unfiltered fetch (one fewer network call on load) is gone.
+    expect(api.logs.query).not.toHaveBeenCalledWith({ limit: 30 })
+  })
+
+  it('uses connection-event terminology, never "queries" (#299)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    await screen.findByText('1234')
+    expect(screen.getByText('Events today')).toBeInTheDocument()
+    expect(screen.getByText('Events (1h)')).toBeInTheDocument()
+    expect(screen.queryByText(/queries/i)).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when no blocked events', async () => {
     mockStats().mockResolvedValue({ ...stats, topBlocked: [] })
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    expect(await screen.findByText(/No blocked queries yet/)).toBeInTheDocument()
-  })
-
-  it('recent activity Time column renders in viewer local time (not UTC slice)', async () => {
-    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    await screen.findByText('example.com')
-    const expected = new Date(recent.ts).toLocaleTimeString()
-    expect(screen.getByText(expected)).toBeInTheDocument()
+    expect(await screen.findByText(/No blocked events yet/)).toBeInTheDocument()
   })
 
   it('renders Now section above stat cards', async () => {
@@ -143,7 +141,7 @@ describe('DashboardPage', () => {
     await screen.findByText('1234')
     await waitFor(() => expect(screen.getByTestId('now-profile-1')).toBeInTheDocument())
     const nowHeading = screen.getByText('Now')
-    const statsCard  = screen.getByText('Queries today')
+    const statsCard  = screen.getByText('Events today')
     const comparison = nowHeading.compareDocumentPosition(statsCard)
     expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -19,12 +19,11 @@ import { BandwidthGauges } from '@/components/dashboard/BandwidthGauges'
 
 export function DashboardPage() {
   const [stats,  setStats]  = useState<DashboardStats | null>(null)
-  const [logs,   setLogs]   = useState<QueryLog[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    Promise.all([api.logs.stats(), api.logs.query({ limit: 30 })])
-      .then(([s, l]) => { setStats(s); setLogs(l.rows) })
+    api.logs.stats()
+      .then(setStats)
       .finally(() => setLoading(false))
   }, [])
 
@@ -47,9 +46,9 @@ export function DashboardPage() {
       {stats && (
         <>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Queries today"  value={stats.totalToday}   accent="emerald" />
+            <StatCard label="Events today"   value={stats.totalToday}   accent="emerald" />
             <StatCard label="Blocked today"  value={stats.blockedToday} accent="red" />
-            <StatCard label="Queries (1h)"   value={stats.totalHour}    accent="emerald" />
+            <StatCard label="Events (1h)"    value={stats.totalHour}    accent="emerald" />
             <StatCard label="Blocked (1h)"   value={stats.blockedHour}  accent="yellow" />
           </div>
 
@@ -59,7 +58,7 @@ export function DashboardPage() {
                 Top Blocked (24h)
               </h2>
               {stats.topBlocked.length === 0
-                ? <EmptyState variant="inline" title="No blocked queries yet" />
+                ? <EmptyState variant="inline" title="No blocked events yet" />
                 : stats.topBlocked.map(d => (
                     <div key={`${d.host.type}:${d.host.value}`} className="flex justify-between items-center py-2 border-b border-brand-border last:border-0">
                       <span className="font-mono text-sm text-brand-text truncate"><HostCell host={d.host} /></span>
@@ -80,7 +79,7 @@ export function DashboardPage() {
                     <p className="text-xs text-brand-text-muted font-mono">{d.mac}</p>
                   </div>
                   <div className="text-right shrink-0">
-                    <p className="text-sm text-brand-text">{d.total} queries</p>
+                    <p className="text-sm text-brand-text">{d.total} events</p>
                     <p className="text-xs text-red-700">{d.blocked} blocked</p>
                   </div>
                 </div>
@@ -89,15 +88,6 @@ export function DashboardPage() {
           </div>
         </>
       )}
-
-      <section className="bg-white rounded-2xl border border-brand-border overflow-hidden">
-        <div className="px-5 py-4 border-b border-brand-border">
-          <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">Recent Queries</h2>
-        </div>
-        <div className="overflow-x-auto">
-          <LogTable logs={logs} />
-        </div>
-      </section>
     </div>
   )
 }
@@ -307,35 +297,6 @@ function StatCard({ label, value, accent }: { label: string; value: number; acce
   )
 }
 
-function LogTable({ logs }: { logs: QueryLog[] }) {
-  return (
-    <table className="w-full text-xs font-mono">
-      <thead>
-        <tr className="text-brand-text-muted border-b border-brand-border">
-          <th className="text-left px-4 py-2">Time</th>
-          <th className="text-left px-4 py-2">Device</th>
-          <th className="text-left px-4 py-2">Domain</th>
-          <th className="text-left px-4 py-2">Status</th>
-          <th className="text-left px-4 py-2 hidden md:table-cell">Reason</th>
-        </tr>
-      </thead>
-      <tbody>
-        {logs.map(l => (
-          <tr key={l.id} className="border-b border-brand-border/50 hover:bg-brand-alt/30">
-            <td className="px-4 py-2 text-brand-text-muted">{new Date(l.ts).toLocaleTimeString()}</td>
-            <td className="px-4 py-2 text-amber-700">{l.deviceName ?? l.mac ?? '?'}</td>
-            <td className="px-4 py-2 text-brand-text max-w-[200px] truncate"><HostCell host={l.host} /></td>
-            <td className={`px-4 py-2 ${l.blocked ? 'text-red-700' : 'text-brand-accent-dark'}`}>
-              {l.blocked ? '✗ blocked' : '✓ ok'}
-            </td>
-            <td className="px-4 py-2 text-brand-text-muted hidden md:table-cell">{blockReasonText(l.reason)}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
-}
-
 function PageLoader() {
   return (
     <div className="flex items-center justify-center h-64">
@@ -344,4 +305,4 @@ function PageLoader() {
   )
 }
 
-export { LogTable, PageLoader, formatRelativeTime }
+export { PageLoader, formatRelativeTime }


### PR DESCRIPTION
Dashboard redesign **chunk 1 of 5** (umbrella #1148, design `docs/design/dashboard-redesign.md` §7). **Frontend only — lowest-risk chunk.**

Closes #823, closes #299.

## What changed
- **Removed the unfiltered "Recent Queries" firehose** from `DashboardPage` — the `<section>` rendering `LogTable` fed by `api.logs.query({ limit: 30 })`, plus the `logs` state and that network call. `/dashboard` now fetches only `api.logs.stats()` on load (one fewer network call). (#823)
- **Renamed dashboard copy "queries" → "events"** to align with the `/usage/events` "Connection Events" page: KPI labels (`Events today`, `Events (1h)`), per-device `N events`, and the `No blocked events yet` empty state. (#299)
- **Removed the `LogTable` component + its re-export** — it had no other importers (verified via grep).

## What is untouched (per scope)
- **"Most Recently Blocked"** (`RecentlyBlockedSection`, #1338) — the *filtered* blocked-only trailing-hour feed and its ws wiring.
- **LIVE BANDWIDTH / NOW** ws-driven sections.
- `/usage` and `/logs` pages and all API fields (rename scoped to the dashboard only).

## Tests
TDD per CLAUDE.md — the `DashboardPage` test was updated and committed RED first, then made green:
- asserts the unfiltered Recent Queries table no longer renders and `api.logs.query({ limit: 30 })` is not called;
- asserts connection-event terminology (`Events today`/`Events (1h)`) with no "queries" copy;
- "Most Recently Blocked" / NOW coverage unchanged.

`npm --prefix web run lint`, `npm --prefix web test` (477 passed), and `npm --prefix web run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)