### PR TITLE
feat(#2064): ads-blocklist pass — 38 unblocked RTB/bidder/ad-server gaps from prod traffic

### DIFF
--- a/.claude/skills/ads-blocklist-pass/SKILL.md
+++ b/.claude/skills/ads-blocklist-pass/SKILL.md
@@ -125,6 +125,35 @@ that edit in the same PR.** If a step above is now wrong, fix the step too.
 
 ## Learnings log (newest first)
 
+- **2026-06-30** (#2064) — **RTB/bidder/exchange genuine-gaps are the richest
+  vein, and they're low-collateral by construction.** This pass added 38 apexes,
+  almost all `*rtb*` / `*bid*` / `*-ads` / `oneadtag` / `imptracking`-class names
+  the `ads-extended` feed misses entirely. These are safe to add in bulk (not
+  just "a handful") because the *name is the function* — no product or shared
+  traffic rides `coldbidder.com` / `rtblab.net` / `openrtbx.com`, so the
+  collateral rule that governs dual-use hosts simply doesn't bite. Reserve the
+  "handful" caution for *covered* apexes (low marginal value) and for
+  dual-use/ambiguous names — not for clearly-ad genuine gaps.
+- **2026-06-30** (#2064) — **BitTorrent trackers recur as high-hit decoys —
+  always check `open*tracker*` / `*-tracker.org` before adding.** `opentrackr.org`
+  (4,485 hits) and `popcorn-tracker.org` (1,212 hits) both *out-hit* every real
+  ad apex this pass but are BitTorrent trackers, not ad infra (same class as
+  #1923's `demonii.com`). A `track`-substring match is NOT an ad signal; classify
+  by what the apex *is*.
+- **2026-06-30** (#2064) — **`antibanads.com` is real ad infra, not an
+  ad-blocker.** Despite the "anti-ban-ads" name it's BIGO Ads' ad-delivery
+  backend, deliberately named + multi-cloud-fronted to survive domain bans
+  (security-research confirmed). When a name reads like an *anti*-ad tool, verify
+  — it may be ad-serving infra wearing camouflage.
+- **2026-06-30** (#2064) — **New dual-use / wrong-category SKIPs seen this pass:**
+  `zetaglobal.io` (Zeta Global marketing-cloud/CRM — first-party customer
+  marketing, dual-use), `minutemediaservices.com` (Minute Media is a *content*
+  publisher; only its `minutemedia-prebid` sibling is ad-specific),
+  `smartborad.com` (scamadviser-flagged malware, unclear identity — belongs to
+  the malware list if anywhere, not ads), `ottadvisors.com` / `advolve.io`
+  (AdOps consultancy / AI-marketing platform — apex is the corporate site, ad
+  -serving ambiguous; held out). Verify ownership before trusting an ad-ish name;
+  unverified apexes are held out, not added.
 - **2026-06-23** (#1923) — **Diff candidates against the StevenBlack
   `ads-extended` feed before adding.** Fetch
   `raw.githubusercontent.com/StevenBlack/hosts/master/hosts`, extract the

--- a/api/resources/blocklists/ads.yml
+++ b/api/resources/blocklists/ads.yml
@@ -142,3 +142,56 @@ hosts:
   - mgid.com
   - creativecdn.com
   - demdex.net
+  # traffic-driven additions (#2064): observed but unblocked ad/RTB/tracker infra.
+  # Sourced from a 30-day prod recent-apexes sweep (26 devices, 2026-06-30).
+  # Cross-checked against the StevenBlack ads-extended feed — every apex below is
+  # a GENUINE GAP that even ads-extended misses entirely, and is unambiguously
+  # ad-dedicated (RTB exchange / bidder / ad server / impression-measurement
+  # tracker), so collateral risk is low. Dual-use / wrong-category SKIPPED:
+  # zetaglobal.io (marketing-cloud/CRM), minutemediaservices.com (content
+  # publisher), smartborad.com (flagged malware, not clearly ad-RTB),
+  # app-ads-services.com / app-analytics-services.com (Google GA4/Firebase, per
+  # #1923), applemediaservices.com (Apple), opentrackr.org / popcorn-tracker.org
+  # (BitTorrent trackers, not ads). See evidence/ads-classification-2064.md for
+  # per-apex hits + what-it-is.
+  # RTB exchanges / bidders / DSPs (gaps not in ads-extended)
+  - rtbhouse.com
+  - bid-algorix.com
+  - amxrtb.com
+  - coldbidder.com
+  - smarterbidder.com
+  - tmbid.com
+  - rtbuniverse.com
+  - rtbrain.app
+  - openrtbx.com
+  - rtblab.net
+  - one-bid.com
+  - ortb.net
+  - bidgx.com
+  - omsrtb.com
+  - rtbscale.com
+  - rtbanalytics.com
+  - rtbwise.com
+  - iqzonertb.live
+  - bidbrain.app
+  - bm-ads.io
+  - rtb-adv.com
+  # Ad servers / tags / impression + attribution trackers (gaps not in ads-extended)
+  - antibanads.com
+  - adkit-advertising.amazon
+  - oneadtag.com
+  - lacunads.com
+  - cleanmediaadserver.com
+  - mobidriven.com
+  - imptracking.com
+  - measureadv.com
+  - iionads.com
+  - liftdsp.com
+  - valorousadvertising.com
+  - rapidtag.net
+  # Sibling apexes of already-curated ad vendors (gaps not in ads-extended)
+  - adjust.io
+  - adnxs.net
+  - adsappier.com
+  - sharethru.com
+  - tiktokpangle-b.us

--- a/api/test/src/feature/BundledBlocklistsSpec.scala
+++ b/api/test/src/feature/BundledBlocklistsSpec.scala
@@ -142,6 +142,8 @@ object BundledBlocklistsSpec
         assertTrue(ads.contains(Hostname.unsafe("doubleclick.net"))) &&
         // traffic-driven addition pinned for presence (#1923)
         assertTrue(ads.contains(Hostname.unsafe("bidmachine.io"))) &&
+        // traffic-driven addition pinned for presence (#2064)
+        assertTrue(ads.contains(Hostname.unsafe("coldbidder.com"))) &&
         assertTrue(meta.isDefined) &&
         assertTrue(meta.exists(m => m.bundled && m.name == "Ads & Trackers"))
     },

--- a/evidence/ads-classification-2064.md
+++ b/evidence/ads-classification-2064.md
@@ -1,0 +1,81 @@
+# Ads-blocklist pass — classification evidence (#2064)
+
+**Date:** 2026-06-30
+**Method:** 30-day prod `GET /api/devices/{mac}/recent-apexes?windowDays=30&limit=500`
+sweep across all 26 devices (read-only). Candidate ad/RTB/tracker apexes diffed
+against the curated `ads.yml` **and** the StevenBlack `ads-extended` feed
+(`raw.githubusercontent.com/StevenBlack/hosts/master/hosts`, ~82.7k hosts). The
+38 apexes below are **genuine gaps** — apexes that even `ads-extended` misses
+entirely — and are each unambiguously ad-dedicated (RTB exchange, bidder, DSP,
+ad server, or impression/measurement tracker), so collateral risk is low.
+
+> IPv4-bias caveat (#1796) still applies — the `recent-apexes` view is
+> attribution-biased toward v4-resolved flows; v6-only ad traffic is
+> under-counted. Re-confirm next pass.
+
+## Added to `ads.yml` (38 apexes, sorted by 30-day bytes)
+
+| apex | bytes (30d) | hits | what it is |
+|------|-------------|------|------------|
+| coldbidder.com | 6,209,155 | 163 | RTB bidder endpoint |
+| adjust.io | 4,701,492 | 49 | Adjust mobile attribution (sibling of curated `adjust.com`) |
+| antibanads.com | 4,252,192 | 64 | BIGO Ads ad-delivery infra, named to evade ad-blocking (security-research confirmed) |
+| smarterbidder.com | 1,263,633 | 77 | RTB bidder |
+| bidbrain.app | 984,029 | 84 | RTB bidding service |
+| measureadv.com | 661,255 | 86 | Ad measurement / verification |
+| tmbid.com | 619,184 | 103 | RTB bidder |
+| tiktokpangle-b.us | 544,865 | 52 | TikTok Pangle ad network (sibling of curated `tiktokpangle.us`) |
+| rtbuniverse.com | 537,242 | 52 | RTB exchange |
+| bid-algorix.com | 500,352 | 170 | AlgoriX mobile ad exchange bidder |
+| oneadtag.com | 405,629 | 23 | Ad tag delivery |
+| bm-ads.io | 349,897 | 2 | Ad network |
+| adkit-advertising.amazon | 325,904 | 17 | Amazon ad infra (`.amazon` brand TLD; ad-dedicated subdomain, peer of SB-listed `paa-reporting-advertising.amazon`) |
+| rtbrain.app | 306,443 | 32 | RTB bidding service |
+| openrtbx.com | 291,727 | 43 | OpenRTB exchange |
+| lacunads.com | 275,694 | 17 | Ad network |
+| rtblab.net | 237,304 | 30 | RTB exchange |
+| one-bid.com | 161,238 | 10 | RTB bidder |
+| rtbhouse.com | 157,345 | 50 | RTB House — retargeting DSP (web-verified) |
+| ortb.net | 152,204 | 15 | OpenRTB exchange |
+| bidgx.com | 136,248 | 41 | RTB bidder/exchange |
+| rtb-adv.com | 122,363 | 9 | RTB ad exchange |
+| mobidriven.com | 111,463 | 6 | Mobile ad network |
+| omsrtb.com | 91,572 | 15 | RTB exchange |
+| adnxs.net | 86,397 | 3 | AppNexus/Xandr (sibling of curated `adnxs.com`) |
+| rtbscale.com | 75,243 | 4 | RTB exchange |
+| adsappier.com | 66,820 | 4 | Appier ads (sibling of curated `appiersig.com`) |
+| amxrtb.com | 64,344 | 47 | AMX SSP / RTB |
+| cleanmediaadserver.com | 64,009 | 4 | Ad server |
+| sharethru.com | 62,636 | 5 | Sharethrough (sibling of curated `sharethrough.com`) |
+| rtbanalytics.com | 58,862 | 7 | RTB analytics/tracking |
+| valorousadvertising.com | 57,423 | 2 | Ad network |
+| rtbwise.com | 56,582 | 13 | RTB exchange |
+| imptracking.com | 55,298 | 3 | Ad impression tracking |
+| rapidtag.net | 53,725 | 1 | Ad tag delivery |
+| iionads.com | 36,181 | 2 | Ad network |
+| iqzonertb.live | 20,866 | 11 | RTB exchange |
+| liftdsp.com | 13,919 | 8 | Demand-side platform |
+
+## Notable SKIPS (and why)
+
+| apex | bytes | hits | why skipped |
+|------|-------|------|-------------|
+| instagram.com | 474,144,517 | 312 | Meta social — name-collision false positive; would block IG entirely (not ads category) |
+| cdninstagram.com | 220,672,236 | 63 | Instagram CDN — content, not ads |
+| app-ads-services.com | 41,420,347 | 272 | Google GA4/ATT segmentation — shared Google infra, dual-use (documented skip from #1923) |
+| app-analytics-services.com | 41,307,477 | 770 | Google GA4 — shared Google infra, dual-use (#1923) |
+| unity3dusercontent.com | 9,479,887 | 7 | Unity game asset CDN — game content, dual-use |
+| minutemediaservices.com | 7,468,363 | 6 | Minute Media is a content publisher; generic `services` apex risks content collateral |
+| smartborad.com | 3,091,497 | 71 | scamadviser-flagged malware, identity unclear — not confidently ad-RTB (malware ≠ ads category) |
+| zetaglobal.io | 169,654 | 18 | Zeta Global marketing cloud / CRM — carries first-party customer-marketing, dual-use |
+| ottadvisors.com | 142,424 | 14 | OTT Advisors AdOps consultancy — apex is corporate/consulting site, ambiguous ad-serving |
+| opentrackr.org | 668,874 | 4485 | BitTorrent tracker (`open.opentrackr.org`) — not ad infra (same class as #1923's `demonii.com`) |
+| popcorn-tracker.org | 55,704 | 1212 | BitTorrent tracker — not ad infra |
+| advolve.io | 76,024 | 13 | AI digital-marketing platform — borderline marketing-automation, low traffic, held out |
+| applemediaservices.com | 11,251 | 1 | Apple infra — dual-use |
+| indoormediastorage.com / mosspf.com / mosspf.net / lpsnmedia.net / imganalytics.com / analytics-sm.com / tmatrackapp.site | — | — | Unverified ownership; held out pending clearer ad-serving evidence |
+
+Apexes covered by `ads-extended` already (lower curated value, not added this
+pass): `rtbhouse`-class names plus `360yield.com`, `adcolony.com`,
+`ads-twitter.com`, `kochava.com`, `revcontent.com`, `sonobi.com`, `eyeota.net`,
+etc. — the extended feed already drops these for profiles that enable it.


### PR DESCRIPTION
## What

Weekly traffic-driven ads-blocklist pass (`/ads-blocklist-pass` skill). Adds **38 apexes** to `api/resources/blocklists/ads.yml` — all ad/RTB/tracker infra that real devices are hitting and that **neither** the curated list **nor** the StevenBlack `ads-extended` feed currently covers.

## How they were found

30-day prod `recent-apexes` sweep across all 26 devices (read-only; admin creds from local memory, never committed). Candidate ad-pattern apexes were diffed against:
1. the curated `ads.yml` (109 hosts), and
2. the live StevenBlack `ads-extended` feed (~82.7k hosts).

The 38 added are **genuine gaps** — apexes even `ads-extended` misses entirely — and each is unambiguously ad-dedicated (RTB exchange / bidder / DSP / ad server / impression-measurement tracker). Because *the name is the function* (`coldbidder.com`, `rtblab.net`, `openrtbx.com`, `oneadtag.com`, …), no product or shared traffic rides these hosts, so collateral risk is low.

Highlights: `coldbidder.com` (6.2 MB/30d), `adjust.io` (Adjust attribution sibling), `antibanads.com` (BIGO Ads delivery infra, security-research-confirmed despite the name), `bid-algorix.com` (AlgoriX), `rtbhouse.com` (RTB House DSP), plus a long tail of `*rtb*`/`*bid*` exchanges and sibling apexes of already-curated vendors (`adnxs.net`, `adsappier.com`, `sharethru.com`, `tiktokpangle-b.us`).

## Notable SKIPS (collateral / dual-use / wrong category)

- `zetaglobal.io` — Zeta Global marketing-cloud/CRM (first-party customer marketing, dual-use)
- `minutemediaservices.com` — Minute Media content publisher (only its `minutemedia-prebid` sibling is ad-specific)
- `smartborad.com` — scamadviser-flagged malware, unclear identity (malware ≠ ads category)
- `app-ads-services.com` / `app-analytics-services.com` — Google GA4/Firebase shared infra (#1923 documented skip)
- `opentrackr.org` (4,485 hits) / `popcorn-tracker.org` (1,212 hits) — BitTorrent trackers, **not** ad infra (same class as #1923's `demonii.com`)
- `instagram.com` / `cdninstagram.com` / `unity3dusercontent.com` — social/game content name-collisions

Full per-apex hit table + what-each-is + skip rationale in [`evidence/ads-classification-2064.md`](evidence/ads-classification-2064.md).

## Changes

- `api/resources/blocklists/ads.yml` — +38 apexes under a dated `#2064` comment block
- `api/test/.../BundledBlocklistsSpec.scala` — pin `coldbidder.com` for presence (per-pass convention, mirrors #1923's `bidmachine.io` pin)
- `evidence/ads-classification-2064.md` — classification evidence
- `.claude/skills/ads-blocklist-pass/SKILL.md` — **Step 5 self-update**: RTB-gap bulk-add rationale, BitTorrent-tracker decoys, `antibanads` camouflage, new dual-use skips

## Validation

`mill api.test.testOnly 'wifihaven.api.feature.BundledBlocklistsSpec'` → **19 passed** (incl. "every inline host parses as a valid hostname" — covers the `.amazon` TLD entry — and the seeder presence test with the new pin). `scalafmt --check` clean.

Relates to #2064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)