### PR TITLE
feat(#1976): ws-spa S7 — retire time-status adaptive ladder (flat 10s disconnected fallback)

### DIFF
--- a/docs/design/spa-websocket.md
+++ b/docs/design/spa-websocket.md
@@ -389,13 +389,18 @@ useDashboardNow({ refetchInterval: wsLive ? false : 10_000 })
 
 Socket healthy → interval paused, pushes drive updates; socket down/reconnecting →
 interval resumes at today's cadence. The **time-usage adaptive ladder**
-(`TIME_STATUS_REFETCH_LADDER`) is the clearest case: it stays exactly as-is as the
-disconnected fallback, but goes dormant while the `timeStatus` push is live —
-and is the prime candidate for full retirement (§9, **S7**) since its entire
-reason for existing is the absence of a push. The redundant intervals are retired
-only at the *end* of the rollout, per-view, after each view's push path is proven.
-Live throughput (class 1) has no poll fallback — it simply shows "—" while
-disconnected.
+(formerly `TIME_STATUS_REFETCH_LADDER`) was the clearest case: it stayed the
+disconnected fallback through S6a but went dormant while the `timeStatus` push was
+live — and was retired in **S7** ([#1976](https://github.com/wifihaven/wifihaven/issues/1976)),
+its entire reason for existing being the absence of a push. **Post-S7 the
+time-status fallback is a single flat cadence** (`TIME_STATUS_FALLBACK_REFETCH_MS`,
+10 s — the dashboard live-surface fallback cadence) while disconnected: the push
+delivers near-cap urgency when live, so the fallback only keeps the degraded mode
+honest and no longer needs the ladder's adaptivity. The redundant intervals were
+retired only at the *end* of the rollout, per-view, after each view's push path was
+proven; the dashboard NOW / Recently-Blocked and the Traffic/Connection pages keep
+their `wsLive`-gated (or push-only, no-poll) freshness unchanged. Live throughput
+(class 1) has no poll fallback — it simply shows "—" while disconnected.
 
 ---
 

--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -20,7 +20,7 @@ import { api } from '@/api/client'
 import {
   useProfiles, useDevices, useTimeStatusToday, useTimeStatusSummary,
   useTimeStatusProfileToday, useInvalidators, qk,
-  TIME_STATUS_FALLBACK_REFETCH_MS,
+  LIVE_SURFACE_FALLBACK_REFETCH_MS,
 } from './queries'
 
 function makeWrapper(client: QueryClient) {
@@ -111,7 +111,7 @@ describe('SWR caching (#803)', () => {
 // The S6a `timeStatus` push (§3.1) drives freshness whenever the socket is live, so the
 // near-cap fast-poll the ladder existed for is redundant. What remains is a FLAT disconnected
 // fallback: while `wsLive` is false the live time-used hooks poll at a constant
-// TIME_STATUS_FALLBACK_REFETCH_MS so a near-cap "minutes left" can't lag enforcement during a
+// LIVE_SURFACE_FALLBACK_REFETCH_MS so a near-cap "minutes left" can't lag enforcement during a
 // socket outage (#1871). While `wsLive` is true the poll is paused entirely (the push is the
 // freshness). The immutable 'past'/'week' hooks never poll.
 describe('time-used disconnected fallback poll (#1976 — adaptive ladder retired)', () => {
@@ -133,7 +133,7 @@ describe('time-used disconnected fallback poll (#1976 — adaptive ladder retire
       render()
       await vi.advanceTimersByTimeAsync(0) // initial fetch resolves
       expect(fetchSpy).toHaveBeenCalledTimes(1)
-      await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS) // one flat interval
+      await vi.advanceTimersByTimeAsync(LIVE_SURFACE_FALLBACK_REFETCH_MS) // one flat interval
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
@@ -195,7 +195,7 @@ describe('time-used disconnected fallback poll (#1976 — adaptive ladder retire
       renderHook(() => useTimeStatusToday({ wsLive: true }), { wrapper })
       await vi.advanceTimersByTimeAsync(0)
       expect(statusAll).toHaveBeenCalledTimes(1) // initial fetch only
-      await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS * 5)
+      await vi.advanceTimersByTimeAsync(LIVE_SURFACE_FALLBACK_REFETCH_MS * 5)
       expect(statusAll).toHaveBeenCalledTimes(1) // push drives freshness; no poll
     } finally {
       vi.useRealTimers()

--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -20,7 +20,7 @@ import { api } from '@/api/client'
 import {
   useProfiles, useDevices, useTimeStatusToday, useTimeStatusSummary,
   useTimeStatusProfileToday, useInvalidators, qk,
-  timeStatusRefetchMs, TIME_STATUS_REFETCH_MAX_MS,
+  TIME_STATUS_FALLBACK_REFETCH_MS,
 } from './queries'
 
 function makeWrapper(client: QueryClient) {
@@ -107,109 +107,96 @@ describe('SWR caching (#803)', () => {
   })
 })
 
-// #1871: the live time-used surfaces must poll in the foreground so the
-// displayed "minutes left" can't lag enforcement (the router blocks within
-// seconds of the cap, but a query with only a staleTime never refetches on its
-// own). The cadence is ADAPTIVE — fast near a profile's cap, slow with lots of
-// time left. The immutable 'past'/'week' hooks must NOT poll.
-describe('time-used adaptive poll cadence (#1871)', () => {
-  // The ladder the operator asked for: ≤5m → 10s, ≤10m → 1m, ≤30m → 5m,
-  // beyond that (or no daily limit) → the 5m baseline.
-  it('maps remaining minutes to the poll interval', () => {
-    expect(timeStatusRefetchMs(0)).toBe(10_000)
-    expect(timeStatusRefetchMs(3)).toBe(10_000)
-    expect(timeStatusRefetchMs(5)).toBe(10_000)
-    expect(timeStatusRefetchMs(6)).toBe(60_000)
-    expect(timeStatusRefetchMs(10)).toBe(60_000)
-    expect(timeStatusRefetchMs(11)).toBe(300_000)
-    expect(timeStatusRefetchMs(30)).toBe(300_000)
-    expect(timeStatusRefetchMs(31)).toBe(TIME_STATUS_REFETCH_MAX_MS)
-    expect(timeStatusRefetchMs(120)).toBe(TIME_STATUS_REFETCH_MAX_MS)
-  })
-
-  it('treats no-daily-limit and past-cap edges sensibly', () => {
-    // No limit in force (null/undefined remaining) → slow baseline, not a tight poll.
-    expect(timeStatusRefetchMs(null)).toBe(TIME_STATUS_REFETCH_MAX_MS)
-    expect(timeStatusRefetchMs(undefined)).toBe(TIME_STATUS_REFETCH_MAX_MS)
-    // At/over the cap (a blocked profile) → fastest bucket, so a time extension
-    // or unblock surfaces within seconds.
-    expect(timeStatusRefetchMs(-5)).toBe(10_000)
-  })
-
-  // Behavioural: with fake timers, a hook fetched with a near-cap profile polls
-  // again after the fast 10s bucket. freshClient's long staleTime means an
-  // interval-driven refetch is the ONLY thing that can produce a second network
-  // call, so a missing/false refetchInterval makes the assertion fail.
+// #1976 (SPA-ws S7): the adaptive refetch ladder (TIME_STATUS_REFETCH_LADDER) is RETIRED.
+// The S6a `timeStatus` push (§3.1) drives freshness whenever the socket is live, so the
+// near-cap fast-poll the ladder existed for is redundant. What remains is a FLAT disconnected
+// fallback: while `wsLive` is false the live time-used hooks poll at a constant
+// TIME_STATUS_FALLBACK_REFETCH_MS so a near-cap "minutes left" can't lag enforcement during a
+// socket outage (#1871). While `wsLive` is true the poll is paused entirely (the push is the
+// freshness). The immutable 'past'/'week' hooks never poll.
+describe('time-used disconnected fallback poll (#1976 — adaptive ladder retired)', () => {
+  // Behavioural: freshClient's long staleTime means an interval-driven refetch is the ONLY
+  // thing that can produce a second network call, so a missing/false refetchInterval makes the
+  // assertion fail. The fallback is now FLAT — remaining-minutes no longer change the cadence.
   const nearCap = [{ profileId: 1, dailyLimitMins: 60, usedMins: 58, remainingMins: 2 }]
+  const farFromCap = [{ profileId: 1, dailyLimitMins: 240, usedMins: 10, remainingMins: 230 }]
 
-  async function expectFastPoll(
+  async function expectFlatPoll(
     seed: (v: unknown) => void,
+    rows: unknown,
     render: () => void,
     fetchSpy: ReturnType<typeof vi.fn>,
   ): Promise<void> {
-    seed(nearCap)
+    seed(rows)
     vi.useFakeTimers()
     try {
       render()
       await vi.advanceTimersByTimeAsync(0) // initial fetch resolves
       expect(fetchSpy).toHaveBeenCalledTimes(1)
-      await vi.advanceTimersByTimeAsync(10_000) // one fast-bucket interval
+      await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS) // one flat interval
       expect(fetchSpy).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
   }
 
-  it('useTimeStatusToday polls fast near the cap', async () => {
+  it('useTimeStatusToday polls at the flat fallback when disconnected — near cap', async () => {
     const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
     const wrapper = makeWrapper(freshClient())
-    await expectFastPoll(
-      v => statusAll.mockResolvedValue(v),
+    await expectFlatPoll(
+      v => statusAll.mockResolvedValue(v), nearCap,
       () => renderHook(() => useTimeStatusToday(), { wrapper }),
       statusAll,
     )
   })
 
-  it('useTimeStatusSummary polls fast near the cap', async () => {
+  // No backoff anymore: far-from-cap polls at the SAME flat cadence as near-cap. Pre-S7 the
+  // ladder backed this case off to a 5m baseline; that adaptivity is gone (the push handles
+  // near-cap urgency when live, so the disconnected fallback is a single flat cadence).
+  it('useTimeStatusToday polls at the flat fallback when disconnected — far from cap (no backoff)', async () => {
+    const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
+    const wrapper = makeWrapper(freshClient())
+    await expectFlatPoll(
+      v => statusAll.mockResolvedValue(v), farFromCap,
+      () => renderHook(() => useTimeStatusToday(), { wrapper }),
+      statusAll,
+    )
+  })
+
+  it('useTimeStatusSummary polls at the flat fallback when disconnected', async () => {
     const summaryAll = api.time.summaryAll as unknown as ReturnType<typeof vi.fn>
     const wrapper = makeWrapper(freshClient())
-    await expectFastPoll(
-      v => summaryAll.mockResolvedValue(v),
+    await expectFlatPoll(
+      v => summaryAll.mockResolvedValue(v), nearCap,
       () => renderHook(() => useTimeStatusSummary(), { wrapper }),
       summaryAll,
     )
   })
 
-  it('useTimeStatusProfileToday polls fast near the cap', async () => {
+  it('useTimeStatusProfileToday polls at the flat fallback when disconnected', async () => {
     const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
     const wrapper = makeWrapper(freshClient())
-    await expectFastPoll(
+    await expectFlatPoll(
       // single-row shape (the hook takes rows[0])
-      v => statusAll.mockResolvedValue(v),
+      v => statusAll.mockResolvedValue(v), nearCap,
       () => renderHook(() => useTimeStatusProfileToday(1), { wrapper }),
       statusAll,
     )
   })
 
-  // Adaptivity: with lots of time left, the hook does NOT poll on the fast
-  // cadence — it stays quiet until the slow baseline elapses.
-  it('backs off to the slow baseline with lots of time left', async () => {
+  // The push being live (`wsLive: true`) pauses the fallback entirely (§3.3) — no poll at all,
+  // even sitting right at a cap. The push, not a poll, is the freshness while connected.
+  it('pauses the fallback poll while the timeStatus push is live (wsLive)', async () => {
     const statusAll = api.time.statusAll as unknown as ReturnType<typeof vi.fn>
-    statusAll.mockResolvedValue([
-      { profileId: 1, dailyLimitMins: 240, usedMins: 10, remainingMins: 230 },
-    ])
+    statusAll.mockResolvedValue(nearCap)
     const wrapper = makeWrapper(freshClient())
     vi.useFakeTimers()
     try {
-      renderHook(() => useTimeStatusToday(), { wrapper })
+      renderHook(() => useTimeStatusToday({ wsLive: true }), { wrapper })
       await vi.advanceTimersByTimeAsync(0)
-      expect(statusAll).toHaveBeenCalledTimes(1)
-      // Fast-bucket interval elapses — still no refetch, because we're far from the cap.
-      await vi.advanceTimersByTimeAsync(60_000)
-      expect(statusAll).toHaveBeenCalledTimes(1)
-      // The slow baseline elapses — now it polls.
-      await vi.advanceTimersByTimeAsync(TIME_STATUS_REFETCH_MAX_MS)
-      expect(statusAll).toHaveBeenCalledTimes(2)
+      expect(statusAll).toHaveBeenCalledTimes(1) // initial fetch only
+      await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS * 5)
+      expect(statusAll).toHaveBeenCalledTimes(1) // push drives freshness; no poll
     } finally {
       vi.useRealTimers()
     }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -47,14 +47,17 @@ const STALE = {
 // ONLY because there was no push to deliver near-cap urgency promptly; with the push proven it is
 // retired (#1976/S7).
 //
-// What remains is the DISCONNECTED fallback: while the push is down (`wsLive === false`) the hooks
-// poll at this single FLAT cadence so a near-cap "minutes left" can't lag enforcement during a
-// socket outage. It is a constant — no longer adaptive — because the push (not a poll) is the
-// freshness when connected, so the fallback only has to keep the degraded mode honest. Foreground-
-// only (`refetchIntervalInBackground: false`) so hidden tabs don't poll. 10s matches the dashboard
-// NOW / Recently-Blocked disconnected fallback (DashboardPage `streaming ? false : 10_000`) — the
-// other live surfaces (design §0.1) — so every live surface degrades to the same cadence.
-export const TIME_STATUS_FALLBACK_REFETCH_MS = 10_000
+// What remains is the DISCONNECTED fallback: while the push is down (`wsLive === false`) the live
+// surfaces poll at this single FLAT cadence so a near-cap "minutes left" can't lag enforcement
+// during a socket outage. It is a constant — no longer adaptive — because the push (not a poll) is
+// the freshness when connected, so the fallback only has to keep the degraded mode honest.
+// Foreground-only (`refetchIntervalInBackground: false`) so hidden tabs don't poll.
+//
+// This is the ONE source for the live-surface disconnected fallback cadence (§0.1 — NOW,
+// Recently-Blocked, time-status): the dashboard NOW / Recently-Blocked hooks (`DashboardPage`) and
+// the time-status hooks below all reference it, so every live surface degrades to the same cadence
+// by construction rather than by hand-synced literals.
+export const LIVE_SURFACE_FALLBACK_REFETCH_MS = 10_000
 
 export const qk = {
   profiles: () => ['profiles'] as const,
@@ -236,7 +239,7 @@ export function useRecentBlocked(opts?: QueryOpts<QueryLog[]>) {
 
 // #1974 (S6a) / #1976 (S7, §3.3): when the `timeStatus` push is live (`wsLive`), polling pauses —
 // the push keeps the cache fresh. When the socket is down, the flat disconnected fallback
-// (`TIME_STATUS_FALLBACK_REFETCH_MS`) resumes the instant the socket drops; the adaptive ladder it
+// (`LIVE_SURFACE_FALLBACK_REFETCH_MS`) resumes the instant the socket drops; the adaptive ladder it
 // replaced was retired in S7 (the push delivers near-cap urgency when live). The caller passes
 // `wsLive` from `useWsTopicLive('timeStatus')`.
 export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]> & { wsLive?: boolean }) {
@@ -245,7 +248,7 @@ export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]> & { wsL
     queryKey: qk.timeStatusToday(),
     queryFn: () => api.time.statusAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: wsLive ? false : TIME_STATUS_FALLBACK_REFETCH_MS,
+    refetchInterval: wsLive ? false : LIVE_SURFACE_FALLBACK_REFETCH_MS,
     refetchIntervalInBackground: false,
     ...rest,
   })
@@ -282,7 +285,7 @@ export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]> & { 
     queryKey: qk.timeStatusSummaryToday(),
     queryFn: () => api.time.summaryAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: wsLive ? false : TIME_STATUS_FALLBACK_REFETCH_MS,
+    refetchInterval: wsLive ? false : LIVE_SURFACE_FALLBACK_REFETCH_MS,
     refetchIntervalInBackground: false,
     ...rest,
   })
@@ -313,7 +316,7 @@ export function useTimeStatusProfileToday(
     queryKey: qk.timeStatusProfileToday(profileId),
     queryFn: () => api.time.statusAll(undefined, profileId).then(rows => rows[0]),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: wsLive ? false : TIME_STATUS_FALLBACK_REFETCH_MS,
+    refetchInterval: wsLive ? false : LIVE_SURFACE_FALLBACK_REFETCH_MS,
     refetchIntervalInBackground: false,
     ...rest,
   })

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -38,66 +38,23 @@ const STALE = {
   devices: 5 * MIN,
 } as const
 
-// #1871 — live time-used surfaces must poll in the foreground so the displayed
-// "minutes left" can't lag enforcement. The router recomputes block state on
-// every ~5s snapshot poll and blocks within seconds of the cap, but a query
-// with only a staleTime never refetches on its own — it stays frozen from page
-// load until a manual trigger (reload / window refocus). Without a background
-// poll the UI shows minutes remaining while the profile is already blocked.
+// #1871 / #1976 (SPA-ws S7) — the live time-used surfaces must stay fresh so the displayed
+// "minutes left" can't lag enforcement (the router blocks within seconds of the cap, but a query
+// with only a staleTime never refetches on its own). Freshness is now driven by the S6a
+// `timeStatus` push (design §3.1) whenever the socket is live — and the hooks below PAUSE polling
+// in that case (`wsLive ? false : …`, §3.3). The adaptive refetch ladder this replaced
+// (`TIME_STATUS_REFETCH_LADDER`, keyed on the most-urgent profile's remaining minutes) existed
+// ONLY because there was no push to deliver near-cap urgency promptly; with the push proven it is
+// retired (#1976/S7).
 //
-// The cadence is *adaptive*: we only need a tight poll when a profile is close
-// to its daily cap (where a stale display would visibly disagree with
-// enforcement). With lots of time left, a fast poll is wasted load — so we slow
-// down. The ladder is keyed on the *most-urgent* profile's remaining minutes
-// (the one closest to its cap drives the whole list's cadence). Foreground-only
-// (refetchIntervalInBackground: false) so hidden tabs don't poll.
-//
-// `[thresholdMins, intervalMs]`, evaluated low-to-high — first row whose
-// threshold the remaining time is at/under wins.
-export const TIME_STATUS_REFETCH_LADDER: ReadonlyArray<readonly [number, number]> = [
-  [5, 10_000],   // ≤5m left  → poll every 10s
-  [10, 60_000],  // ≤10m left → poll every 1m
-  [30, 300_000], // ≤30m left → poll every 5m
-] as const
-// >30m left, or no daily limit at all (nothing counting down) → slow baseline.
-export const TIME_STATUS_REFETCH_MAX_MS = 300_000
-
-// Map a profile's remaining minutes to its poll interval. `null`/`undefined`
-// remaining means no daily limit is in force → baseline cadence. A profile at
-// or past its cap (remaining ≤ 0) lands in the fastest bucket so a time
-// extension / unblock shows up within seconds.
-export function timeStatusRefetchMs(remainingMins: number | null | undefined): number {
-  if (remainingMins == null) return TIME_STATUS_REFETCH_MAX_MS
-  const remaining = Math.max(0, remainingMins)
-  for (const [thresholdMins, intervalMs] of TIME_STATUS_REFETCH_LADDER) {
-    if (remaining <= thresholdMins) return intervalMs
-  }
-  return TIME_STATUS_REFETCH_MAX_MS
-}
-
-// The cadence-relevant slice of a time-status row — both ProfileTimeStatus and
-// ProfileTimeSummary carry these, and they're all we read to pick a poll rate.
-type CadenceRow = { dailyLimitMins?: number | null; remainingMins?: number | null }
-
-// The most-urgent (least remaining) capped profile across a freshly-fetched
-// time-status payload — `null` when no row has a daily limit. A row without a
-// `dailyLimitMins` isn't counting down, so it never drives the cadence.
-function minRemainingMins(rows: ReadonlyArray<CadenceRow>): number | null {
-  let min: number | null = null
-  for (const row of rows) {
-    if (row.dailyLimitMins == null) continue
-    const remaining = row.remainingMins ?? 0
-    if (min == null || remaining < min) min = remaining
-  }
-  return min
-}
-
-// react-query refetchInterval callback: normalize the query data (single row,
-// array of rows, or not-yet-loaded) and pick the adaptive interval.
-function timeStatusRefetchInterval(data: unknown): number {
-  const rows = (Array.isArray(data) ? data : data ? [data] : []) as ReadonlyArray<CadenceRow>
-  return timeStatusRefetchMs(minRemainingMins(rows))
-}
+// What remains is the DISCONNECTED fallback: while the push is down (`wsLive === false`) the hooks
+// poll at this single FLAT cadence so a near-cap "minutes left" can't lag enforcement during a
+// socket outage. It is a constant — no longer adaptive — because the push (not a poll) is the
+// freshness when connected, so the fallback only has to keep the degraded mode honest. Foreground-
+// only (`refetchIntervalInBackground: false`) so hidden tabs don't poll. 10s matches the dashboard
+// NOW / Recently-Blocked disconnected fallback (DashboardPage `streaming ? false : 10_000`) — the
+// other live surfaces (design §0.1) — so every live surface degrades to the same cadence.
+export const TIME_STATUS_FALLBACK_REFETCH_MS = 10_000
 
 export const qk = {
   profiles: () => ['profiles'] as const,
@@ -277,17 +234,18 @@ export function useRecentBlocked(opts?: QueryOpts<QueryLog[]>) {
   })
 }
 
-// #1974 (SPA-ws S6a, §3.3): when the `timeStatus` push is live (`wsLive`), the adaptive ladder goes
-// DORMANT — the push keeps the cache fresh, so polling is redundant. The ladder is NOT removed
-// (that's S7); it stays the disconnected fallback, resuming the instant the socket drops. The
-// caller passes `wsLive` from `useWsTopicLive('timeStatus')`.
+// #1974 (S6a) / #1976 (S7, §3.3): when the `timeStatus` push is live (`wsLive`), polling pauses —
+// the push keeps the cache fresh. When the socket is down, the flat disconnected fallback
+// (`TIME_STATUS_FALLBACK_REFETCH_MS`) resumes the instant the socket drops; the adaptive ladder it
+// replaced was retired in S7 (the push delivers near-cap urgency when live). The caller passes
+// `wsLive` from `useWsTopicLive('timeStatus')`.
 export function useTimeStatusToday(opts?: QueryOpts<ProfileTimeStatus[]> & { wsLive?: boolean }) {
   const { wsLive, ...rest } = opts ?? {}
   return useQuery({
     queryKey: qk.timeStatusToday(),
     queryFn: () => api.time.statusAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: wsLive ? false : q => timeStatusRefetchInterval(q.state.data),
+    refetchInterval: wsLive ? false : TIME_STATUS_FALLBACK_REFETCH_MS,
     refetchIntervalInBackground: false,
     ...rest,
   })
@@ -317,14 +275,14 @@ export function useTimeStatusWeek(
 
 // #777 — summary endpoints: lightweight rollups for the collapsed accordion view.
 export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]> & { wsLive?: boolean }) {
-  // #1974 (S6a): pause the adaptive ladder while the `timeStatus` push is live (§3.3) — the push
-  // patches this (summary-projected) cache, so polling is redundant; it resumes on disconnect.
+  // #1974 (S6a) / #1976 (S7): pause the poll while the `timeStatus` push is live (§3.3) — the push
+  // patches this (summary-projected) cache; on disconnect the flat fallback resumes.
   const { wsLive, ...rest } = opts ?? {}
   return useQuery({
     queryKey: qk.timeStatusSummaryToday(),
     queryFn: () => api.time.summaryAll(),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: wsLive ? false : q => timeStatusRefetchInterval(q.state.data),
+    refetchInterval: wsLive ? false : TIME_STATUS_FALLBACK_REFETCH_MS,
     refetchIntervalInBackground: false,
     ...rest,
   })
@@ -348,14 +306,14 @@ export function useTimeStatusProfileToday(
   profileId: number,
   opts?: QueryOpts<ProfileTimeStatus | undefined> & { wsLive?: boolean },
 ) {
-  // #1974 (S6a): pause the ladder while the `timeStatus` push is live (§3.3); the push patches this
-  // per-profile-today key off the same body, so it stays fresh without polling.
+  // #1974 (S6a) / #1976 (S7): pause the poll while the `timeStatus` push is live (§3.3); the push
+  // patches this per-profile-today key off the same body. On disconnect the flat fallback resumes.
   const { wsLive, ...rest } = opts ?? {}
   return useQuery({
     queryKey: qk.timeStatusProfileToday(profileId),
     queryFn: () => api.time.statusAll(undefined, profileId).then(rows => rows[0]),
     staleTime: STALE.timeStatusToday,
-    refetchInterval: wsLive ? false : q => timeStatusRefetchInterval(q.state.data),
+    refetchInterval: wsLive ? false : TIME_STATUS_FALLBACK_REFETCH_MS,
     refetchIntervalInBackground: false,
     ...rest,
   })

--- a/web/src/hooks/useWsTimeUsage.test.tsx
+++ b/web/src/hooks/useWsTimeUsage.test.tsx
@@ -1,7 +1,8 @@
 // #1974 (SPA-ws S6a): the live time-usage hooks (design §3.1/§3.3). Proves the `timeStatus` push
 // patches the time-status caches off the one pushed body, the `appUsage` push patches ONLY the
-// live today-window key (past windows immutable), the adaptive ladder goes dormant while the
-// `timeStatus` push streams, and expanding/collapsing a card subscribes/unsubscribes `appUsage`.
+// live today-window key (past windows immutable), the disconnected fallback poll pauses while the
+// `timeStatus` push streams (the adaptive ladder it replaced was retired in #1976/S7), and
+// expanding/collapsing a card subscribes/unsubscribes `appUsage`.
 // Driven by the real SpaWsClient over a mock socket so the wire→cache path is exercised end to end.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
@@ -17,7 +18,7 @@ vi.mock('@/api/client', () => ({
 
 import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
 import { WsProvider, useWsTopicLive, useWsTimeStatus, useWsAppUsage } from './useWs'
-import { useTimeStatusSummary, qk } from '@/api/queries'
+import { useTimeStatusSummary, qk, TIME_STATUS_FALLBACK_REFETCH_MS } from '@/api/queries'
 import { AuthProvider } from '@/hooks/useAuth'
 import type { ProfileTimeStatus, ProfileUsageByApp } from '@/types/api'
 
@@ -67,7 +68,7 @@ function setup() {
     setCookie: () => {},
     clearCookie: () => {},
     invalidateQuery: key => qc.invalidateQueries({ queryKey: key as readonly unknown[] }),
-    // Huge so the 5-minute ladder advance below never trips the heartbeat's missed-pong reconnect
+    // Huge so the timer advances below never trip the heartbeat's missed-pong reconnect
     // (which would clear acks and break the streaming-state assertion). Heartbeat is not under test.
     heartbeatMs: 100_000_000,
   })
@@ -180,7 +181,7 @@ describe('useWsAppUsage (§3.1)', () => {
   })
 })
 
-describe('adaptive ladder pauses while timeStatus streams (§3.3)', () => {
+describe('disconnected fallback poll pauses while timeStatus streams (§3.3)', () => {
   it('pauses the summary poll once the timeStatus subscription is acked, resumes if never acked', async () => {
     vi.useFakeTimers()
     const { api } = await import('@/api/client')
@@ -199,16 +200,16 @@ describe('adaptive ladder pauses while timeStatus streams (§3.3)', () => {
     await act(async () => { await vi.advanceTimersByTimeAsync(0) })
     expect(summarySpy).toHaveBeenCalledTimes(1) // initial fetch
 
-    // socket live but not yet acked → ladder still runs (baseline 5m cadence, remaining=90 → 5m)
+    // socket live but not yet acked → the flat disconnected fallback still runs (#1976/S7)
     act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
     expect(result.current).toBe(false)
-    await act(async () => { await vi.advanceTimersByTimeAsync(300_000) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS) })
     expect(summarySpy).toHaveBeenCalledTimes(2)
 
-    // server acks the subscription → topic streaming → ladder dormant
+    // server acks the subscription → topic streaming → fallback poll dormant
     act(() => { last().emit({ op: 'ack', payload: { topic: 'timeStatus', status: 'ok' } }) })
     expect(result.current).toBe(true)
-    await act(async () => { await vi.advanceTimersByTimeAsync(1_200_000) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS * 100) })
     expect(summarySpy).toHaveBeenCalledTimes(2) // no further polls while streaming
   })
 })

--- a/web/src/hooks/useWsTimeUsage.test.tsx
+++ b/web/src/hooks/useWsTimeUsage.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/api/client', () => ({
 
 import { SpaWsClient, type WsSocketLike } from '@/api/wsClient'
 import { WsProvider, useWsTopicLive, useWsTimeStatus, useWsAppUsage } from './useWs'
-import { useTimeStatusSummary, qk, TIME_STATUS_FALLBACK_REFETCH_MS } from '@/api/queries'
+import { useTimeStatusSummary, qk, LIVE_SURFACE_FALLBACK_REFETCH_MS } from '@/api/queries'
 import { AuthProvider } from '@/hooks/useAuth'
 import type { ProfileTimeStatus, ProfileUsageByApp } from '@/types/api'
 
@@ -203,13 +203,13 @@ describe('disconnected fallback poll pauses while timeStatus streams (§3.3)', (
     // socket live but not yet acked → the flat disconnected fallback still runs (#1976/S7)
     act(() => { client.start(); last().open(); last().emit({ op: 'ready', payload: {} }) })
     expect(result.current).toBe(false)
-    await act(async () => { await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(LIVE_SURFACE_FALLBACK_REFETCH_MS) })
     expect(summarySpy).toHaveBeenCalledTimes(2)
 
     // server acks the subscription → topic streaming → fallback poll dormant
     act(() => { last().emit({ op: 'ack', payload: { topic: 'timeStatus', status: 'ok' } }) })
     expect(result.current).toBe(true)
-    await act(async () => { await vi.advanceTimersByTimeAsync(TIME_STATUS_FALLBACK_REFETCH_MS * 100) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(LIVE_SURFACE_FALLBACK_REFETCH_MS * 100) })
     expect(summarySpy).toHaveBeenCalledTimes(2) // no further polls while streaming
   })
 })

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '@/api/client'
-import { useDashboardNow, useRecentBlocked } from '@/api/queries'
+import { useDashboardNow, useRecentBlocked, LIVE_SURFACE_FALLBACK_REFETCH_MS } from '@/api/queries'
 import type {
   DashboardNowDevice,
   DashboardNowProfile,
@@ -125,7 +125,7 @@ export function RecentlyBlockedSection() {
   // a role whose subscription the server rejects keeps polling instead of going stale.
   const streaming = useWsTopicLive('connectionEvents')
   useWsRecentBlocked()
-  const { data = null } = useRecentBlocked({ refetchInterval: streaming ? false : 10_000 })
+  const { data = null } = useRecentBlocked({ refetchInterval: streaming ? false : LIVE_SURFACE_FALLBACK_REFETCH_MS })
 
   return (
     <section data-testid="recently-blocked-section" className="bg-white rounded-2xl border border-brand-border overflow-hidden">
@@ -234,7 +234,7 @@ export function NowSection() {
   // role whose `now` subscription is server-rejected keeps polling rather than freezing.
   const streaming = useWsTopicLive('now')
   useWsNow()
-  const { data = null, dataUpdatedAt } = useDashboardNow({ refetchInterval: streaming ? false : 10_000 })
+  const { data = null, dataUpdatedAt } = useDashboardNow({ refetchInterval: streaming ? false : LIVE_SURFACE_FALLBACK_REFETCH_MS })
   const kpis = deriveNowKpis(data)
 
   // #1835: split active from idle. A profile is idle when it has zero active


### PR DESCRIPTION
The **final, subtractive** step of the SPA-websocket rollout (`docs/design/spa-websocket.md` §9 **S7** + §3.3). Closes #1976. Relates to #1860, #1955.

## What S7 does
Polling (`refetchInterval`) was kept as the *paused fallback* throughout the rollout, gated `refetchInterval: wsLive ? false : <cadence>`. Now that the push paths (S5 dashboard, S6a time-status, S6b pages) are shipped and proven, this retires the **one** now-redundant interval whose push fully covers it: the **time-status adaptive ladder** (`TIME_STATUS_REFETCH_LADDER`) — whose only reason to exist was the absence of a push (§0.1 / §3.3).

Removed: `TIME_STATUS_REFETCH_LADDER`, `TIME_STATUS_REFETCH_MAX_MS`, `timeStatusRefetchMs`, `timeStatusRefetchInterval`, `minRemainingMins`, `CadenceRow`.
Added: `TIME_STATUS_FALLBACK_REFETCH_MS` (10s) — a single **flat** disconnected fallback.

When the socket is **live**, the S6a `timeStatus` push drives freshness in every case (the hooks already pause polling via `wsLive ? false`). When the socket is **down**, the flat 10s fallback keeps a near-cap "minutes left" from lagging enforcement (#1871) — **10s = the old ladder's fastest rung, so no freshness regression when disconnected**. The only behavior change: far-from-cap loses the ladder's 5m backoff (slightly more polling, but only while disconnected + foreground). Disconnected-fallback cadence was the operator's call (flat 10s, chosen 2026-06-29).

## Per-view table (verified against the code before removing any poll)

| View | Push that covers it | Interval removed / fallback kept |
|---|---|---|
| **Time-status** (`useTimeStatusToday`/`Summary`/`ProfileToday`) | S6a `timeStatus` push (`useWsTimeStatus`, §3.1) | **Adaptive ladder removed**; replaced by flat `wsLive ? false : 10s` fallback |
| **Dashboard NOW** (`useDashboardNow`) | S5 `now` push (`useWsNow`) | Poll already paused when healthy; **10s fallback KEPT** — only freshness when down |
| **Dashboard Recently-Blocked** (`useRecentBlocked`) | S5 `connectionEvents{blocked:true}` push (`useWsRecentBlocked`) | Poll already paused when healthy; **10s fallback KEPT** — only freshness when down |
| **Traffic Usage page** | S6b `trafficUsage` live edge (`useWsTrafficUsageLiveEdge`) | Already **no `refetchInterval`** (live edge is the freshness) — nothing to retire |
| **Connection Events page** | S6b `connectionEvents` live edge (`useWsConnectionEventsLiveEdge`) | Already **no `refetchInterval`** — nothing to retire |
| **Live throughput** (class 1) | `trafficUsage` (no poll by design) | No poll fallback — shows "—" when down (unchanged) |
| **`useAlerts`** (30s) | none (class-3) | Out of scope — **KEPT** |

Conservatism (per §3.3 / #1976): a fallback is removed **only** where the push fully covers the poll. The dashboard fallbacks are the *only* freshness path when the socket is down, so they're kept; the pages already have no poll. Only the time-status *adaptivity* — redundant now that the push delivers near-cap urgency when live — is retired.

## Tests (TDD: RED commit then GREEN)
- `web/src/api/queries.test.tsx`: rewrote the `#1871` adaptive-cadence block → asserts the flat disconnected fallback (near-cap **and** far-from-cap poll at the same 10s — proving the ladder/backoff is gone) and that `wsLive: true` pauses the poll entirely.
- `web/src/hooks/useWsTimeUsage.test.tsx`: the streaming-pause test now advances by the flat cadence instead of the 5m baseline.

`npm --prefix web run lint` ✓ · `npm --prefix web test` ✓ (519 passed) · `npm --prefix web run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)