### PR TITLE
feat(#2025): self-describing usage buckets — accurate screen-time from the real activity window

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -471,6 +471,12 @@ case class TrafficReportInsert(
     // pre-#730 agents do not emit it; stored as NULL on traffic_reports.dest_ip
     // for those records.
     destIp: Option[IpAddress] = None,
+    // #2025: the real activity envelope (first/last growth-sample wall-clock).
+    // Optional because pre-#2025 agents do not emit it; stored as NULL on
+    // traffic_reports.active_start / active_end for those records, and
+    // Presence.spanOf falls back to the [period_start, period_end] flush window.
+    activeStart: Option[Instant] = None,
+    activeEnd: Option[Instant] = None,
 )
 
 case class BlockEventInsert(
@@ -1762,7 +1768,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
   def insertBatch(reports: List[TrafficReportInsert]) =
     DbMetrics.timed("traffic.insertBatch")(
       Update[TrafficReportInsert](
-        "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out,dest_ip) VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
+        "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out,dest_ip,active_start,active_end) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
       ).updateMany(reports).transact(xa),
     )
   // TODO(#730): remove this read-side join once usage records carry dest_ip.
@@ -1825,7 +1831,19 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
       fromInstant: Instant,
       toInstant: Instant,
   ): Task[List[wifihaven.api.presence.PresenceRow]] = {
-    type Row = (MacAddress, LocalDate, Instant, HostId, Int, Long, Long, Instant, Instant)
+    type Row = (
+        MacAddress,
+        LocalDate,
+        Instant,
+        HostId,
+        Int,
+        Long,
+        Long,
+        Instant,
+        Instant,
+        Option[Instant],
+        Option[Instant],
+    )
     macs match {
       case Nil => ZIO.succeed(List.empty[wifihaven.api.presence.PresenceRow])
       case ms  =>
@@ -1841,7 +1859,8 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                            THEN 'fqdn' ELSE tr.host_type END,
                       COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
                                tr.host_value),
-                      tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end
+                      tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end,
+                      tr.active_start, tr.active_end
                FROM traffic_reports tr
                ${SqlFragments.resolvedHostLateral}
                WHERE tr.period_start >= $fromInstant AND tr.period_start < $toInstant
@@ -1849,9 +1868,10 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                  AND """ ++ Fragments.in(fr"tr.mac", nel)
         val cio =
           q.query[Row]
-            .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd) =>
+            .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd, aStart, aEnd) =>
               val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt
-              wifihaven.api.presence.PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds)
+              wifihaven.api.presence
+                .PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds, aStart, aEnd)
             }
             .to[List]
         // Bound each per-request read: a pathological window fails fast with a typed
@@ -1868,7 +1888,19 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
       to: LocalDate,
       since: Option[Instant] = None,
   ) = {
-    type Row = (MacAddress, LocalDate, Instant, HostId, Int, Long, Long, Instant, Instant)
+    type Row = (
+        MacAddress,
+        LocalDate,
+        Instant,
+        HostId,
+        Int,
+        Long,
+        Long,
+        Instant,
+        Instant,
+        Option[Instant],
+        Option[Instant],
+    )
     macs match {
       case Nil => ZIO.succeed(List.empty[wifihaven.api.presence.PresenceRow])
       case ms  =>
@@ -1879,7 +1911,8 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                            THEN 'fqdn' ELSE tr.host_type END,
                       COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
                                tr.host_value),
-                      tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end
+                      tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end,
+                      tr.active_start, tr.active_end
                FROM traffic_reports tr
                ${SqlFragments.resolvedHostLateral}
                WHERE tr.date BETWEEN $from AND $to
@@ -1888,9 +1921,10 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
             since.fold(fr"")(s => fr"AND tr.period_start >= $s")
         DbMetrics.timed("traffic.listPresenceRows")(
           q.query[Row]
-            .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd) =>
+            .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd, aStart, aEnd) =>
               val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt
-              wifihaven.api.presence.PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds)
+              wifihaven.api.presence
+                .PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds, aStart, aEnd)
             }
             .to[List]
             .transact(xa),

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -22,6 +22,15 @@ case class PresenceRow(
     activeSeconds: Int,
     bytes: Long,
     periodSeconds: Int,
+    // #2025: the REAL activity envelope for this bucket — the wall-clock of the
+    // first and last sample tick the agent observed byte growth on, as opposed
+    // to the `[periodStart, periodStart + periodSeconds]` FLUSH window the
+    // envelope sits inside. Both present ⇒ [[spanOf]] uses them; either absent
+    // (pre-#2025 agents, NULL columns) ⇒ it falls back to the flush window, so
+    // the over-count defense degrades gracefully. See `traffic_reports`
+    // active_start / active_end (V62).
+    activeStart: Option[Instant] = None,
+    activeEnd: Option[Instant] = None,
 )
 
 /**
@@ -86,25 +95,48 @@ object Presence {
   }
 
   /**
-   * Each non-heartbeat `traffic_reports` row contributes its full `[period_start, period_end]`
-   * interval as evidence of activity (design §4.1) — NOT its sampled `activeSeconds`, which is the
-   * undercount driver. The trailing edge carries up to one report-interval of uncertainty until the
-   * `connection_events`-anchored timing lands (#1466).
+   * The wall-clock activity span a row contributes as evidence (design §4.1).
+   *
+   * #2025: when the row carries a self-describing activity envelope (`activeStart`/`activeEnd` —
+   * the first/last sample tick that saw byte growth), that envelope IS the span: a wide flush
+   * window with a 20 s activity burst contributes a 20 s span, not the whole window. This makes the
+   * #2016 over-count (a stalled flush ballooning `[period_start, period_end]` to cover an
+   * un-monitored gap) structurally impossible — the server no longer trusts the flush window
+   * blindly.
+   *
+   * Falling back to the full `[period_start, period_end]` interval when the envelope is absent
+   * (pre-#2025 agents, or NULL columns) preserves the prior behavior exactly — NOT the sampled
+   * `activeSeconds`, which is the undercount driver. The trailing edge then carries up to one
+   * report-interval of uncertainty until the `connection_events`-anchored timing lands (#1466).
    */
-  def spanOf(r: PresenceRow): Span = {
-    val start = r.periodStart.getEpochSecond
-    Span(start, start + r.periodSeconds.toLong.max(0L))
-  }
+  def spanOf(r: PresenceRow): Span =
+    (r.activeStart, r.activeEnd) match {
+      case (Some(s), Some(e)) =>
+        val start = s.getEpochSecond
+        Span(start, e.getEpochSecond.max(start))
+      case _                  =>
+        val start = r.periodStart.getEpochSecond
+        Span(start, start + r.periodSeconds.toLong.max(0L))
+    }
 
   /**
    * The idle gap actually used: the configured `N`, raised to the `2 × R` collapse guard (design
-   * §4.4 invariant 1). `R` is read from the data (`period_seconds`), never assumed to be 60 s. When
-   * `N < R` contiguous reporting windows stop merging and presence collapses to ~0 (§2d (ii));
-   * clamping up to `2 × R` keeps a misconfigured / coarse-reporting fleet from silently zeroing
-   * out.
+   * §4.4 invariant 1). `R` is the resolution of the EVIDENCE — the widest span a row contributes
+   * via [[spanOf]] — never assumed to be 60 s. When `N < R` contiguous reporting windows stop
+   * merging and presence collapses to ~0 (§2d (ii)); clamping up to `2 × R` keeps a misconfigured /
+   * coarse-reporting fleet from silently zeroing out.
+   *
+   * #2025: `R` is taken from `spanOf` (the activity envelope when present, else the flush window),
+   * NOT from `period_seconds` directly. This is the load-bearing half of the over-count defense:
+   * with a wide flush window and a tight activity envelope, deriving `R` from `period_seconds`
+   * would clamp the gap up to `2 × period_seconds` and BRIDGE the idle gaps between bursts —
+   * re-chaining exactly the inflation [[spanOf]] removed. Reading `R` from the (now tight) evidence
+   * span keeps the gap at the configured `N`, so genuinely idle stretches between bursts split into
+   * separate sessions. For old agents / NULL envelopes `spanOf` returns the flush window, so `R`
+   * equals `period_seconds` and the prior behavior is preserved exactly.
    */
   def effectiveGap(rows: Iterable[PresenceRow], continuationSeconds: Int): Long = {
-    val r = rows.iterator.map(_.periodSeconds.toLong).maxOption.getOrElse(0L)
+    val r = rows.iterator.map(row => spanOf(row).seconds).maxOption.getOrElse(0L)
     continuationSeconds.toLong.max(2L * r)
   }
 

--- a/api/src/routes/RouterIngestService.scala
+++ b/api/src/routes/RouterIngestService.scala
@@ -211,6 +211,12 @@ final class RouterIngestService(
           r.bytesIn,
           r.bytesOut,
           r.destIp,
+          // #2025: persist the real activity envelope when the agent supplied it
+          // (and it parses). A malformed timestamp is dropped to None rather
+          // than failing the batch — Presence.spanOf then falls back to the
+          // [period_start, period_end] flush window for that row.
+          parseInstantOpt(r.activeStart),
+          parseInstantOpt(r.activeEnd),
         ),
       )
       // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
@@ -265,6 +271,12 @@ final class RouterIngestService(
             bytesIn = a.bytesIn + b.bytesIn,
             bytesOut = a.bytesOut + b.bytesOut,
             destIp = a.destIp.orElse(b.destIp),
+            // #2025: union the two records' activity envelopes — earliest start,
+            // latest end. The wire timestamps are fixed-width RFC3339 UTC ("…Z"),
+            // so lexical min/max is chronological (same property the agent's
+            // retry queue relies on for periodEnd ordering).
+            activeStart = minIso(a.activeStart, b.activeStart),
+            activeEnd = maxIso(a.activeEnd, b.activeEnd),
           )
         }
       }
@@ -493,6 +505,30 @@ object RouterIngestService {
   // #1570: a bad timestamp is a typed BadRequest (400) mapped centrally; the boundary logs it.
   private def parseInstant(s: String): IO[ApiError, Instant] =
     ZIO.attempt(Instant.parse(s)).orElseFail(ApiError.BadRequest(s"invalid timestamp: $s"))
+
+  // #2025: best-effort parse of an OPTIONAL activity-envelope timestamp. Unlike
+  // the envelope timestamps above, a malformed/absent value here is NOT a 400 —
+  // it degrades to None so the row simply falls back to its flush window in
+  // Presence.spanOf. The additive wire field must never harden an old/odd agent
+  // into a rejected batch.
+  private def parseInstantOpt(s: Option[String]): Option[Instant] =
+    s.flatMap(v => scala.util.Try(Instant.parse(v)).toOption)
+
+  // #2025: lexical min/max over optional RFC3339 UTC ("…Z") timestamps — used to
+  // union two collapsed records' activity envelopes (earliest start, latest end)
+  // before insert. Fixed-width "…Z" makes lexical order chronological. `None`
+  // is absorbing-free: a present value always wins over an absent one.
+  private def minIso(a: Option[String], b: Option[String]): Option[String] =
+    (a, b) match {
+      case (Some(x), Some(y)) => Some(if (x <= y) x else y)
+      case _                  => a.orElse(b)
+    }
+
+  private def maxIso(a: Option[String], b: Option[String]): Option[String] =
+    (a, b) match {
+      case (Some(x), Some(y)) => Some(if (x >= y) x else y)
+      case _                  => a.orElse(b)
+    }
 
   /**
    * #1569 / #1757: shared per-record skip helper used by both the `usage` (records → UsageRecord)

--- a/api/test/src/feature/TimeStatusServiceSpec.scala
+++ b/api/test/src/feature/TimeStatusServiceSpec.scala
@@ -102,6 +102,47 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       tr.insertBatch(inserts).unit
     }
 
+  /**
+   * #2025: seed `count` consecutive WIDE flush windows of `periodSec` each (the conntrack-stall
+   * shape, sibling #2024) for one device/host, where each window carries only `activeSec` of REAL
+   * activity at its leading edge via the self-describing `active_start`/`active_end` columns. This
+   * is the prod #2016 shape: a ~20 s burst inside a ~500 s flush window. With the activity envelope
+   * the server credits only the real activity; without it (the `withEnvelope = false` arm) it
+   * credits the whole ballooned flush window. Starts at midnight UTC on `date`.
+   */
+  private def seedStallTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      count: Int,
+      periodSec: Int,
+      activeSec: Int,
+      withEnvelope: Boolean = true,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until count).map { i =>
+        val start = day0.plusSeconds(i.toLong * periodSec.toLong)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(periodSec.toLong),
+          math.min(activeSec, periodSec),
+          500_000L,
+          500_000L,
+          None,
+          if (withEnvelope) Some(start) else None,
+          if (withEnvelope) Some(start.plusSeconds(activeSec.toLong)) else None,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
   private def settingsWithTz(
       hsr: HouseholdSettingsRepo,
       tz: String,
@@ -322,6 +363,115 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
             ),
           ),
         )
+    },
+    test("#2025 STALL: wide flush windows with tight activity envelopes give bounded usedMinutes") {
+      // The prod #2016 shape: 5 contiguous 500 s flush windows (the conntrack-gated loop stalling
+      // on a quiet LAN, sibling #2024) each carrying only 20 s of REAL activity. Pre-#2025 the
+      // server credited the whole 2500 s (~41 min) as continuous presence; with self-describing
+      // buckets it credits only the ~100 s activity envelope (<2 min). The withEnvelope=false arm
+      // reproduces the un-defended over-count, pinning that the envelope path is strictly tighter.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:30", "kid-ipad", kid)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _   <- seedStallTraffic(rid, "aa:bb:cc:dd:ee:30", "gimkit.com", today, 5, 500, 20)
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        bounded <- svc.dayStateLive(now, today, s, kid)
+        // Re-seed the SAME shape without the envelope (an old agent) to show the over-count it
+        // structurally prevents.
+        _       <- cleanDb
+        s2      <- settingsWithTz(hsr, "UTC")
+        kid2    <- TestLayers.seedKidsProfile(pr)
+        _       <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:31", "kid-ipad", kid2)
+        rid2    <- seedRouterRow
+        _       <- seedStallTraffic(
+          rid2,
+          "aa:bb:cc:dd:ee:31",
+          "gimkit.com",
+          today,
+          5,
+          500,
+          20,
+          withEnvelope = false,
+        )
+        svc2    <- makeService
+        balloon <- svc2.dayStateLive(now, today, s2, kid2)
+      } yield assertTrue(
+        bounded.exists(_.usedMinutes <= 2),
+        balloon.exists(_.usedMinutes >= 30),
+        bounded.map(_.usedMinutes).getOrElse(0) < balloon.map(_.usedMinutes).getOrElse(0),
+      )
+    },
+    test("#2025 invariant: per-app usedMinutes ⊆ profile usedMinutes for a non-exempt app") {
+      // A NON-exempt app's engaged minutes can never exceed the profile's total — the per-app
+      // surface and the daily total derive from the same #1464 session-stitch primitive, and a
+      // non-exempt app's buckets are a subset of the counted set. (Exempt apps are excluded from
+      // the total and may exceed it — that's the documented carve-out, not tested here.) Pinned
+      // under the stall shape so a refactor that re-inflates one surface but not the other fails.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:32", "kid-ipad", kid)
+        _   <- TestLayers.seedAppAssignment(
+          ar,
+          kid,
+          "gimkit.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(120),
+          exemptFromDaily = false,
+        )
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _   <- seedStallTraffic(rid, "aa:bb:cc:dd:ee:32", "www.gimkit.com", today, 5, 500, 20)
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        stOpt <- svc.dayStateLive(now, today, s, kid)
+      } yield assertTrue(
+        stOpt.exists { st =>
+          val appMins = st.perApp.find(_.domainPattern == "gimkit.com").map(_.usedMinutes)
+          appMins.forall(_ <= st.usedMinutes)
+        },
+      )
+    },
+    test("#2025 invariant: Dedup-mode profile usedMinutes ≤ elapsed wall-clock and ≤ 1440") {
+      // A single profile's presence can never exceed real elapsed wall-clock under Dedup (one human
+      // can't be present longer than the day so far). Two devices on the SAME stalled windows: Sum
+      // would double them, but Dedup unions them — and with the activity envelope the union is the
+      // ~100 s of real activity, comfortably under both the elapsed-since-midnight bound and 1440.
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        s    <- settingsWithTz(hsr, "UTC")
+        kid  <- TestLayers.seedKidsProfile(pr)
+        prof <- pr.findById(kid).map(_.get)
+        _    <- pr.update(prof.copy(crossDeviceOverlapMode = CrossDeviceOverlapMode.Dedup))
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:33", "kid-a", kid)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:34", "kid-b", kid)
+        rid  <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _   <- seedStallTraffic(rid, "aa:bb:cc:dd:ee:33", "gimkit.com", today, 5, 500, 20)
+        _   <- seedStallTraffic(rid, "aa:bb:cc:dd:ee:34", "gimkit.com", today, 5, 500, 20)
+        svc <- makeService
+        // now = 00:45 — elapsed wall-clock since midnight is 45 min.
+        now = LocalDateTime.of(2025, 1, 6, 0, 45).toInstant(ZoneOffset.UTC)
+        stOpt <- svc.dayStateLive(now, today, s, kid)
+      } yield assertTrue(
+        stOpt.exists(st => st.usedMinutes <= 45 && st.usedMinutes <= 1440),
+      )
     },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -76,6 +76,41 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       tr.insertBatch(inserts).unit
     }
 
+  // #2025: seed `count` consecutive WIDE flush windows of `periodSec` each (the conntrack-stall
+  // shape, #2024) on one device/host, where each carries only `activeSec` of REAL activity at its
+  // leading edge via the self-describing active_start/active_end columns. Starts at midnight UTC.
+  private def seedStallTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      count: Int,
+      periodSec: Int,
+      activeSec: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until count).map { i =>
+        val start = day0.plusSeconds(i.toLong * periodSec.toLong)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(periodSec.toLong),
+          math.min(activeSec, periodSec),
+          500_000L,
+          500_000L,
+          None,
+          Some(start),
+          Some(start.plusSeconds(activeSec.toLong)),
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
   private def setTz(hsr: HouseholdSettingsRepo, tz: String): Task[HouseholdSettings] =
     for {
       cur <- hsr.get
@@ -271,6 +306,40 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         _   <- setTz(hsr, "America/Denver")
         post <- ru.getDayMap(today)
       } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
+    },
+    test(
+      "#2025 stall shape: rollup tick == live AND usedMinutes bounded by the activity envelope",
+    ) {
+      // The prod #2016 shape through the REAL rollup path: 5 contiguous 500 s flush windows (the
+      // conntrack stall, #2024) each carrying only 20 s of real activity. The self-describing
+      // active_start/active_end bound the credit to the ~100 s envelope (<2 min), where the
+      // un-defended flush window would have chained to ~41 min. Crucially the rollup tick + read
+      // must still equal the all-live computation — a refactor that re-inflates one path but not
+      // the other fails here.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:60", "kid-a", kid)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedStallTraffic(rid, "aa:bb:cc:dd:ee:60", "gimkit.com", today, 5, 500, 20)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        svc    <- makeService
+        live   <- svc.dayStateAllLive(now, today, s)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
+        cached <- svc.dayStateAll(now, today, s)
+      } yield assertTrue(
+        cached(kid).usedMinutes == live(kid).usedMinutes, // rollup ⇄ live equivalence
+        live(kid).usedMinutes <= 2,                       // bounded by the activity envelope
+      )
     },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -103,6 +103,32 @@ object PresenceSpec extends ZIOSpecDefault {
       periodSeconds,
     )
 
+  /**
+   * #2025: a row whose FLUSH window `[period_start, period_start+periodSeconds]` is wide (a stalled
+   * flush) but whose REAL activity envelope `[activeStart, activeEnd]` is tight. `spanOf` must
+   * credit the tight envelope, not the wide window — the structural #2016 over-count defense.
+   */
+  private def windowedRow(
+      mac: MacAddress,
+      periodStartSec: Long,
+      host: String,
+      periodSeconds: Int,
+      activeStartSec: Long,
+      activeEndSec: Long,
+      bytes: Long = 1_000_000L,
+  ) =
+    PresenceRow(
+      mac,
+      baseDate,
+      base.plusSeconds(periodStartSec),
+      HostId.Fqdn(Hostname.unsafe(host)),
+      activeSeconds = math.min((activeEndSec - activeStartSec).toInt, periodSeconds),
+      bytes,
+      periodSeconds,
+      activeStart = Some(base.plusSeconds(activeStartSec)),
+      activeEnd = Some(base.plusSeconds(activeEndSec)),
+    )
+
   def spec = suite("Presence")(
     suite("totalMinutesByMac")(
       test("collapses multiple hostnames in the same bucket to one count") {
@@ -1409,6 +1435,66 @@ object PresenceSpec extends ZIOSpecDefault {
         val (spans, _) = Presence.appSpansForProfileWithDropCount(rows, List(group))
         val aliasSpans = Presence.appSpansForProfile(rows, List(group))
         assertTrue(spans == aliasSpans)
+      },
+    ),
+    suite("#2025 self-describing activity window")(
+      test("spanOf uses the activity envelope when present (tight burst in a wide window)") {
+        // 517s flush window (the prod #2016 stall), 20s real activity burst.
+        val r = windowedRow(
+          mac1,
+          0L,
+          "www.gimkit.com",
+          periodSeconds = 517,
+          activeStartSec = 100L,
+          activeEndSec = 120L,
+        )
+        assertTrue(Presence.spanOf(r).seconds == 20L)
+      },
+      test("spanOf falls back to the flush window when the envelope is absent (old agent)") {
+        val r = row(mac1, 0, "www.gimkit.com", periodSeconds = 517)
+        assertTrue(Presence.spanOf(r).seconds == 517L)
+      },
+      test("spanOf clamps a backwards envelope (activeEnd < activeStart) to zero, never negative") {
+        val r = windowedRow(
+          mac1,
+          0L,
+          "a.com",
+          periodSeconds = 300,
+          activeStartSec = 200L,
+          activeEndSec = 100L,
+        )
+        assertTrue(Presence.spanOf(r).seconds == 0L)
+      },
+      test("a half-present envelope (only activeStart) falls back to the flush window") {
+        val r = row(mac1, 0, "a.com", periodSeconds = 300)
+          .copy(activeStart = Some(base.plusSeconds(10L)), activeEnd = None)
+        assertTrue(Presence.spanOf(r).seconds == 300L)
+      },
+      test("STALL FIXTURE: wide windows with tight envelopes give bounded usedMinutes") {
+        // Mirror the prod #2016 stall shape: 5 consecutive ~500s flush windows (the conntrack-
+        // gated loop stalling on a quiet LAN, sibling #2024), each carrying only ~20s of real
+        // activity. The OLD model (full flush window) chains these into 40+ min; the envelope
+        // model credits only the real activity. Assert the envelope path is bounded well under
+        // the flush-window path — the over-count is structurally impossible.
+        val windowed    = (0 until 5).toList.map { i =>
+          val ps = i.toLong * 500L
+          windowedRow(
+            mac1,
+            ps,
+            "www.gimkit.com",
+            periodSeconds = 500,
+            activeStartSec = ps,
+            activeEndSec = ps + 20L,
+          )
+        }
+        val flushOnly   = windowed.map(_.copy(activeStart = None, activeEnd = None))
+        val boundedMins = Presence.totalMinutesByMac(windowed, Nil).getOrElse(mac1, 0)
+        val balloonMins = Presence.totalMinutesByMac(flushOnly, Nil).getOrElse(mac1, 0)
+        assertTrue(
+          boundedMins <= 2,         // ~100s of real activity → <2 min
+          balloonMins >= 30,        // the un-defended flush-window over-count
+          boundedMins < balloonMins,// the envelope path is strictly tighter
+        )
       },
     ),
   )

--- a/contract/router-to-api/usage_report.json
+++ b/contract/router-to-api/usage_report.json
@@ -13,7 +13,9 @@
       "activeSeconds" : 240,
       "bytesIn" : 8388608,
       "bytesOut" : 1048576,
-      "destIp" : "151.101.65.69"
+      "destIp" : "151.101.65.69",
+      "activeStart" : "2026-05-17T13:56:00Z",
+      "activeEnd" : "2026-05-17T13:59:20Z"
     },
     {
       "mac" : "76:2d:95:47:d1:8e",

--- a/docs/design/presence-tuning.md
+++ b/docs/design/presence-tuning.md
@@ -331,6 +331,27 @@ presence and event-anchoring would zero it out. The `N ≥ 2 × R` guard (§4.4
 invariant 1) supplies the rate-independence the model needs without per-request
 timestamps.
 
+**Self-describing buckets (#2025, #2016 server-robustness).** The
+`[period_start, period_end]` interval above is the *flush* window — "time since
+the agent last flushed", not "time the device was active". When a flush stalls
+(the conntrack-gated agent loop on a quiet LAN, [#2024](https://github.com/wifihaven/wifihaven/issues/2024)),
+that window balloons to cover the un-monitored gap and the model credits the
+whole thing — the [#2016](https://github.com/wifihaven/wifihaven/issues/2016)
+over-count (a ~20 s burst in a 517 s window read as ~8.6 min). The fix makes the
+bucket *self-describing*: the agent emits the real activity envelope
+`activeStart`/`activeEnd` (the wall-clock of the first and last sample tick that
+saw byte growth) as additive, optional wire fields, persisted on
+`traffic_reports.active_start`/`active_end` (V62). `Presence.spanOf` then uses
+`[activeStart, activeEnd]` when present — a wide flush window with a tight burst
+contributes the burst, not the window — falling back to
+`[period_start, period_end]` only when the envelope is absent (pre-#2025 agents),
+so old agents behave exactly as before. Crucially `effectiveGap` derives `R` from
+`spanOf` too, not from `period_seconds`: otherwise the `2 × R` clamp would raise
+the idle gap to `2 × period_seconds` and *bridge* the idle stretches between
+bursts, re-chaining the very inflation `spanOf` removed. With both halves, the
+over-count is structurally impossible regardless of flush cadence. (This, with
+the agent-side stall fix #2024, supersedes the #2022 window clamp.)
+
 Both outputs come from the same sessions and follow the same two-level rule:
 **within a device, always union; across devices, apply the profile's existing
 `crossDeviceOverlapMode`** (`Sum` default — double-count; `Dedup` — union, #751).

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -283,14 +283,32 @@ end
 local function tracker_key(mac, dst_ip) return mac .. "|" .. dst_ip end
 
 function M.new_tracker()
-  return { last = {}, active_samples = {} }
+  -- first_active / last_active record the wall-clock (epoch seconds) of the
+  -- FIRST and LAST sample tick that observed byte growth for a (mac, dst_ip)
+  -- key — the real activity envelope build_report emits as activeStart/
+  -- activeEnd (issue #2025), distinct from the [period_start, period_end]
+  -- flush window the envelope sits inside.
+  return { last = {}, active_samples = {}, first_active = {}, last_active = {} }
 end
 
 -- Compare each counter to its previous byte total; an increase counts as one
 -- active sample.  A counter that went DOWN is treated as a fresh start
 -- (element expired and reappeared, or counters reset out-of-band); we still
 -- count it as an active sample if the new value is > 0.
-function M.tracker_sample(tracker, counters)
+--
+-- `now` (wall-clock epoch seconds) is optional. When supplied, the first and
+-- last active tick per key are recorded so build_report can emit the real
+-- activity window (#2025). Absent (old callers / unit tests that don't thread
+-- a clock), only the sample COUNT is tracked and build_report omits
+-- activeStart/activeEnd — the server then falls back to the flush window.
+function M.tracker_sample(tracker, counters, now)
+  local function mark_active(key)
+    tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
+    if now then
+      if tracker.first_active[key] == nil then tracker.first_active[key] = now end
+      tracker.last_active[key] = now
+    end
+  end
   for _, c in ipairs(counters or {}) do
     local key   = tracker_key(c.mac, c.dst_ip)
     local prev  = tracker.last[key] or 0
@@ -298,11 +316,11 @@ function M.tracker_sample(tracker, counters)
     -- (device→remote) or bytes_out (remote→device) marks an active sample.
     local total = (c.bytes or 0) + (c.bytes_out or 0)
     if total > prev then
-      tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
+      mark_active(key)
       tracker.last[key] = total
     elseif total < prev then
       if total > 0 then
-        tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
+        mark_active(key)
       end
       tracker.last[key] = total
     end
@@ -312,6 +330,8 @@ end
 function M.tracker_reset(tracker)
   tracker.last           = {}
   tracker.active_samples = {}
+  tracker.first_active   = {}
+  tracker.last_active    = {}
 end
 
 -- ---------------------------------------------------------------------------
@@ -330,7 +350,8 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
 
   for _, c in ipairs(counters or {}) do
     local host    = host_for_ip(c.dst_ip, nft_sets, lookup_hostname)
-    local samples = tracker.active_samples[tracker_key(c.mac, c.dst_ip)] or 0
+    local key     = tracker_key(c.mac, c.dst_ip)
+    local samples = tracker.active_samples[key] or 0
     local active_seconds
     if samples > 0 then
       active_seconds = math.min(sample_seconds * samples, bucket_seconds)
@@ -362,6 +383,18 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
         -- it for write-time FQDN backfill against connection_events.
         destIp        = c.dst_ip,
       }
+      -- #2025: the REAL activity envelope — wall-clock (RFC3339, UTC, same
+      -- format as periodStart/periodEnd) of the first and last sample tick that
+      -- saw byte growth for this (mac, dst_ip). Emitted only when the tracker
+      -- recorded a window (i.e. at least one growth tick was sampled with a
+      -- clock); the no-sample byte>0 fallback above has no window, so we omit
+      -- the fields and the server falls back to [periodStart, periodEnd].
+      local first_active = tracker.first_active and tracker.first_active[key]
+      local last_active  = tracker.last_active and tracker.last_active[key]
+      if first_active and last_active then
+        rec.activeStart = os.date("!%Y-%m-%dT%H:%M:%SZ", first_active)
+        rec.activeEnd   = os.date("!%Y-%m-%dT%H:%M:%SZ", last_active)
+      end
       if leases then
         rec.ip = leases[c.mac]  -- may be nil if MAC not in lease table
       end

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -1304,7 +1304,10 @@ conntrack.watch({
       ts.last_activity_sample = mono
       local counters = read_nft_counters()
       if counters then
-        usage.tracker_sample(activity_tracker, counters)
+        -- #2025: pass wall-clock so the tracker records the real activity
+        -- envelope (first/last growth tick) build_report emits as
+        -- activeStart/activeEnd.
+        usage.tracker_sample(activity_tracker, counters, wall)
       end
     end
 
@@ -1344,7 +1347,9 @@ conntrack.watch({
       if counters then
         -- Final sample at flush so set elements that appeared after the
         -- last activity_sample_int tick still get an active sample counted.
-        usage.tracker_sample(activity_tracker, counters)
+        -- #2025: thread wall-clock so this final tick extends the activity
+        -- envelope build_report emits.
+        usage.tracker_sample(activity_tracker, counters, wall)
         ts.last_activity_sample = mono
         local report = usage.build_report(
           counters, nft_sets, period_start, period_end, router_id,

--- a/openwrt/test/contract_gen.lua
+++ b/openwrt/test/contract_gen.lua
@@ -220,7 +220,10 @@ end
 -- a leases table so the first record carries `ip` and the second omits it.
 
 local USAGE_FIELD_ORDER = {
-  "mac", "ip", "host", "activeSeconds", "bytesIn", "bytesOut",
+  "mac", "ip", "host", "activeSeconds", "bytesIn", "bytesOut", "destIp",
+  -- #2025: additive activity-envelope fields (present on the first record,
+  -- omitted on the second to document the optional/backward-compat shape).
+  "activeStart", "activeEnd",
 }
 
 local function build_usage_report()
@@ -239,11 +242,21 @@ local function build_usage_report()
   local leases = { ["aa:bb:cc:11:22:33"] = "192.168.10.50" }
   -- usage.lua: active_seconds = sample_seconds (10) × samples, capped at bucket_seconds.
   -- Pick 24 → 240s for the first record; pin the second to 60s with 6 samples.
+  -- #2025: the first record carries a real activity envelope (first/last growth
+  -- tick wall-clock, within the [13:55, 14:00] period); the second omits it so
+  -- the golden documents both the populated and the backward-compat shapes.
+  -- 1779026160 = 2026-05-17T13:56:00Z, 1779026360 = 2026-05-17T13:59:20Z.
   local tracker = {
-    last = {},
+    last           = {},
     active_samples = {
       ["aa:bb:cc:11:22:33|151.101.65.69"] = 24,
       ["76:2d:95:47:d1:8e|192.168.10.99"] = 6,
+    },
+    first_active   = {
+      ["aa:bb:cc:11:22:33|151.101.65.69"] = 1779026160,
+    },
+    last_active    = {
+      ["aa:bb:cc:11:22:33|151.101.65.69"] = 1779026360,
     },
   }
   local report = usage.build_report(

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -678,6 +678,42 @@ describe("usage.tracker", function()
     assert.equal(1, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"])
   end)
 
+  -- #2025: when a wall-clock `now` is threaded, the tracker records the real
+  -- activity envelope (first/last growth tick) per key.
+  it("records first_active/last_active wall-clock for the first and last growth tick (#2025)", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  100) }, 1000)  -- +1, first
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  100) }, 1010)  -- no growth
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  500) }, 1020)  -- +1, last so far
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  500) }, 1030)  -- no growth
+    assert.equal(1000, t.first_active["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.equal(1020, t.last_active["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("a counter decrease with bytes>0 extends the activity envelope (#2025)", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) }, 2000)  -- +1, first
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  50) }, 2050)  -- reset, bytes>0 → +1
+    assert.equal(2000, t.first_active["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.equal(2050, t.last_active["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("omits the envelope entirely when no wall-clock is threaded (old callers)", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })  -- no `now`
+    assert.equal(1, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.is_nil(t.first_active["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.is_nil(t.last_active["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("tracker_reset clears the activity envelope too (#2025)", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) }, 3000)
+    usage.tracker_reset(t)
+    assert.is_nil(next(t.first_active))
+    assert.is_nil(next(t.last_active))
+  end)
+
 end)
 
 describe("usage.build_report with tracker", function()
@@ -763,6 +799,31 @@ describe("usage.build_report with tracker", function()
     for _, rec in ipairs(r.records) do by_mac[rec.mac] = rec end
     assert.equal(10, by_mac["aa:bb:cc:11:22:33"].activeSeconds)
     assert.equal(40, by_mac["de:ad:be:ef:00:01"].activeSeconds)
+  end)
+
+  -- #2025: when the tracker recorded a wall-clock activity envelope, build_report
+  -- emits it as RFC3339 activeStart/activeEnd (same format as periodStart).
+  it("emits activeStart/activeEnd from the tracker's activity envelope (#2025)", function()
+    local t = usage.new_tracker()
+    -- Two growth ticks 20s apart, both well inside the 5-min flush window.
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) }, 1715176900)
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) }, 1715176920)
+    local r = usage.build_report(
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
+      NF_SETS, P_START, P_END, ROUTER, nil, nil, t, SAMPLE_S, BUCKET_S)
+    assert.equal(os.date("!%Y-%m-%dT%H:%M:%SZ", 1715176900), r.records[1].activeStart)
+    assert.equal(os.date("!%Y-%m-%dT%H:%M:%SZ", 1715176920), r.records[1].activeEnd)
+  end)
+
+  it("omits activeStart/activeEnd when the tracker has no envelope (old agent) (#2025)", function()
+    local t = usage.new_tracker()
+    -- Sampled WITHOUT a wall-clock, so no envelope recorded.
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })
+    local r = usage.build_report(
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
+      NF_SETS, P_START, P_END, ROUTER, nil, nil, t, SAMPLE_S, BUCKET_S)
+    assert.is_nil(r.records[1].activeStart)
+    assert.is_nil(r.records[1].activeEnd)
   end)
 
 end)

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1431,6 +1431,15 @@ case class UsageRecord(
     // backward-compat with pre-#730 agents that do not emit the field; the
     // API stores NULL on traffic_reports.dest_ip when absent.
     destIp: Option[IpAddress] = None,
+    // #2025: the REAL activity envelope of this bucket — the wall-clock (RFC3339,
+    // UTC, same format as periodStart/periodEnd) of the first and last sample
+    // tick the agent observed byte growth on for this (mac, dst_ip), distinct
+    // from the [periodStart, periodEnd] FLUSH window the envelope sits inside.
+    // Additive + optional: pre-#2025 agents omit them and the API stores NULL on
+    // traffic_reports.active_start / active_end, with the server falling back to
+    // the flush window in Presence.spanOf. Both must be present to be used.
+    activeStart: Option[String] = None,
+    activeEnd: Option[String] = None,
 ) derives JsonCodec
 
 case class UsageReport(


### PR DESCRIPTION
Resolves #2025 — the **server-robustness half of #2016**. Stacked on the schema-only migration #2027 (base will auto-retarget to `main` once #2027 merges).

## Problem
`Presence.spanOf` (the #1464 session-stitch) credits each usage row's full `[period_start, period_end]` **flush** window as continuous engaged presence. That window is "time since the last flush", not "time the device was active". When a flush stalls (the conntrack-gated agent loop on a quiet LAN — sibling #2024), the window balloons and the server over-counts (#2016: a ~20s burst in a 517s window read as ~8.6 min). The server had no defense — it trusted the window blindly.

## Fix — buckets carry their real activity timing; the server computes from that
**Agent** (`usage.lua` + `wifihaven-agent`): the activity tracker now records, per `(mac, dst_ip)`, the wall-clock of the **first and last** sample tick that saw byte growth (`tracker_sample` takes an optional `now`; the agent threads `wall`). `build_report` emits these as additive, optional `activeStart`/`activeEnd` (RFC3339).

**Wire/server**: additive only (router↔API contract — both sides tolerate absence). `UsageRecord` → `RouterIngestService` → `traffic_reports.active_start/active_end` (new nullable cols, #2027) → `PresenceRow`. `spanOf` uses `[activeStart, activeEnd]` when present, **falling back to `[period_start, period_end]`** when absent (old agents) — so old data is unaffected.

`effectiveGap` also derives `R` from `spanOf` (not `period_seconds`): otherwise the `2 × R` collapse guard would raise the idle gap to `2 × period_seconds` and **bridge** the idle stretches between bursts, re-chaining the inflation `spanOf` removed. Both halves together bound the credit regardless of flush cadence — the over-count is structurally impossible.

`aggregateForInsert` unions the envelopes of collapsed `(mac, host)` duplicates (earliest start, latest end); a malformed/absent wire timestamp degrades to the flush-window fallback, never a batch failure.

## Regression tests (the #2016 "refactors can't silently break the math" ask)
- **unit `spanOf`**: envelope used / fallback when absent / backwards-clamp to 0 / half-present → fallback
- **stall fixture** (wide flush window + tight activity envelope) → **bounded** usedMinutes, contrasted against the un-defended flush-window arm, pinned at three levels: unit (`PresenceSpec`), feature `dayStateLive` (`TimeStatusServiceSpec`), and the **real rollup path** `dayState ⇄ dayStateLive` equivalence (`TimeUsedRollupSpec`)
- **invariant pins**: per-app `usedMins` ⊆ profile `usedMins` for a non-exempt app; Dedup-mode profile ≤ elapsed wall-clock and ≤ 1440

TDD: the stall fixtures went red first and surfaced the `effectiveGap` half (the flush-window `R` was bridging the bursts); fixing it turned them green.

## Validation
- `mill api.test` green (full suite); `scalafmt --check` clean.
- Agent busted suite green; **validated on real Lua 5.1.5 (openwrt.lan)** per the no-mock-5.1 practice — module + agent parse, KAT covers tracker first/last recording, no-clock omission, reset, and `build_report` RFC3339 emission/omission.
- Contract golden `usage_report.json` regenerated (documents both populated + omitted shapes); `ContractGoldenSpec` round-trips it through the production decoder.

## Relationship to other work
Server-robustness half of #2016. Together with the agent stall fix #2024, **supersedes the closed PR #2022 clamp** (the stall fix prevents wide windows; this makes the server ignore the window anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)