### PR TITLE
ci(#2033): harden Gate-2 client-VM boot — retry + crash detection + console preservation

### DIFF
--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -100,33 +100,52 @@ fi
 rm -rf "${RUN_DIR}"
 mkdir -p "${RUN_DIR}" "${WH_SOCK_DIR}"
 
-# EXIT trap: if the client never becomes reachable (or any failure between
-# here and the "client booted" sentinel), kill the qemu we just spawned and
-# remove the run directory so no orphan is left behind. Mirrors the pattern
-# from router-up.sh (#1225). Once the client is confirmed reachable, set
-# _client_booted=1 so the trap becomes a no-op on the success path.
-_client_booted=0
-# shellcheck disable=SC2329  # invoked via trap EXIT, not a direct call
-_cleanup_on_fail() {
-  [[ "${_client_booted}" == "1" ]] && return 0
-  local _pid=""
-  if [[ -f "${RUN_DIR}/qemu.pid" ]]; then
-    _pid="$(cat "${RUN_DIR}/qemu.pid" 2>/dev/null || true)"
-  fi
-  if [[ -n "${_pid}" ]] && kill -0 "${_pid}" 2>/dev/null; then
-    echo "[client-up] cleaning up orphan qemu (pid ${_pid})" >&2
-    kill -KILL "${_pid}" 2>/dev/null || true
-  fi
-  rm -rf "${RUN_DIR}"
-}
-trap _cleanup_on_fail EXIT
-
 if [[ -z "${SSH_PORT}" ]]; then
   SSH_PORT="${WH_CLIENT_SSH_PORT_BASE}"
 fi
 
 OVERLAY="${RUN_DIR}/overlay.qcow2"
-qemu-img create -f qcow2 -F qcow2 -b "${WH_CLIENT_BASE_IMG}" "${OVERLAY}" >/dev/null
+PIDFILE="${RUN_DIR}/qemu.pid"
+# QMP socket lives under WH_SOCK_DIR (short path) — see config.sh WH_SOCK_DIR
+# note for the AF_UNIX sun_path reason.
+QMP_SOCK="$(wh_client_qmp_sock "${NAME}")"
+
+# Per-attempt SSH-reachability budget (clients normally come up in ~5s) and the
+# number of boot attempts. One retry by default (#2033): on a loaded shared host
+# the occasional client never finishes its first boot (DHCP not yet served, tap
+# carrier lag, a wedged first boot), reddening an arbitrary scenario with
+# "did not become reachable". A single fresh-overlay retry turns that transient
+# into a ~90s blip instead of a job failure, while the normal ~5s path is
+# unchanged. Overridable for tests / unusual hosts.
+WH_CLIENT_BOOT_TIMEOUT="${WH_CLIENT_BOOT_TIMEOUT:-90}"
+WH_CLIENT_BOOT_ATTEMPTS="${WH_CLIENT_BOOT_ATTEMPTS:-2}"
+
+# EXIT trap: if the client never becomes reachable (or any failure between
+# here and the "client booted" sentinel), kill the qemu we last spawned and
+# drop the disposable overlay + control socket. Mirrors router-up.sh (#1225).
+# Crucially it does NOT remove ${RUN_DIR}: the serial console.log (and any
+# per-attempt console.attemptN.log) must survive so the CI "Upload failure
+# artifacts" step can capture them — a boot timeout was previously
+# undiagnosable because this trap rm -rf'd the whole run dir, deleting
+# console.log before upload (#2033). Leaving the dir behind is safe: the next
+# client-up start reclaims+wipes it (stale-reclaim above) and client-down.sh
+# removes it in teardown. Once the client is reachable, _client_booted=1 makes
+# the trap a no-op on the success path.
+_client_booted=0
+# shellcheck disable=SC2329  # invoked via trap EXIT, not a direct call
+_cleanup_on_fail() {
+  [[ "${_client_booted}" == "1" ]] && return 0
+  local _pid=""
+  if [[ -f "${PIDFILE}" ]]; then
+    _pid="$(cat "${PIDFILE}" 2>/dev/null || true)"
+  fi
+  if [[ -n "${_pid}" ]] && kill -0 "${_pid}" 2>/dev/null; then
+    echo "[client-up] cleaning up orphan qemu (pid ${_pid})" >&2
+    kill -KILL "${_pid}" 2>/dev/null || true
+  fi
+  rm -f "${OVERLAY}" "${QMP_SOCK}" 2>/dev/null || true
+}
+trap _cleanup_on_fail EXIT
 
 ACCEL_ARGS=()
 if [[ -e /dev/kvm ]]; then
@@ -144,43 +163,129 @@ LAN_DEVICE="virtio-net-pci,netdev=lan,mac=${MAC}"
 MGMT_NETDEV="user,id=mgmt,net=10.0.2.0/24,host=10.0.2.2,dhcpstart=10.0.2.15,restrict=on,hostfwd=tcp:127.0.0.1:${SSH_PORT}-10.0.2.15:22"
 MGMT_DEVICE="virtio-net-pci,netdev=mgmt"
 
-PIDFILE="${RUN_DIR}/qemu.pid"
-# QMP socket lives under WH_SOCK_DIR (short path) — see config.sh WH_SOCK_DIR
-# note for the AF_UNIX sun_path reason. Clear any stale socket from a prior run.
-QMP_SOCK="$(wh_client_qmp_sock "${NAME}")"
-rm -f "${QMP_SOCK}"
+# Bridge readiness (#2033): router-up.sh creates and brings up the LAN bridge
+# before the client attaches, but client-up.sh:75 only checked that the netdev
+# *exists* (`ip link show`). On a loaded shared host the bridge's IFF_UP /
+# carrier can lag that existence check, so the client's tap attaches to a bridge
+# that isn't yet passing frames and the first boot's DHCP fails. Poll IFF_UP
+# (flags & 0x1) briefly so we attach to a bridge that is actually up. Best
+# effort and never fatal — the SSH-reachability loop is still the real gate, and
+# the flags file is absent on non-Linux dev hosts / test stubs (skip cleanly).
+_wait_lan_bridge_ready() {
+  local flags_file="${WH_SYS_CLASS_NET:-/sys/class/net}/${WH_LAN_BRIDGE}/flags"
+  [[ -r "${flags_file}" ]] || return 0
+  local flags
+  for _ in $(seq 1 20); do
+    flags="$(cat "${flags_file}" 2>/dev/null || echo 0)"
+    if (( (flags & 0x1) != 0 )); then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "[client-up] warning: bridge ${WH_LAN_BRIDGE} not IFF_UP after wait — attaching anyway" >&2
+}
 
-# Background the qemu process. -daemonize gives us a stable pidfile.
-qemu-system-x86_64 \
-  -name "$(wh_client_vm_name "${NAME}")" \
-  -m 512 -smp 1 \
-  "${ACCEL_ARGS[@]}" \
-  -display none -serial "file:${RUN_DIR}/console.log" \
-  -drive "if=virtio,file=${OVERLAY},format=qcow2" \
-  -netdev "${LAN_NETDEV}" -device "${LAN_DEVICE}" \
-  -netdev "${MGMT_NETDEV}" -device "${MGMT_DEVICE}" \
-  -qmp "unix:${QMP_SOCK},server=on,wait=off" \
-  -pidfile "${PIDFILE}" \
-  -daemonize
+# Boot qemu once and wait up to WH_CLIENT_BOOT_TIMEOUT for SSH. Returns 0 when
+# reachable, 1 on timeout OR if qemu exits during boot (a crashed boot — e.g. a
+# failed tap attach — should not burn the full timeout before we retry).
+_boot_attempt() {
+  local attempt="$1"
+  rm -f "${OVERLAY}"
+  qemu-img create -f qcow2 -F qcow2 -b "${WH_CLIENT_BASE_IMG}" "${OVERLAY}" >/dev/null
+  rm -f "${QMP_SOCK}"
 
-echo "${SSH_PORT}" > "${RUN_DIR}/ssh.port"
-echo "${MAC}"     > "${RUN_DIR}/mac"
+  # Background the qemu process. -daemonize gives us a stable pidfile. A
+  # non-zero launch (e.g. a transient qemu-bridge-helper tap-attach failure
+  # under shared-host bridge contention) is treated as a failed ATTEMPT —
+  # `return 1` so the retry loop re-spawns — not a hard `set -e` abort that
+  # would bypass the retry (#2033).
+  if ! qemu-system-x86_64 \
+    -name "$(wh_client_vm_name "${NAME}")" \
+    -m 512 -smp 1 \
+    "${ACCEL_ARGS[@]}" \
+    -display none -serial "file:${RUN_DIR}/console.log" \
+    -drive "if=virtio,file=${OVERLAY},format=qcow2" \
+    -netdev "${LAN_NETDEV}" -device "${LAN_DEVICE}" \
+    -netdev "${MGMT_NETDEV}" -device "${MGMT_DEVICE}" \
+    -qmp "unix:${QMP_SOCK},server=on,wait=off" \
+    -pidfile "${PIDFILE}" \
+    -daemonize; then
+    echo "[client-up] qemu failed to launch (attempt ${attempt}); see ${RUN_DIR}/console.log" >&2
+    return 1
+  fi
 
-echo "[client-up] '${NAME}' booting (pid $(cat "${PIDFILE}"), ssh 127.0.0.1:${SSH_PORT}, mac ${MAC})"
+  echo "${SSH_PORT}" > "${RUN_DIR}/ssh.port"
+  echo "${MAC}"     > "${RUN_DIR}/mac"
 
-# Wait until SSH is reachable. Cap at 90s; clients normally come up in ~5s.
-deadline=$(( $(date +%s) + 90 ))
-while (( $(date +%s) < deadline )); do
-  if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        -o ConnectTimeout=2 -o BatchMode=yes \
-        -i "${WH_CLIENT_SSH_KEY}" -p "${SSH_PORT}" \
-        root@127.0.0.1 true 2>/dev/null; then
-    echo "[client-up] '${NAME}' ready"
+  local qpid
+  qpid="$(cat "${PIDFILE}" 2>/dev/null || true)"
+  if [[ -z "${qpid}" ]]; then
+    echo "[client-up] qemu wrote no pidfile (attempt ${attempt})" >&2
+    return 1
+  fi
+  echo "[client-up] '${NAME}' booting (attempt ${attempt}/${WH_CLIENT_BOOT_ATTEMPTS}, pid ${qpid}, ssh 127.0.0.1:${SSH_PORT}, mac ${MAC})"
+
+  local deadline
+  deadline=$(( $(date +%s) + WH_CLIENT_BOOT_TIMEOUT ))
+  while (( $(date +%s) < deadline )); do
+    if ! kill -0 "${qpid}" 2>/dev/null; then
+      echo "[client-up] qemu (pid ${qpid}) exited during boot (attempt ${attempt}) — console.log tail:" >&2
+      tail -n 20 "${RUN_DIR}/console.log" >&2 2>/dev/null || true
+      return 1
+    fi
+    if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+          -o ConnectTimeout=2 -o BatchMode=yes \
+          -i "${WH_CLIENT_SSH_KEY}" -p "${SSH_PORT}" \
+          root@127.0.0.1 true 2>/dev/null; then
+      echo "[client-up] '${NAME}' ready (attempt ${attempt})"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "[client-up] '${NAME}' did not become reachable within ${WH_CLIENT_BOOT_TIMEOUT}s (attempt ${attempt}); see ${RUN_DIR}/console.log" >&2
+  return 1
+}
+
+_wait_lan_bridge_ready
+
+attempt=1
+while (( attempt <= WH_CLIENT_BOOT_ATTEMPTS )); do
+  if _boot_attempt "${attempt}"; then
     _client_booted=1   # disarm EXIT trap — clean exit from here
     exit 0
   fi
-  sleep 1
+  # This attempt failed: kill its qemu before re-spawning, and preserve its
+  # console.log under an attempt-scoped name so a successful retry doesn't
+  # overwrite the failed boot's diagnostics (both get swept up by the CI
+  # artifact upload, which globs .run/**/console*.log via the broad .run/**).
+  _failed_pid=""
+  [[ -f "${PIDFILE}" ]] && _failed_pid="$(cat "${PIDFILE}" 2>/dev/null || true)"
+  if [[ -n "${_failed_pid}" ]] && kill -0 "${_failed_pid}" 2>/dev/null; then
+    kill -KILL "${_failed_pid}" 2>/dev/null || true
+  fi
+  if (( attempt < WH_CLIENT_BOOT_ATTEMPTS )); then
+    [[ -f "${RUN_DIR}/console.log" ]] && \
+      mv -f "${RUN_DIR}/console.log" "${RUN_DIR}/console.attempt${attempt}.log" 2>/dev/null || true
+    echo "[client-up] '${NAME}' boot attempt ${attempt} failed — retrying" >&2
+  fi
+  attempt=$(( attempt + 1 ))
 done
 
-echo "[client-up] '${NAME}' did not become reachable within 90s; see ${RUN_DIR}/console.log" >&2
+# Preserve the boot console(s) OUTSIDE the per-client run dir so the diagnostics
+# survive the scenario fixture's client_down (scripts/e2e/scenarios_fake/
+# conftest.py) — which rm -rf's ${WH_RUN_DIR}/${NAME} — and are still present at
+# the CI "Upload failure artifacts" glob (scripts/vm/.run/**). This matters
+# because a boot timeout is a pytest SETUP failure, which the conftest
+# makereport hook does NOT capture, so without this a mode-1 boot failure lands
+# with no console at all (#2033). client_down only removes the per-NAME dir, so
+# a sibling boot-failures/ dir survives.
+_diag_dir="${WH_RUN_DIR}/boot-failures"
+mkdir -p "${_diag_dir}" 2>/dev/null || true
+for _cl in "${RUN_DIR}"/console.log "${RUN_DIR}"/console.attempt*.log; do
+  [[ -f "${_cl}" ]] || continue
+  cp -f "${_cl}" "${_diag_dir}/${NAME}-$(basename "${_cl}")" 2>/dev/null || true
+done
+
+echo "[client-up] '${NAME}' did not become reachable after ${WH_CLIENT_BOOT_ATTEMPTS} attempt(s); see ${RUN_DIR}/console.log (preserved under ${_diag_dir}/)" >&2
 exit 1

--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -175,6 +175,9 @@ _wait_lan_bridge_ready() {
   local flags_file="${WH_SYS_CLASS_NET:-/sys/class/net}/${WH_LAN_BRIDGE}/flags"
   [[ -r "${flags_file}" ]] || return 0
   local flags
+  # ~10s budget (20 × 0.5s) — deliberately short vs. the 90s boot budget: the
+  # bridge is already created+brought-up by router-up.sh, so this only absorbs
+  # a brief IFF_UP/carrier lag under shared-host load, not a real bring-up.
   for _ in $(seq 1 20); do
     flags="$(cat "${flags_file}" 2>/dev/null || echo 0)"
     if (( (flags & 0x1) != 0 )); then

--- a/scripts/vm/client-up_spec.sh
+++ b/scripts/vm/client-up_spec.sh
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
-# Shell-level tests for scripts/vm/client-up.sh — orphan-qemu fix (#1286).
+# Shell-level tests for scripts/vm/client-up.sh.
 #
-# Asserts:
-#   (a) client-up.sh leaves no stale qemu.pid when it exits non-zero
-#       (client never became reachable). The spawned qemu process is killed.
+# Covers the orphan-qemu fix (#1286) and the Gate-2 boot-resilience hardening
+# (#2033):
+#   (a) On a boot timeout, client-up.sh kills the qemu it spawned AND PRESERVES
+#       ${RUN_DIR}/console.log (so the CI artifact upload can capture it). The
+#       trap used to rm -rf the whole run dir, deleting console.log before
+#       upload — boot timeouts were undiagnosable.
 #   (b) A second client-up.sh invocation reclaims a stale client1 instead of
 #       erroring with "already running".
+#   (c) A boot retry: when the first attempt times out, client-up.sh re-spawns
+#       a fresh overlay and a second attempt that succeeds → exit 0.
+#   (d) Early-crash detection: when qemu exits during boot, client-up.sh fails
+#       fast ("exited during boot") instead of burning the whole timeout.
 #
 # Run from the scripts/vm/ directory:
 #   bash client-up_spec.sh
 #
 # No actual qemu is started. A stub PATH intercepts external commands and
-# simulates the minimal responses needed to exercise the cleanup paths.
+# simulates the minimal responses needed to exercise the boot/cleanup paths.
 # The test uses the real .run/ directory (config.sh unconditionally sets
 # WH_RUN_DIR from the script location) and cleans it up after each case.
 
@@ -40,6 +47,8 @@ SCRATCH="$(mktemp -d)"
 STUB_BIN="${SCRATCH}/bin"
 mkdir -p "${STUB_BIN}"
 DATE_COUNTER_FILE="${SCRATCH}/date-count"
+SSH_COUNTER_FILE="${SCRATCH}/ssh-count"
+SSH_OK_AFTER_FILE="${SCRATCH}/ssh-ok-after"
 
 _STRAY_PIDS=()
 _CREATED_CACHE_DIR=0
@@ -50,6 +59,7 @@ _spec_cleanup() {
   for p in "${_STRAY_PIDS[@]:-}"; do kill "${p}" 2>/dev/null || true; done
   # Remove the test's .run state (but not an existing real one, if any).
   rm -rf "${REAL_CLIENT_RUN_DIR}"
+  rm -rf "${REAL_RUN_DIR}/boot-failures"
   # Remove the dummy base image we created (only if we created it).
   [[ "${_CREATED_BASE_IMG}" -eq 1 ]] && rm -f "${REAL_BASE_IMG}"
   [[ "${_CREATED_CACHE_DIR}" -eq 1 ]] && rmdir "${REAL_CACHE_DIR}" 2>/dev/null || true
@@ -81,28 +91,56 @@ exit 0
 EOF
 chmod +x "${STUB_BIN}/qemu-img"
 
-# qemu-system-x86_64 — starts a real background sleep (the "orphan"), writes its
-# pid to -pidfile (simulating -daemonize behaviour), then returns.
+# qemu-system-x86_64 — parses -pidfile and -serial, writes the serial log
+# (simulating qemu's `-serial file:`), then either:
+#   QEMU_CRASH=1 → writes a guaranteed-dead pid (2^31-1) and returns, so the
+#                  caller's `kill -0` fails → early-crash path.
+#   else         → starts a real background sleep (the "orphan VM") and records
+#                  its pid in -pidfile, simulating -daemonize.
 # Uses /bin/sleep (full path) to bypass the no-op sleep stub below.
 cat > "${STUB_BIN}/qemu-system-x86_64" <<'EOF'
 #!/bin/bash
+PIDFILE=""; SERIAL=""
 while [[ $# -gt 0 ]]; do
-  [[ "$1" == "-pidfile" ]] && { PIDFILE="$2"; shift 2; continue; }
-  shift
+  case "$1" in
+    -pidfile) PIDFILE="$2"; shift 2; continue ;;
+    -serial)  SERIAL="$2";  shift 2; continue ;;
+    *) shift ;;
+  esac
 done
-/bin/sleep 300 &
+case "${SERIAL}" in
+  file:*) SLOG="${SERIAL#file:}"; printf 'fake qemu boot log\n' > "${SLOG}" 2>/dev/null || true ;;
+esac
+if [[ "${QEMU_CRASH:-0}" == "1" ]]; then
+  [[ -n "${PIDFILE}" ]] && echo 2147483647 > "${PIDFILE}"
+  exit 0
+fi
+# Detach the background "VM" from inherited stdio so a surviving qemu (the
+# success path leaves it running) can't hold a command-substitution pipe open
+# and wedge the caller. Real qemu -daemonize closes its inherited fds too.
+/bin/sleep 300 </dev/null >/dev/null 2>&1 &
 QPID=$!
-[[ -n "${PIDFILE:-}" ]] && echo "${QPID}" > "${PIDFILE}"
+[[ -n "${PIDFILE}" ]] && echo "${QPID}" > "${PIDFILE}"
 /bin/sleep 0.15   # let parent read the pidfile before we return
 exit 0
 EOF
 chmod +x "${STUB_BIN}/qemu-system-x86_64"
 
-# ssh — always fails (client never becomes reachable)
-cat > "${STUB_BIN}/ssh" <<'EOF'
+# ssh — succeeds on the SSH_OK_AFTER-th call (per the count file), else fails.
+# Default threshold is huge (read from SSH_OK_AFTER_FILE) → "never reachable".
+cat > "${STUB_BIN}/ssh" <<STUBEOF
 #!/bin/sh
+CF="${SSH_COUNTER_FILE}"
+OKF="${SSH_OK_AFTER_FILE}"
+c="\$(cat "\${CF}" 2>/dev/null || echo 0)"
+c=\$((c + 1))
+echo "\${c}" > "\${CF}"
+ok_after="\$(cat "\${OKF}" 2>/dev/null || echo 999999)"
+if [ "\${c}" -ge "\${ok_after}" ]; then
+  exit 0
+fi
 exit 1
-EOF
+STUBEOF
 chmod +x "${STUB_BIN}/ssh"
 
 # sleep — instant no-op so the ssh-wait loop doesn't wait a real second.
@@ -134,31 +172,35 @@ exit 0
 EOF
 chmod +x "${STUB_BIN}/pkill"
 
-# date — stateful stub so the 90s SSH-wait loop expires after a single probe.
-# Call 0 → returns a small epoch; sets deadline = small + 90.
-# Call 1+ → returns large epoch; while condition (large < small+90) = false → loop exits.
+# date — monotonic stub: each call returns a counter that advances by 1. With a
+# small WH_CLIENT_BOOT_TIMEOUT this expires each attempt's wait loop after a
+# couple of iterations while still running the loop body (so the kill-0 and ssh
+# probes execute), and naturally supports multiple boot attempts.
 cat > "${STUB_BIN}/date" <<STUBEOF
 #!/bin/sh
-COUNT_FILE="${DATE_COUNTER_FILE}"
-count="\$(cat "\${COUNT_FILE}" 2>/dev/null || printf 0)"
-if [ "\${count}" -eq 0 ]; then
-  printf '100\n'
-  printf '1' > "\${COUNT_FILE}"
-else
-  printf '9999\n'
-fi
+CF="${DATE_COUNTER_FILE}"
+c="\$(cat "\${CF}" 2>/dev/null || echo 0)"
+c=\$((c + 1))
+echo "\${c}" > "\${CF}"
+echo "\${c}"
 STUBEOF
 chmod +x "${STUB_BIN}/date"
 
-# Helper: reset date stub counter between test cases
-reset_date_stub() { printf '0' > "${DATE_COUNTER_FILE}"; }
+# Reset per-case counters and ssh threshold.
+reset_counters() {
+  printf '0' > "${DATE_COUNTER_FILE}"
+  printf '0' > "${SSH_COUNTER_FILE}"
+  printf '%s' "${1:-999999}" > "${SSH_OK_AFTER_FILE}"   # ssh-ok-after
+}
 
-# ── export environment expected by config.sh ──────────────────────────────────
+# ── export environment expected by config.sh / client-up.sh ──────────────────
 export WH_LAN_BRIDGE="lo"         # ip stub always succeeds; value irrelevant
 export WH_CLIENT_SSH_KEY="${SCRATCH}/id_ed25519"
 touch "${SCRATCH}/id_ed25519"
 export WH_CLIENT_SSH_PORT_BASE="22230"
 export WH_RUN_ID=""               # single-pair mode
+# Tight boot budget so the (stubbed) wait loops expire in a couple iterations.
+export WH_CLIENT_BOOT_TIMEOUT=3
 
 # Prepend stubs before system binaries.
 export PATH="${STUB_BIN}:/usr/bin:/bin"
@@ -166,49 +208,65 @@ export PATH="${STUB_BIN}:/usr/bin:/bin"
 SCRIPT="${HERE}/client-up.sh"
 [[ -f "${SCRIPT}" ]] || { printf "MISSING: %s\n" "${SCRIPT}"; exit 1; }
 
-# ── helper ────────────────────────────────────────────────────────────────────
-run_client_up() {
-  local name="${1:-client1}"
-  reset_date_stub
-  bash "${SCRIPT}" --mac "02:00:00:00:00:01" --name "${name}" 2>&1 || true
-  # Track any "qemu" pid still in the pidfile (may have been cleaned by the fix)
-  local pidfile="${REAL_RUN_DIR}/${name}/qemu.pid"
-  if [[ -f "${pidfile}" ]]; then
-    _STRAY_PIDS+=( "$(cat "${pidfile}")" )
-  fi
+# Track the qemu pid (sleep-300 orphan) written to a run dir's pidfile so the
+# spec cleanup can reap it regardless of outcome.
+track_pidfile() {
+  local pidfile="$1"
+  [[ -f "${pidfile}" ]] && _STRAY_PIDS+=( "$(cat "${pidfile}" 2>/dev/null || true)" )
 }
 
-# ── test (a): no orphan left after unreachable-timeout exit ───────────────────
+# ── test (a): boot timeout kills qemu but PRESERVES console.log (#2033) ───────
+export QEMU_CRASH=0
+export WH_CLIENT_BOOT_ATTEMPTS=1
+reset_counters 999999   # ssh never succeeds
 rm -rf "${REAL_CLIENT_RUN_DIR}"
 
-QEMU_PID_BEFORE_EXIT=""
-# Run client-up; capture any qemu pid written before exit.
-reset_date_stub
-# Launch in a subshell so we can peek at the pidfile while qemu is alive.
-( bash "${SCRIPT}" --mac "02:00:00:00:00:01" --name "client1" 2>/dev/null; ) || true
+( bash "${SCRIPT}" --mac "02:00:00:00:00:01" --name "client1" >/dev/null 2>&1; ) || true
 
-# If pidfile still exists, record it.
+# The qemu stub spawns /bin/sleep 300 — capture its pid (if the dir survived)
+# before asserting it was killed.
+QEMU_PID_A=""
 if [[ -f "${REAL_CLIENT_RUN_DIR}/qemu.pid" ]]; then
-  QEMU_PID_BEFORE_EXIT="$(cat "${REAL_CLIENT_RUN_DIR}/qemu.pid")"
-  _STRAY_PIDS+=( "${QEMU_PID_BEFORE_EXIT}" )
+  QEMU_PID_A="$(cat "${REAL_CLIENT_RUN_DIR}/qemu.pid" 2>/dev/null || true)"
+  [[ -n "${QEMU_PID_A}" ]] && _STRAY_PIDS+=( "${QEMU_PID_A}" )
 fi
 
-if [[ -f "${REAL_CLIENT_RUN_DIR}/qemu.pid" ]]; then
-  check "(a) no orphan qemu.pid after unreachable-timeout exit" \
-    "qemu.pid still exists: ${REAL_CLIENT_RUN_DIR}/qemu.pid"
+if [[ -f "${REAL_CLIENT_RUN_DIR}/console.log" ]]; then
+  check "(a) console.log preserved after boot-timeout failure" ok
 else
-  check "(a) no orphan qemu.pid after unreachable-timeout exit" ok
+  check "(a) console.log preserved after boot-timeout failure" \
+    "console.log was deleted (run dir: ${REAL_CLIENT_RUN_DIR})"
 fi
 
-if [[ -n "${QEMU_PID_BEFORE_EXIT}" ]] && kill -0 "${QEMU_PID_BEFORE_EXIT}" 2>/dev/null; then
-  check "(a) qemu process killed after unreachable-timeout exit" \
-    "sleep-300 stub (pid ${QEMU_PID_BEFORE_EXIT}) still alive — qemu not killed"
-  kill "${QEMU_PID_BEFORE_EXIT}" 2>/dev/null || true
+if [[ -n "${QEMU_PID_A}" ]] && kill -0 "${QEMU_PID_A}" 2>/dev/null; then
+  check "(a) qemu process killed after boot-timeout failure" \
+    "sleep-300 stub (pid ${QEMU_PID_A}) still alive — qemu not killed"
+  kill "${QEMU_PID_A}" 2>/dev/null || true
 else
-  check "(a) qemu process killed after unreachable-timeout exit" ok
+  check "(a) qemu process killed after boot-timeout failure" ok
 fi
+
+# Overlay (disposable) should be gone; console.log (diagnostic) should remain.
+if [[ -f "${REAL_CLIENT_RUN_DIR}/overlay.qcow2" ]]; then
+  check "(a) disposable overlay removed on failure" \
+    "overlay.qcow2 left behind"
+else
+  check "(a) disposable overlay removed on failure" ok
+fi
+
+# console preserved OUTSIDE the per-client dir (survives client_down rm -rf).
+if [[ -f "${REAL_RUN_DIR}/boot-failures/client1-console.log" ]]; then
+  check "(a) console preserved under boot-failures/ for CI upload" ok
+else
+  check "(a) console preserved under boot-failures/ for CI upload" \
+    "no ${REAL_RUN_DIR}/boot-failures/client1-console.log"
+fi
+rm -rf "${REAL_CLIENT_RUN_DIR}" "${REAL_RUN_DIR}/boot-failures"
 
 # ── test (b): second invocation reclaims stale client, no hard-fail ───────────
+export QEMU_CRASH=0
+export WH_CLIENT_BOOT_ATTEMPTS=1
+reset_counters 999999
 
 # Simulate a stale client: create a RUN_DIR with a live-looking pid.
 # Use a disposable background sleep — guaranteed alive and safe for
@@ -221,20 +279,65 @@ rm -rf "${REAL_CLIENT_RUN_DIR}"
 mkdir -p "${REAL_CLIENT_RUN_DIR}"
 echo "${STALE_PID}" > "${REAL_CLIENT_RUN_DIR}/qemu.pid"
 
-out="$(run_client_up "client1")"
+out="$(bash "${SCRIPT}" --mac "02:00:00:00:00:01" --name "client1" 2>&1 || true)"
+track_pidfile "${REAL_CLIENT_RUN_DIR}/qemu.pid"
 if echo "${out}" | grep -q "already running"; then
   check "(b) second client-up reclaims stale client, no 'already running' error" \
     "got 'already running' — stale client was not reclaimed"
 else
   check "(b) second client-up reclaims stale client, no 'already running' error" ok
 fi
+rm -rf "${REAL_CLIENT_RUN_DIR}"
 
-if [[ -f "${REAL_CLIENT_RUN_DIR}/qemu.pid" ]]; then
-  check "(b) no orphan qemu.pid after reclaim+timeout" \
-    "qemu.pid still present after reclaim run"
+# ── test (c): boot retry — first attempt times out, second succeeds ───────────
+export QEMU_CRASH=0
+export WH_CLIENT_BOOT_ATTEMPTS=2
+# With WH_CLIENT_BOOT_TIMEOUT=3 + monotonic date stub, each attempt runs ~2
+# ssh probes. ssh calls 1,2 (attempt 1) fail; call 3 (attempt 2, iter 1)
+# succeeds → exit 0 mid-attempt-2.
+reset_counters 3
+rm -rf "${REAL_CLIENT_RUN_DIR}"
+
+out="$(bash "${SCRIPT}" --mac "02:00:00:00:00:01" --name "client1" 2>&1; echo "RC=$?")"
+rc_c="$(printf '%s\n' "${out}" | sed -n 's/^RC=//p' | tail -n1)"
+track_pidfile "${REAL_CLIENT_RUN_DIR}/qemu.pid"
+
+if [[ "${rc_c}" == "0" ]]; then
+  check "(c) retry: exit 0 when second attempt succeeds" ok
 else
-  check "(b) no orphan qemu.pid after reclaim+timeout" ok
+  check "(c) retry: exit 0 when second attempt succeeds" "rc=${rc_c}; out=${out}"
 fi
+if printf '%s' "${out}" | grep -q "ready (attempt 2)"; then
+  check "(c) retry: second attempt reported ready" ok
+else
+  check "(c) retry: second attempt reported ready" "no 'ready (attempt 2)' in: ${out}"
+fi
+if [[ -f "${REAL_CLIENT_RUN_DIR}/ssh.port" ]]; then
+  check "(c) retry: ssh.port written on success" ok
+else
+  check "(c) retry: ssh.port written on success" "ssh.port missing"
+fi
+# On success the EXIT trap is disarmed, so the success qemu (sleep-300) is left
+# running. Kill it here.
+if [[ -f "${REAL_CLIENT_RUN_DIR}/qemu.pid" ]]; then
+  kill "$(cat "${REAL_CLIENT_RUN_DIR}/qemu.pid")" 2>/dev/null || true
+fi
+rm -rf "${REAL_CLIENT_RUN_DIR}"
+
+# ── test (d): early-crash detection — qemu exits during boot ──────────────────
+export QEMU_CRASH=1
+export WH_CLIENT_BOOT_ATTEMPTS=1
+reset_counters 999999
+rm -rf "${REAL_CLIENT_RUN_DIR}"
+
+out="$(bash "${SCRIPT}" --mac "02:00:00:00:00:01" --name "client1" 2>&1 || true)"
+if printf '%s' "${out}" | grep -q "exited during boot"; then
+  check "(d) early-crash: detected qemu exit during boot" ok
+else
+  check "(d) early-crash: detected qemu exit during boot" "no 'exited during boot' in: ${out}"
+fi
+rm -rf "${REAL_CLIENT_RUN_DIR}"
+unset QEMU_CRASH
 
 # ── summary ───────────────────────────────────────────────────────────────────
 printf "\n%d passed, %d failed\n" "${PASS}" "${FAIL}"


### PR DESCRIPTION
Fixes Mode 1 of #2033 (Gate-2 fake-VM flakiness). Mode 2 (external-DNS egress) split to #2034 to keep this PR focused and reviewable.

## Problem
Master Router CD's **Gate 2 (fake-API VM e2e)** intermittently reddens with `[client-up] '<name>' did not become reachable within 90s` → `scripts/vm/client-up.sh` rc=1, hitting an arbitrary scenario each time. All CD runners share one host; the bridge **pick/reservation** is already well-hardened (atomic `flock` + per-bridge reservation marker in `lib.sh::wh_pick_lan_bridge`, #891/#907/#1369), so the durable fix is **client-VM boot resilience**, not more bridge-pool plumbing.

Worse, a latent diagnostic bug made these failures un-debuggable: `client-up.sh`'s EXIT trap did `rm -rf "${RUN_DIR}"` on timeout — **deleting `console.log` before the CI artifact-upload step**. And a boot timeout is a pytest **setup** failure, which the `scenarios_fake/conftest.py` `pytest_runtest_makereport` hook (guarded on `call.when == "call"`) does not capture, and the `client_factory` finalizer's `client_down` then `rm -rf`s the run dir anyway. Net: mode-1 failures landed with **no console at all**.

## Changes (`scripts/vm/client-up.sh`)
- **One boot retry** (`WH_CLIENT_BOOT_ATTEMPTS=2`, override-able; per-attempt `WH_CLIENT_BOOT_TIMEOUT=90`): a fresh-overlay re-spawn on timeout turns a transient first-boot miss (DHCP not yet served, tap carrier lag, wedged boot) into a ~90s blip instead of a job failure. Normal ~5s path unchanged.
- **Early-crash detection**: if qemu exits during boot (e.g. failed tap attach), fail the attempt immediately instead of burning the full timeout; a non-zero qemu launch (transient `qemu-bridge-helper` failure under bridge contention) is a failed *attempt* (→ retry), not a `set -e` abort that bypasses the retry.
- **Bridge-readiness wait**: poll `IFF_UP` on `WH_LAN_BRIDGE` before attaching (the old check at line 75 only verified the netdev *existed*). Best-effort, never fatal; skips cleanly where `/sys` is absent.
- **console.log preservation**: the EXIT trap now removes only the disposable overlay + control socket (not the run dir), and on total boot failure the console(s) are copied to a sibling `.run/<id>/boot-failures/` dir that `client_down` (which only `rm -rf`s the per-`NAME` dir) does **not** touch — so the boot console is finally captured by the existing `scripts/vm/.run/**` upload glob. Per-attempt failed consoles are kept as `console.attemptN.log`.

## Tests (`scripts/vm/client-up_spec.sh`)
Counter-driven stubs (monotonic `date`, threshold `ssh`) replace the single-probe `date` stub so the spec can exercise multiple attempts. New/updated cases: console-preserved-on-timeout, `boot-failures/` copy, retry succeeds on 2nd attempt, early-crash detected. **9/9 pass; `shellcheck -x` clean** (only the pre-existing SC1091 source-resolution info).

## Validation
- `bash scripts/vm/client-up_spec.sh` → 9/9 pass (run on macOS; `/sys` + `/dev/kvm` absent paths exercised).
- `bash scripts/vm/test-lan-bridge-pick.sh` → still 6/6 (no bridge-pool behavior changed).
- **KVM/VM e2e can't run on macOS** — full Gate-2 validation is via CD. `e2e-vm-fake.yml` dispatched on this branch; re-running it a couple of times is the real proof it's no longer flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)