### PR TITLE
fix(#808): auto-create future weekly partitions — durable fix for P0 #2053

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -14,6 +14,7 @@ case class AppConfig(
     policy: PolicyConfig = PolicyConfig(),
     metrics: MetricsConfig = MetricsConfig(),
     ws: WsConfig = WsConfig(),
+    partition: PartitionConfig = PartitionConfig(),
 ) {
   // WIFIHAVEN_DEBUG env var: when set to a non-empty, non-"0"/"false"/"no"
   // value, mounts the read-only /api/debug/* endpoints (loopback only).
@@ -193,6 +194,18 @@ case class WsConfig(
 
   /** Origin enforcement is on only when an allowlist is configured (cloud/staging). */
   val enforceOrigin: Boolean = allowedOriginHosts.nonEmpty
+}
+
+// #808 — in-process weekly-partition auto-create job (durable fix for the 2026-06-29 P0 #2053).
+// `weeksAhead` is how many weeks of future partitions the job keeps provisioned ahead of the
+// current ISO week on each RANGE-partitioned ingest table. Default 6 (design §"Open operator
+// decisions" recommends ≥ 2 weeks of lead; 6 leaves comfortable runway for a multi-day outage of
+// the API/job). Clamped to a floor of 2 so a misconfigured 0/1 can't reduce the runway to the
+// danger zone the runway alert pages on. Absent HOCON block uses the defaults.
+case class PartitionConfig(
+    weeksAhead: Int = 6,
+) {
+  val weeksAheadClamped: Int = math.max(2, weeksAhead)
 }
 
 object AppConfig {

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -17,6 +17,7 @@ import wifihaven.api.observability.LoggingMiddleware
 import wifihaven.api.observability.LokiDropMetrics
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
+import wifihaven.api.usage.PartitionMaintenanceJob
 import wifihaven.api.usage.RetentionSweepJob
 import wifihaven.api.usage.RollupJobs
 import wifihaven.api.usage.TimeUsedRollupJob
@@ -310,6 +311,17 @@ object Main extends ZIOAppDefault {
         // the tick rather than racing on the same DELETE.
         xaForJobs         <- ZIO.service[Transactor[Task]]
         _                 <- RetentionSweepJob.start(xaForJobs)
+        // #808: durable fix for the 2026-06-29 P0 (#2053). Auto-creates the next
+        // cfg.partition.weeksAhead weekly partitions on traffic_reports + connection_events at
+        // startup and every 24h, so the fixed runway V41/V42 seeded can never silently exhaust.
+        // Emits partition_weeks_ahead{table} for the runway alert. Advisory-locked (multi-instance
+        // safe), forkDaemon inside start.
+        partitionRepo     <- ZIO.service[PartitionRepo]
+        _                 <- PartitionMaintenanceJob.start(
+          partitionRepo,
+          cfg.partition.weeksAheadClamped,
+          clockForJobs,
+        )
         // Keep the process alive on the already-bound server fiber; exits if it dies.
         _                 <- serverFiber.join
       } yield ())

--- a/api/src/db/PartitionRepo.scala
+++ b/api/src/db/PartitionRepo.scala
@@ -1,0 +1,69 @@
+package wifihaven.api.db
+
+import zio.*
+
+import java.time.Instant
+
+/**
+ * #808 (design: docs/design/db-partitioning.md §"Auto-create future partitions"): the data-access
+ * half of the in-process job that keeps the weekly RANGE-partitioned ingest tables provisioned a
+ * few weeks ahead so router writes never hit a missing range. This is the durable fix for the
+ * 2026-06-29 P0 (#2053): V41/V42 created only a fixed 5-week runway at migration time and deferred
+ * ongoing creation to this issue, which never shipped — the runway exhausted at ISO week 2026-27
+ * and every `POST /api/router/{usage,events}` insert 503'd.
+ *
+ * SQL lives here per the "no SQL outside *RepoLive" convention; the scheduling, logging and metric
+ * emission live in [[wifihaven.api.usage.PartitionMaintenanceJob]].
+ */
+trait PartitionRepo {
+
+  /**
+   * Ensure weekly partitions exist for `[current ISO week, +weeksAhead]` on every partitioned
+   * table, then report how many consecutive weeks of runway each table now has.
+   *
+   * Idempotent (`CREATE TABLE IF NOT EXISTS … PARTITION OF`) and multi-instance-safe: the whole
+   * pass runs under a session-scoped Postgres advisory lock on one connection, so two API instances
+   * can't race on the `AccessExclusiveLock` the partition-attach takes on the parent (design
+   * §"Horizontal-scaling safety"). If another instance holds the lock this returns `None` without
+   * touching the catalog.
+   *
+   * `now` is injected (not `CURRENT_DATE`) so the schedule is driven by the shared
+   * [[wifihaven.shared.Clock]] and tests are deterministic; the Monday/ISO-week derivation matches
+   * V41/V42 exactly (`date_trunc('week', …)` Monday boundaries, `to_char(wk,'IYYY_IW')` names).
+   */
+  def ensureFuturePartitions(
+      weeksAhead: Int,
+      now: Instant,
+  ): Task[Option[List[PartitionRepo.TableResult]]]
+}
+
+object PartitionRepo {
+
+  /**
+   * The weekly RANGE-partitioned tables — the SINGLE source of truth for which tables the
+   * maintenance job provisions. `traffic_reports` (V41, RANGE on `period_start`) and
+   * `connection_events` (V42, RANGE on `ts`). Adding a third partitioned table is a one-line edit
+   * here; nothing else hardcodes the pair (`AGENTS.md#single-source-of-truth`).
+   */
+  val PartitionedTables: List[String] = List("traffic_reports", "connection_events")
+
+  /**
+   * Reserved session advisory-lock key for the partition-create pass. Distinct from
+   * [[wifihaven.api.usage.RetentionSweepJob.AdvisoryLockKey]] (`0x726c757073770001`) so the
+   * create-future and retention-drop jobs hold independent locks and can interleave across
+   * instances (design §"Horizontal-scaling safety"). Do not reuse for any other advisory lock.
+   */
+  val AdvisoryLockKey: Long = 0x70617274_6e770001L
+
+  /** How far ahead [[consecutiveWeeksAheadCap]] probes when measuring runway. */
+  private[db] val ConsecutiveWeeksAheadCap: Int = 60
+
+  /**
+   * Per-table outcome of one pass: which partitions were freshly created (for the INFO log) and the
+   * resulting runway — the count of consecutive weekly partitions present starting from the current
+   * ISO week. `weeksAhead = 0` means the current week itself has no partition (the #2053 outage
+   * state); the maintenance job emits this as the `partition_weeks_ahead{table}` gauge the runway
+   * alert watches.
+   */
+  final case class TableResult(table: String, created: List[String], weeksAhead: Int)
+}

--- a/api/src/db/PartitionRepoLive.scala
+++ b/api/src/db/PartitionRepoLive.scala
@@ -1,16 +1,120 @@
 package wifihaven.api.db
 
-import doobie.Transactor
+import cats.implicits.*
+import doobie.*
+import doobie.free.connection.{pure as cpure, raiseError as craiseError}
+import doobie.implicits.*
+import doobie.postgres.implicits.*
 import zio.*
+import zio.interop.catz.*
 
-import java.time.Instant
+import java.time.{Instant, LocalDate}
 
-// STUB (#808, red commit): always reports the lock as held so nothing is created and the runway
-// reads 0. Replaced by the real advisory-locked create-and-measure pass in the green commit.
+/**
+ * #808 (design: docs/design/db-partitioning.md): create-future-partitions data access. See
+ * [[PartitionRepo]] for the contract. Mirrors [[wifihaven.api.usage.RetentionSweepJob]]'s
+ * advisory-lock shape: the lock acquire, the create pass and the unlock all run on ONE connection
+ * (`cio.transact(xa)`), so the session-scoped lock covers exactly the pass and auto-releases if the
+ * connection drops.
+ */
 final case class PartitionRepoLive(xa: Transactor[Task]) extends PartitionRepo {
+
+  import PartitionRepo.*
+
   def ensureFuturePartitions(
       weeksAhead: Int,
       now: Instant,
-  ): Task[Option[List[PartitionRepo.TableResult]]] =
-    ZIO.succeed(None)
+  ): Task[Option[List[TableResult]]] = {
+    val epochSeconds = now.toEpochMilli.toDouble / 1000.0
+
+    val body: ConnectionIO[List[TableResult]] =
+      PartitionedTables.traverse(ensureTable(_, weeksAhead, epochSeconds))
+
+    // Acquire the session advisory lock; if another instance holds it, return None untouched.
+    // Otherwise run the pass and release on the SAME connection whether it succeeds or fails,
+    // re-raising any error after the unlock (so the lock never leaks).
+    val cio: ConnectionIO[Option[List[TableResult]]] =
+      sql"SELECT pg_try_advisory_lock($AdvisoryLockKey)".query[Boolean].unique.flatMap {
+        case false => cpure(Option.empty[List[TableResult]])
+        case true  =>
+          body.attempt.flatMap { res =>
+            sql"SELECT pg_advisory_unlock($AdvisoryLockKey)".query[Boolean].unique.flatMap { _ =>
+              res match {
+                case Right(rs) => cpure(Some(rs))
+                case Left(e)   => craiseError[Option[List[TableResult]]](e)
+              }
+            }
+          }
+      }
+    cio.transact(xa)
+  }
+
+  // One row of the week plan: the ISO-week suffix, the Monday/next-Monday bounds, and whether the
+  // partition already exists. Names + bounds are computed in SQL so they match V41/V42 byte-for-byte
+  // (date_trunc('week', …) Monday, to_char(wk,'IYYY_IW'), [Monday, Monday+7) ).
+  private final case class WeekRow(iw: String, lo: LocalDate, hi: LocalDate, exists: Boolean)
+
+  private def ensureTable(
+      table: String,
+      weeksAhead: Int,
+      epochSeconds: Double,
+  ): ConnectionIO[TableResult] =
+    for {
+      plan <- weekPlan(table, weeksAhead, epochSeconds)
+      missing = plan.filterNot(_.exists)
+      _     <- missing.traverse_(createPartition(table, _))
+      ahead <- consecutiveWeeksAhead(table, epochSeconds)
+    } yield TableResult(table, missing.map(r => s"${table}_${r.iw}"), ahead)
+
+  // weeks 0..weeksAhead from the Monday of `now`, each with its ISO-week name, [lo, hi) bounds, and
+  // current existence. The prefix is a constant from PartitionedTables — never user input.
+  private def weekPlan(
+      table: String,
+      weeksAhead: Int,
+      epochSeconds: Double,
+  ): ConnectionIO[List[WeekRow]] = {
+    val prefix = s"${table}_"
+    sql"""
+      SELECT to_char(d, 'IYYY_IW') AS iw,
+             d::date                AS lo,
+             (d + 7)::date          AS hi,
+             to_regclass($prefix || to_char(d, 'IYYY_IW')) IS NOT NULL AS already
+      FROM (
+        SELECT (date_trunc('week', to_timestamp($epochSeconds))::date + (gs * 7)) AS d
+        FROM generate_series(0, $weeksAhead) AS gs
+      ) w
+      ORDER BY d
+    """.query[(String, LocalDate, LocalDate, Boolean)].to[List].map(_.map(WeekRow.apply.tupled))
+  }
+
+  // CREATE TABLE IF NOT EXISTS <table>_<iw> PARTITION OF <table> FOR VALUES FROM (Monday) TO
+  // (Monday+7) — the EXACT scheme V41/V42 use. Identifiers + date bounds derive from the table
+  // constant + Postgres date arithmetic (never user input), so Fragment.const is safe here. A bare
+  // ISO date literal on a TIMESTAMPTZ partition key coerces to session-tz midnight, identical to
+  // V41's `wk::timestamptz`.
+  private def createPartition(table: String, row: WeekRow): ConnectionIO[Unit] = {
+    val name = s"${table}_${row.iw}"
+    val ddl  =
+      s"CREATE TABLE IF NOT EXISTS $name PARTITION OF $table " +
+        s"FOR VALUES FROM ('${row.lo}') TO ('${row.hi}')"
+    Fragment.const(ddl).update.run.void
+  }
+
+  // Runway = number of consecutive weekly partitions present starting at the current ISO week. The
+  // first week index (from 0) with NO partition is exactly that count; 0 means even the current week
+  // is missing (the #2053 outage state). Capped probe so a fully-provisioned table returns the cap+1
+  // rather than scanning forever.
+  private def consecutiveWeeksAhead(table: String, epochSeconds: Double): ConnectionIO[Int] = {
+    val prefix = s"${table}_"
+    val cap    = ConsecutiveWeeksAheadCap
+    sql"""
+      SELECT COALESCE(MIN(gs), ${cap + 1})
+      FROM generate_series(0, $cap) AS gs
+      WHERE to_regclass(
+        $prefix || to_char(
+          (date_trunc('week', to_timestamp($epochSeconds))::date + (gs * 7)), 'IYYY_IW'
+        )
+      ) IS NULL
+    """.query[Int].unique
+  }
 }

--- a/api/src/db/PartitionRepoLive.scala
+++ b/api/src/db/PartitionRepoLive.scala
@@ -1,0 +1,16 @@
+package wifihaven.api.db
+
+import doobie.Transactor
+import zio.*
+
+import java.time.Instant
+
+// STUB (#808, red commit): always reports the lock as held so nothing is created and the runway
+// reads 0. Replaced by the real advisory-locked create-and-measure pass in the green commit.
+final case class PartitionRepoLive(xa: Transactor[Task]) extends PartitionRepo {
+  def ensureFuturePartitions(
+      weeksAhead: Int,
+      now: Instant,
+  ): Task[Option[List[PartitionRepo.TableResult]]] =
+    ZIO.succeed(None)
+}

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -3449,6 +3449,7 @@ object Repos {
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
   val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
   val appUsedRollupRepo     = ZLayer.fromFunction(AppUsedRollupRepoLive(_))
+  val partitionRepo         = ZLayer.fromFunction(PartitionRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ appTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo ++ appUsedRollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ appTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo ++ appUsedRollupRepo ++ partitionRepo
 }

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -89,6 +89,10 @@ object MetricGuard {
       // so they satisfy the §4 cardinality firewall.
       "role",
       "topic",
+      // #808 — partitioned-table name for `partition_weeks_ahead`. A fixed 2-value enum
+      // (traffic_reports | connection_events — PartitionRepo.PartitionedTables); bounded by
+      // the schema, not by user/device/flow growth, so it satisfies the §4 cardinality firewall.
+      "table",
     )
 
   /**
@@ -326,6 +330,13 @@ object MetricGuard {
     // #1069 named-schedule CRUD — `op` ∈ {create, update, delete}, a fixed enum. Lets an operator
     // see schedule edits land (and rate-alert on a runaway delete loop) without grepping logs.
     "wifihaven_schedule_mutations_total"   -> Set("op"),
+    // #808 — partition runway gauge. `partition_weeks_ahead{table}` is the count of consecutive
+    // weekly partitions present from the current ISO week for each RANGE-partitioned ingest table
+    // (set each run by PartitionMaintenanceJob). `table` is the bounded 2-value enum above. The
+    // runway alert pages when this drops below 2 — the "never silently exhaust again" guard for the
+    // 2026-06-29 P0 (#2053). Without this entry the firewall would reject the name as unknown_name
+    // and the series would never emit.
+    "partition_weeks_ahead"                -> Set("table"),
     // #1243/#1221 HikariCP pool gauges — no labels.
     "wifihaven_db_pool_active_connections" -> Set.empty[String],
     "wifihaven_db_pool_idle_connections"   -> Set.empty[String],
@@ -700,6 +711,16 @@ object AppMetrics {
         RollupDurationBoundaries,
       ) *>
       MetricGuard.gauge("wifihaven_rollup_rows_upserted", Map("rollup_job" -> job), rows.toDouble)
+
+  // ── Partition runway (#808) ──────────────────────────────────────────────────
+  // Set by PartitionMaintenanceJob each run: per partitioned table, the number of consecutive
+  // weekly partitions present starting at the current ISO week (the write runway). A value of 0
+  // means even the current week has no partition — the 2026-06-29 P0 (#2053) state. The runway
+  // alert pages when the worst table drops below 2, so the fixed runway can never silently exhaust
+  // again. `table` is a bounded 2-value enum (the PartitionRepo.PartitionedTables names).
+
+  def setPartitionWeeksAhead(table: String, weeksAhead: Int): UIO[Unit] =
+    MetricGuard.gauge("partition_weeks_ahead", Map("table" -> table), weeksAhead.toDouble)
 
   // ── DB connection pool (#1243, #1221) ───────────────────────────────────────
   // Set from the polling fiber in DbPoolMetrics. threads_awaiting was the

--- a/api/src/routes/ErrorMapper.scala
+++ b/api/src/routes/ErrorMapper.scala
@@ -49,4 +49,28 @@ object ErrorMapper {
       .json(s"""{"status":"error","db":"$label"}""")
       .status(Status.ServiceUnavailable)
       .addHeader("Retry-After", "30")
+
+  /**
+   * #1570 / #2053: render a DB throwable's FULL cause chain as a one-line diagnostic string for the
+   * server LOG (never the response body — the body stays class-name-only per the wire contract and
+   * the SQL-leak guard in DbFailureSpec). The 2026-06-29 P0 cost diagnosis time because the 503
+   * body + logs surfaced only `BatchUpdateException`; the real reason (`no partition of relation …
+   * found for row`) was a `PSQLException` reachable only via `SQLException.getNextException`, which
+   * neither the body nor a plain `Cause.fail` stack render. This walks BOTH the standard `getCause`
+   * chain and the JDBC `getNextException` chain (deduping to avoid cycles) so the underlying PSQL
+   * message is always logged at the ingest boundary.
+   */
+  def dbCauseChain(t: Throwable): String = {
+    val seen                     = scala.collection.mutable.LinkedHashSet.empty[Throwable]
+    def walk(x: Throwable): Unit =
+      if x != null && seen.add(x) then {
+        walk(x.getCause)
+        x match {
+          case s: java.sql.SQLException => walk(s.getNextException)
+          case _                        => ()
+        }
+      }
+    walk(t)
+    seen.iterator.map(e => s"${e.getClass.getSimpleName}: ${e.getMessage}").mkString(" <- ")
+  }
 }

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -64,7 +64,7 @@ object RouterIngestRoutes {
               body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
               _      <- ingest.ingestUsage(router, body)
             } yield Response.ok
-          handle.mapError(ErrorMapper.errorToResponse)
+          handle.tapError(logDbCause).mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "router" / "events" ->
         handler { (req: Request) =>
@@ -74,7 +74,22 @@ object RouterIngestRoutes {
               body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
               _      <- ingest.ingestEvents(router, body)
             } yield Response.ok
-          handle.mapError(ErrorMapper.errorToResponse)
+          handle.tapError(logDbCause).mapError(ErrorMapper.errorToResponse)
         },
     )
+
+  /**
+   * #1570 / #2053 observability fix: when an ingest fails with a DB error, log the full PSQL cause
+   * chain at ERROR before [[ErrorMapper.errorToResponse]] collapses it to the class-name-only 503
+   * body the wire contract mandates. [[wifihaven.api.ErrorBoundary]] still logs the response-level
+   * summary (route/status/body); this adds the diagnostic detail that body deliberately omits, so a
+   * future partition/SQL failure shows the real reason (`no partition of relation … found for row`)
+   * instead of a bare `BatchUpdateException`. Non-DB errors carry their detail in the body the
+   * boundary already logs, so only the `Db` case needs this.
+   */
+  private def logDbCause(e: ApiError): UIO[Unit] = e match {
+    case ApiError.Db(cause) =>
+      ZIO.logError(s"router ingest DB failure: ${ErrorMapper.dbCauseChain(cause)}")
+    case _                  => ZIO.unit
+  }
 }

--- a/api/src/usage/PartitionMaintenanceJob.scala
+++ b/api/src/usage/PartitionMaintenanceJob.scala
@@ -1,13 +1,89 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.PartitionRepo
+import wifihaven.api.metrics.AppMetrics
+import wifihaven.shared.Clock
 import zio.*
 
 import java.time.Instant
 
-// STUB (#808, red commit): no-op tick. Replaced by the real create-pass + INFO log + runway-gauge
-// emission in the green commit.
+/**
+ * #808 (design: docs/design/db-partitioning.md §"Auto-create future partitions"): the scheduling +
+ * observability half of the partition-maintenance job. It keeps the weekly RANGE-partitioned ingest
+ * tables (traffic_reports V41, connection_events V42) provisioned a configurable number of weeks
+ * ahead so router writes never hit a missing range — the durable fix for the 2026-06-29 P0 (#2053),
+ * where the fixed 5-week runway V41/V42 seeded ran out at ISO week 2026-27 and every `POST
+ * /api/router/{usage,events}` insert 503'd.
+ *
+ * All SQL lives in [[PartitionRepo]] per the "no SQL outside *RepoLive" convention; this object
+ * only drives the clock, logs created partitions at INFO, and publishes the runway gauge.
+ *
+ * Multi-instance-safe via the repo's session advisory lock: a tick that loses the race returns
+ * `None` and is a quiet no-op (another instance is provisioning), so this never double-creates or
+ * races on the parent's attach lock.
+ */
 object PartitionMaintenanceJob {
+
+  /**
+   * Tick cadence. `Schedule.fixed` runs the effect once immediately (the startup pass — critical,
+   * since this IS the runway guard) and then every 24 h, satisfying "runs at startup and every 24h"
+   * from #808 without needing a wall-clock hour alignment.
+   */
+  val Interval: Duration = 24.hours
+
+  /**
+   * One maintenance pass. Ensures `[current week, +weeksAhead]` partitions exist on every
+   * partitioned table, logs any freshly-created partitions at INFO, and publishes
+   * `partition_weeks_ahead{table}` for each table. Never fails — DB errors are logged (a
+   * pool-closed-during-shutdown race is benign, logged at DEBUG); the fiber stays alive. `now` is
+   * supplied by the caller (the [[Clock]] in `start`, a fixed instant in tests).
+   */
   def runOnce(repo: PartitionRepo, weeksAhead: Int, now: Instant): UIO[Unit] =
-    ZIO.unit
+    repo
+      .ensureFuturePartitions(weeksAhead, now)
+      .either
+      .flatMap {
+        case Right(None)                               =>
+          ZIO.logDebug(
+            "PartitionMaintenanceJob: advisory lock held by another instance — tick skipped",
+          )
+        case Right(Some(results))                      =>
+          ZIO.foreachDiscard(results) { r =>
+            val createdLog =
+              ZIO
+                .logInfo(
+                  s"PartitionMaintenanceJob: created partitions for ${r.table}: " +
+                    r.created.mkString(", "),
+                )
+                .when(r.created.nonEmpty)
+                .unit
+            createdLog *> AppMetrics.setPartitionWeeksAhead(r.table, r.weeksAhead)
+          } *> {
+            val summary =
+              results.map(r => s"${r.table}=${r.weeksAhead}w(+${r.created.size})").mkString(", ")
+            ZIO.logInfo(s"PartitionMaintenanceJob: runway [$summary]")
+          }
+        case Left(e) if RollupShutdown.isPoolClosed(e) =>
+          ZIO.logDebug(
+            "PartitionMaintenanceJob: tick aborted (pool closed during shutdown)",
+          )
+        case Left(e)                                   =>
+          ZIO.logErrorCause("PartitionMaintenanceJob: tick failed", Cause.fail(e))
+      }
+
+  /**
+   * Fork a daemon fiber that runs the pass at startup and every 24 h. `weeksAhead` comes from
+   * config; `clock` supplies each tick's `now` so the schedule honours the shared injected clock.
+   */
+  def start(repo: PartitionRepo, weeksAhead: Int, clock: Clock): UIO[Fiber.Runtime[Nothing, Long]] =
+    for {
+      _     <- ZIO.logInfo(
+        s"PartitionMaintenanceJob scheduled: startup pass now, then every 24h " +
+          s"(keeping $weeksAhead weeks of partitions ahead)",
+      )
+      fiber <- clock.instant
+        .flatMap(runOnce(repo, weeksAhead, _))
+        .repeat(Schedule.fixed(Interval))
+        .forkDaemon
+    } yield fiber
 }

--- a/api/src/usage/PartitionMaintenanceJob.scala
+++ b/api/src/usage/PartitionMaintenanceJob.scala
@@ -1,0 +1,13 @@
+package wifihaven.api.usage
+
+import wifihaven.api.db.PartitionRepo
+import zio.*
+
+import java.time.Instant
+
+// STUB (#808, red commit): no-op tick. Replaced by the real create-pass + INFO log + runway-gauge
+// emission in the green commit.
+object PartitionMaintenanceJob {
+  def runOnce(repo: PartitionRepo, weeksAhead: Int, now: Instant): UIO[Unit] =
+    ZIO.unit
+}

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -278,5 +278,22 @@ object DbFailureSpec extends ZIOSpecDefault {
         resp <- routes.runZIO(req)
       } yield assertTrue(resp.status == Status.Unauthorized)
     },
+    test(
+      "dbCauseChain surfaces the underlying PSQL message behind a BatchUpdateException (#2053)",
+    ) {
+      // The 2026-06-29 incident: the partition-missing PSQLException was reachable only via
+      // SQLException.getNextException, so logs showed only `BatchUpdateException`. The chain
+      // renderer must walk getNextException (and getCause) to expose the real reason — for the LOG,
+      // never the response body (the SQL-leak guard above pins the body stays class-name-only).
+      val underlying = new SQLException(
+        "ERROR: no partition of relation \"traffic_reports\" found for row",
+      )
+      val batch      = new java.sql.BatchUpdateException("Batch entry 0 INSERT … failed", Array(0))
+      batch.setNextException(underlying)
+      val chain      = ErrorMapper.dbCauseChain(batch)
+      assertTrue(chain.contains("BatchUpdateException")) &&
+      assertTrue(chain.contains("PSQLException") || chain.contains("SQLException")) &&
+      assertTrue(chain.contains("no partition of relation"))
+    },
   )
 }

--- a/api/test/src/feature/PartitionMaintenanceJobSpec.scala
+++ b/api/test/src/feature/PartitionMaintenanceJobSpec.scala
@@ -1,0 +1,147 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.db.TypeMeta.given
+import wifihaven.api.usage.PartitionMaintenanceJob
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import doobie.Transactor
+import doobie.implicits.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.*
+import zio.interop.catz.*
+import zio.metrics.*
+import zio.test.*
+
+import java.time.Instant
+
+/**
+ * #808 / #2053: the in-process job that auto-creates future weekly partitions for the RANGE-
+ * partitioned ingest tables (traffic_reports V41, connection_events V42). Verifies it creates the
+ * expected weeks ahead with the EXACT V41/V42 naming + Monday-boundary range scheme, is idempotent,
+ * lets an insert dated into a provisioned future week succeed, surfaces the runway via the
+ * `partition_weeks_ahead{table}` gauge, and is advisory-lock guarded for multi-instance safety.
+ *
+ * `now` is pinned to a far-future Monday so the partitions the job creates never collide with the
+ * current-week partitions V41/V42 seed at migration time — the assertions are deterministic
+ * regardless of when the suite runs.
+ */
+object PartitionMaintenanceJobSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  // A fixed reference instant well past any real migration-seed window. 2030-06-12 is a Wednesday;
+  // date_trunc('week') resolves it to Monday 2030-06-10 (ISO week 2030-24).
+  private val refNow: Instant = Instant.parse("2030-06-12T12:00:00Z")
+
+  private val weeksAhead = 6
+
+  // Expected ISO-week partition names for weeks 0..6 from refNow's Monday (2030-06-10 = 2030_24).
+  private val expectedWeeks: List[String] =
+    List("2030_24", "2030_25", "2030_26", "2030_27", "2030_28", "2030_29", "2030_30")
+
+  private def partitionExists(xa: Transactor[Task], name: String): Task[Boolean] =
+    sql"SELECT to_regclass($name) IS NOT NULL".query[Boolean].unique.transact(xa)
+
+  private def gaugeValue(table: String): UIO[Double] =
+    Metric.gauge("partition_weeks_ahead").tagged("table", table).value.map(_.value)
+
+  private def mkRepo(xa: Transactor[Task]): PartitionRepo = PartitionRepoLive(xa)
+
+  def spec = suite("PartitionMaintenanceJob")(
+    test("creates the current week + N ahead with V41/V42 naming and Monday boundaries") {
+      for {
+        _  <- cleanDb
+        xa <- ZIO.service[Transactor[Task]]
+        repo = mkRepo(xa)
+        res      <- repo.ensureFuturePartitions(weeksAhead, refNow)
+        // traffic_reports: every expected week now resolves to a real relation.
+        trExists <- ZIO.foreach(expectedWeeks)(w => partitionExists(xa, s"traffic_reports_$w"))
+        ceExists <- ZIO.foreach(expectedWeeks)(w => partitionExists(xa, s"connection_events_$w"))
+        // bounds of the 2030_24 traffic_reports partition: Monday 2030-06-10 → next Monday.
+        bounds   <- sql"""SELECT pg_get_expr(c.relpartbound, c.oid)
+                          FROM pg_class c WHERE c.relname = 'traffic_reports_2030_24'"""
+          .query[String]
+          .unique
+          .transact(xa)
+      } yield assertTrue(res.isDefined) &&
+        assertTrue(trExists.forall(identity)) &&
+        assertTrue(ceExists.forall(identity)) &&
+        assertTrue(bounds.contains("2030-06-10")) &&
+        assertTrue(bounds.contains("2030-06-17"))
+    },
+    test("is idempotent — a second pass creates nothing new") {
+      for {
+        _  <- cleanDb
+        xa <- ZIO.service[Transactor[Task]]
+        repo = mkRepo(xa)
+        r1 <- repo.ensureFuturePartitions(weeksAhead, refNow)
+        r2 <- repo.ensureFuturePartitions(weeksAhead, refNow)
+        created1 = r1.toList.flatten.flatMap(_.created)
+        created2 = r2.toList.flatten.flatMap(_.created)
+      } yield
+      // First pass creates the weeks 0..6 for both tables; second pass creates none.
+      assertTrue(created1.nonEmpty) && assertTrue(created2.isEmpty)
+    },
+    test("an insert dated into a provisioned future week succeeds") {
+      for {
+        _  <- cleanDb
+        xa <- ZIO.service[Transactor[Task]]
+        repo = mkRepo(xa)
+        _   <- repo.ensureFuturePartitions(weeksAhead, refNow)
+        rid <- ZIO.serviceWithZIO[RouterRepo](_.create("part-test", Sha256Hex.unsafe("b" * 64)))
+        // period_start in week +3 (2030-07-03 falls in ISO week 2030_27, which we provisioned).
+        inserted <- sql"""INSERT INTO traffic_reports
+                            (router_id, mac, ip, host_type, host_value, date, period_start,
+                             period_end, active_seconds, bytes_in, bytes_out)
+                          VALUES
+                            ($rid, 'aa:aa:aa:aa:aa:aa', NULL, 'fqdn', 'example.com',
+                             '2030-07-03', '2030-07-03T10:00:00Z'::timestamptz,
+                             '2030-07-03T10:05:00Z'::timestamptz, 1, 1, 1)""".update.run
+          .transact(xa)
+          .either
+      } yield assertTrue(inserted.isRight)
+    },
+    test("runway gauge reflects the consecutive weeks-ahead per table") {
+      for {
+        _  <- cleanDb
+        xa <- ZIO.service[Transactor[Task]]
+        repo = mkRepo(xa)
+        _   <- PartitionMaintenanceJob.runOnce(repo, weeksAhead, refNow)
+        trG <- gaugeValue("traffic_reports")
+        ceG <- gaugeValue("connection_events")
+      } yield
+      // weeks 0..6 present and consecutive from the current week ⇒ runway 7.
+      assertTrue(trG == 7.0) && assertTrue(ceG == 7.0)
+    },
+    test("second pass is skipped while another session holds the advisory lock") {
+      import java.util.concurrent.CountDownLatch
+      val key = PartitionRepo.AdvisoryLockKey
+      for {
+        _  <- cleanDb
+        xa <- ZIO.service[Transactor[Task]]
+        repo = mkRepo(xa)
+        db <- ZIO.service[TestDatabase.TestDb]
+        acquired = new CountDownLatch(1)
+        release  = new CountDownLatch(1)
+        holder <- ZIO.attemptBlocking {
+          val c = db.ds.getConnection
+          try {
+            val s = c.createStatement()
+            s.execute(s"SELECT pg_advisory_lock($key)")
+            acquired.countDown()
+            release.await()
+            s.execute(s"SELECT pg_advisory_unlock($key)")
+          } finally c.close()
+        }.fork
+        _      <- ZIO.attemptBlocking(acquired.await())
+        res    <- repo.ensureFuturePartitions(weeksAhead, refNow)
+        _      <- ZIO.succeed(release.countDown())
+        _      <- holder.join
+      } yield assertTrue(res.isEmpty)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/deploy/grafana/dashboards/db-health.json
+++ b/deploy/grafana/dashboards/db-health.json
@@ -220,6 +220,50 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+      "id": 200,
+      "panels": [],
+      "title": "Partition runway (#808 / #2053)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Weekly-partition runway (weeks ahead) per table",
+      "description": "partition_weeks_ahead{table,env=\"$env\"} — the number of consecutive weekly partitions present from the current ISO week on each RANGE-partitioned ingest table (traffic_reports V41, connection_events V42). Set each run by PartitionMaintenanceJob (#808). The fixed 5-week runway V41/V42 seeded ran out at ISO week 2026-27 and 503'd all ingest (#2053); this job keeps it topped up and this panel makes the runway visible. RED below 2 weeks = the page-now zone (critical alert C8). A value of 0 means even the current week has no partition — the incident state.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 22 },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "always", "lineWidth": 2, "thresholdsStyle": { "mode": "line" } },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 2 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "partition_weeks_ahead{env=\"$env\"}",
+          "legendFormat": "{{table}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",
@@ -263,6 +307,6 @@
   "timezone": "",
   "title": "WifiHaven — DB health",
   "uid": "wifihaven-db-health",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/infra/grafana/alerting-rules-critical.tf
+++ b/infra/grafana/alerting-rules-critical.tf
@@ -141,6 +141,17 @@ locals {
       env       = "prod"
       summary   = "agent_connected_routers{env=\"prod\"} == 0 for 10m (expressed as lt 1 over the integer gauge — Grafana evaluators have no eq). Server-computed from last_seen_at over a 10m window (DB-backed, trustworthy today — unlike the router-pushed family, §2 caveat). At household scale 0 means the single gateway agent stopped reporting entirely: no policy polls, no usage, no events. `for: 10m` aligns with the gauge's own window so it fires once the window has genuinely emptied, not on one missed poll."
     }
+    c8 = {
+      title     = "C8 Partition runway exhausting"
+      expr      = "min(partition_weeks_ahead{env=\"prod\"})"
+      window_s  = 3600
+      op        = "lt"
+      threshold = 2
+      for       = "1h"
+      severity  = "critical"
+      env       = "prod"
+      summary   = "Fewer than 2 weeks of pre-created weekly partitions remain on a RANGE-partitioned ingest table (min across traffic_reports/connection_events, partition_weeks_ahead{env=\"prod\"}, set by PartitionMaintenanceJob #808). This is the standing guard against a repeat of the 2026-06-29 P0 (#2053): V41/V42 seeded only a fixed 5-week runway and the auto-create job never shipped, so the runway silently exhausted at ISO week 2026-27 and 100% of POST /api/router/{usage,events} inserts 503'd. The job keeps ~6 weeks ahead and runs daily; this firing means it has been failing/skipped long enough that runway dropped below 2 weeks — still ~2 weeks of lead time to fix before writes start dropping. `for: 1h` rides over the daily gauge cadence without flapping. min() over the integer gauge (no eq in Grafana evaluators); the API being down makes the series absent → no-data → OK (C5 owns API-down). To force-test: drop the +1/+2-week partitions on staging and wait a tick."
+    }
   }
 }
 


### PR DESCRIPTION
## Durable fix for the 2026-06-29 P0 ([#2053](https://github.com/wifihaven/wifihaven/issues/2053)) — implements [#808](https://github.com/wifihaven/wifihaven/issues/808)

`traffic_reports` (V41, RANGE on `period_start`) and `connection_events` (V42, RANGE on `ts`) are **weekly RANGE-partitioned with no DEFAULT partition**. V41/V42 created only a **fixed 5-week runway** at migration time and deferred ongoing creation to #808 — which never shipped. The runway exhausted at **ISO week 2026-27** and every `POST /api/router/{usage,events}` insert threw `no partition of relation … found for row` → `BatchUpdateException` → **503, 100% ingest down**.

This ships the permanent automation the operator's manual SQL mitigation only bought ~10 weeks for.

## What this adds

**1. In-process scheduled job** (`PartitionMaintenanceJob`, wired into `Main` alongside `RetentionSweepJob`)
- Runs **at startup and every 24h** (`Schedule.fixed(24h)`).
- For **both** partitioned tables, ensures partitions exist for `[current ISO week, +N weeks]`.
- `N` configurable via `wifihaven.partition.weeksAhead` (default **6**, clamped to a floor of **2**).
- SQL lives in `PartitionRepoLive` (per the *no-SQL-outside-`*RepoLive`* convention). Idempotent `CREATE TABLE IF NOT EXISTS <table>_<IYYY_IW> PARTITION OF <table> FOR VALUES FROM (monday) TO (monday+7)` — **byte-identical naming/range scheme to V41/V42** (`date_trunc('week')` Monday boundaries, `to_char(wk,'IYYY_IW')`).
- `PartitionRepo.PartitionedTables` is the **single source of truth** for which tables get provisioned.
- Whole pass runs under a **session advisory lock** (distinct key from `RetentionSweepJob`) → multi-instance safe (design §"Horizontal-scaling safety"; per the #808 comment, concurrent `PARTITION OF` can hit `tuple concurrently updated` on `pg_class`).

**2. Runway metric + alert** — "never silently exhaust again"
- `partition_weeks_ahead{table}` gauge emitted each run (bounded 2-value `table` label, routed through `MetricGuard`).
- New **db-health** Grafana panel (`deploy/grafana/dashboards/db-health.json`) with a red threshold below 2 weeks.
- **Critical alert C8** (`infra/grafana/alerting-rules-critical.tf`): pages when `min(partition_weeks_ahead{env="prod"}) < 2` — ~2 weeks of lead time before writes would drop.

**3. Observability fix** (#1570 / #2053 follow-up)
- `ErrorMapper.dbCauseChain` walks the JDBC `getNextException` **and** `getCause` chains so the ingest error path logs the **real PSQL reason** (`no partition of relation … found for row`) instead of a bare `BatchUpdateException` — the detail that cost diagnosis time. Response **body stays class-name-only** (wire contract + SQL-leak guard unchanged).

## Tests (TDD, red→green in history)
- `PartitionMaintenanceJobSpec` (embedded Postgres, real V41/V42 schema, never mocks the repo): creates the expected weeks ahead with exact V41/V42 naming/bounds; idempotent; an insert dated into a provisioned future week succeeds; the `partition_weeks_ahead` gauge reflects reality; advisory-lock skip.
- `DbFailureSpec`: `dbCauseChain` surfaces the underlying PSQL message behind a `BatchUpdateException`; existing 503 + no-SQL-leak invariants still pass.

## Not a migration
This is a runtime job — **no migration file** (pre-push migration gate confirms). No new DB schema.

## Validation
`mill __.compile` ✓ · targeted specs ✓ · `terraform fmt -check` + `init -backend=false` + `validate` (infra/grafana) ✓ · dashboard JSON parses ✓ · scalafmt ✓
