### PR TITLE
feat(#2048): stream the Traffic Usage page's raw-rows view (prepend new rows + Live badge)

### DIFF
--- a/api/src/routes/SpaPush.scala
+++ b/api/src/routes/SpaPush.scala
@@ -388,41 +388,74 @@ object SpaPush {
         // carry the true interval.
         val (headStart, headEnd) =
           UsageTraffic.windowFor(periodStart, periodEnd, parsed.bucket, parsed.zone)
-        val resolvedMacs = UsageTrafficQuery.resolveMacs(parsed.macs, parsed.profileIds, devices)
-        val filterEmpty  = parsed.filterRequested && resolvedMacs.isEmpty
-        val aggregate    =
-          if (filterEmpty) ZIO.succeed(List.empty)
-          else
-            UsageTrafficQuery.aggregate(
-              trafficRepo,
-              rollupRepo,
-              resolvedMacs,
-              headStart,
-              headEnd,
-              parsed.bucket,
-              parsed.groupBySet,
-              parsed.zone,
-              devByMac,
-              profNames,
-              appsByHost,
+        val resolvedMacs   = UsageTrafficQuery.resolveMacs(parsed.macs, parsed.profileIds, devices)
+        val filterEmpty    = parsed.filterRequested && resolvedMacs.isEmpty
+        // #2048: `raw` WITHOUT a groupBy is the Traffic Usage page's per-host inspector (its DEFAULT
+        // view) — it renders per-host `rawRows`, so its live edge must carry the NEW rawRows for the
+        // ingest period (the rows the page prepends), NOT aggregated points. This mirrors the
+        // `GET /api/usage/traffic` split exactly (`UsageRoutes`: `Bucket.Raw if effectiveGroupBy
+        // .isEmpty` → `buildRaw`, else aggregate), so the stream and the GET stay SSOT. `raw` WITH a
+        // groupBy (the dashboard gauge's `groupBy=profile`) keeps the aggregate path below.
+        val isUngroupedRaw = parsed.bucket == UsageTraffic.Bucket.Raw && parsed.groupBySet.isEmpty
+        val computeBody: Task[TrafficUsageResponse] =
+          if (isUngroupedRaw) {
+            // The head window for `raw` IS the real report period `[periodStart, periodEnd)`
+            // (`UsageTraffic.windowFor`), so reading raw rows over `[headStart, headEnd)` returns
+            // exactly the just-ingested period's rows. No cursor/limit: a single ingest period is
+            // naturally bounded by its distinct `(mac, host)` rows (the page pages OLDER history via
+            // the GET; the push only delivers the fresh head). Built via the shared `buildRaw` (SSOT).
+            val rawZ =
+              if (filterEmpty) ZIO.succeed(List.empty[wifihaven.api.usage.TrafficUsageDbRow])
+              else trafficRepo.listRawInRange(resolvedMacs, headStart, headEnd)
+            rawZ.map(rows =>
+              TrafficUsageResponse(
+                bucket = parsed.bucket.code,
+                groupBy = Nil,
+                from = headStart.toString,
+                to = headEnd.toString,
+                tz = parsed.zone.getId,
+                rawRows = UsageTraffic.buildRaw(rows, devByMac, profNames),
+                aggregateRows = Nil,
+                nextCursor = None,
+              ),
             )
-        aggregate.flatMap { rows =>
-          // `from`/`to` describe the head BUCKET window `[headStart, headEnd)` — not wall-clock
-          // "live edge time". `to` is therefore the bucket end and can sit slightly ahead of `now`
-          // for an in-progress bucket; it's metadata only (the client merges by `windowStart` and
-          // derives B/s from the bucket width, never from this `to`).
-          val body = TrafficUsageResponse(
-            bucket = parsed.bucket.code,
-            groupBy = parsed.groupBySet.toList.map(_.code).sorted,
-            from = headStart.toString,
-            to = headEnd.toString,
-            tz = parsed.zone.getId,
-            rawRows = Nil,
-            aggregateRows = rows,
-            nextCursor = None,
-          )
-          registry.fanOutTrafficUsage(params, body.toJsonAST.getOrElse(Json.Obj()))
-        }
+          } else {
+            val aggZ =
+              if (filterEmpty) ZIO.succeed(List.empty[wifihaven.shared.TrafficUsageAggregateRow])
+              else
+                UsageTrafficQuery.aggregate(
+                  trafficRepo,
+                  rollupRepo,
+                  resolvedMacs,
+                  headStart,
+                  headEnd,
+                  parsed.bucket,
+                  parsed.groupBySet,
+                  parsed.zone,
+                  devByMac,
+                  profNames,
+                  appsByHost,
+                )
+            aggZ.map(rows =>
+              // `from`/`to` describe the head BUCKET window `[headStart, headEnd)` — not wall-clock
+              // "live edge time". `to` is therefore the bucket end and can sit slightly ahead of
+              // `now` for an in-progress bucket; it's metadata only (the client merges by
+              // `windowStart` and derives B/s from the bucket width, never from this `to`).
+              TrafficUsageResponse(
+                bucket = parsed.bucket.code,
+                groupBy = parsed.groupBySet.toList.map(_.code).sorted,
+                from = headStart.toString,
+                to = headEnd.toString,
+                tz = parsed.zone.getId,
+                rawRows = Nil,
+                aggregateRows = rows,
+                nextCursor = None,
+              ),
+            )
+          }
+        computeBody.flatMap(body =>
+          registry.fanOutTrafficUsage(params, body.toJsonAST.getOrElse(Json.Obj())),
+        )
     }
 
   /**

--- a/api/test/src/feature/SpaWsS4Spec.scala
+++ b/api/test/src/feature/SpaWsS4Spec.scala
@@ -435,6 +435,47 @@ object SpaWsS4Spec
       }
     },
     test(
+      // #2048: the Traffic Usage page's DEFAULT view subscribes `raw` WITHOUT a groupBy (the
+      // per-host inspector). Unlike `raw`+groupBy (the gauge, aggregated above), this must push the
+      // new per-host `rawRows` for the ingest period — the rows the page prepends — NOT aggregated
+      // points. SSOT: the streamed rawRows are byte-identical to the `GET /api/usage/traffic`
+      // `bucket=raw` (no groupBy) body for the same window.
+      "ungrouped raw subscription pushes the new rawRows for the ingest period, equal to the GET (SSOT)",
+    ) {
+      withHarness { (port, ingest, router) =>
+        for {
+          tok    <- ZIO.serviceWithZIO[Clock](makeAuth).flatMap(adminToken)
+          frames <- collect(
+            port,
+            tok,
+            List(
+              """{"op":"subscribe","payload":{"topic":"trafficUsage","params":{"bucket":"raw"}}}""",
+            ),
+            trigger = ingestUsage(ingest, router, usageRecord("youtube.com", 1234, 567)),
+            wait = 4.seconds,
+          )
+          tFrames = trafficFrames(frames)
+          pushed <- ZIO.fromEither(parsePush(tFrames.last)).mapError(e => new RuntimeException(e))
+          got    <- getTraffic(port, tok, s"bucket=raw&from=$headFrom&to=$headTo&tz=UTC")
+        } yield assertTrue(tFrames.nonEmpty) &&
+          assertTrue(pushed.bucket == "raw") &&
+          assertTrue(pushed.groupBy.isEmpty) &&
+          // The ungrouped raw push carries per-host rawRows, NOT aggregated points.
+          assertTrue(pushed.aggregateRows.isEmpty) &&
+          assertTrue(pushed.rawRows.nonEmpty) &&
+          assertTrue(
+            pushed.rawRows.exists(r =>
+              r.host == HostId.Fqdn(Hostname.unsafe("youtube.com")) &&
+                r.bytesIn == 1234 && r.bytesOut == 567,
+            ),
+          ) &&
+          // SSOT: the streamed rawRows equal the GET's rawRows for the same window.
+          assertTrue(pushed.rawRows.toSet == got.rawRows.toSet) &&
+          // raw's window is the REAL report period [periodStart, periodEnd).
+          assertTrue(pushed.from == periodStart && pushed.to == periodEnd)
+      }
+    },
+    test(
       // #2018/#2020 PINNING: the streamed `raw` head window MUST equal the actual ingested report
       // period `[periodStart, periodEnd)` (the agent's `usage_report_interval`), NOT a synthetic
       // fixed 5-min window. Ingest a non-5-min-aligned 37 s period and assert the pushed window is

--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -210,10 +210,14 @@ display the dashboard wants is `GET /api/usage/traffic` streamed:
 > whatever cadence the router sends usage data** (today ~60 s batches; sub-minute
 > and toward real-time as #1023 streams usage as the agent has it) — realtime-ness
 > is bounded by the usage-send rate, with **no bespoke high-frequency sample and no
-> router change**. (Note: a `raw` subscription is still **aggregated per the
-> subscription's `groupBy`** at the ingest-period granularity — the gauge gets one
-> overall/per-profile point per arriving usage period, not ungrouped per-host
-> `rawRows`.) (`5m`/`10m` display buckets are trivially addable later.)
+> router change**. (Note: a `raw` subscription **WITH a `groupBy`** (e.g. the gauge's
+> `groupBy:profile`) is **aggregated per that `groupBy`** at the ingest-period
+> granularity — one overall/per-profile point per arriving usage period. A `raw`
+> subscription **WITHOUT a `groupBy`** — the Traffic Usage page's per-host inspector,
+> its default view — instead pushes the **new per-host `rawRows`** for the ingest
+> period, which the page **prepends** like the `connectionEvents` feed (#2048). This
+> split mirrors the `GET /api/usage/traffic` exactly: `raw`+groupBy → `aggregateRows`,
+> `raw`+no-groupBy → `rawRows`.) (`5m`/`10m` display buckets are trivially addable later.)
 
 `connectionEvents` likewise reuses the `/api/logs` `QueryLog` row shape and its
 filter params — it is the `blocked`-feed generalized so the **Connection Events

--- a/web/src/api/wsCache.test.ts
+++ b/web/src/api/wsCache.test.ts
@@ -11,12 +11,14 @@ import {
   mergeHeadBucket,
   overallRate,
   prependHead,
+  prependRawHead,
   rateFor,
 } from './wsCache'
 import type {
   DashboardNow,
   QueryLog,
   TrafficUsageAggregateRow,
+  TrafficUsageRawRow,
   TrafficUsageResponse,
 } from '@/types/api'
 
@@ -270,6 +272,77 @@ describe('prependHead (#1973 §3.1)', () => {
   it('still dedups by id with no limit', () => {
     const out = prependHead([row(2), row(1)], [row(3), row(2)])
     expect(out.map(r => r.id)).toEqual([3, 2, 1])
+  })
+})
+
+// #2048: the Traffic Usage page's raw view prepends new per-host rows, keyed by the same
+// (periodStart, mac, host) identity the server reports them on. Never truncates paged history.
+describe('prependRawHead (#2048)', () => {
+  const raw = (
+    periodStart: string,
+    mac: string,
+    host: string,
+    bytesIn = 0,
+  ): TrafficUsageRawRow => ({
+    mac,
+    deviceName: undefined,
+    profileId: undefined,
+    profileName: undefined,
+    host: { type: 'fqdn', value: host },
+    bytesIn,
+    bytesOut: 0,
+    activeSeconds: 0,
+    periodStart,
+    periodEnd: periodStart,
+  })
+
+  it('prepends new rows, newest first', () => {
+    const out = prependRawHead(
+      [raw('2026-06-26T10:04:00Z', 'aa', 'a.com'), raw('2026-06-26T10:03:00Z', 'aa', 'b.com')],
+      [raw('2026-06-26T10:06:00Z', 'aa', 'c.com'), raw('2026-06-26T10:05:00Z', 'aa', 'd.com')],
+    )
+    expect(out.map(r => `${r.periodStart}|${r.host.value}`)).toEqual([
+      '2026-06-26T10:06:00Z|c.com',
+      '2026-06-26T10:05:00Z|d.com',
+      '2026-06-26T10:04:00Z|a.com',
+      '2026-06-26T10:03:00Z|b.com',
+    ])
+  })
+
+  it('dedups by (periodStart, mac, host) on a GET/push boundary overlap', () => {
+    const out = prependRawHead(
+      [raw('2026-06-26T10:04:00Z', 'aa', 'a.com', 100)],
+      [raw('2026-06-26T10:05:00Z', 'aa', 'b.com'), raw('2026-06-26T10:04:00Z', 'aa', 'a.com', 100)],
+    )
+    expect(out.map(r => `${r.periodStart}|${r.host.value}`)).toEqual([
+      '2026-06-26T10:05:00Z|b.com',
+      '2026-06-26T10:04:00Z|a.com',
+    ])
+  })
+
+  it('keeps same-period rows distinct by mac and host', () => {
+    const out = prependRawHead(
+      [],
+      [
+        raw('2026-06-26T10:05:00Z', 'aa', 'a.com'),
+        raw('2026-06-26T10:05:00Z', 'bb', 'a.com'),
+        raw('2026-06-26T10:05:00Z', 'aa', 'b.com'),
+      ],
+    )
+    expect(out).toHaveLength(3)
+  })
+
+  it('handles an undefined prior list', () => {
+    expect(prependRawHead(undefined, [raw('2026-06-26T10:05:00Z', 'aa', 'a.com')])).toHaveLength(1)
+  })
+
+  it('never truncates paged history (no cap)', () => {
+    const prev = Array.from({ length: 25 }, (_, i) =>
+      raw(`2026-06-26T10:${String(i).padStart(2, '0')}:00Z`, 'aa', `h${i}.com`),
+    )
+    const out = prependRawHead(prev, [raw('2026-06-26T11:00:00Z', 'aa', 'new.com')])
+    expect(out).toHaveLength(26)
+    expect(out[0].host.value).toBe('new.com')
   })
 })
 

--- a/web/src/api/wsCache.ts
+++ b/web/src/api/wsCache.ts
@@ -11,6 +11,7 @@ import type {
   QueryLog,
   TrafficUsageAggregateRow,
   TrafficUsageBucket,
+  TrafficUsageRawRow,
   TrafficUsageResponse,
 } from '@/types/api'
 
@@ -167,6 +168,33 @@ export function prependHead(
     out.push(r)
   }
   return limit === undefined ? out : out.slice(0, limit)
+}
+
+// ── trafficUsage raw: prepend new per-host rawRows, dedup by stable identity (#2048) ──
+//
+// The Traffic Usage page's DEFAULT view is `raw` (per-host rows), excluded from the
+// aggregated head-merge above because rawRows are a different shape. Its live edge instead
+// PREPENDS the pushed new rows — like the connectionEvents feed — keyed by the same
+// `(periodStart, mac, host)` identity the server reports a row on, so a GET/push overlap at
+// the boundary dedups to one. No cap: the page pages OLDER history via the GET (#862), so
+// prepending the live head must never truncate the loaded history (newest-first).
+function rawRowKey(r: TrafficUsageRawRow): string {
+  return `${r.periodStart}|${r.mac}|${r.host.type}:${r.host.value}`
+}
+export function prependRawHead(
+  prev: TrafficUsageRawRow[] | undefined,
+  rows: TrafficUsageRawRow[],
+): TrafficUsageRawRow[] {
+  const merged = [...rows, ...(prev ?? [])]
+  const seen = new Set<string>()
+  const out: TrafficUsageRawRow[] = []
+  for (const r of merged) {
+    const k = rawRowKey(r)
+    if (seen.has(k)) continue
+    seen.add(k)
+    out.push(r)
+  }
+  return out
 }
 
 // ── now: derived KPIs computed client-side off the pushed DashboardNow (§3.1) ───────

--- a/web/src/hooks/useWs.test.tsx
+++ b/web/src/hooks/useWs.test.tsx
@@ -35,7 +35,7 @@ import {
 } from './useWs'
 import { useDashboardNow, useProfiles, useDevices, qk } from '@/api/queries'
 import { AuthProvider } from '@/hooks/useAuth'
-import type { DashboardNow, QueryLog, TrafficUsageAggregateRow, TrafficUsageResponse } from '@/types/api'
+import type { DashboardNow, QueryLog, TrafficUsageAggregateRow, TrafficUsageRawRow, TrafficUsageResponse } from '@/types/api'
 
 class MockSocket implements WsSocketLike {
   static instances: MockSocket[] = []
@@ -472,20 +472,40 @@ const trafficPush = (rows: TrafficUsageAggregateRow[]): TrafficUsageResponse => 
   bucket: '1h', groupBy: ['profile'], from: 'a', to: 'b', tz: 'UTC', rawRows: [], aggregateRows: rows,
 })
 
+// #2048: a raw row + a raw push envelope (per-host rows, no aggregateRows).
+const rawRow = (o: { periodStart: string; mac: string; host: string; bytesIn?: number }): TrafficUsageRawRow => ({
+  mac: o.mac, deviceName: undefined, profileId: undefined, profileName: undefined,
+  host: { type: 'fqdn', value: o.host },
+  bytesIn: o.bytesIn ?? 0, bytesOut: 0, activeSeconds: 0,
+  periodStart: o.periodStart, periodEnd: o.periodStart,
+})
+const rawPush = (rows: TrafficUsageRawRow[]): TrafficUsageResponse => ({
+  bucket: 'raw', groupBy: [], from: 'a', to: 'b', tz: 'UTC', rawRows: rows, aggregateRows: [],
+})
+// Drives the hook with both setters; returns the live mutable state arrays the page would own.
+function liveSetters() {
+  const state = { agg: [] as TrafficUsageAggregateRow[], raw: [] as TrafficUsageRawRow[] }
+  return {
+    state,
+    setters: {
+      setAggRows: (fn: (prev: TrafficUsageAggregateRow[]) => TrafficUsageAggregateRow[]) => { state.agg = fn(state.agg) },
+      setRawRows: (fn: (prev: TrafficUsageRawRow[]) => TrafficUsageRawRow[]) => { state.raw = fn(state.raw) },
+    },
+  }
+}
+
 describe('useWsTrafficUsageLiveEdge (#1975 S6b §3.1)', () => {
   it('subscribes with the page params and merges the head bucket by windowStart, history untouched', () => {
     const { client, wrapper } = setup()
     // paged history loaded by the GET (newest-first); the page owns it in component state.
-    let rows: TrafficUsageAggregateRow[] = [
+    const { state, setters } = liveSetters()
+    state.agg = [
       aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 100 }),
       aggRow({ windowStart: '2026-06-26T10:04:00Z', totalBytesIn: 999 }),
     ]
-    const setRows = (fn: (prev: TrafficUsageAggregateRow[]) => TrafficUsageAggregateRow[]) => {
-      rows = fn(rows)
-    }
     renderHook(
       () => useWsTrafficUsageLiveEdge(
-        { groupBy: ['profile'], bucket: '1h', macs: ['aa'], profileIds: [3], until: null }, setRows,
+        { groupBy: ['profile'], bucket: '1h', macs: ['aa'], profileIds: [3], until: null }, setters,
       ),
       { wrapper },
     )
@@ -495,26 +515,67 @@ describe('useWsTrafficUsageLiveEdge (#1975 S6b §3.1)', () => {
 
     act(() => last().emit({ op: 'trafficUsage', payload: trafficPush([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 250 })]) }))
     // head replaced, older paged bucket untouched
-    expect(rows.map(r => r.windowStart)).toEqual(['2026-06-26T10:05:00Z', '2026-06-26T10:04:00Z'])
-    expect(rows[0].totalBytesIn).toBe(250)
-    expect(rows[1].totalBytesIn).toBe(999)
+    expect(state.agg.map(r => r.windowStart)).toEqual(['2026-06-26T10:05:00Z', '2026-06-26T10:04:00Z'])
+    expect(state.agg[0].totalBytesIn).toBe(250)
+    expect(state.agg[1].totalBytesIn).toBe(999)
   })
 
-  it('does not subscribe in raw mode (push carries aggregate rows, not per-host rawRows)', () => {
+  // #2048: the DEFAULT raw view now streams — subscribes WITHOUT groupBy (so the server takes its
+  // ungrouped-raw → rawRows path) and PREPENDS the pushed per-host rows, dedup, history untouched.
+  it('subscribes in raw mode (no groupBy) and prepends the pushed rawRows, dedup, history untouched', () => {
     const { client, wrapper } = setup()
+    const { state, setters } = liveSetters()
+    // paged history loaded by the GET (newest-first).
+    state.raw = [
+      rawRow({ periodStart: '2026-06-26T10:04:00Z', mac: 'aa', host: 'youtube.com', bytesIn: 100 }),
+      rawRow({ periodStart: '2026-06-26T10:03:00Z', mac: 'aa', host: 'tiktok.com', bytesIn: 999 }),
+    ]
     renderHook(
-      () => useWsTrafficUsageLiveEdge({ groupBy: [], bucket: 'raw', macs: [], profileIds: [], until: null }, () => {}),
+      () => useWsTrafficUsageLiveEdge(
+        // groupBy carried in page state (e.g. set on an aggregate view) MUST be dropped for raw.
+        { groupBy: ['device'], bucket: 'raw', macs: ['aa'], profileIds: [3], until: null }, setters,
+      ),
+      { wrapper },
+    )
+    goLive(client)
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')
+    expect(sub.payload.params).toEqual({ bucket: 'raw', macs: ['aa'], profileIds: [3] })
+
+    // push overlaps the GET boundary (the 10:04 youtube row is already present) → dedup by identity.
+    act(() => last().emit({ op: 'trafficUsage', payload: rawPush([
+      rawRow({ periodStart: '2026-06-26T10:05:00Z', mac: 'aa', host: 'netflix.com', bytesIn: 250 }),
+      rawRow({ periodStart: '2026-06-26T10:04:00Z', mac: 'aa', host: 'youtube.com', bytesIn: 100 }),
+    ]) }))
+    // new rows prepended (newest-first), the boundary row deduped, paged history intact.
+    expect(state.raw.map(r => `${r.periodStart}|${r.host.value}`)).toEqual([
+      '2026-06-26T10:05:00Z|netflix.com',
+      '2026-06-26T10:04:00Z|youtube.com',
+      '2026-06-26T10:03:00Z|tiktok.com',
+    ])
+    expect(state.raw).toHaveLength(3)
+    expect(state.agg).toHaveLength(0) // the aggregate state is never touched in raw mode
+  })
+
+  it('does not subscribe while anchored to a past window (until set — no live edge)', () => {
+    const { client, wrapper } = setup()
+    const { setters } = liveSetters()
+    renderHook(
+      () => useWsTrafficUsageLiveEdge(
+        { groupBy: ['profile'], bucket: '1h', macs: [], profileIds: [], until: '2026-01-01T00:00:00Z' }, setters,
+      ),
       { wrapper },
     )
     goLive(client)
     expect(last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')).toBeUndefined()
   })
 
-  it('does not subscribe while anchored to a past window (until set — no live edge)', () => {
+  // #2048: pinning a past window stays GET-only even on the raw view.
+  it('does not subscribe in raw mode while anchored to a past window (until set)', () => {
     const { client, wrapper } = setup()
+    const { setters } = liveSetters()
     renderHook(
       () => useWsTrafficUsageLiveEdge(
-        { groupBy: ['profile'], bucket: '1h', macs: [], profileIds: [], until: '2026-01-01T00:00:00Z' }, () => {},
+        { groupBy: [], bucket: 'raw', macs: [], profileIds: [], until: '2026-01-01T00:00:00Z' }, setters,
       ),
       { wrapper },
     )
@@ -524,9 +585,10 @@ describe('useWsTrafficUsageLiveEdge (#1975 S6b §3.1)', () => {
 
   it('re-subscribes (unsubscribe+subscribe) when the bucket changes', () => {
     const { client, wrapper } = setup()
+    const { setters } = liveSetters()
     const { rerender } = renderHook(
       ({ bucket }: { bucket: '1h' | '10m' }) =>
-        useWsTrafficUsageLiveEdge({ groupBy: ['profile'], bucket, macs: [], profileIds: [], until: null }, () => {}),
+        useWsTrafficUsageLiveEdge({ groupBy: ['profile'], bucket, macs: [], profileIds: [], until: null }, setters),
       { wrapper, initialProps: { bucket: '1h' as '1h' | '10m' } },
     )
     goLive(client)
@@ -538,6 +600,28 @@ describe('useWsTrafficUsageLiveEdge (#1975 S6b §3.1)', () => {
     expect(i1).toBeGreaterThanOrEqual(0)
     expect(iU).toBeGreaterThan(i1)
     expect(i2).toBeGreaterThan(iU)
+  })
+
+  // #2048: switching raw → 1m re-subscribes and flips the push target from rawRows to the
+  // aggregated head-merge (the raw push path is no longer used once a fixed bucket is selected).
+  it('re-subscribes raw → 1m and switches from rawRows-prepend to aggregate head-merge', () => {
+    const { client, wrapper } = setup()
+    const { state, setters } = liveSetters()
+    const { rerender } = renderHook(
+      ({ bucket }: { bucket: 'raw' | '1m' }) =>
+        useWsTrafficUsageLiveEdge({ groupBy: [], bucket, macs: [], profileIds: [], until: null }, setters),
+      { wrapper, initialProps: { bucket: 'raw' as 'raw' | '1m' } },
+    )
+    goLive(client)
+    // raw push → prepends into raw state.
+    act(() => last().emit({ op: 'trafficUsage', payload: rawPush([rawRow({ periodStart: '2026-06-26T10:05:00Z', mac: 'aa', host: 'a.com', bytesIn: 1 })]) }))
+    expect(state.raw).toHaveLength(1)
+
+    act(() => rerender({ bucket: '1m' }))
+    // now a 1m aggregate push merges into agg state, raw state untouched.
+    act(() => last().emit({ op: 'trafficUsage', payload: { ...trafficPush([aggRow({ windowStart: '2026-06-26T10:05:00Z', totalBytesIn: 7 })]), bucket: '1m' } }))
+    expect(state.agg).toHaveLength(1)
+    expect(state.raw).toHaveLength(1) // unchanged — the raw row from before
   })
 })
 

--- a/web/src/hooks/useWs.tsx
+++ b/web/src/hooks/useWs.tsx
@@ -29,6 +29,7 @@ import {
   mergeHeadBucket,
   overallRate,
   prependHead,
+  prependRawHead,
   projectTimeStatusToSummary,
   rateFor,
   type BandwidthRate,
@@ -41,6 +42,7 @@ import type {
   TrafficUsageAggregateRow,
   TrafficUsageBucket,
   TrafficUsageGroupBy,
+  TrafficUsageRawRow,
   TrafficUsageResponse,
 } from '@/types/api'
 
@@ -362,40 +364,61 @@ export interface TrafficUsageLiveArgs {
   until: string | null
 }
 
+/** The page's two row-state setters: the live edge writes into whichever the bucket renders. */
+export interface TrafficUsageLiveSetters {
+  setAggRows: (fn: (prev: TrafficUsageAggregateRow[]) => TrafficUsageAggregateRow[]) => void
+  setRawRows: (fn: (prev: TrafficUsageRawRow[]) => TrafficUsageRawRow[]) => void
+}
+
 /**
- * Subscribe `trafficUsage` with the Traffic Usage page's CURRENT params and merge the
- * pushed head bucket into the page's aggregate-row state by `windowStart` (§3.1). The
- * page passes its own `setAggRows`. Re-subscribes whenever groupBy / bucket / filters
- * change (the params change → `useWsSubscription` sends unsubscribe-then-subscribe).
+ * Subscribe `trafficUsage` with the Traffic Usage page's CURRENT params and splice the pushed
+ * live edge into the page's row state (§3.1). The page passes both its `setAggRows` and
+ * `setRawRows`; which one the edge writes depends on the bucket. Re-subscribes whenever
+ * groupBy / bucket / filters change (the params change → `useWsSubscription` sends
+ * unsubscribe-then-subscribe).
  *
- * Streaming is gated to the AGGREGATED view anchored at "now": the push carries
- * `aggregateRows` (one point per group per ingest period, design §1.3) — the page's `raw`
- * bucket renders per-host `rawRows`, a different shape the live edge can't merge into; and
- * a pinned `until` window is history, with no live edge to stream. Returns whether the
- * topic is actually streaming (acked) for an optional "Live" indicator.
+ * Two shapes, gated by the bucket — exactly mirroring the GET split (`UsageRoutes`):
+ *   - `raw` (the page's DEFAULT, no groupBy): the push carries the NEW per-host `rawRows` for the
+ *     ingest period (#2048). We PREPEND them (dedup by `(periodStart, mac, host)`) into `setRawRows`,
+ *     like the connectionEvents feed — paged history (#862) is never mutated. The subscription omits
+ *     `groupBy` so the server takes its ungrouped-raw → rawRows path (SSOT with the GET).
+ *   - `1m`/`10m`/…: the push carries `aggregateRows` (one point per group per ingest period, design
+ *     §1.3); we MERGE the head bucket by `windowStart` into `setAggRows`.
+ *
+ * A pinned `until` window is history (no live edge), so both modes stay GET-only there. Returns
+ * whether the topic is actually streaming (acked) for the page's "Live" indicator.
  */
 export function useWsTrafficUsageLiveEdge(
   args: TrafficUsageLiveArgs,
-  setRows: (fn: (prev: TrafficUsageAggregateRow[]) => TrafficUsageAggregateRow[]) => void,
+  setters: TrafficUsageLiveSetters,
 ): boolean {
-  const enabled = args.until == null && args.bucket !== 'raw'
+  const enabled = args.until == null
+  const isRaw = args.bucket === 'raw'
   const params = useMemo(
     () => ({
-      groupBy: args.groupBy,
+      // `raw` (no groupBy) is the per-host inspector → omit groupBy so the server pushes rawRows,
+      // matching the GET (which drops groupBy for raw). Aggregated buckets carry the page's groupBy.
+      ...(isRaw ? {} : { groupBy: args.groupBy }),
       bucket: args.bucket,
       ...(args.macs.length ? { macs: args.macs } : {}),
       ...(args.profileIds.length ? { profileIds: args.profileIds } : {}),
     }),
-    [args.groupBy, args.bucket, args.macs, args.profileIds],
+    [isRaw, args.groupBy, args.bucket, args.macs, args.profileIds],
   )
-  const setRowsRef = useRef(setRows)
-  setRowsRef.current = setRows
+  const settersRef = useRef(setters)
+  settersRef.current = setters
   useWsSubscription(
     'trafficUsage',
     params,
     payload => {
-      const rows = (payload as TrafficUsageResponse).aggregateRows ?? []
-      if (rows.length) setRowsRef.current(prev => mergeAggregateHeadRows(prev, rows))
+      const body = payload as TrafficUsageResponse
+      if (isRaw) {
+        const rows = body.rawRows ?? []
+        if (rows.length) settersRef.current.setRawRows(prev => prependRawHead(prev, rows))
+      } else {
+        const rows = body.aggregateRows ?? []
+        if (rows.length) settersRef.current.setAggRows(prev => mergeAggregateHeadRows(prev, rows))
+      }
     },
     undefined,
     enabled,

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -29,6 +29,9 @@ vi.mock('@/api/client', () => ({
 
 import { api } from '@/api/client'
 import { TrafficUsagePage } from './TrafficUsagePage'
+import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
+import { WsProvider } from '@/hooks/useWs'
+import { AuthProvider } from '@/hooks/useAuth'
 
 const rawResp: TrafficUsageResponse = {
   bucket: 'raw',
@@ -401,5 +404,124 @@ describe('TrafficUsagePage', () => {
     await waitFor(() => expect(screen.getByTestId('aggregate-table')).toBeInTheDocument())
     expect(screen.queryByText(/aborted/i)).not.toBeInTheDocument()
     expect(screen.queryByTestId('error')).not.toBeInTheDocument()
+  })
+})
+
+// ── #2048: the DEFAULT raw view streams live — subscribe, Live badge, prepend new rawRows ──
+//
+// End-to-end over a real SpaWsClient + mock socket: the page wired to WsProvider subscribes
+// `trafficUsage{bucket:raw}` at the live edge, shows the <LiveBadge>, and prepends the pushed
+// per-host rawRows above the GET-loaded history. A pinned past window (`?until=`) stays GET-only.
+describe('TrafficUsagePage raw live-edge (#2048)', () => {
+  class MockSocket implements WsSocketLike {
+    static instances: MockSocket[] = []
+    sent: string[] = []
+    onopen: ((ev?: unknown) => void) | null = null
+    onclose: ((ev: { code: number; reason?: string }) => void) | null = null
+    onmessage: ((ev: { data: string }) => void) | null = null
+    onerror: ((ev?: unknown) => void) | null = null
+    constructor(public url: string) { MockSocket.instances.push(this) }
+    send(d: string) { this.sent.push(d) }
+    close() { this.onclose?.({ code: 1006 }) }
+    open() { this.onopen?.() }
+    emit(frame: Record<string, unknown>) { this.onmessage?.({ data: JSON.stringify(frame) }) }
+    frames() { return this.sent.map(s => JSON.parse(s)) }
+  }
+  const last = () => MockSocket.instances[MockSocket.instances.length - 1]
+
+  beforeEach(() => {
+    // The page test suite fakes Date; the ws path doesn't depend on it, but keep the seeds stable.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-05-22T12:00:00Z'))
+    vi.clearAllMocks()
+    MockSocket.instances = []
+    localStorage.clear()
+    localStorage.setItem('token', 'jwt')
+    ;(api.devices.list as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    ;(api.profiles.list as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    ;(api.apps.list as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    ;(api.usage.traffic as ReturnType<typeof vi.fn>).mockResolvedValue(rawResp)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+  })
+
+  function renderWithWs(initialEntries: string[] = ['/']) {
+    const client = new SpaWsClient({
+      apiBaseUrl: 'https://api.x',
+      origin: 'https://app.x',
+      getToken: () => 'jwt',
+      socketFactory: url => new MockSocket(url),
+      setCookie: () => {},
+      clearCookie: () => {},
+      invalidateQuery: () => {},
+      heartbeatMs: 100000,
+    })
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <AuthProvider>
+          <WsProvider client={client}>
+            <MemoryRouter initialEntries={initialEntries}>
+              <TrafficUsagePage />
+            </MemoryRouter>
+          </WsProvider>
+        </AuthProvider>
+      </QueryClientProvider>,
+    )
+    return { client }
+  }
+
+  function goLive(client: SpaWsClient) {
+    act(() => client.start())
+    act(() => last().open())
+    act(() => last().emit({ op: 'ready', payload: { role: 'admin', serverTime: 't' } }))
+    act(() => last().emit({ op: 'ack', payload: { topic: 'trafficUsage', status: 'ok' } }))
+  }
+
+  it('subscribes trafficUsage{bucket:raw}, shows the Live badge, and prepends the pushed raw rows', async () => {
+    const { client } = renderWithWs()
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByText('youtube.com')).toBeInTheDocument())
+
+    goLive(client)
+
+    // Subscribed with the raw params — no groupBy (the server's ungrouped-raw → rawRows path).
+    const sub = last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')
+    expect(sub.payload.params).toEqual({ bucket: 'raw' })
+    // The Live badge renders once the topic is acked + streaming.
+    await waitFor(() => expect(screen.getByTestId('ws-live-badge')).toBeInTheDocument())
+
+    // A push of a NEW per-host row prepends above the GET-loaded history — no manual refresh.
+    const push: TrafficUsageResponse = {
+      ...rawResp,
+      rawRows: [
+        {
+          mac: 'aa:bb:cc:dd:ee:02',
+          deviceName: 'Adult Laptop',
+          profileId: 2,
+          profileName: 'Adults',
+          host: { type: 'fqdn', value: 'netflix.com' },
+          bytesIn: 5000,
+          bytesOut: 90,
+          activeSeconds: 60,
+          periodStart: '2026-05-21T14:05:00Z',
+          periodEnd: '2026-05-21T14:06:00Z',
+        },
+      ],
+    }
+    act(() => last().emit({ op: 'trafficUsage', payload: push }))
+    await waitFor(() => expect(screen.getByText('netflix.com')).toBeInTheDocument())
+    // The GET-loaded history row is still present (never mutated).
+    expect(screen.getByText('youtube.com')).toBeInTheDocument()
+  })
+
+  it('stays GET-only on a pinned past window (?until=): no subscribe, no Live badge', async () => {
+    const seed = '2026-05-21T14:00:00.000Z'
+    const { client } = renderWithWs([`/?until=${encodeURIComponent(seed)}`])
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalled())
+    goLive(client)
+    expect(last().frames().find(f => f.op === 'subscribe' && f.payload.topic === 'trafficUsage')).toBeUndefined()
+    expect(screen.queryByTestId('ws-live-badge')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -204,13 +204,14 @@ export function TrafficUsagePage() {
     onLoadMore: () => { if (cursor) void load(cursor) },
   })
 
-  // #1975 (S6b): stream the live edge of the aggregated series — subscribe `trafficUsage`
-  // with the page's current params and merge the pushed head bucket into `aggRows` by
-  // windowStart (the helper gates itself to the aggregated, anchored-at-now view; the GET
-  // still owns history + paging). Re-subscribes when groupBy / bucket / filters change.
+  // #1975 (S6b) / #2048: stream the live edge of the page with the current params. The hook
+  // splices the push into whichever row state the bucket renders — aggregated head-merge into
+  // `aggRows` for 1m/10m/…, or PREPEND new per-host `rawRows` into `rawRows` for the default
+  // `raw` view (#2048). The GET still owns history + paging; a pinned `until` stays GET-only.
+  // Re-subscribes when groupBy / bucket / filters change.
   const liveStreaming = useWsTrafficUsageLiveEdge(
     { groupBy, bucket, macs, profileIds, until },
-    setAggRows,
+    { setAggRows, setRawRows },
   )
 
   function toggleGroup(key: string) {
@@ -541,8 +542,10 @@ function RawTable({
               </td>
             </tr>
           )}
-          {rows.map((r, i) => (
-            <tr key={i} className="border-t border-brand-border">
+          {rows.map(r => (
+            // #2048: key on the row's stable identity (periodStart, mac, host) — not the array
+            // index — so the live-edge PREPEND reconciles correctly instead of reusing rows by slot.
+            <tr key={`${r.periodStart}|${r.mac}|${r.host.value}`} className="border-t border-brand-border">
               <td className="px-2 py-1 font-mono text-xs whitespace-nowrap">{localTime(r.periodStart)}</td>
               <td className="px-2 py-1">{r.deviceName ?? r.mac}</td>
               <td className="px-2 py-1 hidden md:table-cell">{r.profileName ?? '-'}</td>


### PR DESCRIPTION
Closes #2048.

## Problem

The Traffic Usage page defaults to `bucket='raw'` (ungrouped per-host `rawRows`), but `raw` was excluded from the live edge — `useWsTrafficUsageLiveEdge` gated `enabled = until == null && bucket !== 'raw'`. So the **default view** never showed a `<LiveBadge>` and never subscribed to `trafficUsage`; new rows only appeared on a manual reload.

## The rawRows-vs-aggregateRows nuance (resolved)

The `trafficUsage` push (`SpaPush.pushOneParamSet`) aggregated per the subscribed `groupBy` and shipped `rawRows = Nil`. The raw page view renders **rawRows**, not aggregated points — so a naive frontend prepend had nothing to prepend.

Verified against the GET (`UsageRoutes`): `bucket=raw` **without** a groupBy → `buildRaw` → `rawRows`; `bucket=raw` **with** a groupBy (the dashboard gauge's `groupBy=profile`, #2040) → aggregated. I made the ws push mirror that split exactly, keeping the GET and the push SSOT for the same params.

## Changes

**Server** (`SpaPush.scala`): an **ungrouped** `raw` param-set now reads the new raw rows for the ingest period via `trafficRepo.listRawInRange` over the real `[periodStart, periodEnd)` head window (`UsageTraffic.windowFor` for raw = the report period) and ships them as `rawRows`, built by the shared `UsageTraffic.buildRaw`. `raw`+groupBy (gauge) and the fixed buckets keep the existing aggregate path untouched.

**Client**:
- `wsCache.prependRawHead` — prepend new raw rows, dedup by `(periodStart, mac, host)`, no cap (history is paged via the GET, #862).
- `useWsTrafficUsageLiveEdge` now enables for raw at the live edge; raw subscribes **without** `groupBy` (so the server takes its rawRows path, matching the GET which drops groupBy for raw) and prepends into the page's `setRawRows`; fixed buckets keep the aggregated head-merge into `setAggRows`. A pinned `until` stays GET-only for both.
- The page passes both setters; the raw `<tr>` key is now the stable row identity so the prepend reconciles correctly.

**Docs**: updated the design-doc note that claimed a raw subscription is *always* aggregated (no longer true for the ungrouped case).

## Tests (TDD, RED first)

- `SpaWsS4Spec`: an ungrouped `raw` subscription's push carries `rawRows` byte-identical to the GET's `bucket=raw` body for the same window (and the existing `raw`+groupBy → aggregate test still passes). Full S4 suite green (9/9).
- vitest: `prependRawHead` (prepend/dedup/no-truncate); the hook subscribes raw (no groupBy) + prepends + dedups + doesn't touch agg state, stays GET-only on pinned `until`, and re-subscribes/flips push target on raw↔1m; page-level — default raw view subscribes `trafficUsage{bucket:raw}`, shows the `<LiveBadge>`, and prepends a pushed row above GET history; pinned `?until=` stays GET-only (no badge/subscribe). Full web suite green (514), lint + build clean.