### PR TITLE
feat(#2037): policy poll dormant while ws link healthy

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -177,6 +177,15 @@ object MetricGuard {
     "policy_apply_duration_seconds"             -> Set("router_id", "installation_id"),
     "snapshot_poll_total"                       -> Set("result", "router_id", "installation_id"),
     "snapshot_poll_duration_seconds"            -> Set("router_id", "installation_id"),
+    // #2037 — policy-poll dormancy. When the ws transport is enabled AND its
+    // health sentinel is fresh (within ws_fallback_after), the agent's 5 s HTTP
+    // `GET /api/router/policy` poll goes dormant — the push channel is the live
+    // transport, so the snapshot is no longer recomputed per poll (#1512). This
+    // counter increments once per suppressed poll so the server-side load win of
+    // enabling ws is directly visible (a climbing rate on a ws router with a flat
+    // snapshot_poll_total is the dormancy working). `reason` is a fixed 1-value
+    // enum today (`ws_healthy`) — bounded, no per-mac/host dimension.
+    "policy_poll_skipped_total"                 -> Set("reason", "router_id", "installation_id"),
     "agent_uptime_seconds"                      -> Set("router_id", "installation_id"),
     "agent_version"                             -> Set("version", "router_id", "installation_id"),
     "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),

--- a/api/test/src/feature/RouterWsAgentMetricsAllowlistSpec.scala
+++ b/api/test/src/feature/RouterWsAgentMetricsAllowlistSpec.scala
@@ -39,6 +39,12 @@ object RouterWsAgentMetricsAllowlistSpec extends ZIOSpecDefault {
       hasEntry("ws_frames_sent_total", Set("op")) &&
       hasEntry("ws_frames_recv_total", Set("op"))
     },
+    // #2037 — policy-poll dormancy. The agent emits this once per HTTP poll it
+    // suppressed because the ws link was healthy; the firewall must permit the
+    // name + its bounded `reason` enum, else the whole push is rejected.
+    test("policy_poll_skipped_total carries reason (the dormancy gate enum)") {
+      hasEntry("policy_poll_skipped_total", Set("reason"))
+    },
     test("a forbidden per-mac label on a ws series is rejected") {
       val rejected = Metric.counter("metrics_rejected_total").tagged("reason", "forbidden_label")
       for {

--- a/deploy/grafana/dashboards/router-ws-transport.json
+++ b/deploy/grafana/dashboards/router-ws-transport.json
@@ -616,6 +616,63 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Policy poll suppressed while ws healthy (#2037)",
+      "description": "sum by (reason) (rate(policy_poll_skipped_total[5m])) — the agent-side dormancy gate (design §3.1). When ws is enabled AND its health sentinel is fresh (within ws_fallback_after), the agent's 5 s HTTP GET /api/router/policy poll goes dormant (reason=ws_healthy) — the push channel is the live transport, so the server stops recomputing the snapshot per poll (#1512). This is the agent-side complement of the 'Policy snapshot builds: computed vs cache_hit' panel above: a climbing skip rate on ws routers alongside a flat snapshot_poll_total is the load win of enabling ws being realized. A skip rate that drops to 0 while ws_state stays 1 means the dormancy gate regressed (poll running despite a healthy link).",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (reason) (rate(policy_poll_skipped_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/openwrt/files/usr/lib/lua/wifihaven/ws_outbound.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/ws_outbound.lua
@@ -21,6 +21,27 @@
 
 local M = {}
 
+-- The SOLE freshness rule for "is the ws link live enough to be the transport":
+-- the sidecar writes os.time() into the health sentinel on every successful
+-- send/recv, so a sentinel timestamp within fallback_after of now means the
+-- link is healthy. A nil timestamp (absent sentinel) is never fresh. The
+-- boundary is inclusive (exactly fallback_after old still counts as fresh) — the
+-- tee falls back only once now-h is STRICTLY past the window.
+local function fresh(h, now_val, fallback_after)
+  return h ~= nil and (now_val - h) <= fallback_after
+end
+
+-- is_healthy(opts) → bool. The single definition of "the ws link is healthy",
+-- consulted by BOTH the outbound tee (M.make, below) and the agent's policy-poll
+-- dormancy gate (#2037), so the two cannot drift. True iff ws is enabled AND the
+-- health sentinel is fresh.
+--   opts: enabled bool, health_read fn()→number|nil, now fn()→number,
+--         fallback_after number
+function M.is_healthy(opts)
+  if not opts.enabled then return false end
+  return fresh(opts.health_read(), opts.now(), opts.fallback_after)
+end
+
 -- make(opts) → post_fn(url, body, headers) → status, resp_body, err
 --
 -- opts:
@@ -49,8 +70,8 @@ function M.make(opts)
       return http_post(url, body, headers)
     end
     -- Fall back to HTTP if the link has been down past the fallback window.
-    local h = health_read()
-    if not h or (now() - h) > fallback_after then
+    -- Same freshness rule as the policy-poll dormancy gate (#2037).
+    if not fresh(health_read(), now(), fallback_after) then
       metrics_inc("http_fallback")
       return http_post(url, body, headers)
     end

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -490,6 +490,25 @@ local usage_events_post = ws_outbound.make({
   fallback_after = ws_fallback_after,
 })
 
+-- #2037: ws-health gate for the policy-poll dormancy. While the ws sidecar is
+-- enabled AND its health sentinel is fresh (within ws_fallback_after), the
+-- persistent push link is the live policy transport, so the 5 s HTTP policy
+-- poll goes DORMANT (the apply-on-push tick keeps enforcement current from
+-- server pushes, and the server touches routers.last_seen_at on every ws
+-- heartbeat frame — RouterWsRoutes.touch — so liveness never staled). The poll
+-- RESUMES — today's behaviour, including the #331/#422 failover render on a
+-- failed poll — when ws is disabled OR the sentinel is stale/absent past
+-- ws_fallback_after. Reuses the SAME freshness predicate as the outbound tee
+-- (ws_outbound.is_healthy) so the two gates cannot drift (design §3.1).
+local function ws_link_healthy()
+  return ws_outbound.is_healthy({
+    enabled        = (ws_enabled == "1"),
+    health_read    = ws_health_read,
+    now            = os.time,
+    fallback_after = ws_fallback_after,
+  })
+end
+
 local function http_get(url, headers)
   local hdr_args = ""
   for k, v in pairs(headers or {}) do
@@ -1047,6 +1066,15 @@ conntrack.watch({
     -- Policy timer
     if (mono - ts.last_policy_run) >= policy_int then
       ts.last_policy_run = mono
+      if ws_link_healthy() then
+        -- #2037: ws is the live policy transport — skip the HTTP poll (dormant).
+        -- Advancing ts.last_policy_run above keeps the cadence anchor moving so
+        -- we re-check once per policy_int; the ws apply-on-push tick below keeps
+        -- enforcement current. The moment the sentinel goes stale past
+        -- ws_fallback_after this gate flips and the poll (and its failover
+        -- render path) resumes on the next tick.
+        metrics.inc_counter(mreg, "policy_poll_skipped_total", { reason = "ws_healthy" })
+      else
       local pt0 = clock.monotonic_seconds()
       local snap, etag = policy.fetch(api_url, router_token, ts.current_etag, http_get, log, policy_opts)
       metrics.observe(mreg, "snapshot_poll_duration_seconds", {},
@@ -1141,6 +1169,7 @@ conntrack.watch({
         end
         ts.in_failover_render = new_in_failover
       end
+      end  -- #2037: close the `else` (ws link not healthy → poll ran)
     end
 
     -- ws apply-on-push timer (#1945). When the ws sidecar is enabled it writes

--- a/openwrt/test/ws_poll_dormant_spec.lua
+++ b/openwrt/test/ws_poll_dormant_spec.lua
@@ -1,0 +1,120 @@
+-- ws_poll_dormant_spec.lua — #2037 policy-poll dormancy while ws is healthy.
+--
+-- With ws enabled the agent runs a persistent push socket AND, until this
+-- change, still HTTP-polled `GET /api/router/policy` every 5 s. The design
+-- (docs/design/websocket-transport.md §3.1) says the poll timer goes DORMANT on
+-- a healthy ws link and resumes only after the link is down past
+-- `ws_fallback_after` (default 300 s). The decision is the SAME freshness
+-- predicate the outbound tee already uses, now exposed as
+-- `ws_outbound.is_healthy` so the two gates cannot drift (single source of
+-- truth). These specs pin:
+--   (a) ws enabled + fresh health sentinel  ⇒ link healthy ⇒ poll dormant
+--                                              (no HTTP policy fetch).
+--   (b) ws enabled + stale/absent sentinel past fallback ⇒ poll resumes.
+--   (c) a resumed poll that FAILS still drives the #331/#422 failover render
+--       path for closed-mode profiles.
+--
+-- Pure over injected now/health/http — runs on the dev host as under OpenWrt
+-- Lua 5.1. The agent's on_tick policy block is a monolith (not require-able), so
+-- the behavioural "tick" model below wires the REAL decision functions
+-- (`ws_outbound.is_healthy` for the dormancy gate, `policy.failover_transition`
+-- for the failover edge) into the same shape on_tick uses.
+
+local ws_outbound = require("wifihaven.ws_outbound")
+local policy      = require("policy")
+
+-- ── (a)/(b): the dormancy gate is ws_outbound.is_healthy ──────────────────
+describe("ws_outbound.is_healthy — #2037 poll-dormancy gate", function()
+  local function gate(opts)
+    return ws_outbound.is_healthy({
+      enabled        = opts.enabled,
+      health_read    = function() return opts.health end,  -- nil ⇒ absent
+      now            = function() return opts.now end,
+      fallback_after = opts.fallback_after or 300,
+    })
+  end
+
+  it("(a) enabled + fresh sentinel ⇒ healthy (poll dormant)", function()
+    assert.is_true(gate({ enabled = true, health = 1000, now = 1100 })) -- 100s < 300
+  end)
+
+  it("treats the exact fallback boundary as still fresh (inclusive)", function()
+    assert.is_true(gate({ enabled = true, health = 1000, now = 1300 })) -- 300s == fallback
+  end)
+
+  it("(b) enabled + stale sentinel past fallback ⇒ not healthy (poll resumes)", function()
+    assert.is_false(gate({ enabled = true, health = 1000, now = 1301 })) -- 301s > 300
+  end)
+
+  it("(b) enabled + absent sentinel ⇒ not healthy (poll resumes)", function()
+    assert.is_false(gate({ enabled = true, health = nil, now = 1100 }))
+  end)
+
+  it("disabled ws ⇒ never healthy even with a fresh sentinel (poll always runs)", function()
+    assert.is_false(gate({ enabled = false, health = 1100, now = 1100 }))
+  end)
+end)
+
+-- ── Behavioural tick model: dormancy + failover preservation ──────────────
+-- Mirrors the agent on_tick policy block: when the ws link is healthy we SKIP
+-- the HTTP fetch; otherwise we fetch and, on a failed fetch, run the real
+-- failover transition. Uses the REAL is_healthy / failover_transition.
+local function poll_tick(state, deps)
+  if ws_outbound.is_healthy(deps.ws) then
+    state.skipped = (state.skipped or 0) + 1
+    return  -- dormant: no HTTP policy fetch
+  end
+  local code = deps.http_get()           -- recorded fake; 200/304 ok, else fail
+  state.fetched = (state.fetched or 0) + 1
+  local fetch_ok = (code == 200 or code == 304)
+  local _, _, new_in_failover = policy.failover_transition(state.in_failover, fetch_ok)
+  state.in_failover = new_in_failover
+end
+
+describe("on_tick policy gate — #2037 dormancy + #331/#422 failover", function()
+  local function deps(opts)
+    local fetches = { n = 0 }
+    return {
+      fetches = fetches,
+      ws = {
+        enabled        = opts.enabled,
+        health_read    = function() return opts.health end,
+        now            = function() return opts.now end,
+        fallback_after = 300,
+      },
+      http_get = function() fetches.n = fetches.n + 1; return opts.code or 200 end,
+    }
+  end
+
+  it("(a) healthy link ⇒ no HTTP policy fetch, no failover", function()
+    local d = deps({ enabled = true, health = 1000, now = 1100 })
+    local st = { in_failover = false }
+    poll_tick(st, d)
+    assert.are.equal(0, d.fetches.n)
+    assert.are.equal(1, st.skipped)
+    assert.is_false(st.in_failover)
+  end)
+
+  it("(b) stale link ⇒ HTTP policy fetch resumes", function()
+    local d = deps({ enabled = true, health = 1000, now = 2000, code = 200 })
+    local st = { in_failover = false }
+    poll_tick(st, d)
+    assert.are.equal(1, d.fetches.n)
+    assert.is_false(st.in_failover)
+  end)
+
+  it("(c) resumed poll that FAILS still trips failover render", function()
+    local d = deps({ enabled = true, health = 1000, now = 2000, code = 0 }) -- stale + curl error
+    local st = { in_failover = false }
+    poll_tick(st, d)
+    assert.are.equal(1, d.fetches.n)
+    assert.is_true(st.in_failover)  -- failover chain applied for closed-mode profiles
+  end)
+
+  it("ws disabled ⇒ always polls (unchanged behaviour)", function()
+    local d = deps({ enabled = false, health = 9999, now = 9999, code = 304 })
+    local st = { in_failover = false }
+    poll_tick(st, d)
+    assert.are.equal(1, d.fetches.n)
+  end)
+end)


### PR DESCRIPTION
## What

Make the OpenWrt agent's HTTP policy poll **dormant while the websocket link is healthy**, so enabling ws delivers the server-side load win (no per-poll snapshot recompute, #1512), not just the push-latency win.

Closes #2037.

## Why

With ws enabled the agent ran the persistent push socket **and** still HTTP-polled `GET /api/router/policy` every 5 s, unconditionally. The poll cadence and the `on_tick` poll gate were never conditioned on ws health, so every ws router kept paying the ~500 ms snapshot recompute per poll. The design (`docs/design/websocket-transport.md` §3.1) specifies the poll timer goes **dormant** on a healthy ws connect and resumes only after the link is down past `ws_fallback_after` (default 300 s).

This is the **agent-side, fully-reversible, no-wire-change** precursor to #1850 (server-side endpoint removal, #376-gated).

## How

- Lifted the freshness predicate the outbound tee already uses into **`ws_outbound.is_healthy`** — a single source of truth so the poll-dormancy gate and the usage/events tee cannot drift.
- `wifihaven-agent` on_tick: when ws is enabled **and** the health sentinel is fresh, **skip** the HTTP poll. The apply-on-push tick (#1945, reads `/etc/wifihaven/policy.json`) keeps enforcement current from server pushes.
- Poll **resumes exactly as today** — including the #331/#422 failover render on a failed poll — when ws is disabled or the sentinel is stale/absent past `ws_fallback_after`. The failover edge is untouched (the resumed poll runs the same path).
- **Liveness verified**: the server touches `routers.last_seen_at` on every recognized ws frame incl. ping/pong heartbeat (`RouterWsRoutes.touch`, RouterWsRoutes.scala:148–159/223), so dropping the poll while ws is up does not stale liveness. No server code changed.

## Instrumentation

- New bounded-label counter `policy_poll_skipped_total{reason="ws_healthy"}` (one increment per suppressed poll) — allowlisted server-side (`MetricGuard.Allowed`) and pinned by `RouterWsAgentMetricsAllowlistSpec`.
- New Grafana panel on `router-ws-transport.json` ("Policy poll suppressed while ws healthy") — the agent-side complement of the existing computed-vs-cache_hit snapshot-build panel.

## Testing

- New busted spec `openwrt/test/ws_poll_dormant_spec.lua` (committed failing first, then green): (a) ws enabled + fresh sentinel ⇒ dormant / no HTTP fetch; (b) stale/absent sentinel past fallback ⇒ poll resumes; (c) a resumed poll that **fails** still trips the #331/#422 failover render (drives the **real** `policy.failover_transition`).
- **Validated on real Lua 5.1 (plex.lan)** per project rule (not just macOS): the agent monolith compiles within the **60-upvalue limit** (#1930); `is_healthy` + the failover-preservation gate model run green under `lua5.1`.
- Full busted suite **983/0**; `RouterWsAgentMetricsAllowlistSpec` green; `scalafmt --check` clean.

## Notes for reviewers

- The `else` body in the on_tick policy block is intentionally **not re-indented** to keep the diff minimal (~100 lines would otherwise churn); a `-- #2037: close the else` marker tags the added `end`. Lua doesn't care about the indentation; real-5.1 compile confirms the structure.
- A pre-existing flaky timing test (`MetricsExportSpec`, my code from #1249) surfaced during this work's full-suite run — filed as #2042 (deliberately **not** folded into this PR to keep it focused).
