### PR TITLE
fix(#2018): raw bucket uses real report period + #2020 guardrail

### DIFF
--- a/.github/scripts/check-usage-period-hardcode.sh
+++ b/.github/scripts/check-usage-period-hardcode.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Guardrail (#2020): the usage-report PERIOD is single-sourced at the agent —
+# `openwrt/files/etc/config/wifihaven` → `usage_report_interval` (default 60s,
+# configurable) — and the real per-report window rides every `traffic_reports`
+# row as `period_start`/`period_end`. The API must NEVER hold its own copy of
+# that period. It once did: #846 hardcoded a 5-minute raw window
+# (`UsageTraffic.floorTo(Raw) % 300`, `stepOf(Raw) = ofMinutes(5)`) five days
+# after the agent moved off 300s (#529), and the API copy silently drifted —
+# the #2018 bug (the dashboard `raw` gauge read ~5x smoothed).
+#
+# This check fails the build if a PR ADDS a hardcoded usage-period literal
+# (`% 300`, `* 300`, `/ 300`, a bare `300`, or `ofMinutes(5)` / `ofSeconds(300)`)
+# to the narrow set of usage/traffic bucket + rollup code paths where such a
+# literal would be re-introducing a fixed period assumption. Derive the window
+# from the row span (`UsageTraffic.windowFor` / `period_start`/`period_end`),
+# never from a constant.
+#
+# Scope: only the files below, and only ADDED *code* lines (full-comment lines
+# are ignored, so it's fine to mention `% 300` / `ofMinutes(5)` in an
+# explanatory comment). Legitimate uses of one of these literals in a scoped
+# file (a genuine display-bucket constant, a page size, a timeout) can opt out
+# by putting the marker `usage-period-ok` on the same line.
+#
+# See docs/process/single-source-of-truth.md ("Usage-report period" worked
+# example) and AGENTS.md #single-source-of-truth.
+set -euo pipefail
+
+BASE="${1:?usage: check-usage-period-hardcode.sh <base-ref>}"
+
+# The bucket / window / rollup derivation paths. A hardcoded period literal in
+# any of these is almost certainly a re-introduced fixed-period assumption.
+SCOPED_FILES=(
+  "api/src/usage/UsageTraffic.scala"
+  "api/src/usage/UsageTrafficQuery.scala"
+  "api/src/usage/AppUsedRollupService.scala"
+  "api/src/usage/TimeUsedRollupJob.scala"
+  "api/src/usage/RollupJobs.scala"
+  "api/src/db/RollupRepo.scala"
+  "api/src/routes/SpaPush.scala"
+  "api/src/routes/UsageRoutes.scala"
+)
+
+# Patterns that smell like a hardcoded usage period.
+#   % 300 / * 300 / / 300  — arithmetic against a 300s grid
+#   ofMinutes(5) / ofSeconds(300) — the dead 5-min agent default
+#   a bare 300 token        — likely a period in seconds
+PERIOD_RE='(%[[:space:]]*300|\*[[:space:]]*300|/[[:space:]]*300|ofMinutes\([[:space:]]*5[[:space:]]*\)|ofSeconds\([[:space:]]*300[[:space:]]*\)|(^|[^0-9])300([^0-9]|$))'
+
+violations=0
+
+for f in "${SCOPED_FILES[@]}"; do
+  # Added lines only (three-dot merge-base diff, no context lines).
+  while IFS= read -r line; do
+    # `git diff --unified=0` prefixes added lines with a single '+'.
+    [[ "${line}" == +++* ]] && continue
+    [[ "${line}" != +* ]] && continue
+    code="${line:1}"
+
+    # Ignore explicit opt-outs.
+    if [[ "${code}" == *usage-period-ok* ]]; then
+      continue
+    fi
+
+    # Ignore full-comment lines (leading // or * or /*). Inline trailing
+    # comments on a real code line are still scanned — the code part counts.
+    trimmed="${code#"${code%%[![:space:]]*}"}"
+    if [[ "${trimmed}" == //* || "${trimmed}" == \** || "${trimmed}" == /\** ]]; then
+      continue
+    fi
+
+    if [[ "${code}" =~ ${PERIOD_RE} ]]; then
+      if [[ ${violations} -eq 0 ]]; then
+        echo "ERROR: new hardcoded usage-period literal in a usage/traffic path (#2020)."
+        echo "The usage-report period is data-derived (period_start/period_end, driven by the"
+        echo "agent's usage_report_interval). Derive the window from the row span"
+        echo "(UsageTraffic.windowFor), never from a constant. If this literal is a legitimate"
+        echo "display-bucket / page-size / timeout, add the marker 'usage-period-ok' on the line."
+        echo
+      fi
+      echo "  ${f}: +${code}"
+      violations=$((violations + 1))
+    fi
+  done < <(git diff --unified=0 "${BASE}...HEAD" -- "${f}")
+done
+
+if [[ ${violations} -gt 0 ]]; then
+  echo
+  echo "Found ${violations} hardcoded usage-period literal(s). See the message above."
+  exit 1
+fi
+
+echo "No new hardcoded usage-period literals in the scoped usage/traffic paths."

--- a/.github/scripts/check-usage-period-hardcode.test.sh
+++ b/.github/scripts/check-usage-period-hardcode.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Tests for check-usage-period-hardcode.sh (#2020).
+#
+# Rule under test: a PR may not ADD a hardcoded usage-period literal
+# (% 300 / * 300 / / 300 / bare 300 / ofMinutes(5) / ofSeconds(300)) to the
+# scoped usage/traffic bucket + rollup paths. Full-comment lines and lines
+# carrying the `usage-period-ok` marker are exempt; the same literal in an
+# UNSCOPED file is ignored.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/check-usage-period-hardcode.sh"
+[[ -x "${SCRIPT}" ]] || chmod +x "${SCRIPT}"
+
+tmp=""
+cleanup() { [[ -n "${tmp}" ]] && rm -rf "${tmp}"; return 0; }
+trap cleanup EXIT
+
+setup() {
+  tmp="$(mktemp -d)"
+  cd "${tmp}"
+  git init -q
+  git config user.email t@t.io
+  git config user.name tester
+  git config commit.gpgsign false
+  mkdir -p api/src/usage api/src/routes api/src/db
+  # Baseline: scoped files exist with innocuous content so the diff only sees
+  # what each case adds.
+  echo "object UsageTraffic { def f = 1 }"          > api/src/usage/UsageTraffic.scala
+  echo "object SpaPush { def f = 1 }"               > api/src/routes/SpaPush.scala
+  echo "object RollupRepo { def f = 1 }"            > api/src/db/RollupRepo.scala
+  echo "object Other { def f = 1 }"                 > api/src/routes/Other.scala
+  git add . && git commit -q -m base
+  BASE="$(git rev-parse HEAD)"
+  git checkout -q -b feature
+}
+
+run_case() {
+  local name="$1"; shift
+  local want="$1"; shift
+  setup
+  "$@"
+  set +e
+  "${SCRIPT}" "${BASE}" >/tmp/uph.out 2>/tmp/uph.err
+  local rc=$?
+  set -e
+  rm -rf "${tmp}"; tmp=""
+  if [[ "${want}" == "pass" && ${rc} -eq 0 ]]; then
+    echo "PASS: ${name}"
+  elif [[ "${want}" == "fail" && ${rc} -ne 0 ]]; then
+    echo "PASS: ${name} (rejected as expected)"
+  else
+    echo "FAIL: ${name} (rc=${rc}, wanted ${want})" >&2
+    echo "--- stdout ---" >&2; cat /tmp/uph.out >&2
+    echo "--- stderr ---" >&2; cat /tmp/uph.err >&2
+    exit 1
+  fi
+}
+
+# ── PASS cases ─────────────────────────────────────────────────────────
+
+case_no_period_literal() {
+  echo "  def stepOf = Duration.ofMinutes(1)" >> api/src/usage/UsageTraffic.scala
+  git add . && git commit -q -m ok
+}
+
+case_period_in_full_comment() {
+  # An explanatory comment mentioning the dead literal is fine.
+  echo "  // the old code did instant % 300 / ofMinutes(5) — removed in #2018" \
+    >> api/src/usage/UsageTraffic.scala
+  git add . && git commit -q -m okcomment
+}
+
+case_opt_out_marker() {
+  echo "  val pageSize = 300 // usage-period-ok: raw row page cap, not a period" \
+    >> api/src/routes/SpaPush.scala
+  git add . && git commit -q -m optout
+}
+
+case_literal_in_unscoped_file() {
+  # 300 in a file outside the scoped set is none of this guard's business.
+  echo "  val x = instant % 300" >> api/src/routes/Other.scala
+  git add . && git commit -q -m unscoped
+}
+
+# ── FAIL cases ─────────────────────────────────────────────────────────
+
+case_mod_300() {
+  echo "  val w = instant.getEpochSecond % 300" >> api/src/usage/UsageTraffic.scala
+  git add . && git commit -q -m bad_mod
+}
+
+case_of_minutes_5() {
+  echo "  def stepOf = Duration.ofMinutes(5)" >> api/src/usage/UsageTraffic.scala
+  git add . && git commit -q -m bad_ofmin
+}
+
+case_of_seconds_300() {
+  echo "  val step = Duration.ofSeconds(300)" >> api/src/db/RollupRepo.scala
+  git add . && git commit -q -m bad_ofsec
+}
+
+case_bare_300() {
+  echo "  val periodSecs = 300" >> api/src/routes/SpaPush.scala
+  git add . && git commit -q -m bad_bare
+}
+
+case_mult_300() {
+  echo "  val ms = buckets * 300" >> api/src/usage/UsageTraffic.scala
+  git add . && git commit -q -m bad_mult
+}
+
+run_case "no period literal added"                 pass case_no_period_literal
+run_case "literal only in a full comment"          pass case_period_in_full_comment
+run_case "opt-out marker on the line"              pass case_opt_out_marker
+run_case "literal in an unscoped file"             pass case_literal_in_unscoped_file
+run_case "% 300 in scoped code (REJECTED)"         fail case_mod_300
+run_case "ofMinutes(5) in scoped code (REJECTED)"  fail case_of_minutes_5
+run_case "ofSeconds(300) in scoped code (REJECTED)" fail case_of_seconds_300
+run_case "bare 300 in scoped code (REJECTED)"      fail case_bare_300
+run_case "* 300 in scoped code (REJECTED)"         fail case_mult_300
+
+echo "All usage-period-hardcode tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,44 @@ jobs:
         if: steps.label.outputs.skip != 'true'
         run: bash .github/scripts/check-migration-isolation.sh "${{ steps.base.outputs.sha }}"
 
+  # ── Usage period: forbid hardcoding the data-derived report period ───────
+  # The usage-report period is single-sourced at the agent (usage_report_interval)
+  # and rides each traffic_reports row as period_start/period_end. The API must
+  # never hold its own copy — #846 did (a hardcoded 5-min raw window) and it
+  # silently drifted off the real 60s cadence (#2018). This guard fails a PR that
+  # ADDS a hardcoded usage-period literal to the scoped usage/traffic + rollup
+  # paths. See docs/process/single-source-of-truth.md and #2020.
+  usage-period-hardcode:
+    name: Usage Period Hardcode Check
+    needs: changes
+    # Path-gated on Scala changes; the script narrows to specific usage/traffic
+    # files. PR + merge_group only (push is redundant post-merge).
+    if: |
+      needs.changes.outputs.scala == 'true'
+      && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Check out the REAL PR head (not the synthetic merge ref) so the
+      # three-dot `BASE...HEAD` diff resolves the true merge-base — same
+      # rationale as the migration jobs above.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Resolve base SHA
+        id: base
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request) echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT" ;;
+            merge_group)  echo "sha=${{ github.event.merge_group.base_sha }}"  >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Reject new hardcoded usage-period literals
+        run: bash .github/scripts/check-usage-period-hardcode.sh "${{ steps.base.outputs.sha }}"
+
   # ── Shell test discovery ─────────────────────────────────────────────────
   # Auto-discovers and runs every *.test.sh in the repo. Add a new test by
   # dropping a *.test.sh file alongside the script/hook it covers — no CI
@@ -765,6 +803,7 @@ jobs:
       - scala
       - migrations-immutable
       - migration-isolation
+      - usage-period-hardcode
       - shell-tests
       - lua-tests
       - contract-tests

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -59,8 +59,10 @@ case class TrafficRollupFilter(
 )
 
 /**
- * One row per 5-min traffic_reports period (with ipv4/ipv6 hosts resolved to their attributed FQDN
- * when possible). Used by [[DashboardNowRoutes]] to compute per-device top hosts.
+ * One row per traffic_reports usage-report period (the agent's `usage_report_interval`, ~60s and
+ * configurable — NOT a fixed 5-min bucket; the real span is `period_start`/`period_end`), with
+ * ipv4/ipv6 hosts resolved to their attributed FQDN when possible. Used by [[DashboardNowRoutes]]
+ * to compute per-device top hosts.
  */
 case class TrafficRollupRow(
     routerId: RouterId,
@@ -519,9 +521,10 @@ trait TrafficReportRepo {
   def listForRouter(routerId: RouterId, limit: Int): Task[List[TrafficReport]]
 
   /**
-   * Per-5-min traffic_reports rows for aggregation: returned ordered by (router_id, mac, hostname,
-   * date, period_start). Filters are AND-composed. `macs = Some(Nil)` returns an empty list (no
-   * devices match).
+   * Per-usage-report-period traffic_reports rows for aggregation (one row per agent report period,
+   * `usage_report_interval` — ~60s, configurable; not a fixed 5-min bucket): returned ordered by
+   * (router_id, mac, hostname, date, period_start). Filters are AND-composed. `macs = Some(Nil)`
+   * returns an empty list (no devices match).
    */
   def listTrafficRollupRows(f: TrafficRollupFilter): Task[List[TrafficRollupRow]]
 
@@ -597,8 +600,8 @@ trait TrafficReportRepo {
   /**
    * #766: per-host aggregates for one device over `[from, to)`, restricted to FQDN-typed rows
    * (after the IP→FQDN LATERAL resolve). One row per resolved hostname, with total `bytes_in +
-   * bytes_out` and the hit count (number of 5-min buckets the host was observed in). Used by the
-   * apps create/edit recently-visited-hosts picker; PSL apex collapse happens in Scala.
+   * bytes_out` and the hit count (number of usage-report periods the host was observed in). Used by
+   * the apps create/edit recently-visited-hosts picker; PSL apex collapse happens in Scala.
    */
   def listFqdnHostAggregatesForDevice(
       mac: MacAddress,

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -16,7 +16,8 @@ import java.time.{Instant, LocalDate, ZoneOffset}
 //
 // Pre-aggregated counterparts of traffic_reports, written by the scheduled
 // fibers in RollupJobs. Read by /api/usage/traffic when the requested window
-// is wider than what raw 5-min rows can serve in <200 ms (#813).
+// is wider than what raw per-report-period rows (the agent's
+// `usage_report_interval`, ~60s) can serve in <200 ms (#813).
 //
 // Hostnames in both tables are post-resolved — bare ipv4/ipv6 host_value rows
 // were promoted to their resolved fqdn at rollup-write time via the same
@@ -65,7 +66,7 @@ case class RollupRun(
 // `/api/usage/traffic`, which doesn't filter heartbeats — so the rollup sums
 // match what the endpoint would have computed from raw rows. If a future
 // change wants heartbeat filtering on `/api/usage/traffic`, the rollups
-// can't apply it post-hoc — the per-5-min `active_seconds/period_seconds`
+// can't apply it post-hoc — the per-report-period `active_seconds/period_seconds`
 // ratio is summed away. That work would need a parallel `heartbeat_seconds`
 // column in the rollups, written at reroll time with the current household
 // filter settings.

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -187,9 +187,12 @@ object DashboardNowRoutes {
   }
 
   /**
-   * Per-device "what is this device watching right now". Reads rows from the latest populated 5-min
-   * bucket and returns its top host. If earlier consecutive buckets share the same top host,
-   * reports a `minutes` run (capped at 60); otherwise `minutes = None`. See #852.
+   * Per-device "what is this device watching right now". Reads rows from the latest populated
+   * usage-report-period bucket (the agent's `usage_report_interval`, ~60s — not a fixed 5-min
+   * window; the streak math below derives its seconds from each row's `period_start`/`period_end`,
+   * so it is granularity-agnostic) and returns its top host. If earlier consecutive buckets share
+   * the same top host, reports a `minutes` run (capped at 60); otherwise `minutes = None`. See
+   * #852.
    */
   def nowActivityFromRows(
       rows: List[TrafficRollupRow],
@@ -209,8 +212,8 @@ object DashboardNowRoutes {
           math.max(0L, e - s)
         }.sum
         val minutes    = math.min(NowActivityMaxMinutes, math.max(1, (streakSecs / 60L).toInt))
-        // Only attach a duration once we have a multi-bucket signal — a single 5-min bucket isn't
-        // strong enough to claim "watching for N minutes".
+        // Only attach a duration once we have a multi-bucket signal — a single usage-report-period
+        // bucket isn't strong enough to claim "watching for N minutes".
         val mins       = if (streakRest.nonEmpty) Some(minutes) else None
         DashboardNowActivity(topHost = top, minutes = mins)
       }

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -97,8 +97,9 @@ object DebugRoutes {
                 .snapshotAll(today)
                 .mapError(ApiError.Db(_))
               // Per-host minutes from `time_usage` over-count wall-clock time when a
-              // single 5-min agent bucket touches multiple hosts (each host row holds
-              // ~60s for that bucket, summing them inflates "online minutes"). Surface
+              // single usage-report-period bucket (the agent's `usage_report_interval`,
+              // ~60s) touches multiple hosts (each host row holds that period's active
+              // seconds, summing them inflates "online minutes"). Surface
               // the bucket-deduplicated per-mac total alongside each row so callers
               // measuring device-online time can read a single value instead of summing.
               // (#474)
@@ -109,7 +110,8 @@ object DebugRoutes {
               // Surface raw active-seconds (sum of max-per-bucket activeSeconds) as well as
               // the floor-divided minute count. The e2e D2 minute-granularity test (#516)
               // ceil-divides this to get tight bounds; bucket-counting via floor(/60) drifts
-              // when activity straddles 5-min agent buckets.
+              // when activity straddles usage-report-period buckets (the agent's
+              // `usage_report_interval`, ~60s).
               totalSecs = wifihaven.api.presence.Presence
                 .totalSecondsByMac(presence, exemptPatterns = Nil)
             } yield Response.json(

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -94,7 +94,7 @@ final class RouterIngestService(
         // the `timeStatus`/`appUsage` push (design §5.2). All one-liners that never block or fail
         // ingest (sliding hub, UIO).
         _        <- ZIO.when(records.nonEmpty)(
-          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested(ps)) *>
+          bus.publish(SpaEvent.NowChanged) *> bus.publish(SpaEvent.UsageIngested(ps, pe)) *>
             bus.publish(SpaEvent.TimeStatusChanged),
         )
       } yield ()

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1405,11 +1405,12 @@ object TimeRoutes {
   /**
    * Roll the range's presence rows up to hourly UTC buckets aligned at `offsetMin` minutes past the
    * hour (#794). Caller passes the offset that makes each bucket fall fully within one local day (0
-   * for whole-hour zones, 30 for half-hour zones, 15/45 for the quarter-hour zones). Each 5-min
-   * `period_start` falls in exactly one hour slot of the chosen grid; per-slot minutes go through
-   * `Presence.totalMinutesByMac` for per-mac bucket-dedup + heartbeat filter, then sum across macs.
-   * Empty slots are omitted (the SPA fills gaps with zero when grouping by local day). Returned
-   * list is sorted by `bucketStart` ascending.
+   * for whole-hour zones, 30 for half-hour zones, 15/45 for the quarter-hour zones). Each
+   * usage-report-period `period_start` (the agent's `usage_report_interval`, ~60s) falls in exactly
+   * one hour slot of the chosen grid; per-slot minutes go through `Presence.totalMinutesByMac` for
+   * per-mac bucket-dedup + heartbeat filter, then sum across macs. Empty slots are omitted (the SPA
+   * fills gaps with zero when grouping by local day). Returned list is sorted by `bucketStart`
+   * ascending.
    */
   private def bucketHourlyAligned(
       presence: List[wifihaven.api.presence.PresenceRow],

--- a/api/src/routes/SpaEvents.scala
+++ b/api/src/routes/SpaEvents.scala
@@ -33,9 +33,11 @@ import java.time.Instant
  *     as a `TrafficUsageResponse` live edge (design §5.3). #2004: the head MUST be anchored on the
  *     ingested `periodStart`, NOT wall-clock `now` — a ~60s report covers the *prior* minute, so
  *     its `period_start` floors to the previous bucket; scoping to `floor(now)` left the head
- *     perpetually empty and the dashboard LIVE BANDWIDTH panel stuck at 0 B/s. Latest-wins (§6.3):
- *     a burst coalesces to the freshest `periodStart`, and a param-set with no subscriber is never
- *     queried.
+ *     perpetually empty and the dashboard LIVE BANDWIDTH panel stuck at 0 B/s. #2018: the event
+ *     carries the WHOLE period `[periodStart, periodEnd)` because for the `raw` bucket the head
+ *     window IS that real report period (the agent's `usage_report_interval`), not a synthetic
+ *     fixed window — the head scoping uses `UsageTraffic.windowFor`. Latest-wins (§6.3): a burst
+ *     coalesces to the freshest `periodStart`, and a param-set with no subscriber is never queried.
  *   - [[SpaEvent.TimeStatusChanged]] — #1974 (S6a): a profile's used/remaining minutes moved. The
  *     consumer rebuilds the `/api/time/status` `ProfileTimeStatus[]` body (via
  *     `TimeStatusService.dayStateAllLive`, role-filtered like the GET) and pushes it to
@@ -50,7 +52,7 @@ enum SpaEvent {
   case NowChanged
   case ConnectionEventsIngested(since: Instant)
   case Stale(topic: StaleTopic, scope: Option[String] = None)
-  case UsageIngested(periodStart: Instant)
+  case UsageIngested(periodStart: Instant, periodEnd: Instant)
   case TimeStatusChanged
 }
 

--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -153,17 +153,19 @@ object SpaPush {
    * `distinct` preserves first-occurrence order. Exposed for unit coverage of the collapse logic.
    */
   private[api] def coalesce(events: Chunk[SpaEvent]): Chunk[SpaEvent] = {
-    val latestUsage: Option[Instant] =
+    // #2018: keep the WHOLE freshest-period event (start + end) — for `raw` the head window IS the
+    // real `[periodStart, periodEnd)`, so the end must survive coalescing, not just the start.
+    val latestUsage: Option[SpaEvent.UsageIngested] =
       events
-        .collect { case SpaEvent.UsageIngested(p) => p }
-        .foldLeft(Option.empty[Instant])((acc, p) =>
-          Some(acc.fold(p)(a => if (p.isAfter(a)) p else a)),
+        .collect { case u: SpaEvent.UsageIngested => u }
+        .foldLeft(Option.empty[SpaEvent.UsageIngested])((acc, u) =>
+          Some(acc.fold(u)(a => if (u.periodStart.isAfter(a.periodStart)) u else a)),
         )
-    val withoutUsage                 = events.filter {
-      case SpaEvent.UsageIngested(_) => false
+    val withoutUsage                                = events.filter {
+      case _: SpaEvent.UsageIngested => false
       case _                         => true
     }.distinct
-    latestUsage.fold(withoutUsage)(p => withoutUsage :+ SpaEvent.UsageIngested(p))
+    latestUsage.fold(withoutUsage)(u => withoutUsage :+ u)
   }
 
   private def handle(
@@ -180,17 +182,17 @@ object SpaPush {
       timeUsage: Option[TimeUsageDeps],
   ): UIO[Unit] =
     event match {
-      case SpaEvent.NowChanged                      =>
+      case SpaEvent.NowChanged                            =>
         pushNow(registry, trafficRepo, connRepo, deviceRepo, profileRepo, appTimeLimitRepo, clock)
           .catchAllCause(c => ZIO.logErrorCause("spa ws push: now recompute failed", c))
-      case SpaEvent.ConnectionEventsIngested(since) =>
+      case SpaEvent.ConnectionEventsIngested(since)       =>
         pushConnectionEvents(registry, connRepo, clock, since)
           .catchAllCause(c => ZIO.logErrorCause("spa ws push: connectionEvents fan-out failed", c))
-      case SpaEvent.Stale(topic, scope)             =>
+      case SpaEvent.Stale(topic, scope)                   =>
         LogContext.annotate(LogContext.Op, "stale") {
           registry.fanOutStale(topic, scope)
         }
-      case SpaEvent.UsageIngested(periodStart)      =>
+      case SpaEvent.UsageIngested(periodStart, periodEnd) =>
         LogContext.annotate(LogContext.Op, "trafficUsage") {
           pushTrafficUsage(
             registry,
@@ -200,10 +202,11 @@ object SpaPush {
             profileRepo,
             appRepo,
             periodStart,
+            periodEnd,
           )
             .catchAllCause(c => ZIO.logErrorCause("spa ws push: trafficUsage recompute failed", c))
         }
-      case SpaEvent.TimeStatusChanged               =>
+      case SpaEvent.TimeStatusChanged                     =>
         // #1974 (S6a): the same change drives BOTH live time-usage topics (design §5.2). Each is
         // independently subscriber-gated (no subscriber → no query) and wrapped so a transient repo
         // error on one never blocks the other or crashes the consumer.
@@ -312,7 +315,8 @@ object SpaPush {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       appRepo: AppRepo,
-      anchor: Instant,
+      periodStart: Instant,
+      periodEnd: Instant,
   ): Task[Unit] =
     registry.trafficUsageParamSets.flatMap { paramSets =>
       ZIO
@@ -339,7 +343,8 @@ object SpaPush {
                 devByMac,
                 profNames,
                 appsByHost,
-                anchor,
+                periodStart,
+                periodEnd,
               ),
             )
           } yield ()
@@ -362,20 +367,27 @@ object SpaPush {
       devByMac: Map[MacAddress, Device],
       profNames: Map[ProfileId, String],
       appsByHost: Map[String, List[AppMembership]],
-      anchor: Instant,
+      periodStart: Instant,
+      periodEnd: Instant,
   ): Task[Unit] =
     decodeParams(params) match {
       case None         =>
         ZIO.logDebug(s"spa ws push: skipping unrenderable trafficUsage params ${params.toJson}")
       case Some(parsed) =>
-        // #2004: anchor the head bucket on the ingested `periodStart`, then scope to exactly that ONE
-        // bucket `[headStart, headEnd)` where `headEnd = headStart + bucketWidth`. Rows are bucketed
-        // by `period_start`, so this captures precisely the bucket the fresh rows landed in (one
-        // `windowStart`) — the client's single-bucket head-merge (`wsCache.mergeHeadBucket`) requires
-        // a single window. Anchoring on wall-clock `now` instead left this window empty in steady
-        // state (a ~60s report's period sits one bucket back), the prod defect this fixes.
-        val headStart    = UsageTraffic.floorTo(anchor, parsed.bucket, parsed.zone)
-        val headEnd      = headStart.plus(UsageTraffic.stepOf(parsed.bucket))
+        // #2004: anchor the head window on the ingested period, then scope the query to exactly that
+        // ONE bucket `[headStart, headEnd)`. Rows are bucketed by `period_start`, so this captures
+        // precisely the bucket the fresh rows landed in (one `windowStart`) — the client's
+        // single-bucket head-merge (`wsCache.mergeHeadBucket`) requires a single window. Anchoring on
+        // wall-clock `now` instead left this window empty in steady state (a ~60s report's period
+        // sits one bucket back), the prod defect #2004 fixed.
+        //
+        // #2018: the window comes from the shared `UsageTraffic.windowFor` SSOT — for a fixed display
+        // bucket it floors `periodStart` and adds the bucket width; for `raw` it is the REAL report
+        // period `[periodStart, periodEnd)` (the agent's `usage_report_interval`), NOT a synthetic
+        // 5-min window. The client derives B/s from this `[windowStart, windowEnd)` span, so raw must
+        // carry the true interval.
+        val (headStart, headEnd) =
+          UsageTraffic.windowFor(periodStart, periodEnd, parsed.bucket, parsed.zone)
         val resolvedMacs = UsageTrafficQuery.resolveMacs(parsed.macs, parsed.profileIds, devices)
         val filterEmpty  = parsed.filterRequested && resolvedMacs.isEmpty
         val aggregate    =

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -1009,7 +1009,7 @@ object UsageRoutes {
       // #862/#809: the prior 31-day window cap is gone. The aggregated path
       // routes coarse buckets to traffic_hourly / traffic_daily (see
       // `tierForBucket` below) so a 90-day, 1d query reads ~50 daily rows per
-      // host instead of millions of 5-min rows. A fine bucket reads raw at any
+      // host instead of millions of per-report-period rows. A fine bucket reads raw at any
       // range, with keyset paging keeping its wide-window cost bounded by the
       // page cap.
       // #865: mac and profileId are comma-separated multi-value lists. A

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -30,8 +30,10 @@ import java.time.{Instant, LocalDate}
  *     ([[wifihaven.api.policy.TimeStatusService.appDayStates]] /
  *     `Presence.patternGroupMinutesForProfile`) — same primitive, same floor-of-sum.
  *   - '''rolled+tail ⇄ live''' (EXACT): rolled + tail equals the all-live computation in seconds,
- *     because presence buckets are 5-min granular and disjoint on either side of the watermark
- *     (same argument as `time_used_daily`; watermarks land in idle gaps so no session straddles).
+ *     because presence buckets are per-report-period granular (the agent's `usage_report_interval`,
+ *     ~60s) and disjoint on either side of the watermark — the exactness argument holds at any
+ *     granularity (same argument as `time_used_daily`; watermarks land in idle gaps so no session
+ *     straddles).
  *   - '''per-app sum ⇄ profile total''' (RESTRICTED equality): `Σ_app engagedSeconds(app)` equals
  *     the profile daily total ([[TimeStatusService.usedSecondsForProfile]]) ONLY when every counted
  *     second belongs to a single, non-exempt-from-daily app and the apps do not overlap in

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -48,8 +48,10 @@ object TimeUsedRollupJob {
    * Refresh cadence. The read path's tail aggregation (`TimeStatusServiceLive`, buckets with
    * `period_start >= rolled_through`) makes the screen-time figure exact regardless of cadence, so
    * this interval only bounds the tail's size — it is not a freshness knob. #1230 widened it from
-   * 3m to 15m to cut DB churn on the 256 MB prod instance (#1228): at 5-min bucket granularity the
-   * tail tops out at ~3 rows per profile, a negligible per-read cost for ~5× fewer recompute ticks.
+   * 3m to 15m to cut DB churn on the 256 MB prod instance (#1228): the tail is roughly `Interval /
+   * report-cadence` rows per profile (the cadence is the agent's `usage_report_interval`, ~60s and
+   * configurable — so ~15 rows at 60s; it was ~3 back when the cadence was 5-min), a negligible
+   * per-read cost for ~5× fewer recompute ticks.
    */
   val Interval: Duration = Duration.ofMinutes(15)
 
@@ -152,8 +154,9 @@ object TimeUsedRollupJob {
   // The cached row covers presence buckets with `period_start < rolled_through`. Setting
   // `rolled_through = now` makes the read path's tail-load filter (`period_start >= rolled_through`)
   // pick up any bucket that lands after this tick — including buckets that finish during the tick
-  // itself but arrive at the DB after the snapshot read. The double-counting risk is bounded by
-  // bucket granularity (5 min); the next tick re-rolls with a fresh `now` and supersedes the row.
+  // itself but arrive at the DB after the snapshot read. The double-counting risk is bounded by the
+  // report-period granularity (the agent's `usage_report_interval`, ~60s); the next tick re-rolls
+  // with a fresh `now` and supersedes the row.
   private def doTick(
       rollup: TimeUsedRollupRepo,
       appRollup: AppUsedRollupRepo,

--- a/api/src/usage/UsageTraffic.scala
+++ b/api/src/usage/UsageTraffic.scala
@@ -51,16 +51,18 @@ case class RawTrafficCursorKey(ts: Instant, mac: String, host: String)
 
 /**
  * #846 — Traffic Usage page. Two views over `traffic_reports`:
- *   - Raw: one row per (period_start, mac, host) — the underlying 5-minute bucket as-stored.
- *   - Aggregated: rolled up into wider windows (10m / 1h / 12h / 1d / 1w) grouped by `domain` (the
- *     bucket's host as-is). Per-apex / per-app grouping is reserved for when PSL/apps tracks land —
- *     endpoint rejects them up-front with a typed message.
+ *   - Raw: one row per (period_start, mac, host) — one agent usage-report period as-stored. The
+ *     period span is whatever the agent's `usage_report_interval` is (~60s today; configurable, and
+ *     heading sub-minute via #1023). It is NOT a fixed 5-min bucket — the real `[periodStart,
+ *     periodEnd)` rides every row and is the single source of truth for the window (#2018/#2020).
+ *   - Aggregated: rolled up into wider *display* windows (10m / 1h / 12h / 1d / 1w) grouped by
+ *     `domain` (the bucket's host as-is). Per-apex / per-app grouping is reserved for when PSL/apps
+ *     tracks land — endpoint rejects them up-front with a typed message.
  *
- * Bucket selection comes from the SPA. `raw` is the storage-native 5m bucket. `1m` is reserved for
- * a future router-side cadence bump (#846 mentions); endpoint rejects with a typed message.
- * Rollup-table-backed paths (#809) are not yet wired — every bucket reads on-the-fly from
- * `traffic_reports`. The on-the-fly path has a window cap so wide ranges return 503 rather than
- * melting the DB.
+ * Bucket selection comes from the SPA. `raw` is the storage-native per-report-period view (the
+ * finest, most real-time). `1m` and coarser are synthetic *display* buckets. Rollup-table-backed
+ * paths (#809) are not yet wired — every bucket reads on-the-fly from `traffic_reports`. The
+ * on-the-fly path has a window cap so wide ranges return 503 rather than melting the DB.
  */
 object UsageTraffic {
 
@@ -121,13 +123,19 @@ object UsageTraffic {
   val maxOnTheFlyDuration: Duration = Duration.ofDays(31)
 
   /**
-   * Align an instant to the start of its bucket in the given zone. Sub-day buckets use UTC
-   * alignment (the source rows are at UTC 5-min boundaries already so this is a no-op for those);
-   * day / week use the household-local zone so calendar boundaries match human intuition.
+   * Align an instant to the start of its *display* bucket in the given zone. Sub-day buckets use
+   * UTC alignment; day / week use the household-local zone so calendar boundaries match human
+   * intuition.
+   *
+   * `Raw` is NOT floored to any synthetic grid (#2018): the row's real `periodStart` — the agent's
+   * actual usage-report period (`usage_report_interval`, data-derived) — IS the window start.
+   * Flooring raw onto a fixed 5-min grid (the old `% 300`) re-snapped it to a dead constant
+   * divorced from the configurable report cadence, which is the bug #2018 fixed. Use [[windowFor]]
+   * to get the full `[start, end)` window for a row — it is the single source of truth shared by
+   * the GET aggregate path and the ws live-edge push.
    */
   def floorTo(instant: Instant, bucket: Bucket, zone: ZoneId): Instant = bucket match {
-    case Bucket.Raw        =>
-      instant.truncatedTo(ChronoUnit.MINUTES).minusSeconds(instant.getEpochSecond % 300)
+    case Bucket.Raw        => instant
     case Bucket.OneMin     => instant.truncatedTo(ChronoUnit.MINUTES)
     case Bucket.TenMin     =>
       val sec = instant.getEpochSecond
@@ -145,15 +153,48 @@ object UsageTraffic {
         .toInstant
   }
 
-  def stepOf(bucket: Bucket): Duration = bucket match {
-    case Bucket.Raw        => Duration.ofMinutes(5)
-    case Bucket.OneMin     => Duration.ofMinutes(1)
-    case Bucket.TenMin     => Duration.ofMinutes(10)
-    case Bucket.OneHour    => Duration.ofHours(1)
-    case Bucket.TwelveHour => Duration.ofHours(12)
-    case Bucket.OneDay     => Duration.ofDays(1)
-    case Bucket.OneWeek    => Duration.ofDays(7)
+  /**
+   * The fixed width of a *display* bucket. `Raw` has NO fixed width — its window is the row's real
+   * `[periodStart, periodEnd)` report period (data-derived from the agent's
+   * `usage_report_interval`, #2018/#2020), so it returns `None` and callers MUST derive raw's
+   * `windowEnd` from the row span, never from a constant. (The old `Bucket.Raw =>
+   * Duration.ofMinutes(5)` baked the dead 300s agent default into the API and is exactly what #2018
+   * fixed.)
+   */
+  def stepOf(bucket: Bucket): Option[Duration] = bucket match {
+    case Bucket.Raw        => None
+    case Bucket.OneMin     => Some(Duration.ofMinutes(1))
+    case Bucket.TenMin     => Some(Duration.ofMinutes(10))
+    case Bucket.OneHour    => Some(Duration.ofHours(1))
+    case Bucket.TwelveHour => Some(Duration.ofHours(12))
+    case Bucket.OneDay     => Some(Duration.ofDays(1))
+    case Bucket.OneWeek    => Some(Duration.ofDays(7))
   }
+
+  /**
+   * The `[windowStart, windowEnd)` a usage row falls in for `bucket` — the single source of truth
+   * shared by the `GET /api/usage/traffic` aggregate path ([[buildAggregate]]) and the ws live-edge
+   * push (`SpaPush.pushOneParamSet`), so the two can never disagree (#2018/#2020).
+   *
+   *   - `raw` → the row's REAL report period `[periodStart, periodEnd)` (the agent's
+   *     `usage_report_interval`); the client divides bytes by this span to get the instantaneous
+   *     rate, so the window must be the true interval, not a synthetic 5-min cell.
+   *   - any fixed display bucket → the floored grid cell `[floor(periodStart), floor + step)`.
+   */
+  def windowFor(
+      periodStart: Instant,
+      periodEnd: Instant,
+      bucket: Bucket,
+      zone: ZoneId,
+  ): (Instant, Instant) =
+    stepOf(bucket) match {
+      case Some(step) =>
+        val start = floorTo(periodStart, bucket, zone)
+        (start, start.plus(step))
+      case None       =>
+        // raw: the real report period rides the row; never a constant window.
+        (periodStart, periodEnd)
+    }
 
   /**
    * Build raw rows for the page. Each `TrafficReport` becomes one `TrafficUsageRawRow`, decorated
@@ -216,7 +257,6 @@ object UsageTraffic {
       // (synthesized in `membershipsFor`), not a shared `__other__` bucket.
       appsByHost: Map[String, List[AppMembership]] = Map.empty,
   ): List[TrafficUsageAggregateRow] = {
-    val step = stepOf(bucket)
 
     def deviceLabel(mac: MacAddress): String              =
       deviceByMac.get(mac).map(_.name).getOrElse(mac.value)
@@ -263,6 +303,12 @@ object UsageTraffic {
     grouped.toList
       .map { case ((windowStart, groupsMap), bucketPairs) =>
         val bucketRows    = bucketPairs.map(_._1)
+        // #2018: windowEnd via the shared `windowFor` SSOT — a fixed display step for 1m/10m/…, or
+        // the row's REAL report period end for raw. All rows in a raw group share one period (the
+        // group key is `periodStart`); take the max defensively.
+        val maxPeriodEnd  =
+          bucketRows.iterator.map(_.periodEnd).reduceLeft((a, b) => if (b.isAfter(a)) b else a)
+        val windowEnd     = windowFor(windowStart, maxPeriodEnd, bucket, zone)._2
         val devices       = bucketRows.iterator.map(r => deviceLabel(r.mac)).toSet
         val profiles      = bucketRows.iterator.map(r => profileLabel(r.mac)).toSet
         val domains       = bucketRows.iterator.map(_.host.value).toSet
@@ -298,7 +344,7 @@ object UsageTraffic {
         TrafficUsageAggregateRow(
           groups = groupsMap,
           windowStart = windowStart.toString,
-          windowEnd = windowStart.plus(step).toString,
+          windowEnd = windowEnd.toString,
           totalBytesIn = totalBytesIn,
           totalBytesOut = totalBytesOut,
           totalSeconds = totalSeconds,

--- a/api/test/src/feature/SpaWsS4Spec.scala
+++ b/api/test/src/feature/SpaWsS4Spec.scala
@@ -431,6 +431,52 @@ object SpaWsS4Spec
       }
     },
     test(
+      // #2018/#2020 PINNING: the streamed `raw` head window MUST equal the actual ingested report
+      // period `[periodStart, periodEnd)` (the agent's `usage_report_interval`), NOT a synthetic
+      // fixed 5-min window. Ingest a non-5-min-aligned 37 s period and assert the pushed window is
+      // exactly that period (windowEnd - windowStart == 37 s, and the response `from`/`to` match),
+      // so the client's span-based B/s comes out correct. FAILS if anyone re-hardcodes a fixed raw
+      // window.
+      "raw head window equals the real ingested report period [periodStart, periodEnd) (not 5-min)",
+    ) {
+      // A period deliberately off every 5-min boundary so a synthetic floor would diverge.
+      val rawPs = "2026-06-25T13:58:11Z"
+      val rawPe = "2026-06-25T13:58:48Z" // +37s
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(a => tokenFor(a, "adult", "mom"))
+          frames <- collect(
+            port,
+            tok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"groupBy":["profile"],"bucket":"raw"}}}""",
+            ),
+            trigger = ingestUsagePeriod(
+              ingest,
+              router,
+              rawPs,
+              rawPe,
+              usageRecord("youtube.com", 3700, 740),
+            ),
+            wait = 4.seconds,
+          )
+          tFrames = trafficFrames(frames)
+          pushed <- ZIO.fromEither(parsePush(tFrames.last)).mapError(e => new RuntimeException(e))
+          row      = pushed.aggregateRows.head
+          spanSecs = java.time.Duration
+            .between(Instant.parse(row.windowStart), Instant.parse(row.windowEnd))
+            .getSeconds
+        } yield assertTrue(pushed.bucket == "raw") &&
+          // The window is the REAL report period, not a 5-min grid cell.
+          assertTrue(row.windowStart == rawPs) &&
+          assertTrue(row.windowEnd == rawPe) &&
+          assertTrue(spanSecs == 37L) &&
+          // Response envelope `from`/`to` agree with the period (the scoped head bucket).
+          assertTrue(pushed.from == rawPs && pushed.to == rawPe) &&
+          assertTrue(row.totalBytesIn == 3700 && row.totalBytesOut == 740)
+      }
+    },
+    test(
       "a burst of ingests converges on the freshest cumulative head bucket (latest-wins, §6.3)",
     ) {
       withHarness { (port, ingest, router) =>

--- a/api/test/src/feature/SpaWsS4Spec.scala
+++ b/api/test/src/feature/SpaWsS4Spec.scala
@@ -426,8 +426,9 @@ object SpaWsS4Spec
           assertTrue(
             pushed.aggregateRows.exists(r => r.totalBytesIn == 500 && r.totalBytesOut == 600),
           ) &&
-          // raw floors to the 5-min boundary.
-          assertTrue(pushed.aggregateRows.head.windowStart == "2026-06-25T14:00:00Z")
+          // #2018: raw's window is the REAL report period [periodStart, periodEnd), not a 5-min grid.
+          assertTrue(pushed.aggregateRows.head.windowStart == periodStart) &&
+          assertTrue(pushed.aggregateRows.head.windowEnd == periodEnd)
       }
     },
     test(
@@ -505,29 +506,33 @@ object SpaWsS4Spec
     test(
       "coalesce collapses a burst of contentless triggers to one recompute each (latest-wins logic)",
     ) {
-      val t1     = Instant.parse("2026-06-25T13:59:00Z")
-      val t2     = Instant.parse("2026-06-25T13:59:30Z")
-      // #2004: UsageIngested now carries the batch's periodStart. A burst must collapse to the ONE
-      // with the LATEST period (latest-wins) so the live edge never regresses to a stale bucket.
-      val pEarly = Instant.parse("2026-06-25T13:58:00Z")
-      val pMid   = Instant.parse("2026-06-25T13:59:00Z")
-      val pLate  = Instant.parse("2026-06-25T14:00:00Z")
-      val burst  = Chunk(
+      val t1                                            = Instant.parse("2026-06-25T13:59:00Z")
+      val t2                                            = Instant.parse("2026-06-25T13:59:30Z")
+      // #2004: UsageIngested carries the batch's period. A burst must collapse to the ONE with the
+      // LATEST period (latest-wins) so the live edge never regresses to a stale bucket. #2018: the
+      // event carries the WHOLE `[periodStart, periodEnd)` (raw's head window is the real period), so
+      // the surviving event must keep BOTH bounds of the freshest period.
+      def usage(start: Instant): SpaEvent.UsageIngested =
+        SpaEvent.UsageIngested(start, start.plusSeconds(60))
+      val pEarly                                        = Instant.parse("2026-06-25T13:58:00Z")
+      val pMid                                          = Instant.parse("2026-06-25T13:59:00Z")
+      val pLate                                         = Instant.parse("2026-06-25T14:00:00Z")
+      val burst                                         = Chunk(
         SpaEvent.NowChanged,
-        SpaEvent.UsageIngested(pMid),
-        SpaEvent.UsageIngested(pLate),
+        usage(pMid),
+        usage(pLate),
         SpaEvent.NowChanged,
-        SpaEvent.UsageIngested(pEarly),
+        usage(pEarly),
         SpaEvent.ConnectionEventsIngested(t1),
         SpaEvent.ConnectionEventsIngested(t1),
         SpaEvent.ConnectionEventsIngested(t2),
       )
-      val out    = SpaPush.coalesce(burst)
+      val out                                           = SpaPush.coalesce(burst)
       ZIO.succeed(
         // Exactly one UsageIngested survives, and it carries the LATEST period (not first-seen).
         assertTrue(
           out.collect { case e: SpaEvent.UsageIngested => e }.toList ==
-            List(SpaEvent.UsageIngested(pLate)),
+            List(usage(pLate)),
         ) &&
           assertTrue(out.count(_ == SpaEvent.NowChanged) == 1) &&
           // Distinct `since`d connection-event events are NOT collapsed (their head re-read differs).

--- a/api/test/src/unit/UsageTrafficSpec.scala
+++ b/api/test/src/unit/UsageTrafficSpec.scala
@@ -118,7 +118,7 @@ object UsageTrafficSpec extends ZIOSpecDefault {
       assertTrue(appSlugs == Set(hostA.value, hostB.value))
     },
     test("floorTo and stepOf agree for each sub-day bucket (no 2× stride anywhere)") {
-      // For every sub-day bucket: flooring an instant inside the bucket should
+      // For every sub-day display bucket: flooring an instant inside the bucket should
       // never produce a window wider than `stepOf(bucket)` — i.e. `start +
       // step` must be strictly after the original instant.
       val sample  = Instant.parse("2026-05-13T07:23:17Z")
@@ -132,6 +132,55 @@ object UsageTrafficSpec extends ZIOSpecDefault {
         val step  = UsageTraffic.stepOf(b)
         !start.isAfter(sample) && start.plus(step).isAfter(sample)
       })
+    },
+    // #2018/#2020 PINNING: `raw` must derive its window from the row's REAL report period
+    // `[periodStart, periodEnd)` (the agent's `usage_report_interval`, data-derived) — NEVER a
+    // synthetic fixed grid. Seed two DIFFERENT, non-5-min-aligned periods (37 s and 90 s) and
+    // assert the aggregated raw window equals each row's actual period and the derived B/s equals
+    // bytes / span. This FAILS the moment anyone re-hardcodes a fixed raw window (e.g. `% 300` /
+    // `ofMinutes(5)`), which is exactly how #2018 regressed.
+    test(
+      "#2018: raw window equals the row's real report period (37 s and 90 s), B/s = bytes/span",
+    ) {
+      // Periods deliberately NOT aligned to any 5-min boundary so a synthetic floor would diverge.
+      val p1Start = Instant.parse("2026-05-13T00:01:13Z")
+      val p1End   = p1Start.plusSeconds(37)
+      val p2Start = Instant.parse("2026-05-13T00:07:41Z")
+      val p2End   = p2Start.plusSeconds(90)
+
+      val row1 = TrafficUsageDbRow(mac1, host, p1Start, p1End, 37, 3700L, 740L)
+      val row2 = TrafficUsageDbRow(mac1, host, p2Start, p2End, 90, 9000L, 1800L)
+
+      def aggOf(r: TrafficUsageDbRow) = UsageTraffic
+        .buildAggregate(
+          rows = List(r),
+          bucket = UsageTraffic.Bucket.Raw,
+          zone = UTC,
+          groupBy = Set(UsageTraffic.GroupBy.Domain),
+          deviceByMac = Map.empty,
+          profileNameById = Map.empty,
+        )
+        .head
+
+      val a1 = aggOf(row1)
+      val a2 = aggOf(row2)
+
+      def spanSeconds(windowStart: String, windowEnd: String): Long =
+        Duration.between(Instant.parse(windowStart), Instant.parse(windowEnd)).getSeconds
+
+      assertTrue(a1.windowStart == p1Start.toString) &&
+      assertTrue(a1.windowEnd == p1End.toString) &&
+      assertTrue(spanSeconds(a1.windowStart, a1.windowEnd) == 37L) &&
+      // derived rate = (bytesIn + bytesOut) / span
+      assertTrue(
+        (a1.totalBytesIn + a1.totalBytesOut) / spanSeconds(a1.windowStart, a1.windowEnd) == 120L,
+      ) &&
+      assertTrue(a2.windowStart == p2Start.toString) &&
+      assertTrue(a2.windowEnd == p2End.toString) &&
+      assertTrue(spanSeconds(a2.windowStart, a2.windowEnd) == 90L) &&
+      assertTrue(
+        (a2.totalBytesIn + a2.totalBytesOut) / spanSeconds(a2.windowStart, a2.windowEnd) == 120L,
+      )
     },
   )
 }

--- a/api/test/src/unit/UsageTrafficSpec.scala
+++ b/api/test/src/unit/UsageTrafficSpec.scala
@@ -7,9 +7,13 @@ import zio.test.*
 import java.time.{Duration, Instant, ZoneOffset}
 
 /**
- * #901: pin Traffic Usage aggregation stride. Regression for "10m bucket shows window starts 20
- * minutes apart, not 10". Tests use a deterministic raw-row layout (router cadence of 5 min,
- * period_starts aligned to UTC minute boundaries) so the floor + group step is unambiguous.
+ * #901: pin Traffic Usage *display*-bucket aggregation stride. Regression for "10m bucket shows
+ * window starts 20 minutes apart, not 10". The display-bucket tests use a deterministic raw-row
+ * layout (synthetic period_starts a fixed 5 min apart, aligned to UTC minute boundaries) ONLY so
+ * the floor + group step is unambiguous — it is NOT a claim about the real report cadence, which is
+ * the agent's `usage_report_interval` (~60s, configurable) carried per-row. The #2018 raw pinning
+ * test below seeds DIFFERENT, non-5-min periods precisely to prove raw never assumes a fixed
+ * granularity.
  */
 object UsageTrafficSpec extends ZIOSpecDefault {
 
@@ -129,7 +133,8 @@ object UsageTrafficSpec extends ZIOSpecDefault {
       )
       assertTrue(buckets.forall { b =>
         val start = UsageTraffic.floorTo(sample, b, UTC)
-        val step  = UsageTraffic.stepOf(b)
+        // Display buckets always have a fixed step; raw (None) is excluded from this list.
+        val step  = UsageTraffic.stepOf(b).getOrElse(Duration.ZERO)
         !start.isAfter(sample) && start.plus(step).isAfter(sample)
       })
     },
@@ -181,6 +186,18 @@ object UsageTrafficSpec extends ZIOSpecDefault {
       assertTrue(
         (a2.totalBytesIn + a2.totalBytesOut) / spanSeconds(a2.windowStart, a2.windowEnd) == 120L,
       )
+    },
+    test("windowFor: raw is the real period; a display bucket is the floored grid cell") {
+      val ps = Instant.parse("2026-05-13T00:01:13Z")
+      val pe = ps.plusSeconds(37)
+      assertTrue(UsageTraffic.windowFor(ps, pe, UsageTraffic.Bucket.Raw, UTC) == (ps, pe)) &&
+      assertTrue(
+        UsageTraffic.windowFor(ps, pe, UsageTraffic.Bucket.OneMin, UTC) ==
+          (Instant.parse("2026-05-13T00:01:00Z"), Instant.parse("2026-05-13T00:02:00Z")),
+      ) &&
+      // stepOf is None for raw (no fixed width), Some for display buckets.
+      assertTrue(UsageTraffic.stepOf(UsageTraffic.Bucket.Raw).isEmpty) &&
+      assertTrue(UsageTraffic.stepOf(UsageTraffic.Bucket.OneMin).contains(Duration.ofMinutes(1)))
     },
   )
 }

--- a/docs/process/single-source-of-truth.md
+++ b/docs/process/single-source-of-truth.md
@@ -51,3 +51,39 @@ hand-mirrored the whole snapshot fold),
 strings in three hand-written copies, fixing a live mislabel), and
 [#1546](https://github.com/wifihaven/wifihaven/issues/1546) (per-device totals
 recomputed off the canonical total, fixing a live over-count).
+
+### Worked example — the usage-report period lives at the agent, never in the API
+
+The usage-report **period** — how often a router posts a `traffic_reports`
+batch — is single-sourced at the agent:
+`openwrt/files/etc/config/wifihaven` → `usage_report_interval` (default
+**60s**, configurable; heading sub-minute as #1023 streams usage). The real
+per-report window then rides **every** stored row as
+`period_start`/`period_end`. **The API must never hold its own copy of that
+period.**
+
+It once did, and it drifted exactly as this rule predicts. The original agent
+default was `300` (5 min, #101); #529 changed it to 60s; then
+[#846](https://github.com/wifihaven/wifihaven/issues/846) hardcoded a
+**5-minute** `raw` window into the API
+(`UsageTraffic.floorTo(Raw) … % 300`, `stepOf(Raw) = ofMinutes(5)`) — five
+days **after** the agent had moved off 300s. A false comment ("source rows are
+at UTC 5-min boundaries already") cemented the wrong mental model. The API copy
+silently disagreed with the real cadence, and the dashboard `raw` bandwidth
+gauge read ~5× smoothed and divorced from `1m`
+([#2018](https://github.com/wifihaven/wifihaven/issues/2018)).
+
+The fix is the rule: derive the window from the row's real
+`[period_start, period_end)` span — one helper, `UsageTraffic.windowFor`,
+shared (COLLAPSE) by the `GET /api/usage/traffic` aggregate path and the
+websocket live-edge push so they cannot disagree; `stepOf(Raw)` returns `None`
+(raw has no fixed width) so callers *must* use the row span. A pinning test
+(TEST-PIN) seeds two different report periods (37s and 90s) and asserts the
+streamed/queried `raw` window equals each, failing the moment a fixed window is
+re-hardcoded. A narrow CI guard
+(`.github/scripts/check-usage-period-hardcode.sh`) rejects a newly-added
+`% 300` / `ofMinutes(5)` / bare `300` literal in the usage/traffic bucket +
+rollup paths, pointing back here
+([#2020](https://github.com/wifihaven/wifihaven/issues/2020)). Same shape as a
+display bucket (10m/1h/…) is a legitimate *display* constant — only the
+*source-period* must never be copied.


### PR DESCRIPTION
## What & why

The dashboard **LIVE BANDWIDTH** gauge's `raw` bucket read **lower/smoother than `1m`** — the opposite of what "raw" should be. Root cause: the API hardcoded a **5-minute** `raw` window in `UsageTraffic` (`floorTo(Raw) … % 300`, `stepOf(Raw) = ofMinutes(5)`), coarser than `1m` and divorced from the real cadence.

**Provenance (git-confirmed):** `300` was the agent's *original* `usage_report_interval` default (#101, 2026-05-07). #529 moved it to **60s** (2026-05-17). Then #846 (2026-05-22) re-baked the dead `% 300` / `ofMinutes(5)` into the API — **five days after** the agent left 300s — with a false comment ("source rows are at UTC 5-min boundaries already"). The API copy silently drifted off the configurable cadence. The real per-report window already rides every `traffic_reports` row as `[periodStart, periodEnd)`.

This PR lands **#2018** (the fix) and **#2020** (prevent the whole class) together.

## Part A — #2018: raw uses the row's real period

- `floorTo(Raw)` no longer floors onto a synthetic grid — the row's real `periodStart` **is** the window start.
- `stepOf` now returns `Option[Duration]`; `Raw` → `None` (no fixed width).
- New `UsageTraffic.windowFor` SSOT: `raw` → the real `[periodStart, periodEnd)` report period; display buckets → the floored grid cell. Shared by the `GET /api/usage/traffic` aggregate path (`buildAggregate`) **and** the ws live-edge push (`SpaPush.pushOneParamSet`), so they can't disagree.
- `SpaEvent.UsageIngested` now carries `periodEnd` too, so the streamed `raw` head window equals the actual ingested period — `windowEnd − windowStart == the report interval`, not 300s. Client B/s (`bytes / span`, `wsCache.bucketSeconds(raw, row)`) comes out correct with **no client change**.
- Deleted the two false "5-minute boundary" comments.
- `GET ?bucket=raw` already emitted per-row `periodStart`/`periodEnd` via `buildRaw` (verified by `UsageApiSpec`) — GET, the Traffic Usage page, and the ws aggregator now all derive raw from the row's real period.

## Part B — #2020: purge + guard

- **Purged** stale "per 5-min" usage-period claims across `api/src` (Repos, RollupRepo, AppUsedRollupService, TimeUsedRollupJob, UsageRoutes, DashboardNowRoutes, DebugRoutes, Routes). Comments now say "usage-report period (`usage_report_interval`, ~60s, configurable)". Display-bucket aggregation (10m/1h/…) untouched — only the *source-period* assumption was wrong. (One comment even self-contradicted: "single 5-min agent bucket … each host row holds ~60s for that bucket".)
- **Pinning tests** (TDD, committed RED first): unit seeds 37s & 90s periods; ws feature ingests a 37s period — both assert the raw window equals the real period and derived B/s == bytes/span. They fail the moment a fixed window is re-hardcoded.
- **CI guard** `.github/scripts/check-usage-period-hardcode.sh` (+ `.test.sh`, wired into `ci.yml` as `usage-period-hardcode`, sibling to the migration checks) rejects new `% 300` / `* 300` / `ofMinutes(5)` / bare `300` literals in the usage/traffic bucket + rollup paths. Comment lines exempt; explicit opt-out marker `usage-period-ok`.
- **Doc** worked example added to `docs/process/single-source-of-truth.md`.

## Tests

- RED→GREEN: `test(#2018): RED …` commit fails on current code; the fix turns it green.
- `mill api.test.testOnly` green for `UsageTrafficSpec`, `SpaWsS4Spec`, `SpaWsSpec`, `UsageApiSpec`, `HouseholdPatchApiSpec`.
- `scalafmt --check` clean; guard `.test.sh` passes (9 cases) and the guard passes on this PR's own diff.

Closes #2018, closes #2020. Relates to #846, #529, #101, #1023, #1148, #2004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)