### PR TITLE
ci(#2034): make Gate-2 fake-VM CNAME suite egress-deterministic (Mode 2 of #2033)

### DIFF
--- a/scripts/e2e/fake-api/fake_api/fixtures.py
+++ b/scripts/e2e/fake-api/fake_api/fixtures.py
@@ -17,4 +17,31 @@ POLICY_SNAPSHOT_PATH = CONTRACT_DIR / "api-to-router" / "policy_snapshot.json"
 
 def load_initial_snapshot() -> dict:
     with POLICY_SNAPSHOT_PATH.open() as f:
-        return json.load(f)
+        snap = json.load(f)
+    _localize_blocklist_urls(snap)
+    return snap
+
+
+def _localize_blocklist_urls(snap: dict) -> None:
+    """Rewrite any *absolute* blocklist URL in the loaded contract golden to a
+    fake-served relative path (#2034, Mode 2 of #2033).
+
+    The contract golden seeds the ``adult`` category blocklist with an EXTERNAL
+    url (``https://example.org/lists/adult.txt``). In Gate-2 fake mode the router
+    VM's blocklists.lua would fetch that over the flaky shared-host egress —
+    ``example.org/lists/...`` 404s, and on an egress blip it times out — which
+    pollutes the agent logs with ``blocklist fetch: fetch failed for adult ...``
+    and couples the suite to external egress (the #1935/#2034 flake).
+
+    We CANNOT edit ``contract/api-to-router/policy_snapshot.json`` itself: it is
+    read verbatim and held byte-identical to the live Scala codec by the CI drift
+    guard (see ``contract/README.md``). So we localize here, after load, leaving
+    the file untouched. The id is preserved, so the rewritten url
+    ``/api/blocklists/<id>`` is served by the fake from the in-memory stub content
+    seeded in ``State.fresh`` — making the base-session blocklist fetch
+    deterministic and egress-free. Relative urls (already fake-served) pass
+    through unchanged.
+    """
+    for bl_id, bl in (snap.get("blocklists") or {}).items():
+        if isinstance(bl, dict) and isinstance(bl.get("url"), str) and "://" in bl["url"]:
+            bl["url"] = f"/api/blocklists/{bl_id}"

--- a/scripts/e2e/fake-api/fake_api/state.py
+++ b/scripts/e2e/fake-api/fake_api/state.py
@@ -74,12 +74,33 @@ class State:
     @classmethod
     def fresh(cls) -> "State":
         snap = load_initial_snapshot()
-        return cls(
+        st = cls(
             initial_snapshot=copy.deepcopy(snap),
             snapshot=copy.deepcopy(snap),
             router_id=str(uuid.uuid4()),
             router_token="rt_" + uuid.uuid4().hex,
         )
+        st._seed_initial_blocklists()
+        return st
+
+    def _seed_initial_blocklists(self) -> None:
+        """Seed empty in-memory content for every blocklist id the initial
+        snapshot references (#2034).
+
+        The base/initial snapshot (the contract golden) carries category
+        blocklists (e.g. ``ads``, ``adult``) whose ``GET /api/blocklists/<id>``
+        would otherwise 404 in fake mode — the ids are never registered, and
+        ``adult`` originally pointed at external egress (now localized in
+        ``fixtures._localize_blocklist_urls``). An unregistered id makes the
+        agent's base-session blocklist fetch fail (``status=404``), polluting the
+        logs and coupling the suite to external egress. Seeding empty content
+        makes the fetch deterministically succeed (200, zero members) without
+        enforcing anything; a scenario that needs real members registers its own
+        via ``POST /test/blocklist``. ``setdefault`` so a pre-registered id is
+        never clobbered.
+        """
+        for bl_id in (self.initial_snapshot.get("blocklists") or {}):
+            self.blocklists.setdefault(bl_id, "")
 
     @property
     def etag(self) -> str:

--- a/scripts/e2e/fake-api/tests/test_blocklist_egress.py
+++ b/scripts/e2e/fake-api/tests/test_blocklist_egress.py
@@ -1,0 +1,69 @@
+"""#2034 (Mode 2 of #2033): the fake serves every blocklist the initial
+snapshot references, with no external-egress dependency.
+
+The contract golden (`contract/api-to-router/policy_snapshot.json`, read
+verbatim for the Scala-codec drift guard) seeds category blocklists — at the
+time of writing `ads` (relative, fake-served) and `adult` (originally an
+EXTERNAL `https://example.org/lists/adult.txt`). In Gate-2 fake mode the router
+VM's blocklists.lua fetches each one; an external url couples the suite to the
+shared CD host's flaky egress and an unregistered id 404s — both surface as
+`blocklist fetch: fetch failed` log noise and intermittent reddening.
+
+These tests pin the two halves of the fix:
+  * `fixtures._localize_blocklist_urls` rewrites any absolute blocklist url to a
+    fake-served relative path.
+  * `State._seed_initial_blocklists` registers (empty) content for every
+    referenced id so `GET /api/blocklists/<id>` is 200, not 404.
+"""
+from __future__ import annotations
+
+from fake_api.fixtures import load_initial_snapshot
+
+
+def test_initial_snapshot_has_no_external_blocklist_urls() -> None:
+    """No blocklist in the loaded initial snapshot points at external egress —
+    every url is a fake-served relative path."""
+    snap = load_initial_snapshot()
+    blocklists = snap.get("blocklists") or {}
+    assert blocklists, "expected the contract golden to carry category blocklists"
+    for bl_id, bl in blocklists.items():
+        url = bl.get("url")
+        assert isinstance(url, str) and "://" not in url, (
+            f"blocklist {bl_id!r} still has an absolute/external url {url!r} — "
+            f"_localize_blocklist_urls (#2034) should have rewritten it to "
+            f"/api/blocklists/{bl_id}"
+        )
+        assert url == f"/api/blocklists/{bl_id}", (
+            f"blocklist {bl_id!r} localized to {url!r}; expected "
+            f"/api/blocklists/{bl_id}"
+        )
+
+
+async def test_initial_snapshot_blocklists_are_served_not_404(client, auth_headers) -> None:
+    """Every blocklist id the initial snapshot references resolves to a 200 from
+    the fake (seeded empty), so the agent's base-session fetch never 404s."""
+    snap = load_initial_snapshot()
+    ids = list((snap.get("blocklists") or {}).keys())
+    assert ids, "expected the contract golden to carry category blocklists"
+    for bl_id in ids:
+        resp = await client.get(f"/api/blocklists/{bl_id}", headers=auth_headers)
+        assert resp.status == 200, (
+            f"GET /api/blocklists/{bl_id} returned {resp.status}, expected 200 — "
+            f"_seed_initial_blocklists (#2034) should have registered it"
+        )
+
+
+async def test_seeding_does_not_clobber_registered_content(client, auth_headers) -> None:
+    """A scenario that registers real members for a referenced id keeps them —
+    the empty seed uses setdefault, so registration wins."""
+    snap = load_initial_snapshot()
+    ids = list((snap.get("blocklists") or {}).keys())
+    assert ids, "expected at least one referenced blocklist id"
+    bl_id = ids[0]
+    await client.post("/test/blocklist", json={"id": bl_id, "hosts": ["real.example"]})
+    resp = await client.get(f"/api/blocklists/{bl_id}", headers=auth_headers)
+    assert resp.status == 200
+    body = await resp.text()
+    assert "real.example" in body, (
+        f"registered content for {bl_id!r} was clobbered by the empty seed"
+    )

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -140,6 +140,31 @@ def dig_ipv4_answers(client, host: str) -> list[str]:
     return [l for l in lines if _IPV4.match(l)]
 
 
+# ── External-DNS-egress health (#2034, Mode 2 of #2033) ──────────────────────
+#
+# Scenarios that resolve the REAL wifihaven.net zone (e.g. the #1351 CNAME-chain
+# suite) go client → router dnsmasq → upstream (WH_ROUTER_LAN_RESOLVER) → ISP →
+# Cloudflare. On the shared CD host that egress is intermittently degraded
+# (#1935/#2034): a whole resolution window returns nothing and the suite reddens
+# even though the enforcement path is sound. A degraded-egress window must NOT be
+# confused with a genuine zone/terraform regression (our e2e records missing),
+# so callers distinguish the two with a control probe through the SAME
+# client→router→upstream path:
+#   * control hosts resolve, our records don't → real zone problem → fail
+#   * control hosts also fail to resolve       → egress degraded   → skip
+# These controls are stable third-party apexes that do NOT depend on
+# infra/cloudflare; they answer whenever upstream egress is healthy.
+EGRESS_CONTROL_HOSTS = ("one.one.one.one", "example.com")
+
+
+def dns_egress_degraded(client) -> bool:
+    """True iff NONE of the third-party control apexes resolve through the
+    router's upstream — i.e. external DNS egress is down right now, independent
+    of our e2e zone. False as soon as any control resolves (egress is healthy;
+    a failure to resolve OUR records is then a real zone/terraform problem)."""
+    return not any(dig_ipv4_answers(client, h) for h in EGRESS_CONTROL_HOSTS)
+
+
 def dig_ipv6_answers(client, host: str) -> list[str]:
     """Return the IPv6 (AAAA) answer lines from `dig +short AAAA <host>`.
 

--- a/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
+++ b/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
@@ -225,8 +225,9 @@ def _wait_for_chain_resolution(client, *, timeout_s: float = 120) -> list[str]:
 
     #2034: on timeout, classify the failure before propagating. A degraded
     external-egress window (the dominant Gate-2 flake) is skipped, not failed; a
-    genuine missing-zone regression (control hosts resolve, ours don't) still
-    raises so the caller's `assert chain_ips` red-gates with the #1351 hint.
+    genuine missing-zone regression (control hosts resolve, ours don't) re-raises
+    the `TimeoutError` (carrying `wait_until`'s `dig {BRAND_HOST} …` description,
+    which already names the terraform/#1351 prerequisite) so the suite red-gates.
     """
     try:
         return wait_until(
@@ -332,10 +333,7 @@ def test_eb_direct_requery_blocked(router, client, fake_api):
 
     # Step 2: re-query the leaf CNAME target directly (simulates Apple device).
     leaf_ips = _requery_leaf_directly(client)
-    # #2034: an empty answer here after the chain already resolved is almost
-    # always a transient egress blip — skip on degraded egress, fail (below) only
-    # if egress is healthy (a real missing-leaf / propagation regression).
-    if not leaf_ips:
+    if not leaf_ips:  # #2034: empty here is a degraded-egress blip → skip, not fail
         _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing or "
@@ -420,10 +418,7 @@ def test_ea_direct_requery_allowed_under_blocked_mac(router, client, fake_api):
 
     # Step 2: re-query the leaf directly.
     leaf_ips = _requery_leaf_directly(client)
-    # #2034: an empty answer here after the chain already resolved is almost
-    # always a transient egress blip — skip on degraded egress, fail (below) only
-    # if egress is healthy (a real missing-leaf / propagation regression).
-    if not leaf_ips:
+    if not leaf_ips:  # #2034: empty here is a degraded-egress blip → skip, not fail
         _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing"
@@ -502,10 +497,7 @@ def test_attribution_reports_branded_host_after_direct_requery(router, client, f
 
     # Step 2: direct re-query of the leaf target.
     leaf_ips = _requery_leaf_directly(client)
-    # #2034: an empty answer here after the chain already resolved is almost
-    # always a transient egress blip — skip on degraded egress, fail (below) only
-    # if egress is healthy (a real missing-leaf / propagation regression).
-    if not leaf_ips:
+    if not leaf_ips:  # #2034: empty here is a degraded-egress blip → skip, not fail
         _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing"
@@ -632,10 +624,7 @@ def test_bl_direct_requery_blocked(router, client, fake_api):
     # log line, resolves the name → BRAND_HOST via the alias map, finds it in
     # the bl-member-index, and calls `nft add element bl_<id> {ip}`.
     leaf_ips = _requery_leaf_directly(client)
-    # #2034: an empty answer here after the chain already resolved is almost
-    # always a transient egress blip — skip on degraded egress, fail (below) only
-    # if egress is healthy (a real missing-leaf / propagation regression).
-    if not leaf_ips:
+    if not leaf_ips:  # #2034: empty here is a degraded-egress blip → skip, not fail
         _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing or "

--- a/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
+++ b/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
@@ -82,11 +82,15 @@ nft set membership is checked as a DIAGNOSTIC secondary assertion, not the prima
 """
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from ._observers import (
+    EGRESS_CONTROL_HOSTS,
     bl_set_name,
     dig_ipv4_answers,
+    dns_egress_degraded,
     ea_set_name,
     eb_set_name,
     mac_in_blocked_set,
@@ -156,7 +160,7 @@ def _resolve_chain(client) -> list[str]:
     return [l for l in lines if ipv4.match(l)]
 
 
-def _requery_leaf_directly(client) -> list[str]:
+def _requery_leaf_directly(client, *, attempts: int = 6, interval_s: float = 3) -> list[str]:
     """Re-query the leaf CNAME target directly, simulating Apple device behavior.
 
     This is step (2): the client issues `dig e2e-edge.wifihaven.net` as a fresh,
@@ -164,8 +168,52 @@ def _requery_leaf_directly(client) -> list[str]:
     dnsmasq's nftset= callback does not fire for the leaf name. dns-tail's
     maybe_populate_ea/eb must recover the branded ancestor from the alias map and
     add the IP to the correct ea_/eb_ set inline (#1346/#1349).
+
+    #2034: `dns_query` is single-shot (`dig +tries=1 +time=2`), so a lone egress
+    blip here — immediately after the 120s chain poll already succeeded — would
+    empty the answer and hard-fail the `assert leaf_ips` at the call site. Retry
+    a handful of times to absorb a transient blip; the answer is normally
+    immediate (dnsmasq already has the chain cached from step 1). This does not
+    change what the step proves — it is still a fresh, standalone direct query of
+    the leaf — only its resilience to a flaky shared-host egress.
     """
-    return dig_ipv4_answers(client, LEAF_HOST)
+    last: list[str] = []
+    for i in range(attempts):
+        last = dig_ipv4_answers(client, LEAF_HOST)
+        if last:
+            return last
+        if i < attempts - 1:
+            time.sleep(interval_s)
+    return last
+
+
+def _skip_if_egress_degraded(client, what: str) -> None:
+    """Skip (not fail) the calling test when external DNS egress is degraded.
+
+    #2034 (Mode 2 of #2033): this suite resolves the REAL wifihaven.net CNAME
+    chain through the router VM's dnsmasq upstream, which depends on the shared CD
+    host's intermittently-flaky external egress (#1935). When a resolution step
+    comes back empty we must distinguish two cases via a control probe through the
+    SAME client→router→upstream path (`dns_egress_degraded`):
+
+      * control apexes ALSO fail to resolve → external egress is down right now →
+        environmental blip, NOT an enforcement regression → ``pytest.skip``.
+      * control apexes resolve but our records don't → a genuine missing-zone /
+        terraform regression (#1351) → return, letting the caller's hard
+        assertion fire with its existing diagnostic.
+
+    Enforcement assertions (block page, eb_/ea_/bl_ membership) are NEVER guarded
+    by this — they run only after a successful resolution and remain hard, so a
+    real enforcement regression still red-gates.
+    """
+    if dns_egress_degraded(client):
+        pytest.skip(
+            f"external DNS egress degraded (#2034): {what} did not resolve, and "
+            f"neither did control hosts {EGRESS_CONTROL_HOSTS} "
+            f"through the router upstream — an environmental egress blip on the "
+            f"shared CD host, not an enforcement regression. Enforcement "
+            f"assertions left intact; re-run to pick up a healthy egress window."
+        )
 
 
 def _wait_for_chain_resolution(client, *, timeout_s: float = 120) -> list[str]:
@@ -174,16 +222,25 @@ def _wait_for_chain_resolution(client, *, timeout_s: float = 120) -> list[str]:
     If the Terraform records haven't propagated yet (TTL or just-applied)
     this guard surfaces the root cause (NXDOMAIN / empty answer) rather than
     letting the test hang at the next step.
+
+    #2034: on timeout, classify the failure before propagating. A degraded
+    external-egress window (the dominant Gate-2 flake) is skipped, not failed; a
+    genuine missing-zone regression (control hosts resolve, ours don't) still
+    raises so the caller's `assert chain_ips` red-gates with the #1351 hint.
     """
-    return wait_until(
-        lambda: _resolve_chain(client) or None,
-        timeout_s=timeout_s,
-        interval_s=5,
-        description=(
-            f"dig {BRAND_HOST} to return at least one IPv4 answer "
-            f"(requires terraform apply for infra/cloudflare)"
-        ),
-    )
+    try:
+        return wait_until(
+            lambda: _resolve_chain(client) or None,
+            timeout_s=timeout_s,
+            interval_s=5,
+            description=(
+                f"dig {BRAND_HOST} to return at least one IPv4 answer "
+                f"(requires terraform apply for infra/cloudflare)"
+            ),
+        )
+    except TimeoutError:
+        _skip_if_egress_degraded(client, f"chain head {BRAND_HOST}")
+        raise
 
 
 def _xfail_if_leaf_unreachable(client) -> None:
@@ -275,6 +332,11 @@ def test_eb_direct_requery_blocked(router, client, fake_api):
 
     # Step 2: re-query the leaf CNAME target directly (simulates Apple device).
     leaf_ips = _requery_leaf_directly(client)
+    # #2034: an empty answer here after the chain already resolved is almost
+    # always a transient egress blip — skip on degraded egress, fail (below) only
+    # if egress is healthy (a real missing-leaf / propagation regression).
+    if not leaf_ips:
+        _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing or "
         f"not yet propagated (terraform apply required)"
@@ -358,6 +420,11 @@ def test_ea_direct_requery_allowed_under_blocked_mac(router, client, fake_api):
 
     # Step 2: re-query the leaf directly.
     leaf_ips = _requery_leaf_directly(client)
+    # #2034: an empty answer here after the chain already resolved is almost
+    # always a transient egress blip — skip on degraded egress, fail (below) only
+    # if egress is healthy (a real missing-leaf / propagation regression).
+    if not leaf_ips:
+        _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing"
     )
@@ -435,6 +502,11 @@ def test_attribution_reports_branded_host_after_direct_requery(router, client, f
 
     # Step 2: direct re-query of the leaf target.
     leaf_ips = _requery_leaf_directly(client)
+    # #2034: an empty answer here after the chain already resolved is almost
+    # always a transient egress blip — skip on degraded egress, fail (below) only
+    # if egress is healthy (a real missing-leaf / propagation regression).
+    if not leaf_ips:
+        _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing"
     )
@@ -560,6 +632,11 @@ def test_bl_direct_requery_blocked(router, client, fake_api):
     # log line, resolves the name → BRAND_HOST via the alias map, finds it in
     # the bl-member-index, and calls `nft add element bl_<id> {ip}`.
     leaf_ips = _requery_leaf_directly(client)
+    # #2034: an empty answer here after the chain already resolved is almost
+    # always a transient egress blip — skip on degraded egress, fail (below) only
+    # if egress is healthy (a real missing-leaf / propagation regression).
+    if not leaf_ips:
+        _skip_if_egress_degraded(client, f"leaf {LEAF_HOST}")
     assert leaf_ips, (
         f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing or "
         f"not yet propagated (terraform apply required)"


### PR DESCRIPTION
Completes **Mode 2** of #2033 (tracked as #2034). Mode 1 (qemu client-VM boot resilience) landed in #2035.

## Problem
Master Router CD's **Gate 2 (fake-API VM e2e)** intermittently reddened on `scenarios_fake/test_cname_direct_requery.py::test_eb_direct_requery_blocked` (and its G2/G3/G4 siblings) — the sole failure on the apk arm — with:
- `policy.apply: smoke check failed; dnsmasq may be serving a stale config — got "nil" for <host>`
- `blocklist fetch: fetch failed for adult/ads (status=404)`

Root cause is **external-DNS egress on the shared CD host**, not test isolation or product code (long-standing #1935; see also #1865's degraded-window guards). Two distinct egress couplings, both removed/guarded here **without weakening what the tests verify**.

## 1. Blocklist fetches no longer depend on external egress
The contract golden (`contract/api-to-router/policy_snapshot.json`, read verbatim for the Scala-codec drift guard) seeds category blocklists `ads` (relative, fake-served) and `adult` (an **external** `https://example.org/lists/adult.txt`, which 404s and on an egress blip times out). The contract file MUST stay byte-identical, so the fix is in the fake's loader/state:
- `fixtures._localize_blocklist_urls` rewrites any **absolute** blocklist url to a fake-served `/api/blocklists/<id>` *after load* (file untouched).
- `State._seed_initial_blocklists` registers empty content for every referenced id so `GET /api/blocklists/<id>` returns 200 (zero members, inert), not 404.

Eliminates the `blocklist fetch: fetch failed` log noise and the external dependency entirely.

## 2. Real-zone CNAME resolution: degraded-egress guard + leaf retry
The suite resolves the **real** wifihaven.net CNAME chain through the router VM's dnsmasq upstream (`WH_ROUTER_LAN_RESOLVER` → ISP → Cloudflare). To avoid masking a genuine zone/terraform regression, a **control probe through the same client→router→upstream path** distinguishes the two cases:
- control hosts resolve but ours don't → real missing-zone regression → **fail** (with the existing #1351 hint)
- control hosts also fail → external egress is down → **skip**

Changes (all in `scenarios_fake/`):
- `_observers.dns_egress_degraded` / `EGRESS_CONTROL_HOSTS` — stable third-party apexes, independent of `infra/cloudflare`.
- `_wait_for_chain_resolution` — on timeout, `pytest.skip` on degraded egress, else re-raise.
- `_requery_leaf_directly` — `dig` is single-shot (`+tries=1 +time=2`), so a lone blip right after the 120s chain poll hard-failed `assert leaf_ips`. Now retries a handful of times (still a fresh standalone direct query — substance unchanged); each of the 4 call sites skips on degraded egress before the hard assert.

**Enforcement assertions** (block page, `eb_`/`ea_`/`bl_` membership) run only *after* a successful resolution and stay **hard** — a real enforcement regression still red-gates.

## Tests / validation
- New `scripts/e2e/fake-api/tests/test_blocklist_egress.py` pins the localization + seeding (no external urls remain; every referenced id serves 200; the empty seed never clobbers registered content). Full fake-api suite **30/30 green** locally — runs in CI's `fake-api-tests` job.
- Egress-guard + leaf-retry helper logic validated locally with stubs: healthy → resolves; control-up + target-down → no skip; all-down → skip; transient blip → retry absorbs.
- **KVM/VM e2e can't run on macOS** — full Gate-2 validation is via CD. `e2e-vm-fake.yml` will be dispatched on this branch and re-run a few times to show `test_eb_direct_requery_blocked` no longer flakes; repeated-green evidence to follow in a comment.

Closes #2034. Completes Mode 2 of #2033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)