### PR TITLE
feat(#2058): extend Eaglercraft app host-set with eaglercraft.com mirror

### DIFF
--- a/.claude/skills/app-catalog-pass/SKILL.md
+++ b/.claude/skills/app-catalog-pass/SKILL.md
@@ -172,6 +172,24 @@ above is now wrong, fix the step too — don't just log around it.
 
 ## Learnings log (newest first)
 
+- **2026-06-29 (#2058)** — A mature catalog means the typical pass yields ZERO
+  new apps: every >1 MB uncovered apex was shared infra/CDN, ad-tech/RTB,
+  shared corporate (Adobe/Autodesk), or analytics/support. The valuable finding
+  was an **existing**-app host-set gap — a *mirror domain* of an already-templated
+  game (`eaglercraft.com` vs the templated `eaglercraft.dev`) the kids hit but
+  that was unattributed. Always run the coverage sweep against `_index.yml` slugs
+  AND the per-app host-sets, not just slugs: a covered slug can still be missing
+  observed brand domains. Extending an app's host-set is a fully valid pass outcome.
+- **2026-06-29 (#2058)** — Distinguish a "game host" from an "unblocked-games
+  proxy portal" before routing. A single-game mirror that serves the game
+  directly (eaglercraft.com/play) extends the app; only multi-proxy / filter-bypass
+  hubs (TitaniumNetwork stack, now.gg, duckmath) go to `games.yml`-only. When a
+  brand the operator already chose to template as an app (#1705) shows a new mirror
+  apex, keep it in the app for consistency — don't reclassify it to a blocklist.
+- **2026-06-29 (#2058)** — YouTube-to-MP3 rippers (`ytmp3.gg`) surface as
+  high-byte / very-low-hit (3.5 MB, 1 hit = one download). No clean piracy
+  category list exists; treat as below-bar incidental and skip-with-note rather
+  than forcing it into games/ads.
 - **2026-06-23 (#1922)** — #1796 IPv6-attribution gap is FIXED (#1807/#1802
   merged); sample is no longer IPv4-biased. Step 0 caveat updated. A site #1815
   skipped as "below bar / IPv4-biased" (mathplayground.com, 181 kB → now 894 kB

--- a/api/resources/app_templates/eaglercraft.yml
+++ b/api/resources/app_templates/eaglercraft.yml
@@ -7,6 +7,13 @@ icon_type: url
 # workers.dev subdomain is the actual game runtime — included specifically
 # because it's account-scoped (NOT the shared workers.dev apex, which would
 # be a #1661 violation).
+# eaglercraft.com added from prod evidence (#2058 app-catalog pass): a direct
+# game mirror of the same Eaglercraft browser-Minecraft project (serves the
+# launcher at eaglercraft.com/play), observed in active kid use but unattributed
+# to this app. It's a game host, not an "unblocked games" proxy portal, so it
+# extends the app host-set (not games.yml) per the operator's #1705 decision
+# that Eaglercraft is a time-limited app, not a block target.
 hosts:
   - eaglercraft.dev
+  - eaglercraft.com
   - eaglercraft-99f.workers.dev

--- a/api/resources/app_templates/evidence/classification-2058.md
+++ b/api/resources/app_templates/evidence/classification-2058.md
@@ -1,0 +1,54 @@
+# App-catalog pass — classification (#2058, 2026-06-29)
+
+Traffic-driven pass via the `app-catalog-pass` skill. Source:
+`GET /api/devices/<mac>/recent-apexes?windowDays=30&limit=500` aggregated by
+apex across the four kid devices (Kid Mac, Octavius / Prima / Quintus iPads),
+prod cloud API. IPv6 attribution confirmed healthy (#1796 closed; #1807/#1802
+merged) so the sample is not IPv4-biased.
+
+## Disposition
+
+The catalog is mature: every uncovered apex in the >1 MB band is shared
+infra/CDN, ad-tech/RTB, shared corporate (Adobe/Autodesk), or analytics/support.
+The only genuine gap is on an **existing** app.
+
+| apex | bytes | hits | disposition |
+|------|------:|-----:|-------------|
+| `eaglercraft.com` | 521 KB | 9 | **Extend `eaglercraft.yml`** — direct mirror of the already-templated Eaglercraft browser-Minecraft game |
+| `ytmp3.gg` (`dmca.`) | 3.5 MB | 1 | Skip — YouTube-to-MP3 ripper, single incidental download, below engagement bar, no clean category list |
+| Apple/Google/Amazon infra (cdn-apple, icloud-content, gstatic, gvt2/gvt3, mzstatic, aaplimg, akadns, amazonaws, ssl-images-amazon, googleusercontent, media-amazon, edge.apple, …) | — | — | Skip — shared CDN / platform infra |
+| Adobe / Autodesk (`adobe.com`, `adobe.io`, `autodesk.com`) | — | — | Skip — shared corporate infra (per skill) |
+| Ad-tech / RTB (flashtalking, innovid, adsrvr, pubmatic, casalemedia, sharethrough, amazon-adsystem, the-ozone-project, nextmillmedia, responsiveads, admanmedia, id5-sync, indexww, nitropay, adlightning, acuityplatform, intentiq, infolinks, fastclick, a-mo.net, dblks, a47b, marphezis, ingage.tech, ay.delivery, cootlogix, …) | — | — | Skip — ad/RTB networks |
+| Analytics / support (sentry, posthog, segment, quantummetric, zendesk, nr-data, ada.support, disqus, medallia, intercomassets) | — | — | Skip — telemetry/support collateral |
+| Payments / shopping (stripe, paypal, temu, amazon) | — | — | Skip — collateral / no app surface |
+| `tenor.com`, `pexels.com`, `fontawesome.com`, `ctfassets.net` | <1 MB | — | Skip — shared media/asset CDNs |
+
+## eaglercraft.com — why extend the app (not games.yml, not new app)
+
+- **Same project as the existing `eaglercraft` app.** Web-confirmed
+  (`eaglercraft.com/`, `eaglercraft.com/play`) as a direct host of the
+  open-source Eaglercraft browser-Minecraft game — the same kid-discovered
+  Minecraft-in-browser clone templated in #1705 (which scoped only
+  `eaglercraft.dev` + the account-scoped `eaglercraft-99f.workers.dev` runtime).
+- **It is a game host, not an "unblocked games" proxy portal.** The skill routes
+  filter-bypass / multi-proxy hubs to `games.yml` only. eaglercraft.com serves
+  the game itself, not a TitaniumNetwork-style proxy stack, so the proxy-only
+  rule does not apply.
+- **Operator decision #1705 stands: Eaglercraft is a time-limited app, not a
+  block target.** A mirror of the same experience belongs in the same app
+  host-set so the kid's play is attributed and counts toward the Eaglercraft
+  time budget / allow-block surface. `games.yml` has no eaglercraft entry; this
+  pass keeps it that way for consistency.
+
+## Host-set coverage check
+
+`eaglercraft.com` is a bare apex with no observed subdomains, so the single apex
+entry suffices. `HostMatch.matchesApex` suffix-matches the entry's own subtree,
+so any future `*.eaglercraft.com` is covered without further entries. No shared
+CDN/anycast collateral pulled in.
+
+## Outcome
+
+One-host extension to `api/resources/app_templates/eaglercraft.yml`
+(`+ eaglercraft.com`). No new slug → no `_index.yml` / `AppTemplatesSpec` change.
+No blocklist changes this pass.


### PR DESCRIPTION
Weekly traffic-driven app-catalog pass (`/app-catalog-pass` skill).

## What & why
30-day `recent-apexes` window across the four kid devices. The catalog is mature — every uncovered apex in the >1 MB band is shared infra/CDN, ad-tech/RTB, shared corporate (Adobe/Autodesk), or analytics/support. The single genuine gap is on an **existing** app:

- **`eaglercraft.com`** (521 KB / 9 hits, bare apex) — web-confirmed direct host of the Eaglercraft browser-Minecraft game (`eaglercraft.com/play`), the same project already templated as the `eaglercraft` app (#1705, which scoped only `eaglercraft.dev` + the account-scoped `eaglercraft-99f.workers.dev` runtime). Kids actively use this mirror but it was unattributed to the app, so it escaped the Eaglercraft time budget / allow-block surface.

It's a game host, **not** a multi-proxy "unblocked games" portal, so it extends the app host-set rather than going to `games.yml`-only — consistent with the operator's #1705 decision that Eaglercraft is a time-limited app, not a block target. `games.yml` has no eaglercraft entry; this pass keeps it that way.

## Scope
- `eaglercraft.yml`: `+ eaglercraft.com` (one host). No new slug → `_index.yml` / `AppTemplatesSpec` unchanged. `AppTemplatesSpec` passes (eaglercraft now seeds `hosts=3`).
- Evidence: `api/resources/app_templates/evidence/classification-2058.md` (full per-apex disposition table).
- Mandatory Step-6 skill self-update appended to `SKILL.md` (newest-first learnings).
- No blocklist changes.

## Noted & skipped
- `ytmp3.gg` (3.5 MB but **1 hit**) — YouTube ripper, single incidental download, no clean category list. Skip.
- All other >1MB uncovered apexes: Apple/Google/Amazon infra, ad-tech/RTB, shared corporate CDN, analytics/support.

Relates to #2058

🤖 Generated with [Claude Code](https://claude.com/claude-code)