### PR TITLE
fix(#2040,#2041): LIVE BANDWIDTH — most-recent COMPLETE bucket + aggregate raw + loading state

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -1096,7 +1096,14 @@ object UsageRoutes {
       // time bucket"). No implicit default.
       effectiveGroupBy = groupBySet
       resp <- bucket match {
-        case UsageTraffic.Bucket.Raw =>
+        // #2040: `raw` WITHOUT a groupBy is the page's per-host raw inspector → `rawRows`. `raw`
+        // WITH a groupBy (e.g. the dashboard gauge's `groupBy=profile`) falls through to the
+        // aggregate path below, which rolls each ingest period up per the groupBy at the row's REAL
+        // `[periodStart, periodEnd)` window (`buildAggregate` floors `raw` to the row itself, #2018)
+        // — one `aggregateRows` point per (period, group), per design §1.3. Without this guard a
+        // `raw&groupBy=profile` read returned per-host `rawRows` and empty `aggregateRows`, leaving
+        // the gauge (which reads `aggregateRows`) blank.
+        case UsageTraffic.Bucket.Raw if effectiveGroupBy.isEmpty =>
           for {
             rawCursor <- req.url.queryParam("cursor") match {
               case None    => ZIO.succeed(Option.empty[RawTrafficCursorKey])
@@ -1142,7 +1149,7 @@ object UsageRoutes {
             rawRowsTruncated = false,
             nextCursor = nextCur,
           )
-        case _                       =>
+        case _                                                   =>
           // Aggregated path: source table = finer of (bucket cap, window cost
           // preference) (#1262). The requested bucket is always honored; the
           // range can only steer the read toward finer/fresher data, never

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -882,6 +882,106 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.rawRows.forall(_.profileName.contains("Kids"))) &&
           assertTrue(out.rawRows.map(_.host.value).toSet == Set("youtube.com", "google.com"))
       },
+      // #2040: a `raw` request WITH a groupBy aggregates per the groupBy at the row's real ingest
+      // period (one point per (periodStart, group)) — it must NOT fall through to the ungrouped
+      // per-host `rawRows` shape (which left the dashboard LIVE BANDWIDTH gauge, reading
+      // `aggregateRows`, perpetually blank). The ungrouped raw inspector (no groupBy) still returns
+      // `rawRows` (covered by the test above).
+      test(
+        "raw view WITH groupBy=profile aggregates per profile on the row's real period (#2040)",
+      ) {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          // Two hosts in the SAME ingest period (14:00, 300s) so they roll up into ONE per-profile
+          // point; a third host in a LATER period (14:05) makes a second point.
+          start1 = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          start2 = start1.plusSeconds(300)
+          _  <- ZIO.serviceWithZIO[TrafficReportRepo](
+            _.insertBatch(
+              List(
+                TrafficReportInsert(
+                  routerId,
+                  MacAddress.unsafe(testMac),
+                  None,
+                  HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                  today,
+                  start1,
+                  start1.plusSeconds(300),
+                  300,
+                  1000L,
+                  2000L,
+                ),
+                TrafficReportInsert(
+                  routerId,
+                  MacAddress.unsafe(testMac),
+                  None,
+                  HostId.Fqdn(Hostname.unsafe("google.com")),
+                  today,
+                  start1,
+                  start1.plusSeconds(300),
+                  300,
+                  500L,
+                  1500L,
+                ),
+                TrafficReportInsert(
+                  routerId,
+                  MacAddress.unsafe(testMac),
+                  None,
+                  HostId.Fqdn(Hostname.unsafe("netflix.com")),
+                  today,
+                  start2,
+                  start2.plusSeconds(300),
+                  300,
+                  300L,
+                  700L,
+                ),
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          from = today.atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          to   = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          req  = Request
+            .get(
+              URL
+                .decode(
+                  s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=raw&groupBy=profile",
+                )
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.bucket == "raw") &&
+          assertTrue(out.groupBy == List("profile")) &&
+          // Aggregated, NOT raw per-host rows — the dashboard gauge reads `aggregateRows`.
+          assertTrue(out.rawRows.isEmpty) &&
+          // One point per (period, profile): period1 (youtube+google) + period2 (netflix) = 2.
+          assertTrue(out.aggregateRows.length == 2) &&
+          assertTrue(out.aggregateRows.forall(_.groups.get("profile").contains("Kids"))) &&
+          // The window is the row's REAL [periodStart, periodEnd) (#2018), not a synthetic grid cell.
+          assertTrue(
+            out.aggregateRows.map(r => (r.windowStart, r.windowEnd)).toSet ==
+              Set(
+                (start1.toString, start1.plusSeconds(300).toString),
+                (start2.toString, start2.plusSeconds(300).toString),
+              ),
+          ) &&
+          // period1 sums both hosts' bytes (1000+500 in, 2000+1500 out); totals match the raw bytes.
+          assertTrue(out.aggregateRows.map(_.totalBytesIn).sum == 1800L) &&
+          assertTrue(out.aggregateRows.map(_.totalBytesOut).sum == 4200L)
+      },
       test(
         "1h aggregated view with groupBy=domain groups by domain and sums bytes/seconds; matches raw sums",
       ) {

--- a/web/src/api/wsCache.test.ts
+++ b/web/src/api/wsCache.test.ts
@@ -5,8 +5,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   bucketSeconds,
+  completeHeadBucketRows,
   deriveNowKpis,
-  headBucketRows,
   mergeAggregateHeadRows,
   mergeHeadBucket,
   overallRate,
@@ -147,18 +147,44 @@ describe('mergeAggregateHeadRows (#1975 S6b §3.1) — page-level row merge', ()
   })
 })
 
-describe('headBucketRows', () => {
-  it('returns only the newest windowStart rows', () => {
+describe('completeHeadBucketRows (#2040)', () => {
+  const now = new Date('2026-06-26T10:07:30Z').getTime()
+
+  it('returns all rows of the newest COMPLETE window (windowEnd <= now)', () => {
     const s = series([
-      aggRow({ windowStart: '2026-06-26T10:06:00Z', groups: { profile: 'Kids' } }),
-      aggRow({ windowStart: '2026-06-26T10:06:00Z', groups: { profile: 'Adults' } }),
-      aggRow({ windowStart: '2026-06-26T10:05:00Z', groups: { profile: 'Kids' } }),
+      // newest, but IN-PROGRESS (windowEnd in the future) — must be skipped.
+      aggRow({ windowStart: '2026-06-26T10:07:00Z', windowEnd: '2026-06-26T10:08:00Z', groups: { profile: 'Kids' } }),
+      // most-recent COMPLETE 1m bucket (ended 10:07:00, in the past).
+      aggRow({ windowStart: '2026-06-26T10:06:00Z', windowEnd: '2026-06-26T10:07:00Z', groups: { profile: 'Kids' } }),
+      aggRow({ windowStart: '2026-06-26T10:06:00Z', windowEnd: '2026-06-26T10:07:00Z', groups: { profile: 'Adults' } }),
+      aggRow({ windowStart: '2026-06-26T10:05:00Z', windowEnd: '2026-06-26T10:06:00Z', groups: { profile: 'Kids' } }),
     ])
-    expect(headBucketRows(s)).toHaveLength(2)
+    const head = completeHeadBucketRows(s, now)
+    expect(head).toHaveLength(2)
+    expect(head.every(r => r.windowStart === '2026-06-26T10:06:00Z')).toBe(true)
   })
+
+  it('selects the newest row for raw (every stored ingest period is complete)', () => {
+    const s = series(
+      [
+        aggRow({ windowStart: '2026-06-26T10:06:20Z', windowEnd: '2026-06-26T10:07:20Z', groups: { profile: 'Kids' }, totalBytesIn: 600 }),
+        aggRow({ windowStart: '2026-06-26T10:05:10Z', windowEnd: '2026-06-26T10:06:15Z', groups: { profile: 'Kids' } }),
+      ],
+      { bucket: 'raw' },
+    )
+    expect(completeHeadBucketRows(s, now).map(r => r.windowStart)).toEqual(['2026-06-26T10:06:20Z'])
+  })
+
+  it('empty when every window is still in progress (no complete bucket yet)', () => {
+    const s = series([
+      aggRow({ windowStart: '2026-06-26T10:07:00Z', windowEnd: '2026-06-26T10:08:00Z', groups: { profile: 'Kids' } }),
+    ])
+    expect(completeHeadBucketRows(s, now)).toEqual([])
+  })
+
   it('empty for an empty/undefined series', () => {
-    expect(headBucketRows(undefined)).toEqual([])
-    expect(headBucketRows(series([]))).toEqual([])
+    expect(completeHeadBucketRows(undefined, now)).toEqual([])
+    expect(completeHeadBucketRows(series([]), now)).toEqual([])
   })
 })
 

--- a/web/src/api/wsCache.ts
+++ b/web/src/api/wsCache.ts
@@ -58,16 +58,28 @@ export function mergeAggregateHeadRows(
   return [...live, ...kept]
 }
 
-// The head (newest) bucket's rows — the slice the live gauge reads. The series is
-// newest-first (GET orders windowStart DESC, mergeHeadBucket prepends the live edge),
-// so the head windowStart is row[0]'s.
-export function headBucketRows(
+// The most-recent COMPLETE bucket's rows — the slice the live gauge reads (#2040). The series is
+// newest-first (GET orders windowStart DESC, mergeHeadBucket prepends the live edge), so we walk
+// from the newest window and take the first one whose full span has already elapsed
+// (`windowEnd <= now`), then return every row (one per group) sharing that windowStart.
+//
+// Why "complete", not just "newest" (the old behavior):
+//   - Fixed buckets (1m/10m/…): the newest window is the still-accumulating IN-PROGRESS cell — it
+//     holds only the elapsed fraction of `bucketWidth`, so `bytes / bucketWidth` understates the
+//     rate. Its `windowEnd` is in the future, so it's skipped; the prior, full-width bucket wins.
+//   - `raw`: every stored row is a closed ingest period (`windowEnd` = the real period end, already
+//     past), so the newest row is selected — fixing the perpetually-empty `[floor(now), now)` seed
+//     (a ~60s report covers the PRIOR period, #2004).
+// `nowMs` is the caller's current time; `windowEnd` is the server's `windowFor` end (SSOT).
+export function completeHeadBucketRows(
   series: TrafficUsageResponse | undefined,
+  nowMs: number,
 ): TrafficUsageAggregateRow[] {
   const rows = series?.aggregateRows ?? []
   if (rows.length === 0) return []
-  const headStart = rows[0].windowStart
-  return rows.filter(r => r.windowStart === headStart)
+  const head = rows.find(r => new Date(r.windowEnd).getTime() <= nowMs)
+  if (!head) return []
+  return rows.filter(r => r.windowStart === head.windowStart)
 }
 
 // ── B/s derivation: client divides bytes-over-bucket (§1.3) — server stays the source ──

--- a/web/src/components/dashboard/BandwidthGauges.test.tsx
+++ b/web/src/components/dashboard/BandwidthGauges.test.tsx
@@ -1,0 +1,65 @@
+// #2040/#2041: the LIVE BANDWIDTH gauge renders three distinct states off `useWsTrafficUsage` —
+// a loading skeleton (never "0 B/s"), the live rates, and a genuinely-idle "No live traffic".
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { WsTrafficUsage } from '@/hooks/useWs'
+import type { BandwidthRate } from '@/api/wsCache'
+
+const hookState = vi.fn<() => WsTrafficUsage>()
+vi.mock('@/hooks/useWs', () => ({ useWsTrafficUsage: () => hookState() }))
+
+import { BandwidthGauges } from './BandwidthGauges'
+
+const ZERO: BandwidthRate = { bytesInPerSec: 0, bytesOutPerSec: 0, bytesPerSec: 0 }
+const base: WsTrafficUsage = {
+  live: true,
+  loading: false,
+  bucket: '1m',
+  setBucket: () => {},
+  rows: [],
+  overall: ZERO,
+  rate: () => ZERO,
+}
+
+beforeEach(() => hookState.mockReset())
+
+describe('BandwidthGauges (#2040/#2041)', () => {
+  it('shows a loading skeleton — NOT "0 B/s" / "No live traffic" — while data is loading', () => {
+    hookState.mockReturnValue({ ...base, loading: true })
+    render(<BandwidthGauges />)
+    expect(screen.getByTestId('bandwidth-loading')).toBeInTheDocument()
+    expect(screen.getByTestId('bandwidth-overall-loading')).toBeInTheDocument()
+    expect(screen.queryByText('No live traffic right now')).not.toBeInTheDocument()
+    expect(screen.queryByText(/0 B\/s/)).not.toBeInTheDocument()
+  })
+
+  it('renders per-profile rates once data is present', () => {
+    const rate: BandwidthRate = { bytesInPerSec: 1024, bytesOutPerSec: 0, bytesPerSec: 1024 }
+    hookState.mockReturnValue({
+      ...base,
+      rows: [{
+        groups: { profile: 'Kids' }, windowStart: 'w', windowEnd: 'w',
+        totalBytesIn: 0, totalBytesOut: 0, totalSeconds: 60,
+      }],
+      overall: rate,
+      rate: () => rate,
+    })
+    render(<BandwidthGauges />)
+    expect(screen.queryByTestId('bandwidth-loading')).not.toBeInTheDocument()
+    expect(screen.getByTestId('bandwidth-profile-Kids')).toBeInTheDocument()
+  })
+
+  it('shows "No live traffic right now" only when data is present and the rate is idle', () => {
+    hookState.mockReturnValue({ ...base, loading: false, rows: [] })
+    render(<BandwidthGauges />)
+    expect(screen.queryByTestId('bandwidth-loading')).not.toBeInTheDocument()
+    expect(screen.getByText('No live traffic right now')).toBeInTheDocument()
+  })
+
+  it('shows the connection-paused message when the socket is down (not loading, not live)', () => {
+    hookState.mockReturnValue({ ...base, live: false, loading: false, rows: [] })
+    render(<BandwidthGauges />)
+    expect(screen.getByTestId('bandwidth-overall-idle')).toBeInTheDocument()
+    expect(screen.getByText(/Live throughput pauses/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/dashboard/BandwidthGauges.tsx
+++ b/web/src/components/dashboard/BandwidthGauges.tsx
@@ -26,8 +26,19 @@ function RateLine({ rate }: { rate: BandwidthRate }) {
   )
 }
 
+// #2041: a shimmer bar stands in for a not-yet-loaded rate, so the gauge never flashes a misleading
+// "0 B/s" before the first data resolves.
+function SkeletonBar({ className = '', testId }: { className?: string; testId?: string }) {
+  return (
+    <span
+      data-testid={testId}
+      className={`inline-block h-4 rounded bg-brand-border/70 animate-pulse ${className}`}
+    />
+  )
+}
+
 export function BandwidthGauges() {
-  const { live, bucket, setBucket, rows, overall, rate } = useWsTrafficUsage('1m')
+  const { live, loading, bucket, setBucket, rows, overall, rate } = useWsTrafficUsage('1m')
 
   // Profile label: groupBy:profile puts the profile name in `groups.profile`.
   const profileLabel = (row: TrafficUsageAggregateRow) =>
@@ -44,33 +55,47 @@ export function BandwidthGauges() {
 
       <div className="flex items-baseline justify-between gap-3 border-b border-brand-border pb-3">
         <span className="text-sm font-medium text-brand-ink">Overall</span>
-        {live
-          ? <RateLine rate={overall} />
-          : <span data-testid="bandwidth-overall-idle" className="font-mono text-sm text-brand-text-muted">—</span>}
+        {/* #2041: three states — loading (skeleton, never "0"), live (rate), or paused ("—"). */}
+        {loading
+          ? <SkeletonBar testId="bandwidth-overall-loading" className="w-28" />
+          : live
+            ? <RateLine rate={overall} />
+            : <span data-testid="bandwidth-overall-idle" className="font-mono text-sm text-brand-text-muted">—</span>}
       </div>
 
-      {!live
+      {loading
         ? (
-          <p className="text-xs text-brand-text-muted">
-            Live throughput pauses while the connection is down.
-          </p>
+          <ul data-testid="bandwidth-loading" className="space-y-2" aria-hidden="true">
+            {[0, 1].map(i => (
+              <li key={i} className="flex items-baseline justify-between gap-3">
+                <SkeletonBar className="w-24" />
+                <SkeletonBar className="w-28" />
+              </li>
+            ))}
+          </ul>
         )
-        : rows.length === 0
-          ? <EmptyState variant="inline" title="No live traffic right now" />
-          : (
-            <ul className="space-y-2">
-              {rows.map(row => (
-                <li
-                  key={row.groups.profile ?? `${row.windowStart}`}
-                  data-testid={`bandwidth-profile-${row.groups.profile ?? 'unknown'}`}
-                  className="flex items-baseline justify-between gap-3"
-                >
-                  <span className="text-sm text-brand-text truncate">{profileLabel(row)}</span>
-                  <RateLine rate={rate(row)} />
-                </li>
-              ))}
-            </ul>
+        : !live
+          ? (
+            <p className="text-xs text-brand-text-muted">
+              Live throughput pauses while the connection is down.
+            </p>
           )
+          : rows.length === 0
+            ? <EmptyState variant="inline" title="No live traffic right now" />
+            : (
+              <ul className="space-y-2">
+                {rows.map(row => (
+                  <li
+                    key={row.groups.profile ?? `${row.windowStart}`}
+                    data-testid={`bandwidth-profile-${row.groups.profile ?? 'unknown'}`}
+                    className="flex items-baseline justify-between gap-3"
+                  >
+                    <span className="text-sm text-brand-text truncate">{profileLabel(row)}</span>
+                    <RateLine rate={rate(row)} />
+                  </li>
+                ))}
+              </ul>
+            )
       }
     </section>
   )

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -288,6 +288,121 @@ describe('useWsTrafficUsage seeds via GET (#2017)', () => {
   })
 })
 
+// ── #2040: the gauge shows the most-recent COMPLETE bucket + renders aggregated raw ───────────────
+//
+// Old behavior requested `[floor(now), now)` and read the NEWEST window: empty for 1m/raw (data
+// lands in the prior period), partial/understated for 10m+ (in-progress cell). These prove the
+// gauge now seeds a wider window and renders the most-recent COMPLETE bucket at full width.
+describe('useWsTrafficUsage shows the most-recent COMPLETE bucket (#2040)', () => {
+  const FUTURE = '2099-01-01T00:00:00Z' // an in-progress bucket: windowEnd not yet elapsed
+  const aggRow = (
+    profile: string,
+    windowStart: string,
+    windowEnd: string,
+    bytesIn = 0,
+    bytesOut = 0,
+  ): TrafficUsageAggregateRow => ({
+    groups: { profile }, windowStart, windowEnd,
+    totalBytesIn: bytesIn, totalBytesOut: bytesOut, totalSeconds: 60,
+  })
+  const resp = (
+    bucket: TrafficUsageResponse['bucket'],
+    rows: TrafficUsageAggregateRow[],
+  ): TrafficUsageResponse => ({
+    bucket, groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [], aggregateRows: rows,
+  })
+
+  it('skips the in-progress newest bucket and renders the prior COMPLETE one', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    // Newest window is still in progress (windowEnd in the future); the prior 1m bucket is complete.
+    trafficSpy.mockResolvedValue(resp('1m', [
+      aggRow('Kids', '2026-06-26T10:06:00Z', FUTURE, 99999),
+      aggRow('Kids', '2026-06-26T10:05:00Z', '2026-06-26T10:06:00Z', 600),
+    ]))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(1))
+    expect(result.current.rows[0].windowStart).toBe('2026-06-26T10:05:00Z')
+    expect(result.current.overall.bytesInPerSec).toBe(10) // 600 / 60s — the complete bucket, not 99999
+  })
+
+  it('seeds a window wide enough (>= 2 bucket widths) to contain the complete bucket', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    trafficSpy.mockResolvedValue(resp('10m', []))
+    const { client, wrapper } = setup()
+    renderHook(() => useWsTrafficUsage('10m'), { wrapper })
+    goLive(client)
+    await waitFor(() => expect(trafficSpy).toHaveBeenCalledTimes(1))
+    const { from, to } = trafficSpy.mock.calls[0][0]
+    // 10m bucket → lookback = max(2×600s, 10min) = 20 min.
+    expect(new Date(to).getTime() - new Date(from).getTime()).toBeGreaterThanOrEqual(20 * 60 * 1000)
+  })
+
+  it('derives the 10m rate over the FULL bucket width (bytes / 600), not elapsed time', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    // A complete 10m bucket carrying 6000 bytes in → 6000 / 600s = 10 B/s.
+    trafficSpy.mockResolvedValue(resp('10m', [
+      aggRow('Kids', '2026-06-26T10:00:00Z', '2026-06-26T10:10:00Z', 6000),
+    ]))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('10m'), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
+    await waitFor(() => expect(result.current.rows).toHaveLength(1))
+    expect(result.current.overall.bytesInPerSec).toBe(10)
+  })
+
+  it('renders raw from aggregated rows over the row real period span', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    // raw aggregate: a 60s ingest period carrying 600 bytes in → 600 / 60s = 10 B/s.
+    trafficSpy.mockResolvedValue(resp('raw', [
+      aggRow('Kids', '2026-06-26T10:05:00Z', '2026-06-26T10:06:00Z', 600),
+    ]))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('raw'), { wrapper })
+    goLive(client)
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
+    await waitFor(() => expect(result.current.rows).toHaveLength(1))
+    expect(result.current.overall.bytesInPerSec).toBe(10)
+  })
+})
+
+// ── #2041: loading state, not a 0 flash ───────────────────────────────────────────────────────────
+describe('useWsTrafficUsage loading state (#2041)', () => {
+  it('is loading until the seed resolves, then not loading once data is present', async () => {
+    const { api } = await import('@/api/client')
+    const trafficSpy = api.usage.traffic as unknown as ReturnType<typeof vi.fn>
+    trafficSpy.mockClear()
+    let resolveSeed: (r: TrafficUsageResponse) => void = () => {}
+    trafficSpy.mockImplementation(() => new Promise<TrafficUsageResponse>(res => { resolveSeed = res }))
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => useWsTrafficUsage('1m'), { wrapper })
+    goLive(client)
+
+    // Seed in flight, no push yet → loading (the gauge shows a skeleton, never "0 B/s").
+    await waitFor(() => expect(result.current.loading).toBe(true))
+    expect(result.current.rows).toHaveLength(0)
+
+    // Seed resolves with no recent traffic → no longer loading; rows empty = genuinely idle.
+    act(() => resolveSeed({
+      bucket: '1m', groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [], aggregateRows: [],
+    }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.rows).toHaveLength(0)
+  })
+})
+
 describe('polling pauses only while the topic streams (§3.3)', () => {
   it('pauses the poll once the `now` subscription is acked, not on bare socket liveness', async () => {
     vi.useFakeTimers()

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -24,7 +24,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { SpaWsClient, type SpaTopicName, type WsStatus } from '@/api/wsClient'
 import {
   bucketSeconds,
-  headBucketRows,
+  completeHeadBucketRows,
   mergeAggregateHeadRows,
   mergeHeadBucket,
   overallRate,
@@ -234,9 +234,15 @@ export function useWsAppUsage(profileId: number, from: string, to: string, enabl
 
 export interface WsTrafficUsage {
   live: boolean
+  /**
+   * True until the first bandwidth data resolves (the GET seed in flight AND no push yet) — the
+   * gauge shows a loading skeleton, not a misleading "0 B/s" (#2041). Once any data is present this
+   * is false; an empty `rows` then means genuinely-idle, not "still loading".
+   */
+  loading: boolean
   bucket: TrafficUsageBucket
   setBucket: (b: TrafficUsageBucket) => void
-  /** The head (current) bucket's per-profile rows (one per profile, groupBy:profile). */
+  /** The most-recent COMPLETE bucket's per-profile rows (one per profile, groupBy:profile). */
   rows: TrafficUsageAggregateRow[]
   /** The household total rate (sum of the per-profile head rows). */
   overall: BandwidthRate
@@ -283,7 +289,7 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
 
   // The GET seed (#2017). A real query observer (not a passive cache read) so it fetches on
   // mount / key change AND receives the push's `setQueryData` cache updates on the same key.
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: key,
     queryFn: async () => {
       const { from, to } = headWindow(bucket)
@@ -305,9 +311,12 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
     refetchInterval: false,
   })
 
-  const rows = headBucketRows(data)
+  // The most-recent COMPLETE bucket (#2040), selected against the current time. `data === undefined`
+  // means neither the GET seed nor a push has landed yet → loading (#2041).
+  const rows = completeHeadBucketRows(data, Date.now())
   return {
     live: streaming,
+    loading: data === undefined && isLoading,
     bucket,
     setBucket,
     rows,
@@ -316,17 +325,22 @@ export function useWsTrafficUsage(initialBucket: TrafficUsageBucket = '1m'): WsT
   }
 }
 
-/**
- * The current head-bucket window `[floor(now, bucket), now]` for the seed GET (#2017).
- * Flooring `from` to the bucket boundary makes the GET return exactly the current (head)
- * window, so `headBucketRows` lands on it and the rate is right. `raw` has no fixed width —
- * we floor to the nominal ~60s edge (`bucketSeconds('raw')`), giving the most-recent slice.
- */
+// The seed GET (#2017) requests a recent window WIDE ENOUGH to contain the most-recent COMPLETE
+// bucket, then `completeHeadBucketRows` selects it (#2040). The lookback must clear both failure
+// modes the old `[floor(now), now)` window had:
+//   - the in-progress fixed bucket is empty/partial → look back ≥ 2 bucket widths so a full prior
+//     bucket is present;
+//   - fine buckets (1m/raw) can sit several reports back — a ~60s `usage_report_interval` covers the
+//     PRIOR period (#2004) and reports can gap — so floor the lookback at `SEED_LOOKBACK_MIN_MS` so
+//     the seed reaches past those gaps. Coarse buckets are dominated by `2 × width` (a 1d/1w bucket
+//     rarely gaps within its own width), keeping their window to ~2 buckets rather than minutes-of-
+//     slack. The selection (not the window) is what guarantees a COMPLETE bucket is shown.
+const SEED_LOOKBACK_MIN_MS = 10 * 60 * 1000 // 10 min — clears multi-minute fine-bucket report gaps
 function headWindow(bucket: TrafficUsageBucket): { from: string; to: string } {
   const nowMs = Date.now()
-  const secs = bucketSeconds(bucket)
-  const fromMs = Math.floor(nowMs / 1000 / secs) * secs * 1000
-  return { from: new Date(fromMs).toISOString(), to: new Date(nowMs).toISOString() }
+  const widthMs = bucketSeconds(bucket) * 1000
+  const lookbackMs = Math.max(widthMs * 2, SEED_LOOKBACK_MIN_MS)
+  return { from: new Date(nowMs - lookbackMs).toISOString(), to: new Date(nowMs).toISOString() }
 }
 
 // ── #1975 (S6b): stream the live edge of the Traffic Usage + Connection Events PAGES ──


### PR DESCRIPTION
Fixes #2040 and #2041 — the dashboard LIVE BANDWIDTH gauge (`BandwidthGauges` + `useWsTrafficUsage`). Landed together per the #2040 note (same component).

## #2040 — the gauge used the *in-progress* bucket; `raw` never rendered

**Most-recent COMPLETE bucket, every bucket.** The #2017 GET-seed requested `[floor(now), now)` — the current bucket — and read the *newest* window. That window is **empty** for 1m/raw (a ~60s report lands in the *prior* period, the #2004 insight) and **partial/understated** for 10m+ (only part of `bucketWidth` has elapsed, so `bytes / bucketWidth` understates the rate).

- `completeHeadBucketRows(series, now)` selects the newest window whose full span has elapsed (`windowEnd <= now`), skipping the still-accumulating in-progress cell. `raw` rows are all closed ingest periods → the newest is shown.
- `headWindow` widens to `max(2×bucketWidth, 10min)` so the most-recent complete bucket is always present (fine buckets can sit several reports back; the current cell is empty/partial). The ws live-edge already anchors on the ingested `periodStart` (#2004) and the same selector now skips any in-progress bucket a push delivers — GET + ws + the #2018 `windowFor`/`buildAggregate` path stay consistent.

**Aggregate `raw` per `groupBy`.** `GET ?bucket=raw&groupBy=profile` returned `aggregateRows=[]` + per-host `rawRows`; the gauge reads `aggregateRows`, so raw never rendered. Now `raw` **with** a groupBy falls through to the aggregate path (one point per `(periodStart, group)` on the row's real `[periodStart, periodEnd)`, #2018), per `docs/design/spa-websocket.md` §1.3. `raw` with **no** groupBy (the Traffic Usage raw inspector) still returns `rawRows`.

## #2041 — "0 B/s" flash before data loads

`useWsTrafficUsage` now exposes `loading` (seed in flight, no data yet). The gauge renders a **skeleton** while loading and shows "0 B/s" / "No live traffic right now" **only** when data is present and the rate is genuinely ~0.

## Live evidence (admin curl vs prod, server ~22:25–22:45Z)

| query | before (prod, today) | after |
|---|---|---|
| `bucket=raw&groupBy=profile` | `aggregateRows=0`, `rawRows=200` | aggregated per-profile rows on the real period (local feature test) |
| `bucket=1m` current bucket | empty → gauge blank | wider window returns the complete `22:38` bucket; selector shows it |
| `bucket=10m` newest window | in-progress `[22:40,22:50)` → understated | complete `[22:30,22:40)`, full-width rate |

## Tests
- **api**: feature test — `raw&groupBy=profile` aggregates per profile on the row's real `[periodStart, periodEnd)` (RED→GREEN); full `mill api.test` green.
- **web** (node 22): `completeHeadBucketRows` complete-vs-in-progress selection; hook tests for complete-bucket render, full-`bucketWidth` 10m rate, raw-from-aggregated, and the loading→loaded transition; `BandwidthGauges` component test for skeleton vs idle vs paused. Lint + full vitest + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)