### PR TITLE
fix(#2024): drive on_tick on a wall-clock heartbeat so idle conntrack can't stall usage

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -223,6 +223,15 @@ object MetricGuard {
     // usage reports flowing or are they stacking up?" without grepping the ring-buffer syslog.
     "usage_queue_depth"                         -> Set("router_id", "installation_id"),
     "usage_post_total"                          -> Set("result", "router_id", "installation_id"),
+    // #2024 — idle-heartbeat stall indicator. The agent now drives its
+    // cooperative timers (usage flush, activity sampler, …) on a wall-clock
+    // heartbeat so on_tick fires even when conntrack is silent. This counter
+    // increments when a reported usage window still ran past 2× the configured
+    // usage_report_interval — i.e. on_tick stalled anyway (heartbeat wedged /
+    // clock jump) and the bucket spanned un-monitored time, the #2016
+    // over-count condition. A healthy fleet holds this flat at 0; a climbing
+    // rate is the leading signal of the over-count regressing.
+    "usage_window_stall_total"                  -> Set("router_id", "installation_id"),
     // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
     "router_metrics_batches_total"              -> Set("status"),
     // #1846 — websocket router transport (server side). `router_ws_connections_active` is the live

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -755,6 +755,48 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Usage window stalls per router (#2024)",
+      "description": "sum by (router_id) (rate(usage_window_stall_total[5m])) — per-router rate of usage buckets whose reported window ran past 2× usage_report_interval, i.e. on_tick stalled even though the #2024 idle heartbeat should keep it firing on a wall-clock cadence. A stalled bucket spans un-monitored time and the server's session-stitch credits the whole window as presence — the #2016 over-count (a kid alone on a long-lived websocket/stream read as tens of minutes from ~1 min of real activity). Steady-state value MUST be 0: a non-zero series means that router's heartbeat is wedged (or its wall clock jumped) and its usedMinutes are inflating right now.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 88 },
+      "id": 24,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "showPoints": "always",
+            "lineWidth": 2,
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.0000001 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (router_id) (rate(usage_window_stall_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{router_id}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/docs/router-tuning.md
+++ b/docs/router-tuning.md
@@ -61,6 +61,36 @@ How often (seconds) the agent samples per-MAC conntrack activity to compute
   at startup if the values are inconsistent and continues with degraded
   accuracy.
 
+### `conntrack_tick_interval` (default `1`)
+
+How often (seconds) the agent's idle heartbeat drives `on_tick` — the
+cooperative dispatcher that runs the usage flush, the `activity_sample_int`
+sampler, the policy poll, the nflog drain, and the metrics push.
+
+Before #2024 those timers fired only when a `conntrack -E -e NEW` line
+arrived. On a quiet LAN — a single device on a long-lived connection (a kid
+alone on a websocket game, one device streaming) emits almost no NEW events —
+`on_tick` stalled for minutes: the usage window ballooned to span the whole
+un-monitored gap (the server's session-stitch then credited it all as
+presence → the #2016 over-count) and the activity sampler starved. The
+watcher now multiplexes a heartbeat line into the conntrack popen stream every
+`conntrack_tick_interval` seconds, so `on_tick` fires on a wall-clock cadence
+regardless of traffic.
+
+- **Lower** → tighter worst-case latency on every cooperative timer when the
+  LAN is idle; marginally more CPU (one extra `on_tick` per second is a few
+  microseconds of monotonic-diff comparisons that early-return — the agent is
+  niced below dnsmasq, #1864).
+- **Raise** → fewer idle wakes; the activity sampler and usage flush can run
+  up to `conntrack_tick_interval` seconds late, so keep this **well below**
+  `activity_sample_int` (a value ≥ `activity_sample_int` reintroduces sampling
+  starvation, the exact failure this knob fixes).
+- **Leading indicator**: the `usage_window_stall_total` metric increments
+  whenever a reported window still exceeds 2× `usage_report_interval` — i.e.
+  the heartbeat failed to keep `on_tick` alive. A healthy fleet holds it flat
+  at 0 (see the "Usage window stalls per router" panel on the router-fleet
+  Grafana dashboard).
+
 ### `event_batch_size` (default `50`)
 
 How many `connection_attempt` events the agent buffers before flushing to
@@ -92,7 +122,8 @@ Force-flush the event buffer after this many seconds even if
 |---|---|---|---|
 | `policy_poll_interval` | 5 | 3–30 | — |
 | `usage_report_interval` | 60 | 30–300 | `activity_sample_int` (must divide evenly) |
-| `activity_sample_int` | 10 | 5–30 | `usage_report_interval` |
+| `activity_sample_int` | 10 | 5–30 | `usage_report_interval`, `conntrack_tick_interval` |
+| `conntrack_tick_interval` | 1 | 1–5 | `activity_sample_int` (must stay well below) |
 | `event_batch_size` | 50 | 10–200 | `event_flush_interval` |
 | `event_flush_interval` | 10 | 5–60 | `event_batch_size` |
 

--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -55,6 +55,19 @@ config wifihaven 'wifihaven'
 	# yields 6 samples per report). See docs/router-tuning.md.
 	option activity_sample_int '10'
 
+	# #2024 idle-heartbeat cadence (seconds). The conntrack watcher's
+	# cooperative timers — the usage flush AND activity_sample_int above, plus
+	# the policy poll, nflog drain, and metrics push — all run inside on_tick,
+	# which fires once per `conntrack -E -e NEW` line. On a quiet LAN (one
+	# device on a long-lived websocket/stream emits no NEW events) on_tick
+	# would stall for minutes, ballooning the usage window and starving the
+	# sampler (the #2016 over-count). The watcher multiplexes a heartbeat line
+	# into the conntrack stream every conntrack_tick_interval seconds so
+	# on_tick fires on a wall-clock cadence regardless of traffic. Keep this
+	# well below activity_sample_int so sampling stays on-cadence. Default 1.
+	# See docs/router-tuning.md.
+	option conntrack_tick_interval '1'
+
 # SNI sidecar (wifihaven-sni-tail) toggle. Lives in its own `config sni`
 # section, distinct from the `config wifihaven 'wifihaven'` anchor above —
 # the init script reads it as `wifihaven.sni.enabled` via

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -26,6 +26,22 @@ local M = {}
 local static_ip_labels = require("wifihaven.static_ip_labels")
 local host_norm        = require("wifihaven.host_norm")
 
+-- #2024 idle-heartbeat cadence. watch()'s cooperative timers (usage flush, the
+-- 10 s activity sampler, policy poll, nflog drain, metrics) all run inside
+-- cfg.on_tick, which was driven ONLY by an incoming `conntrack -E -e NEW` line.
+-- On a quiet LAN (one device on a long-lived websocket/stream emits no NEW
+-- events) on_tick stalled for minutes: the usage window ballooned to span the
+-- whole un-monitored gap and the sampler starved — the root cause of the #2016
+-- over-count. The watcher now multiplexes a wall-clock heartbeat: a shell loop
+-- echoes this sentinel line into the conntrack popen stream every
+-- tick_interval seconds (see watch()'s popen command), and the read loop treats
+-- a sentinel as an inert tick — it skips flow parsing but STILL drives on_tick,
+-- so the timers fire on a wall-clock cadence regardless of conntrack traffic.
+-- The leading control byte (0x01, SOH) guarantees the sentinel can never
+-- collide with a printable-ASCII conntrack line, so parse_conntrack_line never
+-- mistakes it for a flow.
+M.TICK_SENTINEL = "\001wh_tick"
+
 -- ---------------------------------------------------------------------------
 -- eb_san(host) -> string
 --
@@ -1109,8 +1125,13 @@ function M.watch(cfg)
   -- then flush conntrack and nflog events together.
   if cfg.register_batcher then cfg.register_batcher(batcher) end
 
-  log.info("conntrack: starting watcher lan_prefix=%s lan_prefix_v6=%s max_batch=%d flush_interval=%ds",
-           lan_prefix, lan_prefix_v6, max_batch, flush_int)
+  -- #2024 idle-heartbeat cadence (seconds). The shell wrapper below echoes
+  -- M.TICK_SENTINEL into the popen stream every tick_int seconds so the read
+  -- loop wakes — and drives on_tick — even when conntrack is silent.
+  local tick_int = cfg.tick_interval or 1
+
+  log.info("conntrack: starting watcher lan_prefix=%s lan_prefix_v6=%s max_batch=%d flush_interval=%ds tick_interval=%ds",
+           lan_prefix, lan_prefix_v6, max_batch, flush_int, tick_int)
   -- #1688: NO `-f` family flag. conntrack(8) documents the default as ipv4,
   -- but for `-E` (events) conntrack-tools opens the netlink socket with
   -- NFCT_ALL_CT_GROUPS — a family-agnostic subscription — and the `-f` flag
@@ -1119,7 +1140,30 @@ function M.watch(cfg)
   -- v6 attribution path: the Gate 2 e2e suite (`test_v6_*.py`) verifies it
   -- end-to-end, and `+kmod-nf-conntrack6` in the package DEPENDS ensures the
   -- kernel-side v6 hooks the netlink stream pulls from are present.
-  local handle = io.popen("conntrack -E -e NEW 2>/dev/null", "r")
+  --
+  -- #2024: conntrack is backgrounded and a heartbeat loop echoes the sentinel
+  -- alongside it, so read("*l") returns at least once per tick_int even with
+  -- zero NEW events. Both processes write to the same popen pipe; sentinel and
+  -- conntrack lines are far under PIPE_BUF (4096 B), so writes are atomic and
+  -- never tear. Notes on the wrapper:
+  --   * conntrack's argv stays EXACTLY `conntrack -E -e NEW` (the redirect and
+  --     `&` are shell syntax, not argv), so the #1716 orphan sweeper — which
+  --     matches that exact /proc cmdline at ppid==1 — still reaps a conntrack
+  --     left behind across a procd restart.
+  --   * `kill -0 $ct` guards the heartbeat: when conntrack dies the loop exits,
+  --     the wrapper closes the pipe, read() returns nil, and watch() breaks
+  --     (then procd respawns the agent). Without this guard the live heartbeat
+  --     would hold the pipe open and MASK a conntrack crash — never restarting.
+  --   * `echo ... || break` exits the wrapper when the agent closes the read
+  --     end (SIGPIPE on echo), so the wrapper does not linger.
+  local open_reader = cfg.open_reader or function()
+    local cmd = string.format(
+      "conntrack -E -e NEW 2>/dev/null & ct=$!; "
+        .. "while kill -0 \"$ct\" 2>/dev/null; do echo '%s' || break; sleep %d; done",
+      M.TICK_SENTINEL, tick_int)
+    return io.popen(cmd, "r")
+  end
+  local handle = open_reader()
   if not handle then
     log.err("conntrack: cannot start conntrack -E -e NEW")
     return
@@ -1145,7 +1189,10 @@ function M.watch(cfg)
     local line = handle:read("*l")
     if not line then break end
 
-    local flow = M.parse_conntrack_line(line)
+    -- #2024: a heartbeat sentinel is an inert wake — skip flow parsing but fall
+    -- through to batcher.tick() / event-queue drain / on_tick below so the
+    -- cooperative timers fire on the wall-clock cadence even with no NEW flows.
+    local flow = (line ~= M.TICK_SENTINEL) and M.parse_conntrack_line(line) or nil
     -- Only v6 needs the neighbor set for the LAN-source decision; v4 stays on
     -- the prefix and pays no per-line table cost.
     local lan_ip_set = (flow and flow.src_ip:find(":", 1, true)) and neighbor_table() or nil

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -42,6 +42,25 @@ local host_norm        = require("wifihaven.host_norm")
 -- mistakes it for a flow.
 M.TICK_SENTINEL = "\001wh_tick"
 
+-- sanitize_tick_interval(v) -> int >= 1  (#2024)
+--
+-- The heartbeat cadence reaches BOTH string.format("%d", n) (the popen command
+-- builder) and shell `sleep n`, each of which needs a positive integer. On the
+-- Lua 5.1 target string.format("%d", 2.5) is a HARD ERROR
+-- (`integer expected, got number`) — which, raised inside watch()'s foreground
+-- loop, would crash the agent into a procd respawn storm — and `sleep 0`
+-- busy-loops. Every other cadence knob is only ever used in float-safe `>=`
+-- arithmetic, so this is the one value that must be floored + clamped. A
+-- fractional / zero / negative / non-numeric UCI value collapses to the 1 s
+-- default rather than bricking or spinning the watcher.
+function M.sanitize_tick_interval(v)
+  local n = tonumber(v)
+  if not n then return 1 end
+  n = math.floor(n)
+  if n < 1 then return 1 end
+  return n
+end
+
 -- ---------------------------------------------------------------------------
 -- eb_san(host) -> string
 --
@@ -1127,8 +1146,10 @@ function M.watch(cfg)
 
   -- #2024 idle-heartbeat cadence (seconds). The shell wrapper below echoes
   -- M.TICK_SENTINEL into the popen stream every tick_int seconds so the read
-  -- loop wakes — and drives on_tick — even when conntrack is silent.
-  local tick_int = cfg.tick_interval or 1
+  -- loop wakes — and drives on_tick — even when conntrack is silent. Sanitize
+  -- to a positive integer: tick_int feeds string.format("%d") and shell `sleep`
+  -- (a fractional value is a hard error on Lua 5.1; 0 busy-loops).
+  local tick_int = M.sanitize_tick_interval(cfg.tick_interval)
 
   log.info("conntrack: starting watcher lan_prefix=%s lan_prefix_v6=%s max_batch=%d flush_interval=%ds tick_interval=%ds",
            lan_prefix, lan_prefix_v6, max_batch, flush_int, tick_int)

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -1320,7 +1320,11 @@ conntrack.watch({
       -- — exactly the #2016 over-count condition. Count it as a leading
       -- indicator so a regression surfaces on the fleet dashboard before it
       -- shows up as inflated usedMinutes. Guard the backward-clock case (#336):
-      -- a negative span is a wall-clock jump, not a stall.
+      -- a negative span is a wall-clock jump, not a stall. A large FORWARD jump
+      -- (NTP step) can still trip this as a false positive — accepted: it's a
+      -- best-effort diagnostic counter with no enforcement impact, and a forward
+      -- step also genuinely inflates the reported window, so flagging it is not
+      -- wrong.
       local window_seconds = wall - ts.last_usage_wall_ts
       if window_seconds > 2 * usage_int then
         metrics.inc_counter(mreg, "usage_window_stall_total", {})

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -111,6 +111,18 @@ local eb_refresh_int = tonumber(uci_get("eb_refresh_interval", "1800"))
 -- bounding /tmp usage per shard (tmpfs = RAM on OpenWRT).
 local blocklist_max_bytes = tonumber(uci_get("blocklist_max_list_bytes", "10485760"))
 local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
+-- #2024: idle-heartbeat cadence (seconds). The conntrack watcher's cooperative
+-- timers (usage flush, the activity sampler above, policy poll, nflog drain,
+-- metrics) run inside on_tick, which was driven only by an incoming
+-- `conntrack -E -e NEW` line. On a quiet LAN (one device on a long-lived
+-- websocket/stream) no NEW events arrive, so on_tick stalled for minutes — the
+-- usage window ballooned and the sampler starved (root cause of the #2016
+-- over-count). The watcher now multiplexes a heartbeat sentinel into the popen
+-- stream every conntrack_tick_interval seconds so on_tick fires on a wall-clock
+-- cadence regardless of traffic. Default 1 s: at most one wake/sec on an idle
+-- agent (microseconds of mono-diff early-returns, niced below dnsmasq), which
+-- keeps the activity sampler within ~1 s of its 10 s cadence.
+local tick_int      = tonumber(uci_get("conntrack_tick_interval", "1"))
 local debug_opt     = uci_get("debug",                            "0")
 -- #1848: ws transport config (named `config ws 'ws'` section). DEFAULT OFF.
 -- These only affect behaviour when ws_enabled == "1"; the sidecar (a separate
@@ -1013,6 +1025,9 @@ conntrack.watch({
   lan_prefix_v6   = lan_prefix_v6,
   max_batch       = max_batch,
   flush_interval  = flush_int,
+  -- #2024: idle-heartbeat cadence — drives on_tick on a wall-clock tick even
+  -- when conntrack is silent, so the usage flush + activity sampler never stall.
+  tick_interval   = tick_int,
   -- #1848: events POST goes through the ws outbound tee (default-off → identical
   -- to http_post). The tee routes /api/router/events to the spool only when ws
   -- is enabled+healthy; everything else passes straight through.
@@ -1298,6 +1313,20 @@ conntrack.watch({
       -- periodStart/periodEnd are wall-clock RFC3339: the API expects UTC.
       local period_end   = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
       local period_start = os.date("!%Y-%m-%dT%H:%M:%SZ", ts.last_usage_wall_ts)
+      -- #2024 stall indicator. With the idle heartbeat firing on_tick on a
+      -- wall-clock cadence the usage window stays ≈usage_report_interval; a
+      -- window that runs past 2× the interval means on_tick stalled anyway
+      -- (heartbeat wedged / clock jump) and the bucket spans un-monitored time
+      -- — exactly the #2016 over-count condition. Count it as a leading
+      -- indicator so a regression surfaces on the fleet dashboard before it
+      -- shows up as inflated usedMinutes. Guard the backward-clock case (#336):
+      -- a negative span is a wall-clock jump, not a stall.
+      local window_seconds = wall - ts.last_usage_wall_ts
+      if window_seconds > 2 * usage_int then
+        metrics.inc_counter(mreg, "usage_window_stall_total", {})
+        log.warn("usage timer: window=%ds exceeds 2x usage_report_interval (%ds) — on_tick stalled (#2024)",
+                 window_seconds, usage_int)
+      end
       ts.last_usage_run     = mono
       ts.last_usage_wall_ts = wall
 

--- a/openwrt/test/conntrack_tick_spec.lua
+++ b/openwrt/test/conntrack_tick_spec.lua
@@ -49,6 +49,20 @@ describe("watch() idle heartbeat cadence (#2024)", function()
     return cfg
   end
 
+  it("sanitizes tick_interval to a positive integer (#2024 BLOCKER)", function()
+    -- tick_int feeds string.format("%d") + shell `sleep`; on Lua 5.1 a
+    -- fractional value is a hard error and 0 busy-loops. Anything not a
+    -- positive integer must collapse to the 1 s default.
+    assert.are.equal(3, conntrack.sanitize_tick_interval(3))
+    assert.are.equal(2, conntrack.sanitize_tick_interval(2.5))   -- floored
+    assert.are.equal(5, conntrack.sanitize_tick_interval("5"))    -- numeric string
+    assert.are.equal(1, conntrack.sanitize_tick_interval(0))      -- no sleep 0 spin
+    assert.are.equal(1, conntrack.sanitize_tick_interval(-5))     -- negative
+    assert.are.equal(1, conntrack.sanitize_tick_interval(0.4))    -- floors to 0 -> clamp
+    assert.are.equal(1, conntrack.sanitize_tick_interval(nil))    -- unset
+    assert.are.equal(1, conntrack.sanitize_tick_interval("abc"))  -- non-numeric
+  end)
+
   it("exposes a stable TICK_SENTINEL distinct from any conntrack line", function()
     assert.is_string(conntrack.TICK_SENTINEL)
     -- A real conntrack -E NEW line begins with optional spaces then a protocol

--- a/openwrt/test/conntrack_tick_spec.lua
+++ b/openwrt/test/conntrack_tick_spec.lua
@@ -1,0 +1,103 @@
+-- conntrack_tick_spec.lua — #2024 idle-heartbeat cadence for watch().
+--
+-- Root cause of the #2016 over-count: the agent's cooperative timers (usage
+-- flush + 10 s activity sampler + policy poll + nflog drain + metrics) all run
+-- inside `cfg.on_tick`, which watch() previously called ONLY after a
+-- `conntrack -E -e NEW` line arrived. On a quiet LAN (one device on a
+-- long-lived websocket / stream) no NEW events arrive, so on_tick never fired:
+-- the usage window ballooned to span the whole un-monitored gap and the
+-- activity sampler starved.
+--
+-- The fix multiplexes a wall-clock heartbeat sentinel line into the conntrack
+-- popen stream (a shell heartbeat that echoes `M.TICK_SENTINEL` every
+-- `tick_interval` seconds alongside conntrack's own output). watch() treats a
+-- sentinel line as an inert tick: it skips flow parsing but STILL drives
+-- on_tick, so the cooperative timers fire on a wall-clock cadence regardless
+-- of conntrack traffic.
+--
+-- These specs inject a mock reader (via the `cfg.open_reader` seam) that yields
+-- heartbeat sentinels and zero conntrack flow lines, and assert on_tick fires
+-- once per heartbeat — i.e. the cadence survives total conntrack silence.
+
+local conntrack = require("conntrack")
+
+describe("watch() idle heartbeat cadence (#2024)", function()
+  -- A mock popen handle that returns each element of `lines` from successive
+  -- read("*l") calls, then nil (EOF) to break watch()'s loop.
+  local function mock_reader(lines)
+    local i = 0
+    return {
+      read = function(_, fmt)
+        assert.are.equal("*l", fmt)
+        i = i + 1
+        return lines[i]
+      end,
+      close = function() end,
+    }
+  end
+
+  local function base_cfg(overrides)
+    local cfg = {
+      api_url      = "http://test.invalid",
+      router_id    = "r1",
+      router_token = "tok",
+      -- never actually posts in these specs (no events synthesized), but the
+      -- batcher flush callback needs it present.
+      http_post    = function() return true, 200, "" end,
+    }
+    for k, v in pairs(overrides) do cfg[k] = v end
+    return cfg
+  end
+
+  it("exposes a stable TICK_SENTINEL distinct from any conntrack line", function()
+    assert.is_string(conntrack.TICK_SENTINEL)
+    -- A real conntrack -E NEW line begins with optional spaces then a protocol
+    -- token ("[NEW]"/"tcp"/"udp"); parse_conntrack_line must reject the
+    -- sentinel so it can never be mistaken for a flow.
+    assert.is_nil(conntrack.parse_conntrack_line(conntrack.TICK_SENTINEL))
+  end)
+
+  it("fires on_tick on every heartbeat line with zero conntrack flows", function()
+    local ticks = 0
+    conntrack.watch(base_cfg({
+      open_reader = function()
+        return mock_reader({
+          conntrack.TICK_SENTINEL,
+          conntrack.TICK_SENTINEL,
+          conntrack.TICK_SENTINEL,
+          nil, -- EOF
+        })
+      end,
+      on_tick = function() ticks = ticks + 1 end,
+    }))
+    assert.are.equal(3, ticks)
+  end)
+
+  it("does not synthesize/post any event for a heartbeat sentinel", function()
+    local posted = 0
+    conntrack.watch(base_cfg({
+      http_post   = function() posted = posted + 1; return true, 200, "" end,
+      open_reader = function()
+        return mock_reader({ conntrack.TICK_SENTINEL, conntrack.TICK_SENTINEL, nil })
+      end,
+      on_tick = function() end,
+    }))
+    assert.are.equal(0, posted)
+  end)
+
+  it("still drives on_tick once per real conntrack line (regression)", function()
+    -- The pre-#2024 contract — on_tick per conntrack line — must be preserved
+    -- so busy LANs keep their per-line cadence in addition to the heartbeat.
+    local ticks = 0
+    conntrack.watch(base_cfg({
+      open_reader = function()
+        -- WAN-bound lines would normally be parsed; use lines that parse to nil
+        -- (non-flow) so we exercise the tick path without DHCP/ARP stubs. The
+        -- point is purely that a non-sentinel line still reaches on_tick.
+        return mock_reader({ "garbage-not-a-flow", "garbage-not-a-flow", nil })
+      end,
+      on_tick = function() ticks = ticks + 1 end,
+    }))
+    assert.are.equal(2, ticks)
+  end)
+end)


### PR DESCRIPTION
Fixes #2024. Root-cause fix for the #2016 `usedMinutes` over-count, and **supersedes the closed PR #2022** (which only clamped the symptom agent-side).

## Root cause
The agent's cooperative timers — the **usage flush** and the **10 s activity sampler**, plus the policy poll, nflog drain, and metrics push — all run inside `cfg.on_tick`, which `conntrack.watch()` drove **only when a `conntrack -E -e NEW` line arrived** (`conntrack.lua` read loop). On a quiet LAN — one device on a long-lived connection (a kid alone on a websocket game like gimkit; one device streaming) emits almost no NEW events — `on_tick` stalled for minutes. Two failures compounded in the resulting bucket:

1. **Window balloons.** `period_start = last flush`, `period_end = now`, so the flush emitted one bucket spanning the whole un-monitored gap (prod: `period_seconds = 517s`). The server's #1464 session-stitch (`Presence.spanOf`) credits that entire window as continuous presence → the over-count (Octavius headline **51 min** from ~1 min of real bucket presence).
2. **Sampling starves.** The `activity_sample_int` (10 s) sampler is also gated on `on_tick`, so `active_seconds` under-sampled (prod: `active=20` across the 517 s window).

## Fix
`watch()` multiplexes a **wall-clock heartbeat** into the conntrack popen stream: `conntrack -E -e NEW` is backgrounded and a shell loop echoes `M.TICK_SENTINEL` every `conntrack_tick_interval` seconds (default **1 s**). The read loop treats a sentinel as an inert tick — it skips flow parsing but **still** drives `batcher.tick()`, the events-queue drain, and `on_tick` — so every cooperative timer fires on a wall-clock cadence regardless of conntrack traffic. With reliable sampling the window stays ≈`usage_report_interval` and `active_seconds` is accurate, so the presence math is correct at the source.

Why this shape (no new package dependency):
- The main agent runs on **bare Lua 5.1 + busybox** — its `DEPENDS` has **no** luaposix / cqueues / nixio (cqueues ships only with the ws sidecar; nixio is only present where luci is installed). A poll/select approach would force a new, hard-to-validate package dep. The heartbeat needs only `io.popen` + `sh`, both guaranteed.
- The sentinel is `"\001wh_tick"` — a leading **0x01 (SOH)** byte that can never collide with a printable-ASCII conntrack line, so `parse_conntrack_line` rejects it.
- `kill -0 "$ct"` guards the heartbeat: when conntrack dies the loop exits and the pipe EOFs, so `watch()` breaks and procd respawns — the live heartbeat does **not** mask a conntrack crash.
- conntrack's argv stays **exactly** `conntrack -E -e NEW` (the `&`/redirect are shell syntax), so the #1716 orphan sweeper (matches that exact `/proc` cmdline at `ppid==1`) still reaps a conntrack left behind across a restart.

## Stall-indicator metric (carried from #2022)
`usage_window_stall_total` increments whenever a reported usage window still exceeds **2× `usage_report_interval`** — i.e. `on_tick` stalled anyway (heartbeat wedged / wall-clock jump). A healthy fleet holds it flat at 0; a climbing rate is the leading signal of the over-count regressing. Wired end-to-end: agent counter → server allowlist in `api/src/metrics/Metrics.scala` → new "Usage window stalls per router" panel on `deploy/grafana/dashboards/router-fleet.json`.

## Tests / validation (TDD)
- `openwrt/test/conntrack_tick_spec.lua` — **failing spec committed first** (`TICK_SENTINEL` + `cfg.open_reader` seam absent → red), then green. Injects a mock reader yielding heartbeat sentinels and **zero** flow lines; asserts `on_tick` fires once per heartbeat, no event is synthesized for a sentinel, and the per-conntrack-line cadence is preserved.
- Full agent busted suite green: **967 pass / 0 fail / 2 pending** (pending = `nft` binary absent on host, unchanged from baseline).
- `scalafmt --check` clean on `api/src/metrics/Metrics.scala`.
- **Validated on real Lua 5.1.5 (`openwrt.lan`)** per the no-mock-5.1 rule:
  - both `conntrack.lua` and `wifihaven-agent` parse via `loadfile` (the agent file is one macOS-`luac` falsely rejects);
  - the module loads with its real deps; the sentinel is rejected by `parse_conntrack_line` while a real flow still parses;
  - a **live idle `conntrack -E -e NEW`** heartbeat fired on cadence on hardware (5 ticks in ~4 s with the LAN quiet) — the 0x01 sentinel round-trips through `echo`/`read("*l")` intact.

## New knob
`conntrack_tick_interval` (default `1`, range `1–5`, must stay well below `activity_sample_int`). Added to the example UCI config and documented in `docs/router-tuning.md` (new section + summary-table row).

## Rollout
Relief reaches prod when routers pick up the next agent release via auto-update. Wire-shape unchanged (UCI knob is local agent config, not a snapshot field); the only API-visible addition is the allowlisted metric name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
