### PR TITLE
docs(#2021,#2023): verify-and-cite convention + adversarial 'unsourced facts & magic constants' reviewer dimension

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -11,7 +11,10 @@ section, which is authoritative:
 
 Target PR: `$ARGUMENTS` (a PR number, or the current branch's PR if empty).
 
-Apply the checklist's 8 dimensions to the diff, cite `file:line`, classify every
+Apply the checklist's 9 dimensions to the diff (the 9th, **Unsourced facts &
+magic constants**, catches the #2018 class — behavior-driving magic numbers and
+"how it works" comments asserted without tracing to an authoritative source),
+cite `file:line`, classify every
 finding BLOCKER / SHOULD-FIX / NIT, do **not** modify files, and end with
 VERDICT: APPROVE or REQUEST-CHANGES (never APPROVE with an open BLOCKER) plus a
 3-line summary. Then post per the algorithm below.
@@ -33,7 +36,7 @@ VERDICT: APPROVE or REQUEST-CHANGES (never APPROVE with an open BLOCKER) plus a
    ```
 
    - **Empty / null → first run.** Review the full merge-base diff
-     `git diff origin/main...HEAD` (three-dot, never two-dot) against the 8
+     `git diff origin/main...HEAD` (three-dot, never two-dot) against the 9
      dimensions.
    - **Found → re-run.** Extract its prior SHA
      (`grep -oE 'reviewed-sha=[0-9a-f]+' | head -1`) and its findings, then:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,16 @@ shape, wire JSON examples, and the enforcement model.
 > [#1334](https://github.com/wifihaven/wifihaven/issues/1334) fixed the
 > agent's blocklist-fetch call.)
 
+### Stating facts about the system — verify and cite, never confabulate {#verify-and-cite}
+
+Any statement of a constant's value, a cadence / interval / window, a schema
+fact, or "how subsystem X works" must be traced to and cited from its
+authoritative source in the repo (config, the code that sets it, the migration)
+— **not** from a comment (a comment can be the bug), from memory, or from
+inference. A single-sourced value is read/derived, never re-hardcoded; when you
+can't verify, say "unknown / unverified" and stop rather than confabulating a
+plausible explanation. → see [`docs/process/verify-and-cite.md`](docs/process/verify-and-cite.md)
+
 ## Where to look — topic TOC
 
 Each entry below summarizes one previously-inline AGENTS.md section. Anchors

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -194,6 +194,46 @@ are a public contract — API and agents deploy independently.
 - **New routes enforce auth + role.** JWT-authenticated, with the correct
   Admin / ReadOnly check via the middleware.
 
+## 9. Unsourced facts & magic constants
+
+The reviewer that APPROVED the wrong 5-minute `raw` window
+([#2018](https://github.com/wifihaven/wifihaven/issues/2018)) missed a
+behavior-driving magic number and several "how it works" comments that were
+**asserted without being traced to their authoritative source**. Treat every
+comment, docstring, and PR-body claim as a **claim to verify, not a fact** —
+and, where cheap, spend a tool call to actually check the asserted source (grep
+the config / constant) before deciding. Cross-references the
+[verify-and-cite convention](../AGENTS.md#verify-and-cite) and
+[single-source-of-truth](../AGENTS.md#single-source-of-truth).
+
+- **Magic constants not traced to source.** A new literal encoding a cadence /
+  interval / window / size / limit, where the diff doesn't show it derived from
+  or cited to an authoritative source (a config option, the data, an existing
+  named constant). Durations are the highest-risk class — `% 300`,
+  `ofMinutes(5)`, bare `300`, `60`. SHOULD-FIX by default; **BLOCKER when the
+  constant drives behavior** (as the `raw` window did).
+- **Re-hardcoding a single-sourced value = BLOCKER when it can drift.** A value
+  that already lives in one authoritative place (the agent
+  `usage_report_interval`, a config option, a shared constant) copied as a
+  literal elsewhere. The router↔API usage period is the worked example: it is
+  single-sourced at the agent (`usage_report_interval`, default 60s) and rides
+  every row as `period_start`/`period_end`; an API-side `300` / `ofMinutes(5)`
+  copy is exactly the #2018 bug.
+- **Comment / doc asserts behavior the diff doesn't substantiate.** A comment,
+  docstring, or PR-body claim about a cadence, granularity, invariant, or "how
+  subsystem X works" that the code in the diff doesn't back up (or contradicts).
+  Flag it and ask for the citation — don't take the comment's word for it.
+- **Comment contradicts the code it annotates** — e.g. a "5-min boundaries"
+  comment next to logic that no longer matches. The false comment *"source rows
+  are at UTC 5-min boundaries already"* is what cemented the #2018 wrong model.
+
+Worked example: the #2018 `% 300` raw window — a stale agent default
+([#101](https://github.com/wifihaven/wifihaven/issues/101)'s `300`) re-hardcoded
+into the API in [#846](https://github.com/wifihaven/wifihaven/issues/846)
+*after* [#529](https://github.com/wifihaven/wifihaven/issues/529) had moved the
+agent to 60s, cemented by a false comment. A behavior-driving, unsourced,
+re-hardcoded constant — a BLOCKER under this dimension.
+
 ---
 
 ## Output format
@@ -263,7 +303,7 @@ gh pr comment <n> --repo wifihaven/wifihaven --body-file /tmp/pr-review-body.md
 1. Resolve the PR head SHA: `gh pr view <n> --json headRefOid -q .headRefOid`
    (or `git rev-parse HEAD` when reviewing the checked-out branch).
 2. Review the **full merge-base diff** `git diff origin/main...HEAD`
-   (three-dot — never two-dot) against the 8 dimensions above.
+   (three-dot — never two-dot) against the 9 dimensions above.
 3. Post the marked comment for that SHA.
 
 ### Re-run (a prior marked comment exists)

--- a/docs/process/verify-and-cite.md
+++ b/docs/process/verify-and-cite.md
@@ -1,0 +1,86 @@
+# Verify and cite system facts
+
+A standing rule for anyone — human or agent — working in this repo. It is the
+process guardrail against the failure that produced the wrong 5-minute `raw`
+window ([#2018](https://github.com/wifihaven/wifihaven/issues/2018) /
+[#2020](https://github.com/wifihaven/wifihaven/issues/2020)): a constant and
+several "how it works" claims were **asserted without being traced to their
+authoritative source**, and were wrong.
+
+## Stating facts about the system {#verify-and-cite}
+
+Any statement of a **constant's value, a cadence / interval / window, a schema
+fact, or "how subsystem X works"** must be traced to and cited from its
+**authoritative source in the repo** — the config file, the code that sets it,
+or the migration. Not from a comment. Not from memory. Not from inference. If
+you write it down, you must be able to point at the line it came from.
+
+- **Cite the source.** When you assert a value or a behavior, name where it
+  lives: `openwrt/files/etc/config/wifihaven` → `usage_report_interval`, the
+  migration `V{n}__….sql`, the function that computes it. A claim with no
+  traceable source is a guess wearing a fact's clothing.
+
+- **Comments and docstrings are NOT authoritative.** A comment can be the bug —
+  it drifts from the code it annotates, or it was wrong when written. Verify the
+  claim against the actual config / code before repeating it. The false comment
+  *"source rows are at UTC 5-min boundaries already"* is exactly how the #2018
+  wrong mental model got cemented and echoed forward.
+
+- **Single-source constants — derive, never re-hardcode.** A value that already
+  lives in one authoritative place must never be copied as a literal elsewhere;
+  read it or derive it. The usage-report period is single-sourced at the agent
+  (`usage_report_interval`, default 60s) and rides every stored row as
+  `period_start`/`period_end`; the API must hold no copy. Re-hardcoding such a
+  value is a single-source-of-truth violation — see
+  [`single-source-of-truth.md`](single-source-of-truth.md#single-source-of-truth).
+
+- **When you can't verify, say "unknown / unverified" and stop.** Do not
+  construct a plausible explanation to fill the gap. A confident wrong answer is
+  worse than "I don't know — let me check git." If the source isn't traceable in
+  the time you have, say so explicitly rather than inventing a backstory for why
+  the code is the way it is.
+
+- **Own mistakes by fact.** Attribute by `git blame`, not by vibe. Don't
+  distance yourself with "legacy / pre-existing / not me" — it's all our code.
+  Find who/what/when actually introduced it and say that.
+
+## Worked cautionary example — the 5-minute `raw` window (#2018)
+
+The dashboard `raw` bandwidth gauge was bucketed on a hardcoded **5-minute**
+window (`UsageTraffic.floorTo(Raw) … % 300`, `stepOf(Raw) = ofMinutes(5)`). That
+constant was copied from a **dead agent default**: the original
+`usage_report_interval` was `300` (5 min,
+[#101](https://github.com/wifihaven/wifihaven/issues/101)), but
+[#529](https://github.com/wifihaven/wifihaven/issues/529) had already moved the
+agent to **60s** before
+[#846](https://github.com/wifihaven/wifihaven/issues/846) re-hardcoded the stale
+`300` into the API. The full provenance — dates, PRs, the false comment that
+cemented it — lives in the
+[single-source-of-truth worked example](single-source-of-truth.md) and in the
+[#2018](https://github.com/wifihaven/wifihaven/issues/2018) thread; treat those
+as the authoritative record and verify against `git` before restating any of it
+here.
+
+Every guardrail in this doc would have caught it:
+
+- **Cite the source / single-source it** → the period lives at the agent and on
+  each row's `[period_start, period_end)`; the API copy was unsourced.
+- **Comments aren't authoritative** → the "5-min boundaries already" comment was
+  itself the bug, trusted as fact.
+- **Say "unknown," don't confabulate** → when asked *why* it was 5 min, a
+  plausible-but-false backstory ("the router reported in 5-min batches back then,
+  so it was correct at the time") was manufactured instead of checking git.
+
+The fix derives the window from the row's real `[period_start, period_end)` span
+(one shared helper, `UsageTraffic.windowFor`), and a CI guard
+(`.github/scripts/check-usage-period-hardcode.sh`) now rejects a newly-added
+`% 300` / `ofMinutes(5)` / bare `300` in the usage/traffic paths.
+
+## Enforcement
+
+The PR-review checklist
+([`docs/pr-review-checklist.md`](../pr-review-checklist.md)) carries an
+**"Unsourced facts & magic constants"** review dimension that flags exactly this
+class — magic constants not traced to source, re-hardcoded single-sourced
+values, and comments/PR-body claims the diff doesn't substantiate. This doc is
+the convention; that dimension is its automated enforcement on every PR.


### PR DESCRIPTION
## What

Lands the two-part guardrail against asserting/confabulating constants and "how it works" claims without tracing them to an authoritative source — the failure that produced the wrong 5-minute `raw` bandwidth window just fixed in #2018/#2020. #2021 teaches the rule; #2023 catches violators on every PR. They ship together.

Closes #2021. Closes #2023.

### Part A — #2021: the verify-and-cite convention
- **New [`docs/process/verify-and-cite.md`](docs/process/verify-and-cite.md)** — a short standing rule: any constant value / cadence / schema fact / "how subsystem X works" claim must be traced to and cited from its authoritative source in the repo (config, the code that sets it, the migration). Covers: cite-the-source, **comments/docstrings aren't authoritative** (a comment can be the bug), **single-source constants** (derive/read, never re-hardcode — cross-links `single-source-of-truth.md`), **say "unknown / unverified" and stop — don't confabulate**, and **own mistakes by fact** (git blame, not "legacy / not me"). Uses the #2018 5-min `raw` case as the worked cautionary example.
- **`AGENTS.md`** — adds a "Stating facts about the system" entry in the always-in-context Architectural-model section, linking the convention.

### Part B — #2023: the adversarial reviewer dimension
- **`docs/pr-review-checklist.md`** — new **dimension 9 "Unsourced facts & magic constants"**: magic constants not traced to source (durations especially — `% 300`, `ofMinutes(5)`, `300`, `60`), re-hardcoding a single-sourced value (BLOCKER when it can drift), comment/doc asserting behavior the diff doesn't substantiate, comment contradicting the code. SHOULD-FIX by default, BLOCKER when the constant/claim drives behavior; reviewer should grep the asserted source before deciding. #2018 `% 300` worked example. This dimension also serves as the #2021 checklist item (no duplication).
- **`.claude/commands/pr-review.md`** — references the new dimension; dimension count **8 → 9** kept consistent across both files.

## Scope
Docs/process and markdown only — **no source, no test, no behavior change.** All cross-links resolve; anchors `#verify-and-cite` / `#single-source-of-truth` exist.

Motivated by #2018 / #2020.