### PR TITLE
feat(#1837): rollup-back 24h dashboard stats + per-section skeletons (perceived latency #1098)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2838,17 +2838,42 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     withRollupLock(RollupLockKeys.ConnEventsDaily)(q.update.run)
   }
 
+  // #1837: the 24h aggregations (totalToday / blockedToday / topBlocked) read the
+  // pre-aggregated `connection_events_hourly` rollup (#1265 / #809) instead of a raw
+  // 24h scan of the unbounded, weekly-partitioned `connection_events` table — the
+  // #1098 perceived-latency fix. The window is hour-bucket-granular (24 buckets via
+  // the idx_ce_hourly_bucket_start range scan); the dashboard 24h panel is
+  // explicitly request/response, not realtime (design dashboard-redesign.md §8.2),
+  // so the up-to-one-hour tail lag of the hourly reroll (RollupJobs.HourlyInterval)
+  // is acceptable. Two behavioural notes vs the old raw scan, both intentional:
+  //   - the rollup excludes multicast/broadcast at write time (#1265 PR3), so these
+  //     totals omit multicast the raw scan counted — arguably more honest for a
+  //     "connection events" number, and equal to raw on a multicast-free window;
+  //   - the rollup stores only `hostname` (COALESCE(resolved_host_value, host_value)),
+  //     dropping the host_type discriminator, so topBlocked re-infers the HostId kind
+  //     from the string (hostIdFromRollup).
+  // The 1h tiles (totalHour / blockedHour) and the "Most Recently Blocked" recency
+  // feed legitimately need the live raw tail and stay on `connection_events`.
+  // perDevice was dropped from the dashboard in #1836 (per-device volume belongs on
+  // /devices + /profiles), so its raw 24h scan is removed entirely, not re-pointed.
   def stats =
     for {
-      tt  <- sql"SELECT COUNT(*)::INT FROM connection_events WHERE ts > NOW()-INTERVAL '24 hours'"
-        .query[Int]
-        .unique
-        .transact(xa)
-      bt  <-
-        sql"SELECT COUNT(*)::INT FROM connection_events WHERE ts > NOW()-INTERVAL '24 hours' AND NOT allowed"
+      tt  <- DbMetrics.timed("stats.total24h")(
+        sql"""SELECT COALESCE(SUM(count_succeeded + count_blocked), 0)::INT
+              FROM connection_events_hourly
+              WHERE bucket_start > NOW() - INTERVAL '24 hours'"""
           .query[Int]
           .unique
-          .transact(xa)
+          .transact(xa),
+      )
+      bt  <- DbMetrics.timed("stats.blocked24h")(
+        sql"""SELECT COALESCE(SUM(count_blocked), 0)::INT
+              FROM connection_events_hourly
+              WHERE bucket_start > NOW() - INTERVAL '24 hours'"""
+          .query[Int]
+          .unique
+          .transact(xa),
+      )
       th  <- sql"SELECT COUNT(*)::INT FROM connection_events WHERE ts > NOW()-INTERVAL '1 hour'"
         .query[Int]
         .unique
@@ -2858,31 +2883,31 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
           .query[Int]
           .unique
           .transact(xa)
-      top <- sql"""SELECT CASE WHEN resolved_host_value IS NOT NULL THEN 'fqdn' ELSE host_type END,
-                          COALESCE(resolved_host_value, host_value),
-                          COUNT(*)::INT
-                   FROM connection_events
-                   WHERE NOT allowed AND ts > NOW()-INTERVAL '24 hours'
-                   GROUP BY 1, 2 ORDER BY COUNT(*) DESC LIMIT 10"""
-        .query[(HostId, Int)]
-        .map(DomainCount.apply)
-        .to[List]
-        .transact(xa)
-      dev <- sql"""SELECT ce.mac::TEXT,
-                          COALESCE(d.name, ce.mac),
-                          COUNT(*)::INT,
-                          SUM(CASE WHEN NOT ce.allowed THEN 1 ELSE 0 END)::INT
-                   FROM connection_events ce
-                   LEFT JOIN devices d ON d.mac = ce.mac
-                   WHERE ce.ts > NOW()-INTERVAL '24 hours'
-                     AND ce.mac IS NOT NULL
-                   GROUP BY ce.mac, d.name
-                   ORDER BY COUNT(*) DESC LIMIT 20"""
-        .query[(MacAddress, String, Int, Int)]
-        .map(DeviceStats.apply)
-        .to[List]
-        .transact(xa)
-    } yield DashboardStats(tt, bt, th, bh, top, dev)
+      top <- DbMetrics.timed("stats.topBlocked24h")(
+        sql"""SELECT hostname, SUM(count_blocked)::INT AS c
+              FROM connection_events_hourly
+              WHERE bucket_start > NOW() - INTERVAL '24 hours'
+              GROUP BY hostname HAVING SUM(count_blocked) > 0
+              ORDER BY c DESC LIMIT 10"""
+          .query[(String, Int)]
+          .map { case (h, c) => DomainCount(hostIdFromRollup(h), c) }
+          .to[List]
+          .transact(xa),
+      )
+    } yield DashboardStats(tt, bt, th, bh, top)
+
+  // #1837: reconstruct a HostId from the rollup's bare `hostname` string. The
+  // hourly/daily rollups drop host_type, so re-infer it: an IP literal → IPv4/IPv6,
+  // a parseable hostname → Fqdn, otherwise a synthetic Label (the rare static-ip-
+  // range attribution, #1708, which is never pattern-matched). IP is tried first
+  // because some IP literals also parse as bare hostname labels.
+  private def hostIdFromRollup(s: String): HostId =
+    IpAddress
+      .parse(s)
+      .toOption
+      .map(HostId.ip)
+      .orElse(Hostname.parse(s).toOption.map(HostId.fqdn))
+      .getOrElse(HostId.Label(s))
 
   def topBlocked(hours: Int, lim: Int) =
     sql"""SELECT CASE WHEN resolved_host_value IS NOT NULL THEN 'fqdn' ELSE host_type END,

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -346,6 +346,9 @@ object LogApiSpec
             ),
           ),
         )
+        // #1837: 24h aggregations now read connection_events_hourly — roll the
+        // just-inserted events into the hourly tier so the rollup-backed read sees them.
+        _        <- connRepo.rerollConnEventsHourly(Instant.now().minusSeconds(7200))
         routes = LogRoutes.routes(auth, connRepo, upRepo)
         resp  <- getJson(routes, "/api/stats", token)
         body  <- resp.body.asString
@@ -478,6 +481,8 @@ object LogApiSpec
             ),
           ),
         )
+        // #1837: topBlocked now reads connection_events_hourly — roll first.
+        _        <- connRepo.rerollConnEventsHourly(Instant.now().minusSeconds(7200))
         routes = LogRoutes.routes(auth, connRepo, upRepo)
         resp  <- getJson(routes, "/api/stats", token)
         body  <- resp.body.asString

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -356,6 +356,80 @@ object LogApiSpec
         assertTrue(stats.topBlocked.exists(_.host.value == "badsite.com")) &&
         assertTrue(stats.topBlocked.find(_.host.value == "badsite.com").exists(_.count == 2))
     },
+    // ── #1837: the 24h aggregations ride the connection_events_hourly rollup ────
+    // (not a raw 24h scan of the unbounded connection_events table). Proof: roll
+    // the just-inserted events into the hourly tier, WIPE raw, and assert /api/stats
+    // still returns the 24h totals — only the rollup could have served them. The
+    // 1h tiles (totalHour/blockedHour) legitimately stay on raw, so they read 0
+    // here after the wipe; this test asserts only the rollup-backed 24h fields.
+    test("GET /api/stats 24h aggregations are served from the rollup, not a raw scan (#1837)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "google.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "badsite.com", allowed = false),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "badsite.com", allowed = false),
+          ),
+        )
+        _        <- connRepo.rerollConnEventsHourly(Instant.now().minusSeconds(7200))
+        xa       <- ZIO.service[Transactor[Task]]
+        _        <- sql"DELETE FROM connection_events".update.run.transact(xa)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp  <- getJson(routes, "/api/stats", token)
+        body  <- resp.body.asString
+        stats <- ZIO.fromEither(body.fromJson[DashboardStats])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(stats.totalToday == 3) &&
+        assertTrue(stats.blockedToday == 2) &&
+        assertTrue(stats.topBlocked.find(_.host.value == "badsite.com").exists(_.count == 2))
+    },
+    // #1837: cross-check the rollup-backed 24h counts equal the legacy raw 24h
+    // scan for a stable window — the "no accuracy regression" guard. All events
+    // sit in one recent hour bucket and are non-multicast, so the hourly SUM
+    // equals the raw COUNT exactly.
+    test("GET /api/stats 24h counts equal the raw 24h scan for a stable window (#1837)") {
+      for {
+        _          <- cleanDb
+        routerId   <- seedRouter()
+        connRepo   <- ZIO.service[ConnectionEventRepo]
+        upRepo     <- ZIO.service[UserProfileRepo]
+        auth       <- makeAuth
+        token      <- auth.login("admin", "changeme").map(_.token.value)
+        _          <- connRepo.insertBatch(
+          List(
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "google.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:02", "badsite.com", allowed = false),
+            ceFqdn(routerId, "aa:bb:cc:00:00:02", "badsite.com", allowed = false),
+            ceFqdn(routerId, "aa:bb:cc:00:00:02", "ads.example", allowed = false),
+          ),
+        )
+        xa         <- ZIO.service[Transactor[Task]]
+        rawTotal   <-
+          sql"SELECT COUNT(*)::INT FROM connection_events WHERE ts > NOW()-INTERVAL '24 hours'"
+            .query[Int]
+            .unique
+            .transact(xa)
+        rawBlocked <-
+          sql"SELECT COUNT(*)::INT FROM connection_events WHERE ts > NOW()-INTERVAL '24 hours' AND NOT allowed"
+            .query[Int]
+            .unique
+            .transact(xa)
+        _          <- connRepo.rerollConnEventsHourly(Instant.now().minusSeconds(7200))
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp  <- getJson(routes, "/api/stats", token)
+        body  <- resp.body.asString
+        stats <- ZIO.fromEither(body.fromJson[DashboardStats])
+      } yield assertTrue(stats.totalToday == rawTotal) &&
+        assertTrue(stats.blockedToday == rawBlocked) &&
+        assertTrue(stats.totalToday == 5 && stats.blockedToday == 3)
+    },
     test("GET /api/stats topBlocked is sorted by frequency descending") {
       for {
         _        <- cleanDb

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -647,6 +647,35 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Dashboard /api/stats 24h query p95 (rollup-backed, #1837)",
+      "description": "histogram_quantile(0.95, ...) of db_query_duration_seconds_bucket for the dashboard's rollup-backed 24h aggregations — op ∈ {stats.total24h, stats.blocked24h, stats.topBlocked24h}, emitted by DbMetrics.timed in ConnectionEventRepoLive.stats. #1837 (#1098) re-pointed these from a raw 24h scan of the weekly-partitioned connection_events table to the connection_events_hourly rollup (#809/#1265); prod EXPLAIN: single idx_ce_hourly_bucket_start index scan (~1.8ms) vs the old per-partition bitmap fan-out (~7.9ms planning + 4.8ms exec). A sustained climb here is the leading indicator the rollup read regressed (e.g. a missing index after a schema change) — the same #809-class regression the by-op panels above watch generically, isolated to the stats path that gates dashboard render.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 48 },
+      "id": 30,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(db_query_duration_seconds_bucket{op=~\"stats\\\\..*24h\", env=\"$env\"}[5m])))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -822,18 +822,19 @@ case class GrantExtensionRequest(
     note: Option[String],
 ) derives JsonCodec
 
+// #1837: `perDevice` (per-device 24h volume leaderboard) was dropped from the
+// dashboard in #1836 — that data belongs on /devices + /profiles, not a security
+// panel. The field and its now-dead raw 24h scan are removed; the 24h aggregations
+// below ride the connection_events rollup (see ConnectionEventRepoLive.stats).
 case class DashboardStats(
     totalToday: Int,
     blockedToday: Int,
     totalHour: Int,
     blockedHour: Int,
     topBlocked: List[DomainCount],
-    perDevice: List[DeviceStats],
 ) derives JsonCodec
 
 case class DomainCount(host: HostId, count: Int) derives JsonCodec
-case class DeviceStats(mac: MacAddress, deviceName: String, total: Int, blocked: Int)
-    derives JsonCodec
 
 // ── Connection-events aggregation (#847) ───────────────────────────────────
 // Bucket widths supported by /api/connection-events/series. "off" = caller

--- a/web-marketing/site/index.html
+++ b/web-marketing/site/index.html
@@ -469,6 +469,59 @@
       .qrow .bk {
         color: var(--red);
       }
+      /* #1837 redesign mirror: freshness pill, live bandwidth, blocking-activity rows */
+      .lbl .fresh {
+        font-family: 'Inter', sans-serif;
+        font-weight: 400;
+        text-transform: none;
+        letter-spacing: 0;
+        color: var(--muted);
+        font-size: 11px;
+        margin-left: 8px;
+      }
+      .bw {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        background: #fff;
+        border: 1px solid var(--b);
+        border-radius: 14px;
+        padding: 10px 14px;
+        margin-bottom: 18px;
+        font-family: ui-monospace, Menlo, monospace;
+        font-size: 13px;
+        color: var(--slate);
+      }
+      .bw .k {
+        font-family: 'Inter', sans-serif;
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .barow {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 14px;
+        border-bottom: 1px solid rgba(229, 221, 201, 0.6);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+      }
+      .barow:last-child {
+        border-bottom: 0;
+      }
+      .barow .h {
+        color: var(--slate);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .barow .bk {
+        color: var(--red);
+        font-weight: 600;
+      }
       /* Block-page preview */
       .blockpage {
         background: var(--offwhite);
@@ -676,39 +729,43 @@
                   </div>
                   <div class="app-body">
                     <h1 class="app-h1">Dashboard</h1>
-                    <p class="lbl">Now</p>
+                    <!-- Status-first KPI strip, above NOW (#1834): Online now / Blocked now / Events (1h) / Blocked (1h). -->
+                    <div class="stats">
+                      <div class="stat"><p class="k">Online now</p><p class="v acc">3</p></div>
+                      <div class="stat"><p class="k">Blocked now</p><p class="v red">1</p></div>
+                      <div class="stat"><p class="k">Events (1h)</p><p class="v">540</p></div>
+                      <div class="stat"><p class="k">Blocked (1h)</p><p class="v amb">22</p></div>
+                    </div>
+                    <!-- Live household bandwidth (#747). -->
+                    <div class="bw"><span class="k">Bandwidth</span><span>▲ 2.4 MB/s</span><span>▼ 18 MB/s</span></div>
+                    <p class="lbl">Now <span class="fresh">updated 12s ago · live ●</span></p>
                     <div class="pcards">
                       <div class="pcard live">
                         <h4>Kids</h4>
                         <div class="dev">
-                          <div class="row"><span class="nm">Maya's iPad</span><span class="ago">2m ago</span></div>
+                          <div class="row"><span class="nm">Maya's iPad</span></div>
                           <p class="watch">watching <b>youtube.com</b> · 14m</p>
                         </div>
                       </div>
                       <div class="pcard live">
                         <h4>Teens</h4>
                         <div class="dev">
-                          <div class="row"><span class="nm">Leo's Laptop</span><span class="ago">just now</span></div>
+                          <div class="row"><span class="nm">Leo's Laptop</span></div>
                           <p class="watch">watching <b>discord.com</b> · 3m</p>
                         </div>
                       </div>
                     </div>
-                    <div class="stats">
-                      <div class="stat"><p class="k">Queries today</p><p class="v acc">8,412</p></div>
-                      <div class="stat"><p class="k">Blocked today</p><p class="v red">326</p></div>
-                      <div class="stat"><p class="k">Queries (1h)</p><p class="v">540</p></div>
-                      <div class="stat"><p class="k">Blocked (1h)</p><p class="v amb">22</p></div>
-                    </div>
+                    <!-- Merged ranked-blocked-host panel (#1836), rollup-backed over 24h (#1837). -->
                     <div class="qtable">
-                      <div class="qh">Recent queries</div>
-                      <div class="qrow"><span class="t">4:12:08</span><span class="d">Maya's iPad</span><span class="h">i.ytimg.com</span><span class="ok">✓ ok</span></div>
-                      <div class="qrow"><span class="t">4:12:03</span><span class="d">Leo's Laptop</span><span class="h">tiktok.com</span><span class="bk">✗ blocked</span></div>
-                      <div class="qrow"><span class="t">4:11:54</span><span class="d">Living Room TV</span><span class="h">api.netflix.com</span><span class="ok">✓ ok</span></div>
+                      <div class="qh">Blocking activity (24h)</div>
+                      <div class="barow"><span class="h">tiktok.com</span><span class="bk">42</span></div>
+                      <div class="barow"><span class="h">doubleclick.net</span><span class="bk">17</span></div>
+                      <div class="barow"><span class="h">roblox.com</span><span class="bk">9</span></div>
                     </div>
                   </div>
                 </div>
               </div>
-              <p class="preview-cap">The household dashboard — live activity, daily counts, and a rolling query feed.</p>
+              <p class="preview-cap">The household dashboard — who's online now, live bandwidth, and the day's blocking activity at a glance.</p>
             </div>
 
             <!-- Kid-side block page -->

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -32,9 +32,6 @@ const stats: DashboardStats = {
     { host: { type: 'fqdn', value: 'evil.com' }, count: 42 },
     { host: { type: 'fqdn', value: 'ads.example' }, count: 17 },
   ],
-  perDevice: [
-    { mac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", total: 500, blocked: 20 },
-  ],
 }
 
 // #1338: a recent connection-layer drop, returned by /api/logs?blocked=true.
@@ -302,6 +299,37 @@ describe('DashboardPage', () => {
     const now   = await screen.findByTestId('now-section')
     const comparison = strip.compareDocumentPosition(now)
     expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  // ── #1837 (#1098): per-section skeletons — NOW paints independent of stats ──
+  it('paints NOW independently — does not gate the whole page on stats (#1837/#1098)', async () => {
+    // stats never resolves; the page must NOT block on it (the old page-level
+    // PageLoader gated the whole render on Promise resolution).
+    mockStats().mockReturnValue(new Promise<DashboardStats>(() => {}))
+    mockNow().mockResolvedValue(liveNow)
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    // NOW + its live card paint without waiting on stats.
+    expect(await screen.findByTestId('now-section')).toBeInTheDocument()
+    expect(await screen.findByTestId('now-profile-1')).toBeInTheDocument()
+    // The 24h Blocking activity panel shows a skeleton — never placeholder zeros
+    // or a premature "zero blocks" empty state (the #1098 anti-pattern).
+    expect(screen.getByTestId('blocking-activity-skeleton')).toBeInTheDocument()
+    expect(screen.queryByText(/0 hosts/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('No blocked connection events in the last 24h'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows a skeleton (never "0") on the stats-backed 1h tiles until stats resolves (#1837)', async () => {
+    mockStats().mockReturnValue(new Promise<DashboardStats>(() => {}))
+    mockNow().mockResolvedValue(kpiNow)
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    const strip = await screen.findByTestId('kpi-strip')
+    // Live KPIs derived from the NOW snapshot paint immediately (onlineNow=3).
+    await waitFor(() => expect(within(strip).getByText('3')).toBeInTheDocument())
+    // The stats-backed Events(1h)/Blocked(1h) tiles render a skeleton, not "0".
+    expect(within(strip).queryByText('0')).not.toBeInTheDocument()
+    expect(within(strip).getAllByTestId('stat-skeleton').length).toBeGreaterThan(0)
   })
 
   it('renders the Most Recently Blocked panel above the Now section (#1338)', async () => {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -431,14 +431,14 @@ function formatDuration(seconds: number): string {
 function KpiStrip({ stats }: { stats: DashboardStats | null }) {
   const { data: now = null } = useDashboardNow({ refetchInterval: false })
   const kpis = deriveNowKpis(now)
-  // #1837: Online now / Blocked now derive from the NOW snapshot and paint as soon
-  // as that resolves — independent of `stats`. The Events(1h)/Blocked(1h) tiles are
-  // stats-backed, so they pass `null` until stats resolves and render a skeleton
-  // rather than a placeholder "0" (the #1098 false-all-clear).
+  // #1837: every tile passes `null` until its source resolves and renders a
+  // skeleton rather than a placeholder "0" (the #1098 false-all-clear) — Online
+  // now / Blocked now until the NOW snapshot arrives, Events(1h)/Blocked(1h) until
+  // `stats` does. Both sources are independent, so each tile paints on its own.
   return (
     <div data-testid="kpi-strip" className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <StatCard label="Online now"   value={kpis.onlineNow}  accent="emerald" />
-      <StatCard label="Blocked now"  value={kpis.blockedNow} accent="red" />
+      <StatCard label="Online now"   value={now === null ? null : kpis.onlineNow}  accent="emerald" />
+      <StatCard label="Blocked now"  value={now === null ? null : kpis.blockedNow} accent="red" />
       <StatCard label="Events (1h)"  value={stats?.totalHour ?? null}   accent="emerald" />
       <StatCard label="Blocked (1h)" value={stats?.blockedHour ?? null} accent="yellow" />
     </div>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -18,22 +18,23 @@ import { LiveBadge } from '@/components/dashboard/LiveBadge'
 import { BandwidthGauges } from '@/components/dashboard/BandwidthGauges'
 
 export function DashboardPage() {
-  const [stats,  setStats]  = useState<DashboardStats | null>(null)
-  const [loading, setLoading] = useState(true)
+  // #1837 (#1098): per-section skeletons replace the page-level PageLoader that
+  // gated the WHOLE render on api.logs.stats(). The live sections (NOW, Recently
+  // Blocked, Bandwidth) are independently sourced (ws push + poll) and paint
+  // immediately; only the stats-backed 24h panel and the 1h KPI tiles wait on
+  // `stats`, and they show skeletons — never placeholder zeros (the #1098
+  // anti-pattern) — until it resolves. `stats === null` is the loading state.
+  const [stats, setStats] = useState<DashboardStats | null>(null)
 
   useEffect(() => {
-    api.logs.stats()
-      .then(setStats)
-      .finally(() => setLoading(false))
+    api.logs.stats().then(setStats).catch(() => { /* keep skeleton on error */ })
   }, [])
-
-  if (loading) return <PageLoader />
 
   return (
     <div className="space-y-6">
       <h1 className="text-xl font-bold text-brand-ink">Dashboard</h1>
 
-      {stats && <KpiStrip stats={stats} />}
+      <KpiStrip stats={stats} />
 
       <NewDevicesHint />
 
@@ -45,7 +46,7 @@ export function DashboardPage() {
 
       <NowSection />
 
-      {stats && <BlockingActivitySection stats={stats} />}
+      <BlockingActivitySection stats={stats} />
     </div>
   )
 }
@@ -61,7 +62,27 @@ export function DashboardPage() {
 // an empty 24h renders a single honest line, not two empty cards (design §7).
 // Per-host → "which devices triggered it" expansion is out of scope for v1 —
 // `topBlocked` carries no per-device linkage (design §7 Q3).
-function BlockingActivitySection({ stats }: { stats: DashboardStats }) {
+function BlockingActivitySection({ stats }: { stats: DashboardStats | null }) {
+  // #1837: until the (now rollup-backed) 24h stats resolve, show a skeleton — not
+  // a "0 hosts · 0 blocked events" subtitle, which would flash a false all-clear
+  // before the real numbers arrive (#1098). The header stays so the panel doesn't
+  // jump on resolve.
+  if (stats === null) {
+    return (
+      <section className="bg-white rounded-2xl border border-brand-border p-5">
+        <div className="flex items-baseline justify-between gap-3 mb-4">
+          <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">
+            Blocking activity (24h)
+          </h2>
+        </div>
+        <div data-testid="blocking-activity-skeleton" className="space-y-2" aria-hidden>
+          <div className="h-5 bg-brand-border/60 rounded animate-pulse" />
+          <div className="h-5 bg-brand-border/60 rounded animate-pulse w-4/5" />
+          <div className="h-5 bg-brand-border/60 rounded animate-pulse w-3/5" />
+        </div>
+      </section>
+    )
+  }
   const hostCount = stats.topBlocked.length
   const eventCount = stats.topBlocked.reduce((sum, d) => sum + d.count, 0)
   return (
@@ -407,20 +428,24 @@ function formatDuration(seconds: number): string {
 // (refetchInterval:false; NowSection drives the refresh, both observers re-render).
 // The cumulative "today" volume tiles are dropped: daily volume is analytics and
 // lives on /usage/events (design §2 non-goals).
-function KpiStrip({ stats }: { stats: DashboardStats }) {
+function KpiStrip({ stats }: { stats: DashboardStats | null }) {
   const { data: now = null } = useDashboardNow({ refetchInterval: false })
   const kpis = deriveNowKpis(now)
+  // #1837: Online now / Blocked now derive from the NOW snapshot and paint as soon
+  // as that resolves — independent of `stats`. The Events(1h)/Blocked(1h) tiles are
+  // stats-backed, so they pass `null` until stats resolves and render a skeleton
+  // rather than a placeholder "0" (the #1098 false-all-clear).
   return (
     <div data-testid="kpi-strip" className="grid grid-cols-2 md:grid-cols-4 gap-4">
       <StatCard label="Online now"   value={kpis.onlineNow}  accent="emerald" />
       <StatCard label="Blocked now"  value={kpis.blockedNow} accent="red" />
-      <StatCard label="Events (1h)"  value={stats.totalHour}  accent="emerald" />
-      <StatCard label="Blocked (1h)" value={stats.blockedHour} accent="yellow" />
+      <StatCard label="Events (1h)"  value={stats?.totalHour ?? null}   accent="emerald" />
+      <StatCard label="Blocked (1h)" value={stats?.blockedHour ?? null} accent="yellow" />
     </div>
   )
 }
 
-function StatCard({ label, value, accent }: { label: string; value: number; accent: string }) {
+function StatCard({ label, value, accent }: { label: string; value: number | null; accent: string }) {
   const colors: Record<string, string> = {
     emerald: 'text-brand-accent',
     red: 'text-red-700',
@@ -429,7 +454,10 @@ function StatCard({ label, value, accent }: { label: string; value: number; acce
   return (
     <div className="bg-white rounded-2xl border border-brand-border p-5">
       <p className="text-xs font-semibold text-brand-text-muted uppercase tracking-wider mb-2">{label}</p>
-      <p className={`text-3xl font-bold ${colors[accent] ?? 'text-brand-ink'}`}>{value}</p>
+      {value === null
+        ? <div data-testid="stat-skeleton" className="h-9 w-16 bg-brand-border/60 rounded animate-pulse" aria-hidden />
+        : <p className={`text-3xl font-bold ${colors[accent] ?? 'text-brand-ink'}`}>{value}</p>
+      }
     </div>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -277,7 +277,6 @@ export interface DashboardStats {
   totalHour: number
   blockedHour: number
   topBlocked: DomainCount[]
-  perDevice: DeviceStats[]
 }
 
 export interface DashboardNowHost {
@@ -316,13 +315,6 @@ export interface DashboardNow {
 export interface DomainCount {
   host: HostId
   count: number
-}
-
-export interface DeviceStats {
-  mac: string
-  deviceName: string
-  total: number
-  blocked: number
 }
 
 export interface AppUsage {


### PR DESCRIPTION
Final chunk (5/5) of the `/dashboard` holistic redesign (umbrella #1148, design `docs/design/dashboard-redesign.md` §7.4 chunk 5). Addresses the perceived-latency input #1098 for the 24h panels. Backend rollup-back + frontend per-section skeletons + marketing-preview refresh.

## Backend — rollup-back the 24h aggregations
`/api/stats` `totalToday` / `blockedToday` / `topBlocked` now read the pre-aggregated **`connection_events_hourly`** rollup (#1265 / #809) instead of a raw 24h scan of the weekly-partitioned `connection_events` table (`ConnectionEventRepoLive.stats`, `api/src/db/Repos.scala`).

- **1h tiles (`totalHour`/`blockedHour`) and the "Most Recently Blocked" feed stay on the raw tail** — they legitimately need it.
- **`perDevice` removed, not re-pointed** — per-device 24h volume was dropped from the dashboard in #1836 (it belongs on /devices + /profiles), so the field, its raw scan, and the `DeviceStats` model are deleted.
- **No new index needed** — the existing `idx_ce_hourly_bucket_start` covers the window scan.
- **Two intentional behavioural notes** (documented at the call site): the rollup excludes multicast at write time (so totals omit multicast the raw scan counted — equal on a multicast-free window); and the rollup drops `host_type`, so `topBlocked` re-infers the `HostId` kind from the hostname string (`hostIdFromRollup`).
- **Window freshness:** the hourly reroll lags up to ~1h (`RollupJobs.HourlyInterval`); acceptable because the 24h panel is explicitly request/response, not realtime (design §8.2).

### Query plan — proven at prod scale (read-only `EXPLAIN (ANALYZE, BUFFERS)`)
Prod `connection_events_hourly`: 132,458 rows / 42 MB; the 24h window touches **1,607** rollup rows (vs **8,789** raw events).

**NEW `totalToday` (rollup):**
```
Aggregate (actual time=0.885..0.886 rows=1)
  -> Index Scan using idx_ce_hourly_bucket_start on connection_events_hourly (actual time=0.016..0.712 rows=1607)
       Index Cond: (bucket_start > (now() - '24:00:00'::interval))
Execution Time: 0.994 ms
```
**NEW `topBlocked` (rollup):** single `idx_ce_hourly_bucket_start` index scan → HashAggregate → top-N heapsort, **Execution Time: 1.831 ms** (~280 shared buffers).
**OLD `topBlocked` (raw 24h scan), for comparison:** bitmap-index probe fanned across **every weekly partition** (`connection_events_2026_33…36`, an 80-row plan), **Planning Time: 7.910 ms + Execution Time: 4.835 ms**.

The rollup eliminates the per-partition pruning overhead and is the #809-class win.

### Accuracy cross-check (no regression)
Pinned in `LogApiSpec`: seed → roll into `connection_events_hourly` → assert the rollup-backed `totalToday`/`blockedToday` **equal the raw 24h `COUNT`** for a stable window, and a second test that wipes raw after rolling to prove the 24h fields are rollup-sourced (the 1h tiles correctly read 0 after the wipe).

### Metrics + dashboard
New query path instrumented via `DbMetrics.timed` → `db_query_duration_seconds` / `db_queries_total`, `op ∈ {stats.total24h, stats.blocked24h, stats.topBlocked24h}`. Added a focused p95 panel (`op=~"stats\..*24h"`) on the `api-self-metrics` Grafana dashboard targeting exactly those series (`metrics-need-a-dashboard` gate; dashboard already registered in `infra/grafana/main.tf`).

## Frontend — per-section skeletons
Dropped the page-level `PageLoader` that gated the whole dashboard on `api.logs.stats()`. NOW / Recently Blocked / Bandwidth are independently sourced (ws push + poll) and now paint immediately. Only the rollup-backed 24h Blocking-activity panel and the stats-backed Events(1h)/Blocked(1h) tiles wait on `stats`, and they render **skeletons — never placeholder zeros** or a premature zero-blocks empty state (the #1098 anti-pattern). Online now / Blocked now keep deriving from the NOW snapshot. `PageLoader` stays exported (other pages use it).

## Marketing preview
Refreshed the "See it in action" dashboard preview in `web-marketing/site/index.html` to mirror the shipped redesign: status-first KPI strip → live bandwidth → NOW (single freshness pill) → merged "Blocking activity (24h)" panel; dropped the old cumulative "Queries today" tiles and "Recent queries" firehose; connection-events terminology. (#1837 checkbox / #1148.)

## Tests
- `mill api.test` — green (incl. new `LogApiSpec` rollup-sourcing + accuracy tests). `mill shared.test` green.
- `npm --prefix web run lint` + `npx vitest run` (520 tests) + `npm run build` — green (incl. new DashboardPage skeleton tests).
- RED→GREEN commits visible in history for both backend and frontend.

Closes input #1098. Parent #1148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
