### PR TITLE
fix(#2017): seed dashboard LIVE BANDWIDTH gauge via GET (blank on load/bucket-switch)

### DIFF
--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -12,6 +12,12 @@ vi.mock('@/api/client', () => ({
     dashboard: { now: vi.fn().mockResolvedValue({ asOf: 'x', profiles: [] }) },
     profiles: { list: vi.fn().mockResolvedValue([]) },
     devices: { list: vi.fn().mockResolvedValue([]) },
+    // #2017: the dashboard gauge seeds its series with one GET on mount / bucket change.
+    usage: {
+      traffic: vi.fn().mockResolvedValue({
+        bucket: '1m', groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [], aggregateRows: [],
+      }),
+    },
   },
 }))
 
@@ -187,6 +193,89 @@ describe('useWsTrafficUsage (§3.1/#747)', () => {
     expect(i1).toBeGreaterThanOrEqual(0)
     expect(iU).toBeGreaterThan(i1)
     expect(i2).toBeGreaterThan(iU)
+  })
+})
+
+// ── #2017: the dashboard gauge seeds via a GET so it shows data instantly ─────────────
+//
+// Regression: S5 (#1973) shipped the ws-only series with NO initial GET, so the gauge was
+// blank ("No live traffic right now") for up to ~70s after each load / bucket switch —
+// until the first usage-ingest push. The design (§3.1/§5.3) loads the window via the GET
+// and lets the socket push only the live edge. These prove the one-shot seed.
+describe('useWsTrafficUsage seeds via GET (#2017)', () => {
+  // newest-first head-bucket response (the GET orders windowStart DESC).
+  const seedResp = (
+    bucket: TrafficUsageResponse['bucket'],
+    rows: { profile: string; windowStart: string; bytesIn?: number; bytesOut?: number }[],
+  ): TrafficUsageResponse => ({
+    bucket, groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [],
+    aggregateRows: rows.map(r => ({
+      groups: { profile: r.profile },
+      windowStart: r.windowStart,
+      windowEnd: '2026-06-26T10:06:00Z',
+      totalBytesIn: r.bytesIn ?? 0,
+      totalBytesOut: r.bytesOut ?? 0,
+      totalSeconds: 60,
+    })),
+  })
+
+  it('shows the seeded head-bucket rate immediately, before any trafficUsage push', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    trafficSpy.mockResolvedValue(seedResp('1m', [{ profile: 'Kids', windowStart: '2026-06-26T10:05:00Z', bytesIn: 600 }]))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
+
+    // The series populates from the GET alone — NO ws push emitted.
+    await waitFor(() => expect(result.current.rows).toHaveLength(1))
+    expect(result.current.live).toBe(true)
+    expect(result.current.overall.bytesInPerSec).toBe(10) // 600 bytes / 60s
+
+    // One GET for the current head window: groupBy:profile, the selected bucket, a from/to span.
+    expect(trafficSpy).toHaveBeenCalledTimes(1)
+    const arg = trafficSpy.mock.calls[0][0]
+    expect(arg.bucket).toBe('1m')
+    expect(arg.groupBy).toEqual(['profile'])
+    expect(typeof arg.from).toBe('string')
+    expect(typeof arg.to).toBe('string')
+    expect(new Date(arg.from).getTime()).toBeLessThanOrEqual(new Date(arg.to).getTime())
+  })
+
+  it('merges a later ws push on top of the GET seed (mergeHeadBucket)', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    trafficSpy.mockResolvedValue(seedResp('1m', [{ profile: 'Kids', windowStart: '2026-06-26T10:05:00Z', bytesIn: 600 }]))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
+    await waitFor(() => expect(result.current.rows).toHaveLength(1))
+
+    // A push for the SAME head window with higher cumulative bytes replaces the head in place.
+    act(() => last().emit({ op: 'trafficUsage', payload: seedResp('1m', [{ profile: 'Kids', windowStart: '2026-06-26T10:05:00Z', bytesIn: 1200 }]) }))
+    expect(result.current.rows).toHaveLength(1)
+    expect(result.current.overall.bytesInPerSec).toBe(20) // 1200 bytes / 60s — push merged on the seed
+  })
+
+  it('re-seeds via a fresh GET when the bucket changes', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    trafficSpy.mockImplementation((p: { bucket: TrafficUsageResponse['bucket'] }) =>
+      Promise.resolve(seedResp(p.bucket, [{ profile: 'Kids', windowStart: '2026-06-26T10:05:00Z', bytesIn: 600 }])))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+    await waitFor(() => expect(trafficSpy).toHaveBeenCalledTimes(1))
+    expect(trafficSpy.mock.calls[0][0].bucket).toBe('1m')
+
+    act(() => result.current.setBucket('10m'))
+    await waitFor(() => expect(trafficSpy).toHaveBeenCalledTimes(2))
+    expect(trafficSpy.mock.calls[1][0].bucket).toBe('10m')
   })
 })
 

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -157,7 +157,7 @@ describe('useWsRecentBlocked (§3.1)', () => {
 })
 
 describe('useWsTrafficUsage (§3.1/#747)', () => {
-  it('merges the live-edge bucket into the series cache and subscribes with the bucket', () => {
+  it('merges the live-edge bucket into the series cache and subscribes with the bucket', async () => {
     const { qc, client, wrapper } = setup()
     const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
     goLive(client)
@@ -176,9 +176,11 @@ describe('useWsTrafficUsage (§3.1/#747)', () => {
     act(() => last().emit({ op: 'trafficUsage', payload: push }))
     const key = qk.trafficUsageLive({ groupBy: ['profile'], bucket: '1m' })
     expect(qc.getQueryData<TrafficUsageResponse>(key)?.aggregateRows).toHaveLength(1)
-    // hook surfaces the derived overall rate (600 bytes / 60s = 10 B/s)
+    // hook surfaces the derived overall rate (600 bytes / 60s = 10 B/s). #2017: the gauge now
+    // reads via a `useQuery` observer (GET-seeded), which re-renders one tick after the push's
+    // setQueryData (vs the old synchronous cache read) — so await the derived value.
     expect(result.current.live).toBe(true)
-    expect(result.current.overall.bytesInPerSec).toBe(10)
+    await waitFor(() => expect(result.current.overall.bytesInPerSec).toBe(10))
   })
 
   it('re-subscribes (unsubscribe+subscribe) when the bucket selector changes', () => {
@@ -254,11 +256,12 @@ describe('useWsTrafficUsage seeds via GET (#2017)', () => {
     goLive(client)
     act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
     await waitFor(() => expect(result.current.rows).toHaveLength(1))
+    expect(result.current.overall.bytesInPerSec).toBe(10) // seed: 600 / 60s
 
     // A push for the SAME head window with higher cumulative bytes replaces the head in place.
     act(() => last().emit({ op: 'trafficUsage', payload: seedResp('1m', [{ profile: 'Kids', windowStart: '2026-06-26T10:05:00Z', bytesIn: 1200 }]) }))
+    await waitFor(() => expect(result.current.overall.bytesInPerSec).toBe(20)) // 1200 / 60s — push merged on the seed
     expect(result.current.rows).toHaveLength(1)
-    expect(result.current.overall.bytesInPerSec).toBe(20) // 1200 bytes / 60s — push merged on the seed
   })
 
   it('re-seeds via a fresh GET when the bucket changes', async () => {

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -279,6 +279,12 @@ describe('useWsTrafficUsage seeds via GET (#2017)', () => {
     act(() => result.current.setBucket('10m'))
     await waitFor(() => expect(trafficSpy).toHaveBeenCalledTimes(2))
     expect(trafficSpy.mock.calls[1][0].bucket).toBe('10m')
+
+    // Returning to a previously-selected bucket re-seeds too (gcTime:0 drops the switched-away
+    // series, so the gauge never shows a stale head window from minutes ago — review SHOULD-FIX).
+    act(() => result.current.setBucket('1m'))
+    await waitFor(() => expect(trafficSpy).toHaveBeenCalledTimes(3))
+    expect(trafficSpy.mock.calls[2][0].bucket).toBe('1m')
   })
 })
 

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -17,11 +17,13 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from 'react'
-import { useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from '@/api/client'
 import { qk, RECENT_BLOCKED_LIMIT, useInvalidators } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import { SpaWsClient, type SpaTopicName, type WsStatus } from '@/api/wsClient'
 import {
+  bucketSeconds,
   headBucketRows,
   mergeAggregateHeadRows,
   mergeHeadBucket,
@@ -246,9 +248,18 @@ export interface WsTrafficUsage {
  * `trafficUsage{groupBy:profile, bucket}` (§3.1, class 1): the live bandwidth gauge.
  * Subscribes with the chosen window (bucket); re-subscribes when the selector changes
  * (#747). The push carries only the live-edge bucket — we MERGE it into the cached
- * series by `windowStart` (§3.1). The series is ws-only (no poll fallback, §3.3): it
- * lives purely in the React Query cache, written by the push and read passively here, so
- * it shows "—" (empty rows) until the first push lands and while disconnected.
+ * series by `windowStart` (§3.1).
+ *
+ * #2017: the series is GET-seeded then ws-kept-live, per the design (§3.1/§5.3 — "the
+ * gauge loads its window via the existing GET … the socket pushes only the live edge").
+ * On mount and on every bucket change (the cache key changes → a fresh query) we issue
+ * ONE `GET /api/usage/traffic` for the current head window, so the gauge shows data
+ * instantly instead of blank until the first usage-ingest push (~up to ~70s). The `useQuery`
+ * observer writes — and re-renders on — the SAME `qk.trafficUsageLive(key)` the push patches,
+ * so the push's `mergeHeadBucket` keeps it live on top of the seed. This is a one-shot seed,
+ * NOT a poll (class-1 keeps no poll fallback, §3.3): `staleTime: Infinity` + no
+ * `refetchInterval` — it fetches on mount / key change only, and a reconnect invalidates the
+ * key (refetchKey) for a single reseed.
  */
 export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsTrafficUsage {
   const qc = useQueryClient()
@@ -270,10 +281,23 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
     key,
   )
 
-  // Passive cache reader: never fetches (§3.3 — no poll fallback for the live rate), just
-  // re-renders when the push writes the series cache. A disabled `useQuery` observer does
-  // NOT get cache-update notifications, so subscribe to the cache directly.
-  const data = useCachedQueryData<TrafficUsageResponse>(qc, key)
+  // The GET seed (#2017). A real query observer (not a passive cache read) so it fetches on
+  // mount / key change AND receives the push's `setQueryData` cache updates on the same key.
+  const { data } = useQuery({
+    queryKey: key,
+    queryFn: async () => {
+      const { from, to } = headWindow(bucket)
+      const body = await api.usage.traffic({ groupBy, bucket, from, to })
+      // A push can write the live edge while the GET is in flight; keep it on top so a
+      // late-resolving seed never clobbers fresher live data (the push's head ≥ the GET's
+      // for the same window). mergeHeadBucket keeps the GET's history, the push's head.
+      const live = qc.getQueryData<TrafficUsageResponse>(key)
+      return live ? mergeHeadBucket(body, live) : body
+    },
+    staleTime: Infinity,
+    refetchInterval: false,
+  })
+
   const rows = headBucketRows(data)
   return {
     live: streaming,
@@ -286,17 +310,16 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
 }
 
 /**
- * Subscribe to a single React Query key's cached data WITHOUT fetching — re-renders when
- * a `setQueryData` writes it (a disabled `useQuery` observer doesn't receive those). Used
- * for the ws-only trafficUsage series, which has no GET fallback (§3.3).
+ * The current head-bucket window `[floor(now, bucket), now]` for the seed GET (#2017).
+ * Flooring `from` to the bucket boundary makes the GET return exactly the current (head)
+ * window, so `headBucketRows` lands on it and the rate is right. `raw` has no fixed width —
+ * we floor to the nominal ~60s edge (`bucketSeconds('raw')`), giving the most-recent slice.
  */
-function useCachedQueryData<T>(qc: QueryClient, key: readonly unknown[]): T | undefined {
-  const keyHash = JSON.stringify(key)
-  const subscribe = useCallback((cb: () => void) => qc.getQueryCache().subscribe(cb), [qc])
-  // Re-read when the key changes (keyHash), not on every render. `key` is intentionally
-  // not a dep — keyHash is its serialized identity.
-  const getSnapshot = useCallback(() => qc.getQueryData<T>(key), [qc, keyHash])
-  return useSyncExternalStore(subscribe, getSnapshot)
+function headWindow(bucket: TrafficUsageBucket): { from: string; to: string } {
+  const nowMs = Date.now()
+  const secs = bucketSeconds(bucket)
+  const fromMs = Math.floor(nowMs / 1000 / secs) * secs * 1000
+  return { from: new Date(fromMs).toISOString(), to: new Date(nowMs).toISOString() }
 }
 
 // ── #1975 (S6b): stream the live edge of the Traffic Usage + Connection Events PAGES ──

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -294,7 +294,14 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
       const live = qc.getQueryData<TrafficUsageResponse>(key)
       return live ? mergeHeadBucket(body, live) : body
     },
+    // One-shot seed, then socket-driven: `staleTime: Infinity` so the active bucket never
+    // auto-refetches (no poll, §3.3) — the push keeps it live and a reconnect invalidates the
+    // key for a single reseed. `gcTime: 0` so a bucket switched AWAY from is dropped, and
+    // returning to it always re-seeds with a fresh GET (without it, a re-visited bucket within
+    // the gc window would render a stale head window until the next push). The active bucket's
+    // query has an observer, so gcTime never collects it mid-use.
     staleTime: Infinity,
+    gcTime: 0,
     refetchInterval: false,
   })
 


### PR DESCRIPTION
## Problem

On `app.wifihaven.net/dashboard` the **LIVE BANDWIDTH** gauge showed nothing — `Overall ↓0 B/s ↑0 B/s` / *"No live traffic right now"* — for **up to ~60–70s after every page load and after every bucket switch**, for all buckets including the 1m default. Closes #2017.

## Root cause

The dashboard gauge (`useWsTrafficUsage`, `web/src/hooks/useWs.tsx`) was **websocket-only**: its series lived purely in the `qk.trafficUsageLive({groupBy, bucket})` React Query cache, written **only** by the `trafficUsage` push and read passively (`useCachedQueryData`). There was **no initial `GET /api/usage/traffic`**, so on a fresh load (or any bucket change → new cache key) the series stayed empty until the next usage-ingest push (~up to ~70s).

This contradicts the design (`docs/design/spa-websocket.md` §3.1/§5.3): *"the page/gauge loads its window via the existing GET … the socket pushes only the live edge."* S5 (#1973) shipped the live-edge push but skipped the GET seed for the dashboard gauge.

### Live evidence (from the issue, verified in-browser post-#2004)
- The **server pushes valid data for every bucket** — direct ws probes returned real bytes with correct `windowStart`/`windowEnd`. Not a server bug, not per-bucket.
- The React Query cache held only the selected bucket's `usage/traffic/live/<bucket>/profile` key, empty until a push merged in.
- After selecting a bucket and **waiting ~70s**, the gauge **did** populate. Pure first-paint latency.

## Fix (frontend-only)

Replace the passive cache read with a real `useQuery` observer keyed on the **same** `qk.trafficUsageLive(key)` the push patches. It issues **one** `GET /api/usage/traffic` for the current head window `[floor(now, bucket), now]` with `groupBy:['profile']` on mount and on every bucket change, seeding the series so `headBucketRows` has the current bucket immediately. The existing `mergeHeadBucket` then merges live pushes on top exactly as before.

- **One-shot seed, NOT a poll** — `staleTime: Infinity` + no `refetchInterval` (class-1 keeps no poll fallback, §3.3). A reconnect invalidates the key (existing `refetchKey`) for a single reseed, matching the other live queries.
- The seed **merges any push already in cache** (`mergeHeadBucket(getBody, cachedPush)`) so a late-resolving GET never clobbers fresher live data — the push's head ≥ the GET's for the same window.
- Reuses the existing `api.usage.traffic(...)` client and the `wsCache` helpers (`mergeHeadBucket`/`headBucketRows`/`rateFor`/`bucketSeconds`) unchanged. No `web/src/types/api.ts` changes, no server changes, no Traffic Usage PAGE changes (S6b already streams it).

## Tests (red → green)

`web/src/hooks/useWs.test.tsx`, committed RED first:
- **Seeds via GET on mount** — the gauge shows the seeded head-bucket rate (600 B / 60s = 10 B/s) with **no** ws push, and issues exactly one GET for the head window. (Fails on old ws-only code: GET never called, rows empty → "No live traffic".)
- **A later push merges on top of the seed** (`mergeHeadBucket`, 1200 B → 20 B/s).
- **Bucket change re-seeds via a fresh GET** for the new bucket.

The existing live-edge merge test was updated to `await` the derived value (the gauge now reads via a query observer that re-renders one tick after the push's `setQueryData`, vs the old synchronous cache read — an imperceptible lag in production).

Full `web` suite (480 tests), lint, and build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)