### PR TITLE
fix(#2047): Traffic Usage page must not surface its own request cancellations

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -3,7 +3,8 @@
 // `profileId=` param (parseMultiProfileIdParam splits on comma and only reads
 // the first occurrence), plus pass-through of date/tz/topN/groupBy.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { api } from './client'
+import { api, isCanceledError } from './client'
+import { apiHealth } from './apiHealth'
 import type { UsageSeriesBatchResponse } from '@/types/api'
 
 function okJson(body: unknown): Response {
@@ -106,5 +107,62 @@ describe('req opts every call out of the browser HTTP cache (#1299)', () => {
 
     const opts = fetchMock.mock.calls[0][1] as RequestInit
     expect(opts.cache).toBe('no-store')
+  })
+})
+
+// #2047 — a request the *caller* cancels (the Traffic Usage page superseding its
+// in-flight load on a bucket switch / filter change) must be distinguished from
+// the 10s timeout abort: a cancellation is NOT an API-health signal, so it must
+// never trip the unreachable banner, and it surfaces as a typed cancellation the
+// caller swallows rather than the cryptic "signal is aborted without reason".
+describe('req caller-cancellation is not an API-down signal (#2047)', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'tok')
+    apiHealth.reset()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    apiHealth.reset()
+  })
+
+  it('forwards the caller signal and reports a cancellation, not unreachable', async () => {
+    // Real fetch semantics: a fetch given an already-aborted signal rejects with
+    // an AbortError DOMException.
+    const fetchMock = vi.fn().mockRejectedValue(
+      new DOMException('signal is aborted without reason', 'AbortError'),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const controller = new AbortController()
+    controller.abort()
+
+    const p = api.usage.traffic({ bucket: '1m', signal: controller.signal })
+    await expect(p).rejects.toSatisfy(isCanceledError)
+    // The banner must stay clear — the caller cancelled, the API is fine.
+    expect(apiHealth.snapshot().unreachable).toBe(false)
+  })
+
+  it('still reports a genuine 10s timeout as unreachable (not a cancellation)', async () => {
+    vi.useFakeTimers()
+    // A fetch that never resolves until its own (timeout) signal aborts it.
+    const fetchMock = vi.fn(
+      (_url: string, opts: RequestInit) =>
+        new Promise<Response>((_res, rej) => {
+          opts.signal?.addEventListener('abort', () =>
+            rej(new DOMException('signal is aborted without reason', 'AbortError')),
+          )
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const p = api.usage.traffic({ bucket: '1m' })
+    const assertion = expect(p).rejects.toThrow()
+    await vi.advanceTimersByTimeAsync(10_001)
+    await assertion
+    // No caller signal → the abort is the timeout → genuine unreachable.
+    expect(apiHealth.snapshot().unreachable).toBe(true)
+    expect(apiHealth.snapshot().reason).toBe('timeout')
+    vi.useRealTimers()
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -30,18 +30,52 @@ function getToken(): string | null {
 // don't leak signal across calls.
 const REQUEST_TIMEOUT_MS = 10_000
 
+// #2047 — a request the *caller* cancelled (e.g. the Traffic Usage page
+// superseding its in-flight load on a bucket switch / filter change). This is
+// categorically NOT an API-health signal: the API is fine, the client just
+// stopped caring about the old answer. It must never trip the unreachable
+// banner, and callers swallow it rather than rendering the cryptic
+// "signal is aborted without reason". Distinct from the 10s timeout abort
+// (a genuine "API is hung" signal), which keeps reporting unreachable.
+export class RequestCanceledError extends Error {
+  constructor() {
+    super('request canceled')
+    this.name = 'RequestCanceledError'
+  }
+}
+
+export function isCanceledError(e: unknown): boolean {
+  return e instanceof RequestCanceledError
+}
+
 async function req<T>(
   method: string,
   path: string,
   body?: unknown,
   skipAuth = false,
+  signal?: AbortSignal,
 ): Promise<T> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   const token = getToken()
   if (!skipAuth && token) headers['Authorization'] = `Bearer ${token}`
 
+  // #2047: one fetch-scoped controller fed by two sources — our 10s timeout and
+  // the caller's optional supersede signal. `timedOut` records which one fired
+  // so the catch can tell a genuine timeout (report unreachable) from a caller
+  // cancellation (silent). The caller's abort is forwarded to our controller so
+  // the in-flight fetch is actually torn down.
   const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  let timedOut = false
+  const timeoutId = setTimeout(() => { timedOut = true; controller.abort() }, REQUEST_TIMEOUT_MS)
+  const onCallerAbort = () => controller.abort()
+  if (signal) {
+    if (signal.aborted) controller.abort()
+    else signal.addEventListener('abort', onCallerAbort)
+  }
+  const cleanup = () => {
+    clearTimeout(timeoutId)
+    if (signal) signal.removeEventListener('abort', onCallerAbort)
+  }
 
   let res: Response
   try {
@@ -59,14 +93,17 @@ async function req<T>(
       cache: 'no-store',
     })
   } catch (e) {
-    clearTimeout(timeoutId)
-    // Network error or abort (timeout). Either way the API isn't reachable
+    cleanup()
+    // #2047: caller cancellation (supersede) — the API is fine, don't light the
+    // banner. Surface a typed cancellation the caller swallows.
+    if (signal?.aborted && !timedOut) throw new RequestCanceledError()
+    // Network error or timeout abort. Either way the API isn't reachable
     // right now — light up the global banner via apiHealth.
     const aborted = e instanceof DOMException && e.name === 'AbortError'
     apiHealth.reportFailure(aborted ? 'timeout' : 'network')
     throw e
   }
-  clearTimeout(timeoutId)
+  cleanup()
 
   if (res.status === 401) {
     // 401 is an auth-state outcome, not an API-down signal. The API answered.
@@ -319,6 +356,11 @@ export const api = {
       tz?: string
       limit?: number
       cursor?: string
+      // #2047: the page passes its load-lifecycle signal so a superseded
+      // request (bucket switch / filter change) is cancelled cleanly rather
+      // than left in flight to resolve stale data — or to time out and trip
+      // the unreachable banner.
+      signal?: AbortSignal
     }) => {
       const qs = new URLSearchParams()
       if (params.macs?.length)             qs.set('mac', params.macs.join(','))
@@ -330,7 +372,7 @@ export const api = {
       if (params.tz)                       qs.set('tz', params.tz)
       if (params.limit !== undefined)      qs.set('limit', String(params.limit))
       if (params.cursor)                   qs.set('cursor', params.cursor)
-      return req<TrafficUsageResponse>('GET', `/usage/traffic?${qs}`)
+      return req<TrafficUsageResponse>('GET', `/usage/traffic?${qs}`, undefined, false, params.signal)
     },
   },
 

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -22,6 +22,9 @@ vi.mock('@/api/client', () => ({
     profiles: { list:    vi.fn() },
     apps:     { list:    vi.fn() },
   },
+  // #2047: the page swallows caller-cancellation errors via this predicate.
+  isCanceledError: (e: unknown) =>
+    e instanceof Error && e.name === 'RequestCanceledError',
 }))
 
 import { api } from '@/api/client'

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -354,4 +354,49 @@ describe('TrafficUsagePage', () => {
     renderPage()
     await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('window_too_large'))
   })
+
+  // #2047 — a cancelled/aborted in-flight request ("signal is aborted without
+  // reason") is a client-side cancellation, NOT a server failure. It must never
+  // be surfaced as a user-facing table error (the prod regression: the whole
+  // page showed the AbortError + "No rows in window.").
+  it('does not surface an AbortError as a user-facing error (#2047)', async () => {
+    const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
+    trafficMock.mockRejectedValueOnce(
+      new DOMException('signal is aborted without reason', 'AbortError'),
+    )
+    renderPage()
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalled())
+    // The page recovers to a clean empty state (the abort is swallowed).
+    await waitFor(() => expect(screen.getByText('No rows in window.')).toBeInTheDocument())
+    expect(screen.queryByText(/aborted/i)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument()
+  })
+
+  // #2047 — switching bucket supersedes the in-flight request. When the
+  // superseded request later rejects with an abort, the page must NOT surface
+  // it as an error: the replacement load owns the view.
+  it('superseding a request (bucket switch) cancels cleanly without an error (#2047)', async () => {
+    const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
+    const aggEmptyResp: TrafficUsageResponse = {
+      ...aggResp,
+      groupBy: [],
+      aggregateRows: [{ ...aggResp.aggregateRows[0], groups: {} }],
+    }
+    let rejectFirst: (e: unknown) => void = () => {}
+    trafficMock
+      .mockReturnValueOnce(new Promise<TrafficUsageResponse>((_, rej) => { rejectFirst = rej }))
+      .mockResolvedValueOnce(aggEmptyResp)
+    renderPage()
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(1))
+
+    await userEvent.click(screen.getByTestId('bucket-1m'))
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(2))
+
+    // The superseded raw request now aborts — the page must swallow it.
+    rejectFirst(new DOMException('signal is aborted without reason', 'AbortError'))
+
+    await waitFor(() => expect(screen.getByTestId('aggregate-table')).toBeInTheDocument())
+    expect(screen.queryByText(/aborted/i)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument()
+  })
 })

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { api } from '@/api/client'
+import { api, isCanceledError } from '@/api/client'
 import { useUsageConfig } from '@/api/queries'
 import type {
   Device,
@@ -82,6 +82,12 @@ export function TrafficUsagePage() {
   // #769: surface the "no apps yet" empty-state on group-by=app.
   const [appCount, setAppCount] = useState<number | null>(null)
   const sentinelRef             = useRef<HTMLDivElement | null>(null)
+  // #2047: one AbortController per load-lifecycle (per filterKey). The reset
+  // effect rotates it — aborting the prior in-flight load — so a bucket switch
+  // / filter change supersedes its predecessor cleanly. Crucially it lives in a
+  // ref created only on filterKey change, NOT per render, so live-edge pushes
+  // (`setAggRows` → re-render) never abort the active request.
+  const abortRef                = useRef<AbortController | null>(null)
 
   useEffect(() => {
     api.devices.list().then(setDevices).catch(() => setDevices([]))
@@ -128,6 +134,10 @@ export function TrafficUsagePage() {
 
   const load = useCallback(
     async (curs: string | null) => {
+      // The controller for THIS load-lifecycle (set by the reset effect). A
+      // paging load reuses it; a superseded load is the one whose controller
+      // already aborted.
+      const controller = abortRef.current
       setLoading(true)
       setError(null)
       try {
@@ -144,6 +154,7 @@ export function TrafficUsagePage() {
           groupBy: bucket === 'raw' ? undefined : groupBy,
           limit,
           cursor: curs ?? undefined,
+          signal: controller?.signal,
         })
         if (bucket === 'raw') {
           setRawRows(prev => curs ? prev.concat(resp.rawRows) : resp.rawRows)
@@ -153,22 +164,38 @@ export function TrafficUsagePage() {
         setCursor(resp.nextCursor ?? null)
         setHasMore(!!resp.nextCursor)
       } catch (e) {
+        // #2047: a cancelled/superseded request (the page aborted it on a
+        // bucket switch / filter change, or it raced a teardown) is not a
+        // failure — the replacement load owns the view. Never surface it as a
+        // table error, never stop paging. The replacement load already set its
+        // own loading state, so leave loading alone if this load is stale.
+        if (isCanceledError(e) || (e instanceof DOMException && e.name === 'AbortError')) {
+          return
+        }
         setError((e as Error).message || 'failed to load')
         setHasMore(false)
       } finally {
-        setLoading(false)
+        // Only the still-current load owns the spinner; a superseded load's
+        // late settle must not clear the spinner its replacement just raised.
+        if (abortRef.current === controller) setLoading(false)
       }
     },
     [bucket, groupBy, macs, profileIds, until],
   )
 
   useEffect(() => {
+    // Supersede any in-flight load, then start a fresh lifecycle.
+    abortRef.current?.abort()
+    abortRef.current = new AbortController()
     setRawRows([])
     setAggRows([])
     setCursor(null)
     setHasMore(true)
     void load(null)
   }, [filterKey])
+
+  // Abort the active load on unmount so a late settle can't touch unmounted state.
+  useEffect(() => () => abortRef.current?.abort(), [])
 
   useInfiniteScroll({
     sentinelRef,


### PR DESCRIPTION
Fixes #2047.

## Symptom (prod, app.wifihaven.net/usage)
The whole Traffic Usage page was unusable across all buckets:
- **raw** (default): table showed **"signal is aborted without reason"** + **"No rows in window."**
- **1m / 10m / …**: stuck on **"Loading…"**.
- A red **"WifiHaven can't reach the API right now"** banner throughout.

But the API is healthy: probed from the page's own context (its `localStorage` token),
`GET /api/usage/traffic?bucket=1m&groupBy=profile&from=…&to=…` → **200, aggregateRows=10**,
and `/api/dashboard/now` → 200. So this is purely **client-side**: the page surfaced its own
request cancellation as a user-facing error and a false API-unreachable state.

## Root cause (confirmed in code, not assumed)
The only `AbortController` in the SPA is the per-request 10s timeout in
[`client.ts`](web/src/api/client.ts). Its catch treated **every** abort identically:
`apiHealth.reportFailure('timeout')` (→ trips `ApiUnreachableBanner`) and re-threw the raw
`AbortError` DOMException. [`TrafficUsagePage.load`](web/src/pages/TrafficUsagePage.tsx) then
caught **any** thrown error — `AbortError` included — and rendered it via `ErrorBanner`. So any
abort of a Traffic Usage request (e.g. a request superseded by the live-edge/#1975 × paging/#862
interaction, or a transient timeout) shows the cryptic message in the table *and* lights the
red banner, even though the API is fine.

## Fix (request-lifecycle only — the API is healthy)
- **`client.req`**: distinguish a **caller cancellation** from the **10s timeout** abort. The
  page now passes a load-lifecycle `AbortSignal`; a caller-aborted request throws a typed
  `RequestCanceledError` and does **not** report an `apiHealth` failure. A genuine timeout still
  reports `'timeout'` → unreachable (unchanged, test-pinned).
- **`TrafficUsagePage`**: owns one `AbortController` per load-lifecycle, rotated by the reset
  effect on `filterKey` change and stored in a **ref** (created on filterKey change, **not** per
  render) so live-edge pushes (`setAggRows` → re-render) never abort the active request. A
  superseded load (bucket switch / filter change) is cancelled cleanly; `load()` swallows
  cancellation/`AbortError` — no table error, no banner, paging untouched — and a stale settle
  never clobbers the replacement load's spinner.

## Tests (TDD: red → green)
- page: a load rejected with `AbortError` must not render an error (was RED — showed
  "signal is aborted without reason").
- page: a superseded (bucket-switch) request cancels cleanly with no error.
- client: a caller-cancelled request throws a cancellation and does **not** trip `apiHealth`;
  a genuine 10s timeout still reports unreachable.

`npm run lint`, `npm test` (494 passed), and `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
