### PR TITLE
feat(#1835): dashboard NOW density — top-3 devices + idle collapse + single freshness

### DIFF
--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, act, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import type { DashboardNow, DashboardStats, QueryLog } from '@/types/api'
 
@@ -20,7 +21,7 @@ vi.mock('@/api/client', () => ({
 
 import { api } from '@/api/client'
 import { DashboardPage, NowSection, RecentlyBlockedSection } from './DashboardPage'
-import { withQuery } from '@/test/queryWrapper'
+import { withQuery, makeTestQueryClient } from '@/test/queryWrapper'
 
 const stats: DashboardStats = {
   totalToday: 1234,
@@ -104,6 +105,79 @@ const kpiNow: DashboardNow = {
   ],
 }
 
+// ── #1835 fixtures: device ranking, top-N cap, idle collapse ──────────────────
+type Dev = DashboardNow['profiles'][number]['activeDevices'][number]
+const dev = (name: string, lastSeenSeconds: number, activeSeconds: number): Dev => ({
+  id: Number(name.replace(/\D/g, '')) || name.charCodeAt(0),
+  name,
+  mac: `aa:bb:cc:dd:ff:${name.slice(0, 2)}`,
+  lastSeenSeconds,
+  topHosts: activeSeconds > 0
+    ? [{ host: { type: 'fqdn', value: `${name.toLowerCase()}.example` }, activeSeconds }]
+    : [],
+})
+
+// An 11-device "Family" card. Ranked by active-seconds DESC, the top 3 are
+// Streamer (900) · Browser (600) · Music (300). "Recent" is the *newest* device
+// (lastSeenSeconds 1) but has the LOWEST active-seconds (5) — so a recency rank
+// would float it to the top, while the active-seconds rank (#1835/Q6) sinks it
+// behind the expander. That contrast is the regression this fixture pins.
+const familyNow: DashboardNow = {
+  asOf: '2026-05-13T10:00:00Z',
+  profiles: [
+    {
+      id: 5,
+      name: 'Family',
+      paused: false,
+      activeDevices: [
+        dev('Recent', 1, 5),
+        dev('Streamer', 50, 900),
+        dev('Browser', 40, 600),
+        dev('Music', 45, 300),
+        dev('Dev05', 60, 250),
+        dev('Dev06', 60, 240),
+        dev('Dev07', 60, 230),
+        dev('Dev08', 60, 220),
+        dev('Dev09', 60, 210),
+        dev('Dev10', 60, 200),
+        dev('Dev11', 60, 190),
+      ],
+    },
+  ],
+}
+
+// One active profile + three idle profiles (one paused). Idle = zero active
+// devices; the paused-and-idle profile lives in the idle group too, tagged paused
+// when expanded.
+const idleNow: DashboardNow = {
+  asOf: '2026-05-13T10:00:00Z',
+  profiles: [
+    {
+      id: 1,
+      name: 'Kids',
+      paused: false,
+      activeDevices: [dev('iPhone', 30, 120)],
+    },
+    { id: 2, name: 'Adults', paused: false, activeDevices: [] },
+    { id: 3, name: 'Guest', paused: true, activeDevices: [] },
+    { id: 4, name: 'IoT', paused: false, activeDevices: [] },
+  ],
+}
+
+// Fresh row (30s) vs materially-stale row (120s, >60s vs the snapshot). Only the
+// stale row keeps its inline "Xs ago" flag (#825).
+const staleNow: DashboardNow = {
+  asOf: '2026-05-13T10:00:00Z',
+  profiles: [
+    {
+      id: 1,
+      name: 'Kids',
+      paused: false,
+      activeDevices: [dev('Fresh', 30, 120), dev('Stale', 120, 90)],
+    },
+  ],
+}
+
 const mockStats = () => api.logs.stats as unknown as ReturnType<typeof vi.fn>
 const mockQuery = () => api.logs.query as unknown as ReturnType<typeof vi.fn>
 const mockNow   = () => api.dashboard.now as unknown as ReturnType<typeof vi.fn>
@@ -112,6 +186,9 @@ const mockAlerts = () => api.alerts.list as unknown as ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   vi.resetAllMocks()
+  // #1835: expander/idle-collapse state is per-session in sessionStorage; reset
+  // it between tests so one test's expansion doesn't leak into the next.
+  sessionStorage.clear()
   mockStats().mockResolvedValue(stats)
   // #1833: the unfiltered "Recent Queries" firehose is gone; only the
   // "Most recently blocked" panel hits api.logs.query (blocked=true).
@@ -255,25 +332,135 @@ describe('RecentlyBlockedSection (#1338)', () => {
 })
 
 describe('NowSection', () => {
-  it('renders one card per profile in id order, idle profiles dimmed', async () => {
+  it('renders an active card for an active profile; idle profiles collapse below', async () => {
     mockNow().mockResolvedValue(liveNow)
     render(withQuery(<NowSection />))
-    const kids   = await screen.findByTestId('now-profile-1')
-    const adults = screen.getByTestId('now-profile-2')
+    const kids = await screen.findByTestId('now-profile-1')
     expect(kids).toBeInTheDocument()
-    expect(adults).toHaveClass('opacity-60')
-    expect(screen.getByText(/No activity in the last 5 minutes/)).toBeInTheDocument()
+    // The idle "Adults" profile is no longer a top-level dimmed card — it lives in
+    // the idle-collapse row (#820), so it isn't rendered as its own card by default.
+    expect(screen.queryByTestId('now-profile-2')).not.toBeInTheDocument()
+    const collapse = screen.getByTestId('now-idle-collapse')
+    expect(within(collapse).getByText(/Idle \(1\)/)).toBeInTheDocument()
+    expect(within(collapse).getByText(/Adults/)).toBeInTheDocument()
   })
 
-  it('shows device name, last-seen, and top hosts', async () => {
+  it('shows device name and top hosts; no per-row timestamp for a fresh row (#825)', async () => {
     mockNow().mockResolvedValue(liveNow)
     render(withQuery(<NowSection />))
     await screen.findByTestId('now-device-aa:bb:cc:dd:ee:01')
     expect(screen.getByText('iPhone')).toBeInTheDocument()
-    expect(screen.getByText('30s ago')).toBeInTheDocument()
+    // iPhone's lastSeenSeconds (30) is not materially stale vs the snapshot, so no
+    // inline "Xs ago" — the single freshness pill in the header covers freshness.
+    expect(screen.queryByText('30s ago')).not.toBeInTheDocument()
     expect(screen.getAllByText('youtube.com').length).toBeGreaterThan(0)
     expect(screen.getByText('tiktok.com')).toBeInTheDocument()
     expect(screen.getByText('14m')).toBeInTheDocument()
+  })
+
+  // ── #1835: top-N device cap (#819) ──────────────────────────────────────────
+  it('caps an active card at the top-3 devices ranked by active-seconds, not recency (#819/Q6)', async () => {
+    mockNow().mockResolvedValue(familyNow)
+    render(withQuery(<NowSection />))
+    const card = await screen.findByTestId('now-profile-5')
+    // Top 3 by summed active-seconds: Streamer (900) · Browser (600) · Music (300).
+    expect(within(card).getByText('Streamer')).toBeInTheDocument()
+    expect(within(card).getByText('Browser')).toBeInTheDocument()
+    expect(within(card).getByText('Music')).toBeInTheDocument()
+    // "Recent" is the newest device but the least active — a recency rank would
+    // surface it; the active-seconds rank keeps it hidden behind the expander.
+    expect(within(card).queryByText('Recent')).not.toBeInTheDocument()
+    expect(within(card).queryByText('Dev11')).not.toBeInTheDocument()
+  })
+
+  it('renders a "show 8 more" expander on an 11-device card and reveals the rest in place (#819)', async () => {
+    const user = userEvent.setup()
+    mockNow().mockResolvedValue(familyNow)
+    render(withQuery(<NowSection />))
+    const card = await screen.findByTestId('now-profile-5')
+    const more = within(card).getByRole('button', { name: /show 8 more/i })
+    expect(more).toBeInTheDocument()
+    await user.click(more)
+    // Expanding reveals the rest in the same card (no modal / new section).
+    expect(within(card).getByText('Recent')).toBeInTheDocument()
+    expect(within(card).getByText('Dev11')).toBeInTheDocument()
+    expect(within(card).getByRole('button', { name: /show fewer/i })).toBeInTheDocument()
+  })
+
+  it('persists the card expander across remounts via sessionStorage (#819)', async () => {
+    const user = userEvent.setup()
+    mockNow().mockResolvedValue(familyNow)
+    const client = makeTestQueryClient()
+    const { unmount } = render(withQuery(<NowSection />, client))
+    const card = await screen.findByTestId('now-profile-5')
+    await user.click(within(card).getByRole('button', { name: /show 8 more/i }))
+    expect(sessionStorage.getItem('wh.now.card.5')).toBe('1')
+    // Remount (e.g. SPA navigation away and back) — expanded state survives.
+    unmount()
+    render(withQuery(<NowSection />, client))
+    const reCard = await screen.findByTestId('now-profile-5')
+    expect(within(reCard).getByText('Recent')).toBeInTheDocument()
+    expect(within(reCard).getByRole('button', { name: /show fewer/i })).toBeInTheDocument()
+  })
+
+  // ── #1835: idle-profile collapse (#820) ─────────────────────────────────────
+  it('collapses zero-active profiles into one row, expandable to dimmed cards with paused tags (#820)', async () => {
+    const user = userEvent.setup()
+    mockNow().mockResolvedValue(idleNow)
+    render(withQuery(<NowSection />))
+    await screen.findByTestId('now-profile-1') // active "Kids" card
+    const collapse = screen.getByTestId('now-idle-collapse')
+    // One ≤1-line row naming the three idle profiles.
+    expect(within(collapse).getByText(/Idle \(3\)/)).toBeInTheDocument()
+    for (const name of ['Adults', 'Guest', 'IoT']) {
+      expect(within(collapse).getByText(new RegExp(name))).toBeInTheDocument()
+    }
+    // Collapsed: no dimmed cards yet.
+    expect(screen.queryByTestId('now-profile-3')).not.toBeInTheDocument()
+    // Expand in place → full dimmed cards; the paused-and-idle "Guest" keeps its tag.
+    await user.click(within(collapse).getByRole('button'))
+    const guest = await screen.findByTestId('now-profile-3')
+    expect(guest).toHaveClass('opacity-60')
+    expect(within(guest).getByText('Paused')).toBeInTheDocument()
+    expect(screen.getByTestId('now-profile-2')).toHaveClass('opacity-60')
+  })
+
+  it('does not reorder active profiles when idle ones collapse (#820)', async () => {
+    mockNow().mockResolvedValue(idleNow)
+    render(withQuery(<NowSection />))
+    const kids = await screen.findByTestId('now-profile-1')
+    const collapse = screen.getByTestId('now-idle-collapse')
+    // Active card precedes the idle-collapse row in document order.
+    expect(kids.compareDocumentPosition(collapse) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('persists the idle-collapse expansion via sessionStorage (#820)', async () => {
+    const user = userEvent.setup()
+    mockNow().mockResolvedValue(idleNow)
+    render(withQuery(<NowSection />))
+    const collapse = await screen.findByTestId('now-idle-collapse')
+    await user.click(within(collapse).getByRole('button'))
+    expect(sessionStorage.getItem('wh.now.idle')).toBe('1')
+  })
+
+  // ── #1835: single freshness pill (#825) ─────────────────────────────────────
+  it('shows exactly one freshness pill in the header, sourced from dataUpdatedAt (#825)', async () => {
+    mockNow().mockResolvedValue(liveNow)
+    render(withQuery(<NowSection />))
+    const pill = await screen.findByTestId('now-freshness')
+    expect(pill).toHaveTextContent(/updated .*ago/i)
+    // It's the ONE freshness indicator — typical device rows carry no timestamp.
+    expect(screen.getByTestId('now-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument()
+    expect(screen.queryByText('30s ago')).not.toBeInTheDocument()
+  })
+
+  it('still flags a materially-stale row (>60s vs snapshot) inline (#825)', async () => {
+    mockNow().mockResolvedValue(staleNow)
+    render(withQuery(<NowSection />))
+    await screen.findByText('Stale')
+    // The fresh row (30s) has no inline timestamp; the stale row (120s) does.
+    expect(screen.getByText('2m ago')).toBeInTheDocument()
+    expect(screen.queryByText('30s ago')).not.toBeInTheDocument()
   })
 
   it('renders "watching X · Nm" activity line for an active device', async () => {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -168,11 +168,23 @@ function formatRelativeTime(tsIso: string): string {
 // before the card switches to "show N more".
 const NOW_DEVICE_CAP = 3
 
+// #1835 (#825) — a device row is "materially stale" (and keeps its inline "Xs ago"
+// flag despite the section freshness pill) when last seen more than this many
+// seconds before the snapshot's asOf. The >60s window is the #825 design call.
+const NOW_STALE_SECONDS = 60
+
 // #1835 — a device's rank inside its card is its summed top-hosts active-seconds
 // over the NOW window, NOT recency (design §7 Q6): recency would float a Sonos
 // heartbeat above an actively-streaming MacBook.
 function deviceActiveSeconds(d: DashboardNowDevice): number {
   return d.topHosts.reduce((sum, h) => sum + h.activeSeconds, 0)
+}
+
+// #1835 — a profile is idle when it has zero active devices. The snapshot's
+// activeDevices is already the last-5-min set (§7 Q4), so this is the whole test;
+// paused-and-idle profiles are idle too (the paused tag is preserved on render).
+function profileIsIdle(p: DashboardNowProfile): boolean {
+  return p.activeDevices.length === 0
 }
 
 // #1835 — per-session UI toggle (top-N expander, idle collapse) backed by
@@ -207,8 +219,8 @@ export function NowSection() {
   // #1835: split active from idle. A profile is idle when it has zero active
   // devices (the snapshot's activeDevices is already the last-5-min set, §7 Q4);
   // paused-and-idle profiles fall here too. Active order is preserved as-is.
-  const active = data?.profiles.filter(p => p.activeDevices.length > 0) ?? []
-  const idle = data?.profiles.filter(p => p.activeDevices.length === 0) ?? []
+  const active = data?.profiles.filter(p => !profileIsIdle(p)) ?? []
+  const idle = data?.profiles.filter(profileIsIdle) ?? []
 
   return (
     <section data-testid="now-section" className="space-y-3">
@@ -255,7 +267,7 @@ function FreshnessPill({ updatedAt }: { updatedAt: number }) {
 }
 
 function NowProfileCard({ profile, dimmed = false }: { profile: DashboardNowProfile; dimmed?: boolean }) {
-  const idle = profile.activeDevices.length === 0
+  const idle = profileIsIdle(profile)
   const muted = dimmed || idle
   return (
     <div
@@ -331,7 +343,7 @@ function NowDeviceRow({ device }: { device: DashboardNowDevice }) {
   // #1835 (#825): no per-row timestamp — the section's single freshness pill
   // covers freshness. The exception: a row materially staler than the snapshot
   // (lastSeenSeconds is measured against the snapshot's asOf) still flags inline.
-  const stale = device.lastSeenSeconds > 60
+  const stale = device.lastSeenSeconds > NOW_STALE_SECONDS
   return (
     <div data-testid={`now-device-${device.mac}`} className="border-t border-brand-border first:border-0 pt-3 first:pt-0">
       <div className="flex items-baseline justify-between gap-2">

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useDashboardNow, useRecentBlocked } from '@/api/queries'
@@ -162,6 +162,38 @@ function formatRelativeTime(tsIso: string): string {
 // (it keeps the previous `data` reference when a refetch errors), so the
 // imperative setInterval / try-catch from before is gone.
 
+// #1835 — top-N device cap. Cards show only the 3 most active devices by default,
+// the rest behind an in-place expander, so a card full of chatty IoT devices no
+// longer dominates the page (the prod `Family` card listed ~11). Device count
+// before the card switches to "show N more".
+const NOW_DEVICE_CAP = 3
+
+// #1835 — a device's rank inside its card is its summed top-hosts active-seconds
+// over the NOW window, NOT recency (design §7 Q6): recency would float a Sonos
+// heartbeat above an actively-streaming MacBook.
+function deviceActiveSeconds(d: DashboardNowDevice): number {
+  return d.topHosts.reduce((sum, h) => sum + h.activeSeconds, 0)
+}
+
+// #1835 — per-session UI toggle (top-N expander, idle collapse) backed by
+// sessionStorage, so it survives SPA navigation within the tab session but resets
+// when the tab/session ends (unlike localStorage, which would persist forever).
+function useSessionToggle(key: string, initial = false): [boolean, (v: boolean) => void] {
+  const [on, setOn] = useState<boolean>(() => {
+    try {
+      const raw = sessionStorage.getItem(key)
+      return raw === null ? initial : raw === '1'
+    } catch {
+      return initial
+    }
+  })
+  const set = useCallback((v: boolean) => {
+    setOn(v)
+    try { sessionStorage.setItem(key, v ? '1' : '0') } catch { /* storage unavailable */ }
+  }, [key])
+  return [on, set]
+}
+
 export function NowSection() {
   // #1973: `now` is pushed whole (§3.1) — replace the dashboard-now cache live. Derived
   // "Online now" KPI recomputes client-side off the pushed body. Polling stays the paused
@@ -169,8 +201,14 @@ export function NowSection() {
   // role whose `now` subscription is server-rejected keeps polling rather than freezing.
   const streaming = useWsTopicLive('now')
   useWsNow()
-  const { data = null } = useDashboardNow({ refetchInterval: streaming ? false : 10_000 })
+  const { data = null, dataUpdatedAt } = useDashboardNow({ refetchInterval: streaming ? false : 10_000 })
   const kpis = deriveNowKpis(data)
+
+  // #1835: split active from idle. A profile is idle when it has zero active
+  // devices (the snapshot's activeDevices is already the last-5-min set, §7 Q4);
+  // paused-and-idle profiles fall here too. Active order is preserved as-is.
+  const active = data?.profiles.filter(p => p.activeDevices.length > 0) ?? []
+  const idle = data?.profiles.filter(p => p.activeDevices.length === 0) ?? []
 
   return (
     <section data-testid="now-section" className="space-y-3">
@@ -180,6 +218,7 @@ export function NowSection() {
           <span data-testid="now-kpi-online" className="text-xs text-brand-text-muted">
             Online now: <span className="font-semibold text-brand-ink tabular-nums">{kpis.onlineNow}</span>
           </span>
+          {data !== null && <FreshnessPill updatedAt={dataUpdatedAt} />}
           <LiveBadge />
         </div>
       </div>
@@ -188,21 +227,40 @@ export function NowSection() {
         : data.profiles.length === 0
           ? <EmptyState variant="inline" title="No profiles configured yet." />
           : (
-            <div className="grid md:grid-cols-2 gap-4">
-              {data.profiles.map(p => <NowProfileCard key={p.id} profile={p} />)}
-            </div>
+            <>
+              {active.length > 0 && (
+                <div className="grid md:grid-cols-2 gap-4">
+                  {active.map(p => <NowProfileCard key={p.id} profile={p} />)}
+                </div>
+              )}
+              {idle.length > 0 && <IdleCollapseRow profiles={idle} />}
+            </>
           )
       }
     </section>
   )
 }
 
-function NowProfileCard({ profile }: { profile: DashboardNowProfile }) {
+// #1835 (#825): single freshness indicator for the whole NOW section, sourced from
+// TanStack Query's `dataUpdatedAt` (the last successful fetch/push), NOT a
+// per-component self-timer. Elapsed is recomputed at render; the section re-renders
+// on every poll/ws push (≤10s), so the label stays current without its own timer.
+function FreshnessPill({ updatedAt }: { updatedAt: number }) {
+  const elapsed = Math.max(0, (Date.now() - updatedAt) / 1000)
+  return (
+    <span data-testid="now-freshness" className="text-xs text-brand-text-muted tabular-nums">
+      updated {formatLastSeen(elapsed)}
+    </span>
+  )
+}
+
+function NowProfileCard({ profile, dimmed = false }: { profile: DashboardNowProfile; dimmed?: boolean }) {
   const idle = profile.activeDevices.length === 0
+  const muted = dimmed || idle
   return (
     <div
       data-testid={`now-profile-${profile.id}`}
-      className={`bg-white rounded-2xl border p-5 ${idle ? 'border-brand-border opacity-60' : 'border-brand-accent-dark/50'}`}
+      className={`bg-white rounded-2xl border p-5 ${muted ? 'border-brand-border opacity-60' : 'border-brand-accent-dark/50'}`}
     >
       <div className="flex items-center gap-2 mb-3">
         <h3 className="text-base font-semibold text-brand-ink">{profile.name}</h3>
@@ -214,22 +272,73 @@ function NowProfileCard({ profile }: { profile: DashboardNowProfile }) {
       </div>
       {idle
         ? <EmptyState variant="inline" title="No activity in the last 5 minutes" />
-        : (
-          <div className="space-y-3">
-            {profile.activeDevices.map(d => <NowDeviceRow key={d.mac} device={d} />)}
-          </div>
-        )
+        : <NowDeviceList profile={profile} />
       }
     </div>
   )
 }
 
+// #1835 (#819): rank by active-seconds, cap at top-3, expander for the rest.
+function NowDeviceList({ profile }: { profile: DashboardNowProfile }) {
+  const [expanded, setExpanded] = useSessionToggle(`wh.now.card.${profile.id}`)
+  const ranked = [...profile.activeDevices].sort(
+    (a, b) => deviceActiveSeconds(b) - deviceActiveSeconds(a),
+  )
+  const overflow = ranked.length - NOW_DEVICE_CAP
+  const shown = expanded ? ranked : ranked.slice(0, NOW_DEVICE_CAP)
+  return (
+    <div className="space-y-3">
+      {shown.map(d => <NowDeviceRow key={d.mac} device={d} />)}
+      {overflow > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="text-xs text-brand-accent-dark hover:underline"
+        >
+          {expanded ? 'show fewer' : `show ${overflow} more`}
+        </button>
+      )}
+    </div>
+  )
+}
+
+// #1835 (#820): collapse all zero-active profiles into one line below the active
+// grid, expandable in place to the full dimmed cards (paused tags preserved).
+function IdleCollapseRow({ profiles }: { profiles: DashboardNowProfile[] }) {
+  const [expanded, setExpanded] = useSessionToggle('wh.now.idle')
+  return (
+    <div data-testid="now-idle-collapse">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="text-sm text-brand-text-muted hover:text-brand-text w-full text-left"
+      >
+        <span className="font-medium text-brand-text">Idle ({profiles.length}):</span>{' '}
+        <span className="truncate">{profiles.map(p => p.name).join(' · ')}</span>{' '}
+        <span aria-hidden>{expanded ? '▾' : '▸'}</span>
+      </button>
+      {expanded && (
+        <div className="grid md:grid-cols-2 gap-4 mt-3">
+          {profiles.map(p => <NowProfileCard key={p.id} profile={p} dimmed />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function NowDeviceRow({ device }: { device: DashboardNowDevice }) {
+  // #1835 (#825): no per-row timestamp — the section's single freshness pill
+  // covers freshness. The exception: a row materially staler than the snapshot
+  // (lastSeenSeconds is measured against the snapshot's asOf) still flags inline.
+  const stale = device.lastSeenSeconds > 60
   return (
     <div data-testid={`now-device-${device.mac}`} className="border-t border-brand-border first:border-0 pt-3 first:pt-0">
       <div className="flex items-baseline justify-between gap-2">
         <p className="text-sm font-medium text-brand-ink truncate">{device.name}</p>
-        <p className="text-xs text-brand-text-muted shrink-0">{formatLastSeen(device.lastSeenSeconds)}</p>
+        {stale && (
+          <p className="text-xs text-brand-text-muted shrink-0">{formatLastSeen(device.lastSeenSeconds)}</p>
+        )}
       </div>
       <NowActivityLine device={device} />
       {device.topHosts.length > 0 && (


### PR DESCRIPTION
Implements **chunk 3 of 5** of the `/dashboard` holistic redesign (umbrella #1148, design `docs/design/dashboard-redesign.md` §7). Highest-value chunk; **frontend only** — `useDashboardNow` already returns the full device list, and no API/endpoint changes.

Closes #819, #820, #825. Part of #1148.

## What changed (all in `web/src/pages/DashboardPage.tsx`)

- **Top-N device cap (#819).** Each active profile card now shows only the **top-3 devices ranked by summed `topHosts[].activeSeconds`** over the NOW window — by *activity, not recency* (design §7 Q6: recency would float a Sonos heartbeat above an actively-streaming MacBook). The rest sit behind an in-place **"show N more"** expander (no modal, no scroll-jump). Expander state is per-session via `sessionStorage` (`useSessionToggle`), so it survives SPA navigation and resets when the tab session ends.
- **Idle-profile collapse (#820).** Profiles with **zero active devices** fold into one `Idle (N): name · name · name ▸` row below the active grid, expandable **in place** to the full **dimmed** cards (paused-and-idle profiles keep their **Paused** tag when expanded). Active profiles are **not reordered**.
- **Single freshness pill (#825).** One `updated Xs ago` indicator in the NOW section header, sourced from TanStack Query's **`dataUpdatedAt`** (not a self-timer). Per-row `formatLastSeen` timestamps are dropped — **except** the stale-row exception: a row whose `lastSeenSeconds` is materially older (>60s vs the snapshot) still flags inline.

The live data flow is left intact: LIVE BANDWIDTH, the `now` ws push / 10s poll fallback, and the Recently-Blocked feed are unchanged — this only restructures how NOW cards *render*.

## Out of scope (per #1835)
Device *classification* / de-emphasising IoT/infra / refining the "Online now" count — design §7 Q6/Q7 says the top-3 + active-seconds ranking already contains the noise; that's a separate future issue.

## Tests
TDD: red-then-green. New/updated `NowSection` tests pin: top-3-by-active-seconds (with a newest-but-idle device proving it's *not* recency), the 11-device `show 8 more` expander revealing the rest in place, sessionStorage persistence across remount, idle collapse → dimmed cards + paused tags + no active reordering, the single `dataUpdatedAt` pill with no per-row timestamp on fresh rows, and the >60s stale-row inline exception.

- `npm run lint` clean, `npm test` green (490 tests), `npm run build` succeeds.
- No API/endpoint change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)