### PR TITLE
fix(#2036): ship cqueues + luaossl with the agent so enabling ws needs no manual apk add

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -38,7 +38,18 @@ define Package/wifihaven
   # HKDF-derived from the destination connection ID + v1 salt; the payload is
   # AEAD-encrypted with AES-128-GCM and the header bits are protected with an
   # AES-128-ECB mask. ~464 KiB installed — additive, attribution-only.
-  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +kmod-nf-conntrack6 +libustream-mbedtls +openssl-util +tcpdump-mini +lua-openssl
+  # #2036: cqueues + luaossl are the wifihaven-ws sidecar's runtime deps.
+  # Shipping them in DEPENDS makes enabling ws a pure
+  # `uci set wifihaven.ws.enabled=1` + restart with no manual `apk add` — the
+  # prod-cutover gate for #1023. Marginal cost is ~0.5 MB (cqueues 328 KiB +
+  # luaossl 205 KiB) and ZERO new transitive packages: their dep closure
+  # (libc/liblua5.1.5/libopenssl3) is already pulled by +lua / +lua-openssl /
+  # +openssl-util. luaossl (daurnimator) provides the `openssl.ssl.context`
+  # submodule API the sidecar needs; it is DISTINCT from lua-openssl (zhaozg,
+  # monolithic `openssl.so`) above — both are required, and the #1949
+  # coexistence (quic.resolve_openssl() force-loads lua-openssl's .so even
+  # though luaossl shadows the bare require("openssl")) still holds.
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +kmod-nf-conntrack6 +libustream-mbedtls +openssl-util +tcpdump-mini +lua-openssl +cqueues +luaossl
   PKGARCH:=all
 endef
 
@@ -61,10 +72,10 @@ define Package/wifihaven/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-nflog-tail $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-sni-tail $(1)/usr/sbin/
 	# #1848: websocket transport sidecar. Default-off (UCI wifihaven.ws.enabled);
-	# the init script only starts it when enabled. Needs cqueues + luaossl at
-	# runtime, which the operator installs when turning ws on (see
-	# docs/design/websocket-transport.md / the ws UCI section) — NOT a hard
-	# DEPENDS, so a default (ws-off) install stays lean.
+	# the init script only starts it when enabled. Its runtime deps cqueues +
+	# luaossl are shipped as hard DEPENDS (#2036), so enabling ws is purely
+	# `uci set wifihaven.ws.enabled=1` + restart with no manual `apk add` (see
+	# docs/design/websocket-transport.md / the ws UCI section).
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-ws $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-update $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-rotate-dnsmasq-log $(1)/usr/sbin/

--- a/openwrt/test/build_depends_sync_spec.test.sh
+++ b/openwrt/test/build_depends_sync_spec.test.sh
@@ -26,13 +26,19 @@ if [ ! -x "$HELPER" ]; then
 fi
 
 # (c) Regression pins. lua-openssl was the live #1717 miss; kmod-nf-conntrack6
-# was its #1690 sibling that also escaped the stale builders.
+# was its #1690 sibling that also escaped the stale builders. cqueues +
+# luaossl (#2036) are the wifihaven-ws sidecar's runtime deps — shipping them
+# in DEPENDS makes enabling ws a pure `uci set wifihaven.ws.enabled=1` with no
+# manual `apk add`; pin them so a future "lean install" revert can't silently
+# drop them and reintroduce the prod-cutover footgun. Note luaossl
+# (daurnimator, `openssl.ssl.context`) is distinct from lua-openssl (zhaozg,
+# monolithic `openssl.so`); both must be present (#1949 coexistence).
 lines=$("$HELPER" lines || true)
 if [ -z "$lines" ]; then
     echo "FAIL: depends-list.sh emitted nothing — openwrt/Makefile DEPENDS unparsable?" >&2
     exit 1
 fi
-for required in lua-openssl kmod-nf-conntrack6 tcpdump-mini kmod-nf-log kmod-nf-log6; do
+for required in lua-openssl kmod-nf-conntrack6 tcpdump-mini kmod-nf-log kmod-nf-log6 cqueues luaossl; do
     if ! printf '%s\n' "$lines" | grep -qx "$required"; then
         echo "FAIL: canonical DEPENDS missing $required (regression-pinned by #1717)" >&2
         echo "  current list:" >&2


### PR DESCRIPTION
## What

Add `+cqueues +luaossl` to the `Package/wifihaven` `DEPENDS` in [`openwrt/Makefile`](openwrt/Makefile) so the websocket transport sidecar's runtime deps ship with every agent install/upgrade.

Enabling ws currently requires a manual `apk add cqueues luaossl` before `uci set wifihaven.ws.enabled=1` + restart. If skipped, the `wifihaven-ws` sidecar **silently fails to load** (`require("cqueues")` errors) and the agent stays on the unchanged HTTP path — a prod-cutover footgun confirmed on real hardware during the #1023 validation (2026-06-28).

## Cost

~0.5 MB total (cqueues 328 KiB + luaossl 205 KiB) and **zero new transitive packages** — their dep closure (`libc`/`liblua5.1.5`/`libopenssl3`) is already pulled via the existing `+lua` / `+lua-openssl` / `+openssl-util` deps.

## Notes

- **`luaossl` is added ALONGSIDE the existing `lua-openssl`, not replacing it.** They are different packages: `lua-openssl` (zhaozg, monolithic `openssl.so`, used by the agent's QUIC SNI path) vs `luaossl` (daurnimator, the `openssl.ssl.context` submodule API the sidecar needs). Both are required. The #1949 coexistence (`quic.resolve_openssl()` force-loads lua-openssl's `.so` even though luaossl shadows the bare `require("openssl")`) is undisturbed.
- Updated the `Package/wifihaven/install` comment block so it no longer claims a manual install is needed.

## TDD

Extended `openwrt/test/build_depends_sync_spec.test.sh` to pin `cqueues` + `luaossl` in the canonical DEPENDS regression set. Committed red (failing) first, then the Makefile change to green. `build_depends_sync_spec`, `install_spec`, `spec_coverage_spec`, `update_multi_pkg_spec` all pass.

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)