### PR TITLE
docs(#2044): flag wall-clock/timing-sensitive tests in PR-review dimension 2

### DIFF
--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -105,10 +105,10 @@ in [#1561](https://github.com/wifihaven/wifihaven/issues/1561).
   `MetricsExportSpec` forked the rollup loop, `ZIO.sleep(600.millis)`,
   interrupted, slept again, then asserted; it passed in isolation but flaked
   an unrelated PR's CI under 14-worker contention. The standing rule lives in
-  [`docs/process/testing.md`](process/testing.md) ("Clock is always injected —
-  use `Clock.TestClock`"); this dimension enforces it at review. Legitimate
-  live-clock uses (measuring *real* elapsed duration) are exempt but must say
-  why inline.
+  [`docs/process/testing.md`](process/testing.md) ("Clock is always
+  injected") — use `Clock.TestClock` in tests; this dimension enforces it at
+  review. Legitimate live-clock uses (measuring *real* elapsed duration) are
+  exempt but must say why inline.
 - **Bug fix → regression test that FAILS without the fix.** Confirm the test
   actually pins the bug, not just adjacent behavior.
 

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -90,8 +90,19 @@ in [#1561](https://github.com/wifihaven/wifihaven/issues/1561).
   (HTTP → route → service → repo → embedded Postgres) are preferred; unit tests
   are reserved for pure edge cases (policy logic, schedule boundaries, pattern
   matching, time arithmetic).
-- **No forbidden mocks.** Never mock repositories, `AuthService`, or `Clock`.
-  `Clock` comes via `TestClock`; the DB layer uses real embedded Postgres.
+- **Mocks: external I/O only.** Only mock what genuinely can't run in CI — the
+  router agents' network I/O, injected as function parameters (`get_fn` /
+  `write_fn` / `exec_fn`), never a stubbed HTTP client. **Never** mock
+  repositories, `AuthService`, or `Clock`: repos run against real embedded
+  Postgres (`zonkyio/embedded-postgres` via `TestDatabase.layer`) so the actual
+  SQL is exercised, and `Clock` comes via `Clock.TestClock`. A test that mocks a
+  repo / `AuthService` / `Clock`, or stubs something runnable in CI, is a
+  **finding** (BLOCKER when it lets a regression through untested SQL or auth).
+- **ZIO primitives for mutable state.** Test (and prod) mutable state uses ZIO
+  primitives — `Ref` / `Ref.Synchronized` / `Queue` / `Hub` — not raw mutable
+  Scala collections. A `mutable.HashMap`/`var`/`ArrayBuffer` shared across
+  fibers or effects is a finding (race-prone); a tight single-fiber inner loop
+  is the only exemption and must document why inline.
 - **No wall-clock waits / timing-sensitive tests.** A test that `ZIO.sleep`s
   (or otherwise blocks on real wall-time) to *wait for* a background fiber,
   poller, cache refresh, or scheduled effect to land — typically under

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -92,6 +92,23 @@ in [#1561](https://github.com/wifihaven/wifihaven/issues/1561).
   matching, time arithmetic).
 - **No forbidden mocks.** Never mock repositories, `AuthService`, or `Clock`.
   `Clock` comes via `TestClock`; the DB layer uses real embedded Postgres.
+- **No wall-clock waits / timing-sensitive tests.** A test that `ZIO.sleep`s
+  (or otherwise blocks on real wall-time) to *wait for* a background fiber,
+  poller, cache refresh, or scheduled effect to land — typically under
+  `@@ TestAspect.withLiveClock` / a `Clock.live` layer — is **flaky by
+  construction** and a **finding** (SHOULD-FIX, or BLOCKER if it gates an
+  enforcement / metric path). The clock is injected: drive async work to
+  completion **synchronously** (call the single-tick function directly, not
+  `.fork` + sleep) and advance time **deterministically** with
+  `TestClock.adjust`. A bare `ZIO.sleep` in a test body is the tell. Worked
+  example: [#2042](https://github.com/wifihaven/wifihaven/issues/2042) —
+  `MetricsExportSpec` forked the rollup loop, `ZIO.sleep(600.millis)`,
+  interrupted, slept again, then asserted; it passed in isolation but flaked
+  an unrelated PR's CI under 14-worker contention. The standing rule lives in
+  [`docs/process/testing.md`](process/testing.md) ("Clock is always injected —
+  use `Clock.TestClock`"); this dimension enforces it at review. Legitimate
+  live-clock uses (measuring *real* elapsed duration) are exempt but must say
+  why inline.
 - **Bug fix → regression test that FAILS without the fix.** Confirm the test
   actually pins the bug, not just adjacent behavior.
 

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -86,40 +86,19 @@ in [#1561](https://github.com/wifihaven/wifihaven/issues/1561).
   gates, so the gate only holds if test weakening is caught here.)
 - **Is the new behavior actually asserted** — not merely compiled or exercised
   without a check? Are negative / edge / boundary cases covered?
-- **Right level.** Feature tests through the full stack
-  (HTTP → route → service → repo → embedded Postgres) are preferred; unit tests
-  are reserved for pure edge cases (policy logic, schedule boundaries, pattern
-  matching, time arithmetic).
-- **Mocks: external I/O only.** Only mock what genuinely can't run in CI — the
-  router agents' network I/O, injected as function parameters (`get_fn` /
-  `write_fn` / `exec_fn`), never a stubbed HTTP client. **Never** mock
-  repositories, `AuthService`, or `Clock`: repos run against real embedded
-  Postgres (`zonkyio/embedded-postgres` via `TestDatabase.layer`) so the actual
-  SQL is exercised, and `Clock` comes via `Clock.TestClock`. A test that mocks a
-  repo / `AuthService` / `Clock`, or stubs something runnable in CI, is a
-  **finding** (BLOCKER when it lets a regression through untested SQL or auth).
-- **ZIO primitives for mutable state.** Test (and prod) mutable state uses ZIO
-  primitives — `Ref` / `Ref.Synchronized` / `Queue` / `Hub` — not raw mutable
-  Scala collections. A `mutable.HashMap`/`var`/`ArrayBuffer` shared across
-  fibers or effects is a finding (race-prone); a tight single-fiber inner loop
-  is the only exemption and must document why inline.
-- **No wall-clock waits / timing-sensitive tests.** A test that `ZIO.sleep`s
-  (or otherwise blocks on real wall-time) to *wait for* a background fiber,
-  poller, cache refresh, or scheduled effect to land — typically under
-  `@@ TestAspect.withLiveClock` / a `Clock.live` layer — is **flaky by
-  construction** and a **finding** (SHOULD-FIX, or BLOCKER if it gates an
-  enforcement / metric path). The clock is injected: drive async work to
-  completion **synchronously** (call the single-tick function directly, not
-  `.fork` + sleep) and advance time **deterministically** with
-  `TestClock.adjust`. A bare `ZIO.sleep` in a test body is the tell. Worked
-  example: [#2042](https://github.com/wifihaven/wifihaven/issues/2042) —
-  `MetricsExportSpec` forked the rollup loop, `ZIO.sleep(600.millis)`,
-  interrupted, slept again, then asserted; it passed in isolation but flaked
-  an unrelated PR's CI under 14-worker contention. The standing rule lives in
-  [`docs/process/testing.md`](process/testing.md) ("Clock is always
-  injected") — use `Clock.TestClock` in tests; this dimension enforces it at
-  review. Legitimate live-clock uses (measuring *real* elapsed duration) are
-  exempt but must say why inline.
+- **Tests conform to [`docs/process/testing.md`](process/testing.md)** — that
+  file is the authoritative source for how tests are written; **read it and
+  check the diff against it, don't re-derive its rules here.** The ones that
+  most often surface as findings: **right level** (feature test through the full
+  stack vs unit only for the edge cases it enumerates), **mocks — external I/O
+  only** (never a repo / `AuthService` / `Clock`; CI-runnable code uses the real
+  thing), **`Clock` injected via `TestClock`** — including **no wall-clock
+  `ZIO.sleep` waits** for a background fiber / poller / cache to catch up (the
+  [#2042](https://github.com/wifihaven/wifihaven/issues/2042) flaky class) — and
+  **ZIO primitives for mutable state**. A test that breaks a rule there is a
+  finding — **BLOCKER** when it hides a regression (mocked SQL/auth, weakened
+  assertion) or gates an enforcement / metric path (a flaky wall-clock wait),
+  otherwise SHOULD-FIX.
 - **Bug fix → regression test that FAILS without the fix.** Confirm the test
   actually pins the bug, not just adjacent behavior.
 

--- a/docs/process/testing.md
+++ b/docs/process/testing.md
@@ -63,6 +63,19 @@ for
 yield ...
 ```
 
+**Never wait on wall-clock time for async work.** A test must not `ZIO.sleep`
+(or otherwise block on real wall-time) to *wait for* a background fiber, poller,
+cache refresh, or scheduled effect to land — typically under
+`@@ TestAspect.withLiveClock` or a `Clock.live` layer. That shape is flaky by
+construction: it passed `MetricsExportSpec` in isolation (it forked the rollup
+loop, `ZIO.sleep(600.millis)`, interrupted, slept again, then asserted) but
+flaked an unrelated PR's CI under 14-worker contention
+([#2042](https://github.com/wifihaven/wifihaven/issues/2042)). Drive async work
+to completion **synchronously** (call the single-tick function directly, not
+`.fork` + sleep) and advance time **deterministically** with `TestClock.adjust`.
+Measuring *real* elapsed duration is the only legitimate live-clock use, and it
+must say why inline.
+
 ### ZIO primitives for mutable state
 
 Use ZIO primitives everywhere except tight inner loops:


### PR DESCRIPTION
## What

Closes the #2044 gap — a reviewer following the checklist verbatim would APPROVE the #2042 flaky-timing shape (a test that `ZIO.sleep`s under `withLiveClock` to await a background fiber, then asserts). Two docs files change:

1. **`docs/process/testing.md`** — authors the new **"Never wait on wall-clock time for async work"** rule in the Clock section (its single-source-of-truth home), with the #2042 worked example and the `TestClock.adjust` + synchronous-drive remedy.
2. **`docs/pr-review-checklist.md`** dimension 2 — references `testing.md` as the authoritative testing-rules source and tells the reviewer to check the diff against it, naming the rules as **pointers** (right level, mocks — external I/O only, `Clock` via `TestClock` incl. no wall-clock waits, ZIO primitives). It does **not** restate their content.

## Why reference, not copy

The testing rules are authored in `testing.md`. Duplicating them into the checklist is a single-source-of-truth violation — the two copies drift. The checklist's job is to point the reviewer at the source and flag which rule-classes most often surface as findings; the rule *content* (the remedy mechanics, the `get_fn`/`write_fn`/`exec_fn` list, the `Ref`/`Queue`/`Hub` table) lives in one place: `testing.md`.

## Mirror

`docs/pr-review-checklist.md` (lines ~18–19) says it must stay in sync with the orchestrator-side prompt `reference_pr_review_prompt.md`. **That file does not exist in the repo** (`find . -name reference_pr_review_prompt.md` → empty). The `/pr-review` slash command (`.claude/commands/pr-review.md`) `@`-includes `docs/pr-review-checklist.md` directly, so updating the checklist is sufficient — there is no in-repo mirror to update.

## Scope

Pure docs change — only `docs/process/testing.md` and `docs/pr-review-checklist.md`. No source / test / CI / build churn.

Closes #2044

🤖 Generated with [Claude Code](https://claude.com/claude-code)