### PR TITLE
feat(#1834): dashboard KPI strip above NOW + status-first restate

### DIFF
--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -162,7 +162,7 @@ describe('DashboardPage', () => {
 
   it('does not render the unfiltered Recent Queries firehose (#823)', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    await screen.findByText('1234')
+    await screen.findByTestId('kpi-strip')
     expect(screen.queryByText('Recent Queries')).not.toBeInTheDocument()
     // The firehose's unfiltered fetch (one fewer network call on load) is gone.
     expect(api.logs.query).not.toHaveBeenCalledWith({ limit: 30 })

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, act, waitFor } from '@testing-library/react'
+import { render, screen, act, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { DashboardNow, DashboardStats, QueryLog } from '@/types/api'
 
@@ -77,6 +77,33 @@ const liveNow: DashboardNow = {
   ],
 }
 
+// #1834: a snapshot exercising the status-first KPI derivation — `deriveNowKpis`
+// counts every active device as "Online now" and the active devices of *paused*
+// profiles as "Blocked now". Kids is paused with 1 active device (blocked); Adults
+// is active with 2. So onlineNow = 3, blockedNow = 1.
+const kpiNow: DashboardNow = {
+  asOf: '2026-05-13T10:00:00Z',
+  profiles: [
+    {
+      id: 1,
+      name: 'Kids',
+      paused: true,
+      activeDevices: [
+        { id: 10, name: 'iPhone', mac: 'aa:bb:cc:dd:ee:01', lastSeenSeconds: 30, topHosts: [] },
+      ],
+    },
+    {
+      id: 2,
+      name: 'Adults',
+      paused: false,
+      activeDevices: [
+        { id: 20, name: 'MacBook', mac: 'aa:bb:cc:dd:ee:02', lastSeenSeconds: 10, topHosts: [] },
+        { id: 21, name: 'iPad', mac: 'aa:bb:cc:dd:ee:03', lastSeenSeconds: 45, topHosts: [] },
+      ],
+    },
+  ],
+}
+
 const mockStats = () => api.logs.stats as unknown as ReturnType<typeof vi.fn>
 const mockQuery = () => api.logs.query as unknown as ReturnType<typeof vi.fn>
 const mockNow   = () => api.dashboard.now as unknown as ReturnType<typeof vi.fn>
@@ -100,17 +127,37 @@ beforeEach(() => {
 })
 
 describe('DashboardPage', () => {
-  it('renders stat cards, top-blocked, and per-device', async () => {
+  it('renders the 1h KPI tiles, top-blocked, and per-device', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    expect(await screen.findByText('1234')).toBeInTheDocument()
-    expect(screen.getByText('56')).toBeInTheDocument()
-    expect(screen.getByText('78')).toBeInTheDocument()
-    expect(screen.getByText('9')).toBeInTheDocument()
+    expect(await screen.findByText('78')).toBeInTheDocument()  // Events (1h)
+    expect(screen.getByText('9')).toBeInTheDocument()          // Blocked (1h)
     expect(screen.getByText('evil.com')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
     expect(screen.getAllByText("Kid's iPad").length).toBeGreaterThan(0)
     expect(screen.getByText('500 events')).toBeInTheDocument()
     expect(screen.getByText('20 blocked')).toBeInTheDocument()
+  })
+
+  it('restates the KPI tiles status-first: Online now / Blocked now / Events (1h) / Blocked (1h) (#1834)', async () => {
+    mockNow().mockResolvedValue(kpiNow)
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    const strip = await screen.findByTestId('kpi-strip')
+    for (const label of ['Online now', 'Blocked now', 'Events (1h)', 'Blocked (1h)']) {
+      expect(within(strip).getByText(label)).toBeInTheDocument()
+    }
+    // Online now / Blocked now derive from the NOW snapshot via deriveNowKpis
+    // (onlineNow = 3 active devices, blockedNow = 1 active device in a paused profile).
+    await waitFor(() => expect(within(strip).getByText('3')).toBeInTheDocument())
+    expect(within(strip).getByText('1')).toBeInTheDocument()
+    expect(within(strip).getByText('78')).toBeInTheDocument()  // Events (1h) = stats.totalHour
+    expect(within(strip).getByText('9')).toBeInTheDocument()   // Blocked (1h) = stats.blockedHour
+  })
+
+  it('drops the cumulative "today" KPI tiles from the dashboard (#1834)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    await screen.findByTestId('kpi-strip')
+    expect(screen.queryByText('Events today')).not.toBeInTheDocument()
+    expect(screen.queryByText('Blocked today')).not.toBeInTheDocument()
   })
 
   it('does not render the unfiltered Recent Queries firehose (#823)', async () => {
@@ -123,8 +170,7 @@ describe('DashboardPage', () => {
 
   it('uses connection-event terminology, never "queries" (#299)', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    await screen.findByText('1234')
-    expect(screen.getByText('Events today')).toBeInTheDocument()
+    await screen.findByTestId('kpi-strip')
     expect(screen.getByText('Events (1h)')).toBeInTheDocument()
     expect(screen.queryByText(/queries/i)).not.toBeInTheDocument()
   })
@@ -135,14 +181,12 @@ describe('DashboardPage', () => {
     expect(await screen.findByText(/No blocked events yet/)).toBeInTheDocument()
   })
 
-  it('renders Now section above stat cards', async () => {
+  it('renders the KPI strip above the NOW section (#1834)', async () => {
     mockNow().mockResolvedValue(liveNow)
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    await screen.findByText('1234')
-    await waitFor(() => expect(screen.getByTestId('now-profile-1')).toBeInTheDocument())
-    const nowHeading = screen.getByText('Now')
-    const statsCard  = screen.getByText('Events today')
-    const comparison = nowHeading.compareDocumentPosition(statsCard)
+    const strip = await screen.findByTestId('kpi-strip')
+    const now   = await screen.findByTestId('now-section')
+    const comparison = strip.compareDocumentPosition(now)
     expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -33,6 +33,8 @@ export function DashboardPage() {
     <div className="space-y-6">
       <h1 className="text-xl font-bold text-brand-ink">Dashboard</h1>
 
+      {stats && <KpiStrip stats={stats} />}
+
       <NewDevicesHint />
 
       <AccessRequestsBanner />
@@ -45,13 +47,6 @@ export function DashboardPage() {
 
       {stats && (
         <>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard label="Events today"   value={stats.totalToday}   accent="emerald" />
-            <StatCard label="Blocked today"  value={stats.blockedToday} accent="red" />
-            <StatCard label="Events (1h)"    value={stats.totalHour}    accent="emerald" />
-            <StatCard label="Blocked (1h)"   value={stats.blockedHour}  accent="yellow" />
-          </div>
-
           <div className="grid md:grid-cols-2 gap-6">
             <section className="bg-white rounded-2xl border border-brand-border p-5">
               <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-4">
@@ -281,6 +276,27 @@ function formatDuration(seconds: number): string {
   const h = Math.floor(mins / 60)
   const m = mins % 60
   return m === 0 ? `${h}h` : `${h}h ${m}m`
+}
+
+// #1834: status-first KPI strip, rendered immediately under the <h1> and ABOVE the
+// NOW section (design docs/design/dashboard-redesign.md §7.3 Q1). "Online now" /
+// "Blocked now" derive from the live NOW snapshot via deriveNowKpis — the same
+// dashboard-now cache NowSection populates (10s poll + `now` ws push, wsCache §3.1)
+// — so this is a pure cache reader: no new endpoint and no second poller
+// (refetchInterval:false; NowSection drives the refresh, both observers re-render).
+// The cumulative "today" volume tiles are dropped: daily volume is analytics and
+// lives on /usage/events (design §2 non-goals).
+function KpiStrip({ stats }: { stats: DashboardStats }) {
+  const { data: now = null } = useDashboardNow({ refetchInterval: false })
+  const kpis = deriveNowKpis(now)
+  return (
+    <div data-testid="kpi-strip" className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <StatCard label="Online now"   value={kpis.onlineNow}  accent="emerald" />
+      <StatCard label="Blocked now"  value={kpis.blockedNow} accent="red" />
+      <StatCard label="Events (1h)"  value={stats.totalHour}  accent="emerald" />
+      <StatCard label="Blocked (1h)" value={stats.blockedHour} accent="yellow" />
+    </div>
+  )
 }
 
 function StatCard({ label, value, accent }: { label: string; value: number; accent: string }) {


### PR DESCRIPTION
Chunk **2 of 5** of the `/dashboard` holistic redesign (umbrella #1148). **Frontend only, no API change.**

## What changed
- **Moved** the 4-tile KPI strip to render immediately under `<h1>Dashboard</h1>`, **above** `<NowSection />` (it previously rendered after the entire NOW grid, below the fold — #821).
- **Restated** the tiles status-first (design [§7.3 Q1](docs/design/dashboard-redesign.md)):
  - **Online now** — active devices in the last 5 min, derived from the `useDashboardNow` snapshot via the existing `deriveNowKpis` helper (`web/src/api/wsCache.ts`). No new query.
  - **Blocked now** — active devices in currently-paused profiles, same snapshot/helper.
  - **Events (1h)** — `stats.totalHour` (already renamed from "Queries", #299/#1833).
  - **Blocked (1h)** — `stats.blockedHour`.
- **Dropped** the cumulative "Events today" / "Blocked today" tiles — daily volume is analytics and lives on `/usage/events` (design §2 non-goals).
- Kept `grid-cols-2 md:grid-cols-4` (mobile wraps 2×2).

## How "now" KPIs stay live without a new endpoint
`KpiStrip` reads the **shared** `dashboardNow` React Query cache with `refetchInterval: false` — `NowSection`'s existing 10s poll + `now` websocket push (S5, `wsCache` §3.1) keep that cache fresh, and both observers re-render on update. No second poller, no new route.

LIVE BANDWIDTH / NOW / Recently-Blocked sections and their ws wiring are untouched.

## Tests
TDD: committed the failing `DashboardPage` test first (RED), then the implementation. New/updated assertions cover tile order (strip above `now-section`), the four status-first labels, `Online now`/`Blocked now` derived from a mocked snapshot (onlineNow=3, blockedNow=1 with a paused profile), no "today" tile, no "queries" copy. `npm --prefix web run lint` + `test` (482 pass) + `build` all green.

Closes #821, applies #299. Part of #1148.