### PR TITLE
feat(#1836): merge Top Blocked + Per Device into one Blocking activity (24h) panel

### DIFF
--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -204,15 +204,39 @@ beforeEach(() => {
 })
 
 describe('DashboardPage', () => {
-  it('renders the 1h KPI tiles, top-blocked, and per-device', async () => {
+  it('renders the 1h KPI tiles and the merged Blocking activity panel (#1836)', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
     expect(await screen.findByText('78')).toBeInTheDocument()  // Events (1h)
     expect(screen.getByText('9')).toBeInTheDocument()          // Blocked (1h)
+    // The ranked blocked-host list (existing topBlocked shape) is the body.
     expect(screen.getByText('evil.com')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
-    expect(screen.getAllByText("Kid's iPad").length).toBeGreaterThan(0)
-    expect(screen.getByText('500 events')).toBeInTheDocument()
-    expect(screen.getByText('20 blocked')).toBeInTheDocument()
+    expect(screen.getByText('ads.example')).toBeInTheDocument()
+    expect(screen.getByText('17')).toBeInTheDocument()
+  })
+
+  // ── #1836: merge Top Blocked + Per Device → one "Blocking activity (24h)" panel ──
+  it('renders ONE "Blocking activity (24h)" panel, replacing Top Blocked + Per Device (#1836)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    expect(await screen.findByText('Blocking activity (24h)')).toBeInTheDocument()
+    // The two old panels are gone.
+    expect(screen.queryByText('Top Blocked (24h)')).not.toBeInTheDocument()
+    expect(screen.queryByText('Per Device (24h)')).not.toBeInTheDocument()
+  })
+
+  it('subtitles the panel "N hosts · M blocked events" derived from stats (#1836)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    // topBlocked = [evil.com·42, ads.example·17] → 2 hosts, 42+17 = 59 events.
+    expect(await screen.findByText('2 hosts · 59 blocked events')).toBeInTheDocument()
+  })
+
+  it('never renders a "0 blocked" row and drops per-device volume (#1836)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    await screen.findByText('Blocking activity (24h)')
+    expect(screen.queryByText(/0 blocked/)).not.toBeInTheDocument()
+    // Per-device volume (events / N blocked) belongs on /devices + /profiles, not here.
+    expect(screen.queryByText('500 events')).not.toBeInTheDocument()
+    expect(screen.queryByText('20 blocked')).not.toBeInTheDocument()
   })
 
   it('restates the KPI tiles status-first: Online now / Blocked now / Events (1h) / Blocked (1h) (#1834)', async () => {
@@ -252,10 +276,14 @@ describe('DashboardPage', () => {
     expect(screen.queryByText(/queries/i)).not.toBeInTheDocument()
   })
 
-  it('shows empty state when no blocked events', async () => {
+  it('renders a one-line empty state (not two cards) when 24h had zero blocks (#1836)', async () => {
     mockStats().mockResolvedValue({ ...stats, topBlocked: [] })
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
-    expect(await screen.findByText(/No blocked events yet/)).toBeInTheDocument()
+    expect(
+      await screen.findByText('No blocked connection events in the last 24h'),
+    ).toBeInTheDocument()
+    // Zero hosts, zero events — the subtitle stays honest.
+    expect(screen.getByText('0 hosts · 0 blocked events')).toBeInTheDocument()
   })
 
   it('renders the KPI strip above the NOW section (#1834)', async () => {

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -230,6 +230,15 @@ describe('DashboardPage', () => {
     expect(await screen.findByText('2 hosts · 59 blocked events')).toBeInTheDocument()
   })
 
+  it('uses the singular "host" when exactly one host was blocked (#1836)', async () => {
+    mockStats().mockResolvedValue({
+      ...stats,
+      topBlocked: [{ host: { type: 'fqdn', value: 'captive.apple.com' }, count: 3 }],
+    })
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    expect(await screen.findByText('1 host · 3 blocked events')).toBeInTheDocument()
+  })
+
   it('never renders a "0 blocked" row and drops per-device volume (#1836)', async () => {
     render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
     await screen.findByText('Blocking activity (24h)')

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -45,45 +45,45 @@ export function DashboardPage() {
 
       <NowSection />
 
-      {stats && (
-        <>
-          <div className="grid md:grid-cols-2 gap-6">
-            <section className="bg-white rounded-2xl border border-brand-border p-5">
-              <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-4">
-                Top Blocked (24h)
-              </h2>
-              {stats.topBlocked.length === 0
-                ? <EmptyState variant="inline" title="No blocked events yet" />
-                : stats.topBlocked.map(d => (
-                    <div key={`${d.host.type}:${d.host.value}`} className="flex justify-between items-center py-2 border-b border-brand-border last:border-0">
-                      <span className="font-mono text-sm text-brand-text truncate"><HostCell host={d.host} /></span>
-                      <span className="text-red-700 font-mono text-sm ml-4 shrink-0">{d.count}</span>
-                    </div>
-                  ))
-              }
-            </section>
-
-            <section className="bg-white rounded-2xl border border-brand-border p-5">
-              <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-4">
-                Per Device (24h)
-              </h2>
-              {stats.perDevice.map(d => (
-                <div key={d.mac} className="flex items-center gap-3 py-2 border-b border-brand-border last:border-0">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-brand-ink truncate">{d.deviceName}</p>
-                    <p className="text-xs text-brand-text-muted font-mono">{d.mac}</p>
-                  </div>
-                  <div className="text-right shrink-0">
-                    <p className="text-sm text-brand-text">{d.total} events</p>
-                    <p className="text-xs text-red-700">{d.blocked} blocked</p>
-                  </div>
-                </div>
-              ))}
-            </section>
-          </div>
-        </>
-      )}
+      {stats && <BlockingActivitySection stats={stats} />}
     </div>
+  )
+}
+
+// ── "Blocking activity (24h)" — merged ranked-blocked-host panel ─────────────
+//
+// #1836 (#822): one panel replaces the old "Top Blocked (24h)" + "Per Device
+// (24h)" pair. Per-device traffic *volume* was a leaderboard wearing a security-
+// panel hat (17-of-18 rows reading "0 blocked" on prod) — it belongs on /devices
+// and /profiles, so the dashboard no longer consumes `stats.perDevice`. The body
+// is the ranked blocked-host list (existing `topBlocked` shape); the subtitle
+// counts the ranked hosts and sums their blocked events. No "0 blocked" row ever:
+// an empty 24h renders a single honest line, not two empty cards (design §7).
+// Per-host → "which devices triggered it" expansion is out of scope for v1 —
+// `topBlocked` carries no per-device linkage (design §7 Q3).
+function BlockingActivitySection({ stats }: { stats: DashboardStats }) {
+  const hostCount = stats.topBlocked.length
+  const eventCount = stats.topBlocked.reduce((sum, d) => sum + d.count, 0)
+  return (
+    <section className="bg-white rounded-2xl border border-brand-border p-5">
+      <div className="flex items-baseline justify-between gap-3 mb-4">
+        <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">
+          Blocking activity (24h)
+        </h2>
+        <span className="text-xs text-brand-text-muted shrink-0">
+          {hostCount} {hostCount === 1 ? 'host' : 'hosts'} · {eventCount} blocked events
+        </span>
+      </div>
+      {hostCount === 0
+        ? <p className="text-sm text-brand-text-muted">No blocked connection events in the last 24h</p>
+        : stats.topBlocked.map(d => (
+            <div key={`${d.host.type}:${d.host.value}`} className="flex justify-between items-center py-2 border-b border-brand-border last:border-0">
+              <span className="font-mono text-sm text-brand-text truncate"><HostCell host={d.host} /></span>
+              <span className="text-red-700 font-mono text-sm ml-4 shrink-0">{d.count}</span>
+            </div>
+          ))
+      }
+    </section>
   )
 }
 


### PR DESCRIPTION
Implementation chunk **4 of 5** of the `/dashboard` holistic redesign (umbrella #1148). **Frontend only — no API change.**

Closes #822. Refs #1148. Design: `docs/design/dashboard-redesign.md` §7 (decision Q3).

## What & why
On prod the two side-by-side panels were wildly asymmetric and mostly empty: **Top Blocked (24h)** was a single noise row (`captive.apple.com · 3`) while **Per Device (24h)** was 18 rows, 17 reading "0 blocked" — a traffic-volume leaderboard wearing a security-panel hat.

This replaces both `<section>` blocks with **one** "Blocking activity (24h)" panel:

- Header subtitle **"N hosts · M blocked events"** derived from `stats` (count of ranked blocked hosts + sum of their blocked-event counts).
- Body: the ranked blocked-host list using the existing `stats.topBlocked` shape.
- **Drops per-device volume entirely** — the dashboard no longer consumes `stats.perDevice` (per-device volume lives on `/devices` and `/profiles`). The API still returns `perDevice`; this is a consumer-side drop only, no wire change.
- **No "0 blocked" rows, ever.** A 24h with zero blocks renders a **one-line** "No blocked connection events in the last 24h" — not two empty cards.
- Total vertical space ≤ the previous Top-Blocked panel alone.

## Out of scope
Per-blocked-host → "which devices triggered it" inline expansion — `stats.topBlocked` carries no per-device linkage today and it needs an additive backend contract. Shipped v1 without it (design §7 Q3).

## Verification
- TDD: failing test committed first (RED), then green.
- `npm run lint` clean; `npm test` 517/517 pass; `npm run build` succeeds.
- `grep` confirms the dashboard no longer consumes `stats.perDevice` (only a code comment mentions it; other pages — ProfileTimeline — use a different `UsageBucket.perDevice`).
- LIVE BANDWIDTH / NOW / Recently-Blocked ws sections unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)